### PR TITLE
feat: add --no-fallback-hint flag to suppress API retry suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Advanced flags
 
 | Area | Flags |
 | --- | --- |
-| Browser | `--browser-timeout`, `--browser-input-timeout`, `--browser-inline-cookies[(-file)]`, `--browser-inline-files`, `--browser-bundle-files`, `--browser-keep-browser`, `--browser-headless`, `--browser-hide-window`, `--browser-no-cookie-sync`, `--browser-allow-cookie-errors`, `--browser-chrome-path`, `--browser-cookie-path`, `--chatgpt-url` |
+| Browser | `--browser-timeout`, `--browser-input-timeout`, `--browser-inline-cookies[(-file)]`, `--browser-inline-files`, `--browser-bundle-files`, `--browser-keep-browser`, `--browser-headless`, `--browser-hide-window`, `--browser-no-cookie-sync`, `--browser-allow-cookie-errors`, `--browser-chrome-path`, `--browser-cookie-path`, `--chatgpt-url`, `--no-fallback-hint` |
 | Azure/OpenAI | `--azure-endpoint`, `--azure-deployment`, `--azure-api-version`, `--base-url` |
 
 Remote browser example

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -117,6 +117,7 @@ interface CliOptions extends OptionValues {
   browserManualLogin?: boolean;
   browserExtendedThinking?: boolean;
   browserAllowCookieErrors?: boolean;
+  noFallbackHint?: boolean;
   browserInlineFiles?: boolean;
   browserBundleFiles?: boolean;
   remoteChrome?: string;
@@ -367,6 +368,7 @@ program
   .addOption(new Option('--browser-hide-window', 'Hide the Chrome window after launch (macOS headful only).').hideHelp())
   .addOption(new Option('--browser-keep-browser', 'Keep Chrome running after completion.').hideHelp())
   .addOption(new Option('--browser-extended-thinking', 'Select Extended thinking time for GPT-5.2 Thinking model.').hideHelp())
+  .addOption(new Option('--no-fallback-hint', 'Suppress the API fallback suggestion when browser mode fails.').hideHelp())
   .addOption(
     new Option('--browser-allow-cookie-errors', 'Continue even if Chrome cookies cannot be copied.').hideHelp(),
   )
@@ -1060,6 +1062,7 @@ async function runRootCommand(options: CliOptions): Promise<void> {
       userConfig,
       true,
       browserDeps,
+      options.noFallbackHint,
     );
     return;
   }
@@ -1079,6 +1082,7 @@ async function runInteractiveSession(
   userConfig?: UserConfig,
   suppressSummary = false,
   browserDeps?: BrowserSessionRunnerDeps,
+  noFallbackHint = false,
 ): Promise<void> {
   const { logLine, writeChunk, stream } = sessionStore.createLogWriter(sessionMeta.id);
   let headerAugmented = false;
@@ -1114,6 +1118,7 @@ async function runInteractiveSession(
       notifications:
         notifications ?? deriveNotificationSettingsFromMetadata(sessionMeta, process.env, userConfig?.notify),
       browserDeps,
+      noFallbackHint,
     });
     const latest = await sessionStore.readSession(sessionMeta.id);
     if (!suppressSummary) {

--- a/src/cli/sessionRunner.ts
+++ b/src/cli/sessionRunner.ts
@@ -55,6 +55,7 @@ export interface SessionRunParams {
   notifications?: NotificationSettings;
   browserDeps?: BrowserSessionRunnerDeps;
   muteStdout?: boolean;
+  noFallbackHint?: boolean;
 }
 
 export async function performSessionRun({
@@ -69,6 +70,7 @@ export async function performSessionRun({
   notifications,
   browserDeps,
   muteStdout = false,
+  noFallbackHint = false,
 }: SessionRunParams): Promise<void> {
   const writeInline = (chunk: string): boolean => {
     // Keep session logs intact while still echoing inline output to the user.
@@ -445,7 +447,7 @@ export async function performSessionRun({
           }
         : undefined,
     });
-    if (mode === 'browser') {
+    if (mode === 'browser' && !noFallbackHint) {
       log(dim('Next steps (browser fallback):')); // guides users when automation breaks
       log(dim('- Rerun with --engine api to bypass Chrome entirely.'));
       log(


### PR DESCRIPTION
When browser mode fails, Oracle prints a "retry with --engine api" suggestion. Agents see that and automatically retry with API, but that isn't ideal for those trying to avoid surprise API bills. Added `--no-fallback-hint` to suppress that message.