### PR TITLE
feat(browser): add Gemini browser mode via gemini-webapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Engine auto-picks API when `OPENAI_API_KEY` is set, otherwise browser; browser i
 
 **CLI**
 - API mode expects API keys in your environment: `OPENAI_API_KEY` (GPT-5.x), `GEMINI_API_KEY` (Gemini 3 Pro), `ANTHROPIC_API_KEY` (Claude Sonnet 4.5 / Opus 4.1).
+- Gemini browser mode uses Chrome cookies instead of an API key—just be logged into `gemini.google.com` in Chrome. Requires Python 3.8+.
 - Prefer API mode or `--copy` + manual paste; browser automation is experimental.
 - Browser support: stable on macOS; works on Linux (add `--browser-chrome-path/--browser-cookie-path` when needed) and Windows (manual-login or inline cookies recommended when app-bound cookies block decryption).
 - Remote browser service: `oracle serve` on a signed-in host; clients use `--remote-host/--remote-token`.
@@ -109,6 +110,9 @@ npx -y @steipete/oracle oracle-mcp
 | `--dry-run [summary\|json\|full]` | Preview without sending. |
 | `--remote-host`, `--remote-token` | Use a remote `oracle serve` host (browser). |
 | `--remote-chrome <host:port>` | Attach to an existing remote Chrome session (browser). |
+| `--youtube <url>` | YouTube video URL to analyze (Gemini browser mode). |
+| `--generate-image <file>` | Generate image and save to file (Gemini browser mode). |
+| `--edit-image <file>` | Edit existing image with `--output` (Gemini browser mode). |
 | `--azure-endpoint`, `--azure-deployment`, `--azure-api-version` | Target Azure OpenAI endpoints (picks Azure client automatically). |
 
 ## Configuration

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "docs:list": "tsx scripts/docs-list.ts",
     "build": "tsc -p tsconfig.build.json && pnpm run build:vendor",
-    "build:vendor": "node -e \"const fs=require('fs'); const path=require('path'); const src=path.join('vendor','oracle-notifier'); const dest=path.join('dist','vendor','oracle-notifier'); fs.mkdirSync(dest,{recursive:true}); if(fs.existsSync(src)){ fs.cpSync(src,dest,{recursive:true,force:true}); }\"",
+    "build:vendor": "node -e \"const fs=require('fs'); const path=require('path'); const vendors=[['oracle-notifier'],['gemini-webapi']]; vendors.forEach(([name])=>{const src=path.join('vendor',name); const dest=path.join('dist','vendor',name); fs.mkdirSync(dest,{recursive:true}); if(fs.existsSync(src)){fs.cpSync(src,dest,{recursive:true,force:true});}});\"",
     "start": "pnpm run build && node ./dist/scripts/run-cli.js",
     "oracle": "pnpm start",
     "check": "pnpm run typecheck",

