### PR TITLE
When outputting code blocks with markdown in ChatGPT Web the blocks get

### DIFF
--- a/src/cli/markdownBundle.ts
+++ b/src/cli/markdownBundle.ts
@@ -1,10 +1,17 @@
-import fs from 'node:fs/promises';
-import { DEFAULT_SYSTEM_PROMPT } from '../oracle/config.js';
-import { buildPrompt } from '../oracle/request.js';
-import { createFileSections, readFiles } from '../oracle/files.js';
-import { createFsAdapter } from '../oracle/fsAdapter.js';
-import { buildPromptMarkdown } from '../oracle/promptAssembly.js';
-import type { MinimalFsModule, RunOracleOptions, FileContent } from '../oracle/types.js';
+import fs from "node:fs/promises";
+import {
+  DEFAULT_SYSTEM_PROMPT,
+  DEFAULT_SYSTEM_PROMPT_MARKDOWN_BUNDLE_ADDITIONS,
+} from "../oracle/config.js";
+import { buildPrompt } from "../oracle/request.js";
+import { createFileSections, readFiles } from "../oracle/files.js";
+import { createFsAdapter } from "../oracle/fsAdapter.js";
+import { buildPromptMarkdown } from "../oracle/promptAssembly.js";
+import type {
+  MinimalFsModule,
+  RunOracleOptions,
+  FileContent,
+} from "../oracle/types.js";
 
 export interface MarkdownBundle {
   markdown: string;
@@ -14,15 +21,20 @@ export interface MarkdownBundle {
 }
 
 export async function buildMarkdownBundle(
-  options: Pick<RunOracleOptions, 'prompt' | 'file' | 'system'>,
+  options: Pick<RunOracleOptions, "prompt" | "file" | "system">,
   deps: { cwd?: string; fs?: MinimalFsModule } = {},
 ): Promise<MarkdownBundle> {
   const cwd = deps.cwd ?? process.cwd();
   const fsModule = deps.fs ?? createFsAdapter(fs);
   const files = await readFiles(options.file ?? [], { cwd, fsModule });
   const sections = createFileSections(files, cwd);
-  const systemPrompt = options.system?.trim() || DEFAULT_SYSTEM_PROMPT;
-  const userPrompt = (options.prompt ?? '').trim();
+  const systemPrompt =
+    options.system?.trim() ||
+    [
+      DEFAULT_SYSTEM_PROMPT,
+      DEFAULT_SYSTEM_PROMPT_MARKDOWN_BUNDLE_ADDITIONS,
+    ].join(" ");
+  const userPrompt = (options.prompt ?? "").trim();
 
   const markdown = buildPromptMarkdown(systemPrompt, userPrompt, sections);
   const promptWithFiles = buildPrompt(userPrompt, files, cwd);

--- a/src/oracle/config.ts
+++ b/src/oracle/config.ts
@@ -1,19 +1,30 @@
-import { countTokens as countTokensGpt5 } from 'gpt-tokenizer/model/gpt-5';
-import { countTokens as countTokensGpt5Pro } from 'gpt-tokenizer/model/gpt-5-pro';
-import type { ModelConfig, ModelName, KnownModelName, ProModelName, TokenizerFn } from './types.js';
-import { countTokens as countTokensAnthropicRaw } from '@anthropic-ai/tokenizer';
-import { stringifyTokenizerInput } from './tokenStringifier.js';
+import { countTokens as countTokensGpt5 } from "gpt-tokenizer/model/gpt-5";
+import { countTokens as countTokensGpt5Pro } from "gpt-tokenizer/model/gpt-5-pro";
+import type {
+  ModelConfig,
+  ModelName,
+  KnownModelName,
+  ProModelName,
+  TokenizerFn,
+} from "./types.js";
+import { countTokens as countTokensAnthropicRaw } from "@anthropic-ai/tokenizer";
+import { stringifyTokenizerInput } from "./tokenStringifier.js";
 
-export const DEFAULT_MODEL: ModelName = 'gpt-5.1-pro';
-export const PRO_MODELS = new Set<ProModelName>(['gpt-5.1-pro', 'gpt-5-pro', 'claude-4.5-sonnet', 'claude-4.1-opus']);
+export const DEFAULT_MODEL: ModelName = "gpt-5.1-pro";
+export const PRO_MODELS = new Set<ProModelName>([
+  "gpt-5.1-pro",
+  "gpt-5-pro",
+  "claude-4.5-sonnet",
+  "claude-4.1-opus",
+]);
 
 const countTokensAnthropic: TokenizerFn = (input: unknown): number =>
   countTokensAnthropicRaw(stringifyTokenizerInput(input));
 
 export const MODEL_CONFIGS: Record<KnownModelName, ModelConfig> = {
-  'gpt-5.1-pro': {
-    model: 'gpt-5.1-pro',
-    provider: 'openai',
+  "gpt-5.1-pro": {
+    model: "gpt-5.1-pro",
+    provider: "openai",
     tokenizer: countTokensGpt5Pro as TokenizerFn,
     inputLimit: 196000,
     pricing: {
@@ -22,9 +33,9 @@ export const MODEL_CONFIGS: Record<KnownModelName, ModelConfig> = {
     },
     reasoning: null,
   },
-  'gpt-5-pro': {
-    model: 'gpt-5-pro',
-    provider: 'openai',
+  "gpt-5-pro": {
+    model: "gpt-5-pro",
+    provider: "openai",
     tokenizer: countTokensGpt5Pro as TokenizerFn,
     inputLimit: 196000,
     pricing: {
@@ -33,31 +44,31 @@ export const MODEL_CONFIGS: Record<KnownModelName, ModelConfig> = {
     },
     reasoning: null,
   },
-  'gpt-5.1': {
-    model: 'gpt-5.1',
-    provider: 'openai',
+  "gpt-5.1": {
+    model: "gpt-5.1",
+    provider: "openai",
     tokenizer: countTokensGpt5 as TokenizerFn,
     inputLimit: 196000,
     pricing: {
       inputPerToken: 1.25 / 1_000_000,
       outputPerToken: 10 / 1_000_000,
     },
-    reasoning: { effort: 'high' },
+    reasoning: { effort: "high" },
   },
-  'gpt-5.1-codex': {
-    model: 'gpt-5.1-codex',
-    provider: 'openai',
+  "gpt-5.1-codex": {
+    model: "gpt-5.1-codex",
+    provider: "openai",
     tokenizer: countTokensGpt5 as TokenizerFn,
     inputLimit: 196000,
     pricing: {
       inputPerToken: 1.25 / 1_000_000,
       outputPerToken: 10 / 1_000_000,
     },
-    reasoning: { effort: 'high' },
+    reasoning: { effort: "high" },
   },
-  'gemini-3-pro': {
-    model: 'gemini-3-pro',
-    provider: 'google',
+  "gemini-3-pro": {
+    model: "gemini-3-pro",
+    provider: "google",
     tokenizer: countTokensGpt5Pro as TokenizerFn,
     inputLimit: 200000,
     pricing: {
@@ -68,10 +79,10 @@ export const MODEL_CONFIGS: Record<KnownModelName, ModelConfig> = {
     supportsBackground: false,
     supportsSearch: true,
   },
-  'claude-4.5-sonnet': {
-    model: 'claude-4.5-sonnet',
-    apiModel: 'claude-sonnet-4-5',
-    provider: 'anthropic',
+  "claude-4.5-sonnet": {
+    model: "claude-4.5-sonnet",
+    apiModel: "claude-sonnet-4-5",
+    provider: "anthropic",
     tokenizer: countTokensAnthropic,
     inputLimit: 200000,
     pricing: {
@@ -82,24 +93,24 @@ export const MODEL_CONFIGS: Record<KnownModelName, ModelConfig> = {
     supportsBackground: false,
     supportsSearch: false,
   },
-  'claude-4.1-opus': {
-    model: 'claude-4.1-opus',
-    apiModel: 'claude-opus-4-1',
-    provider: 'anthropic',
+  "claude-4.1-opus": {
+    model: "claude-4.1-opus",
+    apiModel: "claude-opus-4-1",
+    provider: "anthropic",
     tokenizer: countTokensAnthropic,
     inputLimit: 200000,
     pricing: {
       inputPerToken: 15 / 1_000_000,
       outputPerToken: 75 / 1_000_000,
     },
-    reasoning: { effort: 'high' },
+    reasoning: { effort: "high" },
     supportsBackground: false,
     supportsSearch: false,
   },
-  'grok-4.1': {
-    model: 'grok-4.1',
-    apiModel: 'grok-4-1-fast-reasoning',
-    provider: 'xai',
+  "grok-4.1": {
+    model: "grok-4.1",
+    apiModel: "grok-4-1-fast-reasoning",
+    provider: "xai",
     tokenizer: countTokensGpt5Pro as TokenizerFn,
     inputLimit: 2_000_000,
     pricing: {
@@ -109,13 +120,19 @@ export const MODEL_CONFIGS: Record<KnownModelName, ModelConfig> = {
     reasoning: null,
     supportsBackground: false,
     supportsSearch: true,
-    searchToolType: 'web_search',
+    searchToolType: "web_search",
   },
 };
 
 export const DEFAULT_SYSTEM_PROMPT = [
-  'You are Oracle, a focused one-shot problem solver.',
-  'Emphasize direct answers and cite any files referenced.',
-].join(' ');
+  "You are Oracle, a focused one-shot problem solver.",
+  "Emphasize direct answers and cite any files referenced.",
+].join(" ");
 
-export const TOKENIZER_OPTIONS = { allowedSpecial: 'all' } as const;
+export const DEFAULT_SYSTEM_PROMPT_MARKDOWN_BUNDLE_ADDITIONS = [
+  "When outputting any code, markdown or file contents, wrap the entire output inside a single fence using FOUR backticks: ````.",
+  "Escape any inner ``` or backticks normally.",
+  "Do not add any Markdown outside the fence.",
+].join(" ");
+
+export const TOKENIZER_OPTIONS = { allowedSpecial: "all" } as const;


### PR DESCRIPTION
When outputting code blocks with markdown in ChatGPT Web the blocks get
cut up by default. Adding instructions to use a four backtick fence
solves this. These instructions are saved in
DEFAULT_SYSTEM_PROMPT_MARKDOWN_BUNDLE_ADDITIONS and added to the
DEFAULT_SYSTEM_PROMPT for markdownBundle only.

Example: 

```
[SYSTEM] You are Oracle, a focused one-shot problem solver.
Emphasize direct answers and cite any files referenced. When outputting
any code, markdown or file contents, wrap the entire output inside a
single fence using FOUR backticks: ````. Escape any inner ``` or
backticks normally. Do not add any Markdown outside the fence. 
[USER]
```

Before instructions:

<img width="1376" height="746" alt="CleanShot 2025-12-02 at 09 59 11" src="https://github.com/user-attachments/assets/7f25e7d8-2bac-446c-9f9c-e2b9a3258eba" />

After:
<img width="1376" height="748" alt="CleanShot 2025-12-02 at 10 11 47" src="https://github.com/user-attachments/assets/bb9c70fe-5652-4724-bc76-0ad3c0ca7919" />
