### PR TITLE
fix(browser): use full mouse event sequence for send button

### DIFF
--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -106,6 +106,8 @@ export async function submitPrompt(
         const editor = document.querySelector(${primarySelectorLiteral});
         if (editor) {
           editor.textContent = ${encodedPrompt};
+          // Nudge ProseMirror to register the textContent write so its state/send-button updates
+          editor.dispatchEvent(new InputEvent('input', { bubbles: true, data: ${encodedPrompt}, inputType: 'insertFromPaste' }));
         }
       })()`,
     });
@@ -152,7 +154,12 @@ async function attemptSendButton(Runtime: ChromeClient['Runtime']): Promise<bool
       style.pointerEvents === 'none' ||
       style.display === 'none';
     if (disabled) return 'disabled';
-    (button as HTMLElement).click();
+    // Use full mouse event sequence for React compatibility
+    (button).dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, cancelable: true }));
+    (button).dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+    (button).dispatchEvent(new MouseEvent('pointerup', { bubbles: true, cancelable: true }));
+    (button).dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true }));
+    (button).dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
     return 'clicked';
   })()`;
 


### PR DESCRIPTION
When using Oracle in browser mode, prompts would be correctly injected into ChatGPT's textarea—you could see the text appear—but then nothing would happen. Oracle would hang indefinitely, waiting for a response that never came because the send button was never actually triggered.

The root cause: ChatGPT's React-based UI doesn't respond to simple `.click()` calls. React's synthetic event system requires the full pointer/mouse event sequence (pointerdown → mousedown → pointerup → mouseup → click) to properly trigger event handlers. The codebase already uses this pattern for the "Answer now" button, but `attemptSendButton` was still using `.click()`.

Changes:
- Update `attemptSendButton` to dispatch the full mouse event sequence
- Add InputEvent dispatch after setting editor.textContent so React/ProseMirror recognizes the injected text