### PR TITLE
feat: add configurable base URL 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ npx -y @steipete/oracle -p "Review the TS data layer" --file "src/**/*.ts" --fil
 # Mixed glob + single file
 npx -y @steipete/oracle -p "Audit data layer" --file "src/**/*.ts" --file README.md
 
+# Alternate base URL (LiteLLM, Azure, self-hosted gateways)
+OPENAI_API_KEY=sk-... oracle --base-url https://litellm.example.com/v1 -p "Summarize the risk register"
+
 # Inspect past sessions
 oracle status --clear --hours 168   # prune a week of cached runs
 oracle status                       # list runs; grab an ID
@@ -86,6 +89,7 @@ Put per-user defaults in `~/.oracle/config.json` (parsed as JSON5, so comments/t
 | `-f, --file <paths...>` | Attach files/dirs (supports globs and `!` excludes). |
 | `-e, --engine <api\|browser>` | Choose API or browser automation. Omitted: API when `OPENAI_API_KEY` is set, otherwise browser. |
 | `-m, --model <name>` | `gpt-5-pro` (default) or `gpt-5.1`. |
+| `--base-url <url>` | Point the API engine at any OpenAI-compatible endpoint (LiteLLM, Azure, etc.). |
 | `--files-report` | Print per-file token usage. |
 | `--preview [summary\|json\|full]` | Inspect the request without sending. |
 | `--render-markdown` | Print the assembled `[SYSTEM]/[USER]/[FILE]` bundle. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,7 +31,8 @@ Oracle reads an optional per-user config from `~/.oracle/config.json`. The file 
   heartbeatSeconds: 30,     // default heartbeat interval
   filesReport: false,       // default per-file token report
   background: true,         // default background mode for API runs
-  promptSuffix: "// signed-off by me" // appended to every prompt
+  promptSuffix: "// signed-off by me", // appended to every prompt
+  apiBaseUrl: "https://api.openai.com/v1" // override for LiteLLM / custom gateways
 }
 ```
 
@@ -39,7 +40,7 @@ Oracle reads an optional per-user config from `~/.oracle/config.json`. The file 
 
 CLI flags → `config.json` → environment → built-in defaults.
 
-- `engine`, `model`, `search`, `filesReport`, and `heartbeatSeconds` in `config.json` override the auto-detected values unless explicitly set on the CLI.
+- `engine`, `model`, `search`, `filesReport`, `heartbeatSeconds`, and `apiBaseUrl` in `config.json` override the auto-detected values unless explicitly set on the CLI.
 - `OPENAI_API_KEY` only influences engine selection when neither the CLI nor `config.json` specify an engine (API when present, otherwise browser).
 - `ORACLE_NOTIFY*` env vars still layer on top of the config’s `notify` block.
 

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -85,6 +85,11 @@ export function normalizeModelOption(value: string | undefined): string {
   return (value ?? '').trim();
 }
 
+export function normalizeBaseUrl(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed?.length ? trimmed : undefined;
+}
+
 export function resolveApiModel(modelValue: string): ModelName {
   const normalized = normalizeModelOption(modelValue).toLowerCase();
   if (normalized in MODEL_CONFIGS) {

--- a/src/cli/runOptions.ts
+++ b/src/cli/runOptions.ts
@@ -2,7 +2,7 @@ import type { RunOracleOptions } from '../oracle.js';
 import type { UserConfig } from '../config.js';
 import type { EngineMode } from './engine.js';
 import { resolveEngine } from './engine.js';
-import { normalizeModelOption, inferModelFromLabel, resolveApiModel } from './options.js';
+import { normalizeModelOption, inferModelFromLabel, resolveApiModel, normalizeBaseUrl } from './options.js';
 
 export interface ResolveRunOptionsInput {
   prompt: string;
@@ -41,6 +41,8 @@ export function resolveRunOptionsFromConfig({
   const heartbeatIntervalMs =
     userConfig?.heartbeatSeconds !== undefined ? userConfig.heartbeatSeconds * 1000 : 30_000;
 
+  const baseUrl = normalizeBaseUrl(userConfig?.apiBaseUrl ?? env.OPENAI_BASE_URL);
+
   const runOptions: RunOracleOptions = {
     prompt: promptWithSuffix,
     model: resolvedModel,
@@ -49,6 +51,7 @@ export function resolveRunOptionsFromConfig({
     heartbeatIntervalMs,
     filesReport: userConfig?.filesReport,
     background: userConfig?.background,
+    baseUrl,
   };
 
   return { runOptions, resolvedEngine };

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,6 +32,7 @@ export interface UserConfig {
   filesReport?: boolean;
   background?: boolean;
   promptSuffix?: string;
+  apiBaseUrl?: string;
 }
 
 function resolveConfigPath(): string {

--- a/src/oracle/run.ts
+++ b/src/oracle/run.ts
@@ -57,6 +57,7 @@ export async function runOracle(options: RunOracleOptions, deps: RunOracleDeps =
     client,
     wait = defaultWait,
   } = deps;
+  const baseUrl = options.baseUrl?.trim() || process.env.OPENAI_BASE_URL?.trim();
 
   const maskApiKey = (key: string | undefined | null): string | null => {
     if (!key) return null;
@@ -84,6 +85,9 @@ export async function runOracle(options: RunOracleOptions, deps: RunOracleDeps =
   const maskedKey = maskApiKey(apiKey);
   if (maskedKey) {
     log(dim(`Using OPENAI_API_KEY=${maskedKey}`));
+  }
+  if (baseUrl) {
+    log(dim(`Using OpenAI BASE URL: ${baseUrl}`));
   }
 
   const modelConfig = MODEL_CONFIGS[options.model];
@@ -184,7 +188,7 @@ export async function runOracle(options: RunOracleOptions, deps: RunOracleDeps =
     };
   }
 
-  const openAiClient: ClientLike = client ?? clientFactory(apiKey);
+  const openAiClient: ClientLike = client ?? clientFactory(apiKey, { baseUrl });
   logVerbose('Dispatching request to OpenAI Responses API...');
   const stopOscProgress = startOscProgress({
     label: useBackground ? 'Waiting for OpenAI (background)' : 'Waiting for OpenAI',

--- a/src/oracle/types.ts
+++ b/src/oracle/types.ts
@@ -71,6 +71,8 @@ export interface ClientLike {
   };
 }
 
+export type ClientFactory = (apiKey: string, options?: { baseUrl?: string }) => ClientLike;
+
 export interface RunOracleOptions {
   prompt: string;
   model: ModelName;
@@ -85,6 +87,7 @@ export interface RunOracleOptions {
   preview?: boolean | string;
   previewMode?: PreviewMode;
   apiKey?: string;
+  baseUrl?: string;
   sessionId?: string;
   verbose?: boolean;
   heartbeatIntervalMs?: number;
@@ -125,7 +128,7 @@ export interface RunOracleDeps {
   log?: (message: string) => void;
   write?: (chunk: string) => boolean;
   now?: () => number;
-  clientFactory?: (apiKey: string) => ClientLike;
+  clientFactory?: ClientFactory;
   client?: ClientLike;
   wait?: (ms: number) => Promise<void>;
 }

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -68,6 +68,7 @@ export interface StoredRunOptions {
   browserBundleFiles?: boolean;
   background?: boolean;
   search?: boolean;
+  baseUrl?: string;
 }
 
 export interface SessionMetadata {
@@ -232,6 +233,7 @@ export async function initializeSession(
       browserBundleFiles: options.browserBundleFiles,
       background: options.background,
       search: options.search,
+      baseUrl: options.baseUrl,
     },
   };
   await fs.writeFile(metaPath(sessionId), JSON.stringify(metadata, null, 2), 'utf8');

--- a/tests/oracle-cli.test.ts
+++ b/tests/oracle-cli.test.ts
@@ -557,6 +557,30 @@ describe('runOracle file reports', () => {
 
     await rm(dir, { recursive: true, force: true });
   });
+
+  test('passes baseUrl through to clientFactory', async () => {
+    const stream = new MockStream([], buildResponse());
+    const client = new MockClient(stream);
+    const captured: Array<{ apiKey: string; baseUrl?: string }> = [];
+    await runOracle(
+      {
+        prompt: 'Custom endpoint',
+        model: 'gpt-5-pro',
+        baseUrl: 'https://litellm.test/v1',
+        background: false,
+      },
+      {
+        apiKey: 'sk-test',
+        clientFactory: (apiKey, options) => {
+          captured.push({ apiKey, baseUrl: options?.baseUrl });
+          return client;
+        },
+        log: () => {},
+        write: () => true,
+      },
+    );
+    expect(captured).toEqual([{ apiKey: 'sk-test', baseUrl: 'https://litellm.test/v1' }]);
+  });
 });
 
 describe('renderPromptMarkdown', () => {

--- a/tests/runOptions.test.ts
+++ b/tests/runOptions.test.ts
@@ -64,6 +64,24 @@ describe('resolveRunOptionsFromConfig', () => {
     expect(runOptions.filesReport).toBe(true);
     expect(runOptions.background).toBe(false);
   });
+
+  it('includes apiBaseUrl from config', () => {
+    const { runOptions } = resolveRunOptionsFromConfig({
+      prompt: basePrompt,
+      userConfig: { apiBaseUrl: 'https://proxy.test/v1' },
+    });
+    expect(runOptions.baseUrl).toBe('https://proxy.test/v1');
+  });
+
+  it('falls back to OPENAI_BASE_URL env', () => {
+    const env = {} as NodeJS.ProcessEnv;
+    env.OPENAI_BASE_URL = 'https://env.example/v2';
+    const { runOptions } = resolveRunOptionsFromConfig({
+      prompt: basePrompt,
+      env,
+    });
+    expect(runOptions.baseUrl).toBe('https://env.example/v2');
+  });
 });
 
 describe('estimateRequestTokens', () => {


### PR DESCRIPTION
## Why
Until now the CLI always talked to api.openai.com with the openai package. Anyone routing through LiteLLM, Azure OpenAI, or an internal proxy had to rewrite the binary. This change makes the endpoint first-class so they can point Oracle at whatever OpenAI-compatible gateway they run. 

Vibed this with GPT 5.1 Codex + some manual changes, if I should make any changes please let me know! I would love to see this get merged in.  

## What’s new
- `--base-url <url>` flag on the CLI. Example:
```
  OPENAI_API_KEY=sk-*** oracle \
    --engine api \
    --base-url https://gateway.example.com/v1 \
    --prompt "Summarize the changelog" \
    --wait --verbose