--- a/src/browser/sessionRunner.ts
+++ b/src/browser/sessionRunner.ts
@@ -38,11 +38,6 @@ export async function runBrowserSessionExecution(
   { runOptions, browserConfig, cwd, log }: RunBrowserSessionArgs,
   deps: BrowserSessionRunnerDeps = {},
 ): Promise<BrowserExecutionResult> {
-  if (runOptions.model.startsWith('gemini')) {
-    throw new BrowserAutomationError('Gemini models are not available in browser mode. Re-run with --engine api.', {
-      stage: 'preflight',
-    });
-  }
   const assemblePrompt = deps.assemblePrompt ?? assembleBrowserPrompt;
   const executeBrowser = deps.executeBrowser ?? runBrowserMode;
   const promptArtifacts = await assemblePrompt(runOptions, { cwd });

--- a/src/cli/sessionRunner.ts
+++ b/src/cli/sessionRunner.ts
@@ -84,9 +84,6 @@ export async function performSessionRun({
   const modelForStatus = runOptions.model ?? sessionMeta.model;
   try {
     if (mode === 'browser') {
-      if (runOptions.model.startsWith('gemini')) {
-        throw new Error('Gemini models are not available in browser mode. Re-run with --engine api.');
-      }
       if (!browserConfig) {
         throw new Error('Missing browser configuration for session.');
       }

--- a/src/gemini-web/executor.ts
+++ b/src/gemini-web/executor.ts
@@ -1,0 +1,190 @@
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { BrowserRunOptions, BrowserRunResult, BrowserLogger } from '../browser/types.js';
+import type { GeminiWebOptions, GeminiWebResponse, SpawnResult } from './types.js';
+
+// biome-ignore lint/style/useNamingConvention: __dirname is standard Node.js ESM convention
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const VENDOR_DIR = path.resolve(__dirname, '../../vendor/gemini-webapi');
+const WRAPPER_SCRIPT = path.join(VENDOR_DIR, 'wrapper.py');
+
+function estimateTokenCount(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+async function spawnPython(args: string[], log?: BrowserLogger): Promise<SpawnResult> {
+  const venvPython = path.join(VENDOR_DIR, '.venv', 'bin', 'python');
+  const pythonPath = existsSync(venvPython) ? venvPython : 'python3';
+
+  return new Promise((resolve, reject) => {
+    const proc = spawn(pythonPath, [WRAPPER_SCRIPT, ...args], {
+      cwd: VENDOR_DIR,
+      env: { ...process.env },
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr.on('data', (data) => {
+      const chunk = data.toString();
+      stderr += chunk;
+      if (log) {
+        for (const line of chunk.split('\n').filter(Boolean)) {
+          log(`[gemini-web] ${line}`);
+        }
+      }
+    });
+
+    proc.on('error', (err) => {
+      reject(new Error(`Failed to spawn Python: ${err.message}`));
+    });
+
+    proc.on('close', (code) => {
+      resolve({ stdout, stderr, exitCode: code ?? 0 });
+    });
+  });
+}
+
+async function spawnCommand(command: string, args: string[], cwd?: string): Promise<SpawnResult> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(command, args, { cwd: cwd ?? VENDOR_DIR });
+
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    proc.on('error', (err) => {
+      reject(new Error(`Failed to spawn ${command}: ${err.message}`));
+    });
+
+    proc.on('close', (code) => {
+      resolve({ stdout, stderr, exitCode: code ?? 0 });
+    });
+  });
+}
+
+async function ensureVenvSetup(log?: BrowserLogger): Promise<void> {
+  const venvPath = path.join(VENDOR_DIR, '.venv');
+
+  if (existsSync(venvPath)) {
+    return;
+  }
+
+  log?.('[gemini-web] First run: setting up Python environment...');
+
+  await mkdir(VENDOR_DIR, { recursive: true });
+
+  const createVenv = await spawnCommand('python3', ['-m', 'venv', venvPath]);
+  if (createVenv.exitCode !== 0) {
+    throw new Error(`Failed to create venv: ${createVenv.stderr}`);
+  }
+
+  const pipPath = path.join(venvPath, 'bin', 'pip');
+  const requirementsPath = path.join(VENDOR_DIR, 'requirements.txt');
+
+  const installResult = await spawnCommand(pipPath, ['install', '-r', requirementsPath]);
+  if (installResult.exitCode !== 0) {
+    throw new Error(`Failed to install dependencies: ${installResult.stderr}`);
+  }
+
+  log?.('[gemini-web] Python environment ready');
+}
+
+export function createGeminiWebExecutor(
+  geminiOptions: GeminiWebOptions,
+): (runOptions: BrowserRunOptions) => Promise<BrowserRunResult> {
+  return async (runOptions: BrowserRunOptions): Promise<BrowserRunResult> => {
+    const startTime = Date.now();
+    const log = runOptions.log;
+
+    log?.('[gemini-web] Starting Gemini WebAPI executor');
+
+    await ensureVenvSetup(log);
+
+    const args: string[] = [runOptions.prompt, '--json'];
+
+    for (const attachment of runOptions.attachments ?? []) {
+      args.push('--file', attachment.path);
+    }
+
+    if (geminiOptions.youtube) {
+      args.push('--youtube', geminiOptions.youtube);
+    }
+    if (geminiOptions.generateImage) {
+      args.push('--generate-image', geminiOptions.generateImage);
+    }
+    if (geminiOptions.editImage) {
+      args.push('--edit', geminiOptions.editImage);
+    }
+    if (geminiOptions.outputPath) {
+      args.push('--output', geminiOptions.outputPath);
+    }
+    if (geminiOptions.aspectRatio) {
+      args.push('--aspect', geminiOptions.aspectRatio);
+    }
+    if (geminiOptions.showThoughts) {
+      args.push('--show-thoughts');
+    }
+
+    log?.(`[gemini-web] Calling wrapper with ${args.length} args`);
+
+    const result = await spawnPython(args, log);
+
+    if (result.exitCode !== 0) {
+      const errorMsg = result.stderr || 'Unknown error from Gemini WebAPI';
+      throw new Error(`Gemini WebAPI failed: ${errorMsg}`);
+    }
+
+    let response: GeminiWebResponse;
+    try {
+      response = JSON.parse(result.stdout);
+    } catch {
+      if (result.stdout.trim()) {
+        response = { text: result.stdout.trim(), thoughts: null, has_images: false, image_count: 0 };
+      } else {
+        throw new Error(`Failed to parse Gemini response: ${result.stdout}`);
+      }
+    }
+
+    if (response.error) {
+      throw new Error(`Gemini error: ${response.error}`);
+    }
+
+    const answerText = response.text ?? '';
+    let answerMarkdown = answerText;
+
+    if (geminiOptions.showThoughts && response.thoughts) {
+      answerMarkdown = `## Thinking\n\n${response.thoughts}\n\n## Response\n\n${answerText}`;
+    }
+
+    if (response.has_images && response.image_count > 0) {
+      const imagePath = geminiOptions.generateImage || geminiOptions.outputPath || 'generated.png';
+      answerMarkdown += `\n\n*Generated ${response.image_count} image(s). Saved to: ${imagePath}*`;
+    }
+
+    const tookMs = Date.now() - startTime;
+    log?.(`[gemini-web] Completed in ${tookMs}ms`);
+
+    return {
+      answerText,
+      answerMarkdown,
+      tookMs,
+      answerTokens: estimateTokenCount(answerText),
+      answerChars: answerText.length,
+    };
+  };
+}

--- a/src/gemini-web/index.ts
+++ b/src/gemini-web/index.ts
@@ -1,0 +1,2 @@
+export { createGeminiWebExecutor } from './executor.js';
+export type { GeminiWebOptions, GeminiWebResponse } from './types.js';

--- a/src/gemini-web/types.ts
+++ b/src/gemini-web/types.ts
@@ -1,0 +1,22 @@
+export interface GeminiWebOptions {
+  youtube?: string;
+  generateImage?: string;
+  editImage?: string;
+  outputPath?: string;
+  showThoughts?: boolean;
+  aspectRatio?: string;
+}
+
+export interface GeminiWebResponse {
+  text: string | null;
+  thoughts: string | null;
+  has_images: boolean;
+  image_count: number;
+  error?: string;
+}
+
+export interface SpawnResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}

--- a/tests/cli/browserGuard.pty.test.ts
+++ b/tests/cli/browserGuard.pty.test.ts
@@ -81,7 +81,7 @@ ptyDescribe('oracle CLI browser guard (PTY)', () => {
       'TTY guard prompt for grok browser path',
     ]);
     expect(code).not.toBe(0);
-    expect(stripAnsi(output)).toMatch(/Browser engine only supports GPT-series ChatGPT models/i);
+    expect(stripAnsi(output)).toMatch(/Browser engine only supports GPT and Gemini models/i);
   }, 15_000);
 
   it('fails fast when multi-model list includes non-GPT under browser engine', async () => {
@@ -94,6 +94,6 @@ ptyDescribe('oracle CLI browser guard (PTY)', () => {
       'TTY guard prompt for mixed models',
     ]);
     expect(code).not.toBe(0);
-    expect(stripAnsi(output)).toMatch(/Browser engine only supports GPT-series ChatGPT models/i);
+    expect(stripAnsi(output)).toMatch(/Browser engine only supports GPT and Gemini models/i);
   }, 15_000);
 });

