### PR TITLE
fix(browser): Chrome session reuse and response truncation

### DIFF
--- a/src/browser/constants.ts
+++ b/src/browser/constants.ts
@@ -1,5 +1,5 @@
 export const CHATGPT_URL = 'https://chatgpt.com/';
-export const DEFAULT_MODEL_TARGET = 'ChatGPT 5.1';
+export const DEFAULT_MODEL_TARGET = 'ChatGPT 5.2';
 export const COOKIE_URLS = ['https://chatgpt.com', 'https://chat.openai.com', 'https://atlas.openai.com'];
 
 export const INPUT_SELECTORS = [


### PR DESCRIPTION
## Summary
- **Chrome Session Reuse**: Fix consecutive requests failing with `ECONNREFUSED` by writing DevToolsActivePort file after Chrome launch, adding retry logic, and cleaning stale lock files
- **Response Truncation**: Fix ChatGPT responses being captured prematurely by scoping completion detection to the last assistant turn only and requiring stable cycles before capture
- **Model Update**: Update default model target to ChatGPT 5.2

## Test plan
- [x] Build passes (`pnpm build`)
- [x] TypeScript check passes (`pnpm typecheck`)
- [x] Browser tests pass (84/84)
- [x] Manual testing: consecutive oracle server requests work correctly
- [x] Manual testing: responses are captured completely without truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)