```
    
  Sample output now includes:
    `Using OPENAI_API_KEY=sk-A***Z`
    `Using OpenAI base URL https://gateway.example.com/v1`
- `~/.oracle/config.json` gains `apiBaseUrl`. If you add:
  ```json
  {
    "apiBaseUrl": "https://gateway.example.com/v1",
    "promptSuffix": "\n(added from config)"
  }
  ```
  every API run (including stored-session replays) automatically uses that endpoint unless you override it with `--base-url`. CLI flag > config > `OPENAI_BASE_URL` env remains the precedence, and sessions record the chosen URL so `oracle session <id>` replays against the same gateway.
- Base URL handling now flows through `buildRunOptions`, `runOracle`, session metadata, and the client factory. Type safety improved by moving `ClientFactory` to `src/oracle/types.ts`, and all normalization lives in `src/cli/options.ts`.
- README + docs now explain the flag/config knobs and show the “Using OpenAI base URL …” log line so users know the override stuck. Tests cover config/env precedence and lint-safe env mocking.

Tested both CLI argument + config.json file on both GPT 5.1 and GPT-5 Pro. 

Example run:
<img width="661" height="225" alt="image" src="https://github.com/user-attachments/assets/a9842f8a-34d7-42aa-ba37-dd690ffe3eeb" />