--- a/tests/runOptions.test.ts
+++ b/tests/runOptions.test.ts
@@ -90,35 +90,35 @@ describe('resolveRunOptionsFromConfig', () => {
     expect(runOptions.baseUrl).toBe('https://env.example/v2');
   });
 
-  it('forces api engine for gemini when engine is auto-detected', () => {
+  it('keeps browser engine for gemini when auto-detected (no API key)', () => {
     const { runOptions, resolvedEngine, engineCoercedToApi } = resolveRunOptionsFromConfig({
       prompt: basePrompt,
       model: 'gemini-3-pro',
-      env: {}, // no OPENAI_API_KEY, would normally choose browser
+      env: {},
     });
-    expect(resolvedEngine).toBe('api');
-    expect(engineCoercedToApi).toBe(true);
+    expect(resolvedEngine).toBe('browser');
+    expect(engineCoercedToApi).toBe(false);
     expect(runOptions.model).toBe('gemini-3-pro');
   });
 
-  it('rejects browser engine explicitly set for gemini', () => {
-    expect(() =>
-      resolveRunOptionsFromConfig({
-        prompt: basePrompt,
-        model: 'gemini-3-pro',
-        engine: 'browser',
-      }),
-    ).toThrow(/Browser engine only supports GPT-series/);
+  it('accepts browser engine explicitly set for gemini', () => {
+    const { resolvedEngine, runOptions } = resolveRunOptionsFromConfig({
+      prompt: basePrompt,
+      model: 'gemini-3-pro',
+      engine: 'browser',
+    });
+    expect(resolvedEngine).toBe('browser');
+    expect(runOptions.model).toBe('gemini-3-pro');
   });
 
-  it('rejects browser engine in config when model is gemini', () => {
-    expect(() =>
-      resolveRunOptionsFromConfig({
-        prompt: basePrompt,
-        model: 'gemini-3-pro',
-        userConfig: { engine: 'browser' },
-      }),
-    ).toThrow(/Browser engine only supports GPT-series/);
+  it('accepts browser engine in config when model is gemini', () => {
+    const { resolvedEngine, runOptions } = resolveRunOptionsFromConfig({
+      prompt: basePrompt,
+      model: 'gemini-3-pro',
+      userConfig: { engine: 'browser' },
+    });
+    expect(resolvedEngine).toBe('browser');
+    expect(runOptions.model).toBe('gemini-3-pro');
   });
 
   it('forces api engine for gpt-5.1-codex when engine is auto-detected', () => {
@@ -167,7 +167,7 @@ describe('resolveRunOptionsFromConfig', () => {
         model: 'grok',
         engine: 'browser',
       }),
-    ).toThrow(/Browser engine only supports GPT-series/);
+    ).toThrow(/Browser engine only supports GPT and Gemini/);
   });
 
   it('forces api engine for grok when auto-selected browser and applies XAI base url', () => {

--- a/vendor/gemini-webapi/requirements.txt
+++ b/vendor/gemini-webapi/requirements.txt
@@ -1,0 +1,2 @@
+gemini-webapi>=1.0.0
+browser-cookie3>=0.20.0

--- a/vendor/gemini-webapi/wrapper.py
+++ b/vendor/gemini-webapi/wrapper.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+
+import sys
+import asyncio
+import json
+from pathlib import Path
+
+try:
+    from gemini_webapi import set_log_level
+    set_log_level("ERROR")
+except ImportError:
+    pass
+
+def print_help():
+    help_text = """Usage: webapi [OPTIONS] PROMPT
+
+All-purpose Gemini 3 Pro client with Thinking enabled.
+Uses browser cookies for authentication - no API key required.
+
+Arguments:
+  PROMPT                Text prompt for query/generation
+
+Options:
+  --file, -f FILE       Input file (MP4, PDF, PNG, JPG, etc.)
+  --youtube URL         YouTube video URL to analyze
+  --generate-image FILE Generate image and save to FILE
+  --edit IMAGE          Edit existing image (use with --output)
+  --output, -o FILE     Output file path (for image generation/editing)
+  --aspect RATIO        Aspect ratio for image generation (16:9, 1:1, 4:3, 3:4)
+  --show-thoughts       Display model's thinking process
+  --model MODEL         Model to use (default: gemini-3.0-pro)
+  --json                Output response as JSON
+  --help, -h            Show this help message
+
+Examples:
+  # Text query
+  webapi "Explain quantum computing"
+
+  # Analyze local video
+  webapi "Summarize this video" --file video.mp4
+
+  # Analyze YouTube video
+  webapi "What are the key points?" --youtube "https://youtube.com/watch?v=..."
+
+  # Analyze document
+  webapi "Summarize this report" --file report.pdf
+
+  # Generate image
+  webapi "A sunset over mountains" --generate-image sunset.png
+
+  # Edit image
+  webapi "Make the sky purple" --edit photo.jpg --output edited.png
+
+  # Show thinking process
+  webapi "Solve this step by step: What is 15% of 240?" --show-thoughts
+
+Model: gemini-3.0-pro (Thinking with 3 Pro)
+
+Prerequisites:
+  1. Log into gemini.google.com in Chrome
+  2. pip install -r requirements.txt (or use the venv)
+  3. First run on macOS will prompt for Keychain access"""
+    print(help_text)
+
+def parse_args(args):
+    result = {
+        "prompt": None,
+        "file": None,
+        "youtube": None,
+        "generate_image": None,
+        "edit": None,
+        "output": None,
+        "aspect": None,
+        "show_thoughts": False,
+        "model": "gemini-3.0-pro",
+        "json_output": False,
+    }
+
+    i = 0
+    positional = []
+
+    while i < len(args):
+        arg = args[i]
+
+        if arg in ("--help", "-h"):
+            print_help()
+            sys.exit(0)
+        elif arg in ("--file", "-f"):
+            i += 1
+            if i >= len(args):
+                print("Error: --file requires a path", file=sys.stderr)
+                sys.exit(1)
+            result["file"] = args[i]
+        elif arg == "--youtube":
+            i += 1
+            if i >= len(args):
+                print("Error: --youtube requires a URL", file=sys.stderr)
+                sys.exit(1)
+            result["youtube"] = args[i]
+        elif arg == "--generate-image":
+            i += 1
+            if i >= len(args):
+                print("Error: --generate-image requires an output filename", file=sys.stderr)
+                sys.exit(1)
+            result["generate_image"] = args[i]
+        elif arg == "--edit":
+            i += 1
+            if i >= len(args):
+                print("Error: --edit requires an input image", file=sys.stderr)
+                sys.exit(1)
+            result["edit"] = args[i]
+        elif arg in ("--output", "-o"):
+            i += 1
+            if i >= len(args):
+                print("Error: --output requires a filename", file=sys.stderr)
+                sys.exit(1)
+            result["output"] = args[i]
+        elif arg == "--aspect":
+            i += 1
+            if i >= len(args):
+                print("Error: --aspect requires a ratio", file=sys.stderr)
+                sys.exit(1)
+            result["aspect"] = args[i]
+        elif arg == "--show-thoughts":
+            result["show_thoughts"] = True
+        elif arg == "--model":
+            i += 1
+            if i >= len(args):
+                print("Error: --model requires a model name", file=sys.stderr)
+                sys.exit(1)
+            result["model"] = args[i]
+        elif arg == "--json":
+            result["json_output"] = True
+        elif not arg.startswith("-"):
+            positional.append(arg)
+        else:
+            print(f"Error: Unknown option {arg}", file=sys.stderr)
+            sys.exit(1)
+
+        i += 1
+
+    if not positional:
+        print("Error: PROMPT is required", file=sys.stderr)
+        print("Use --help for usage information", file=sys.stderr)
+        sys.exit(1)
+
+    result["prompt"] = " ".join(positional)
+    return result
+
+async def run(args):
+    try:
+        from gemini_webapi import GeminiClient
+    except ImportError:
+        print("Error: gemini-webapi not installed", file=sys.stderr)
+        print("Run: pip install -r requirements.txt", file=sys.stderr)
+        sys.exit(1)
+
+    prompt = args["prompt"]
+    files = []
+
+    if args["aspect"] and (args["generate_image"] or args["edit"]):
+        prompt = f"{prompt} (aspect ratio: {args['aspect']})"
+
+    if args["file"]:
+        file_path = Path(args["file"])
+        if not file_path.exists():
+            print(f"Error: File not found: {args['file']}", file=sys.stderr)
+            sys.exit(1)
+        files.append(str(file_path.resolve()))
+
+    edit_image_path = None
+    if args["edit"]:
+        edit_path = Path(args["edit"])
+        if not edit_path.exists():
+            print(f"Error: Image not found: {args['edit']}", file=sys.stderr)
+            sys.exit(1)
+        edit_image_path = str(edit_path.resolve())
+
+    if args["youtube"]:
+        prompt = f"{prompt}\n\nYouTube video: {args['youtube']}"
+
+    if args["generate_image"] and not args["edit"]:
+        prompt = f"Generate an image: {prompt}"
+
+    model = args["model"]
+
+    print(f"Initializing Gemini client...", file=sys.stderr)
+
+    try:
+        client = GeminiClient()
+        await client.init(timeout=120, auto_close=False, auto_refresh=True)
+    except Exception as e:
+        print(f"Error initializing client: {e}", file=sys.stderr)
+        print("Make sure you're logged into gemini.google.com in Chrome", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Querying {model}...", file=sys.stderr)
+
+    try:
+        if edit_image_path:
+            chat = client.start_chat()
+            await chat.send_message("Here is an image to edit", files=[edit_image_path])
+            edit_prompt = f"Use image generation tool to {prompt}"
+            response = await chat.send_message(edit_prompt)
+        elif files:
+            response = await client.generate_content(prompt, files=files, model=model)
+        else:
+            response = await client.generate_content(prompt, model=model)
+
+        if args["generate_image"] or edit_image_path:
+            if not response.images:
+                print("No images generated. Response text:", file=sys.stderr)
+                if response.text:
+                    print(response.text)
+                else:
+                    print("(empty response)")
+                sys.exit(1)
+
+            output_path = Path(args["generate_image"] or args["output"] or "generated.png")
+            output_dir = output_path.parent if output_path.parent != Path(".") else Path(".")
+
+            image = response.images[0]
+            await image.save(path=str(output_dir), filename=output_path.name)
+
+            if len(response.images) > 1:
+                print(f"({len(response.images)} images generated, saved first one)", file=sys.stderr)
+
+            if args["json_output"]:
+                output = {
+                    "text": f"Saved: {output_path}",
+                    "thoughts": None,
+                    "has_images": True,
+                    "image_count": len(response.images),
+                }
+                print(json.dumps(output, indent=2))
+            else:
+                print(f"Saved: {output_path}")
+                if response.text:
+                    print(f"\nResponse: {response.text}")
+        else:
+            if args["json_output"]:
+                output = {
+                    "text": response.text,
+                    "thoughts": response.thoughts if args["show_thoughts"] else None,
+                    "has_images": bool(response.images),
+                    "image_count": len(response.images) if response.images else 0,
+                }
+                print(json.dumps(output, indent=2))
+            else:
+                if args["show_thoughts"] and response.thoughts:
+                    print("=== Thinking ===")
+                    print(response.thoughts)
+                    print("\n=== Response ===")
+
+                if response.text:
+                    print(response.text)
+                else:
+                    print("(empty response)")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        await client.close()
+
+def main():
+    args = parse_args(sys.argv[1:])
+    asyncio.run(run(args))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Oracle can now see images/pdf's, create, and edit images (and watch mp4 videos/youtube)

Teaches Oracle some new tricks via Gemini browser mode:

- YouTube video analysis - pass a URL, get a summary
- Local file analysis - MP4 videos, PDFs, images (bypasses the 1MB limit)
- Image generation - text to image
- Image editing - modify existing images
- Thinking mode - see the model's reasoning

Uses the gemini-webapi Python library to talk to Gemini via your Chrome cookies - no API key needed.

## web search just works
`oracle -m gemini-3-pro --engine browser "What's the top news in quantum computing today?"`

## youtube/video analysis (not available in API mode)
`oracle -m gemini-3-pro --engine browser --youtube "https://..." "summarize this"`
`oracle -m gemini-3-pro --engine browser --file video.mp4 "what's in this video"`

## image gen/edit (not available in API mode)
`oracle -m gemini-3-pro --engine browser --generate-image out.png "a frog on a lily pad"`
`oracle -m gemini-3-pro --engine browser --edit-image photo.jpg --output out.png "make it green"`

## analyze pdf documents
`oracle -m gemini-3-pro --engine browser --file report.pdf "summarize this"`

## thinking mode
`oracle -m gemini-3-pro --engine browser --gemini-show-thoughts "solve this step by step: 15% of 240"`

Tried CDP automation first but Google's session security kept invalidating cookies. This approach reads cookies directly and hits their web API instead.

Python venv gets created automatically on first run. Just need Python 3.8+ and be logged into gemini.google.com in Chrome.

Tested and manually verified each of these:
 - Text queries with thinking and web search
 - YouTube video analysis 
 - Local MP4 analysis
 - Local PDF analysis 
 - Image generation
 - Image editing (required using chat sessions since single-shot API calls don't return edited images) 