### PR TITLE
fix(browser): correct GPT-5.2 model selection and add thinking time parameter

### DIFF
--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -117,6 +117,7 @@ interface CliOptions extends OptionValues {
   browserHideWindow?: boolean;
   browserKeepBrowser?: boolean;
   browserManualLogin?: boolean;
+  browserThinkingTime?: 'light' | 'standard' | 'extended' | 'heavy';
   browserExtendedThinking?: boolean;
   browserAllowCookieErrors?: boolean;
   browserAttachments?: string;
@@ -369,7 +370,15 @@ program
   .addOption(new Option('--browser-headless', 'Launch Chrome in headless mode.').hideHelp())
   .addOption(new Option('--browser-hide-window', 'Hide the Chrome window after launch (macOS headful only).').hideHelp())
   .addOption(new Option('--browser-keep-browser', 'Keep Chrome running after completion.').hideHelp())
-  .addOption(new Option('--browser-extended-thinking', 'Select Extended thinking time for GPT-5.2 Thinking model.').hideHelp())
+  .addOption(
+    new Option('--browser-thinking-time <level>', 'Thinking time intensity for Thinking/Pro models: light, standard, extended, heavy.')
+      .choices(['light', 'standard', 'extended', 'heavy'])
+      .hideHelp(),
+  )
+  .addOption(
+    new Option('--browser-extended-thinking', 'Deprecated: use --browser-thinking-time extended instead.')
+      .hideHelp(),
+  )
   .addOption(
     new Option('--browser-allow-cookie-errors', 'Continue even if Chrome cookies cannot be copied.').hideHelp(),
   )

--- a/src/browser/actions/thinkingTime.ts
+++ b/src/browser/actions/thinkingTime.ts
@@ -1,27 +1,34 @@
 import type { ChromeClient, BrowserLogger } from '../types.js';
+import type { ThinkingTimeLevel } from '../../oracle/types.js';
 import { MENU_CONTAINER_SELECTOR, MENU_ITEM_SELECTOR } from '../constants.js';
 import { logDomFailure } from '../domDebug.js';
 import { buildClickDispatcher } from './domEvents.js';
 
 type ThinkingTimeOutcome =
-  | { status: 'already-extended'; label?: string | null }
+  | { status: 'already-selected'; label?: string | null }
   | { status: 'switched'; label?: string | null }
   | { status: 'chip-not-found' }
   | { status: 'menu-not-found' }
-  | { status: 'extended-not-found' };
+  | { status: 'option-not-found' };
 
-export async function ensureExtendedThinking(
+/**
+ * Selects a specific thinking time level in ChatGPT's composer pill menu.
+ * @param level - The thinking time intensity: 'light', 'standard', 'extended', or 'heavy'
+ */
+export async function ensureThinkingTime(
   Runtime: ChromeClient['Runtime'],
+  level: ThinkingTimeLevel,
   logger: BrowserLogger,
 ) {
-  const result = await evaluateThinkingTimeSelection(Runtime);
+  const result = await evaluateThinkingTimeSelection(Runtime, level);
+  const capitalizedLevel = level.charAt(0).toUpperCase() + level.slice(1);
 
   switch (result?.status) {
-    case 'already-extended':
-      logger(`Thinking time: ${result.label ?? 'Extended'} (already selected)`);
+    case 'already-selected':
+      logger(`Thinking time: ${result.label ?? capitalizedLevel} (already selected)`);
       return;
     case 'switched':
-      logger(`Thinking time: ${result.label ?? 'Extended'}`);
+      logger(`Thinking time: ${result.label ?? capitalizedLevel}`);
       return;
     case 'chip-not-found': {
       await logDomFailure(Runtime, logger, 'thinking-chip');
@@ -31,38 +38,41 @@ export async function ensureExtendedThinking(
       await logDomFailure(Runtime, logger, 'thinking-time-menu');
       throw new Error('Unable to find the Thinking time dropdown menu.');
     }
-    case 'extended-not-found': {
-      await logDomFailure(Runtime, logger, 'extended-option');
-      throw new Error('Unable to find the Extended option in the Thinking time menu.');
+    case 'option-not-found': {
+      await logDomFailure(Runtime, logger, `${level}-option`);
+      throw new Error(`Unable to find the ${capitalizedLevel} option in the Thinking time menu.`);
     }
     default: {
       await logDomFailure(Runtime, logger, 'thinking-time-unknown');
-      throw new Error('Unknown error selecting Extended thinking time.');
+      throw new Error(`Unknown error selecting ${capitalizedLevel} thinking time.`);
     }
   }
 }
 
 /**
- * Best-effort selection of the "Extended" thinking-time option in ChatGPT's composer pill menu.
+ * Best-effort selection of a thinking time level in ChatGPT's composer pill menu.
  * Safe by default: if the pill/menu/option isn't present, we continue without throwing.
+ * @param level - The thinking time intensity: 'light', 'standard', 'extended', or 'heavy'
  */
-export async function ensureExtendedThinkingIfAvailable(
+export async function ensureThinkingTimeIfAvailable(
   Runtime: ChromeClient['Runtime'],
+  level: ThinkingTimeLevel,
   logger: BrowserLogger,
 ): Promise<boolean> {
   try {
-    const result = await evaluateThinkingTimeSelection(Runtime);
+    const result = await evaluateThinkingTimeSelection(Runtime, level);
+    const capitalizedLevel = level.charAt(0).toUpperCase() + level.slice(1);
 
     switch (result?.status) {
-      case 'already-extended':
-        logger(`Thinking time: ${result.label ?? 'Extended'} (already selected)`);
+      case 'already-selected':
+        logger(`Thinking time: ${result.label ?? capitalizedLevel} (already selected)`);
         return true;
       case 'switched':
-        logger(`Thinking time: ${result.label ?? 'Extended'}`);
+        logger(`Thinking time: ${result.label ?? capitalizedLevel}`);
         return true;
       case 'chip-not-found':
       case 'menu-not-found':
-      case 'extended-not-found':
+      case 'option-not-found':
         if (logger.verbose) {
           logger(`Thinking time: ${result.status.replaceAll('-', ' ')}; continuing with default.`);
         }
@@ -85,9 +95,10 @@ export async function ensureExtendedThinkingIfAvailable(
 
 async function evaluateThinkingTimeSelection(
   Runtime: ChromeClient['Runtime'],
+  level: ThinkingTimeLevel,
 ): Promise<ThinkingTimeOutcome | undefined> {
   const outcome = await Runtime.evaluate({
-    expression: buildThinkingTimeExpression(),
+    expression: buildThinkingTimeExpression(level),
     awaitPromise: true,
     returnByValue: true,
   });
@@ -95,15 +106,17 @@ async function evaluateThinkingTimeSelection(
   return outcome.result?.value as ThinkingTimeOutcome | undefined;
 }
 
-function buildThinkingTimeExpression(): string {
+function buildThinkingTimeExpression(level: ThinkingTimeLevel): string {
   const menuContainerLiteral = JSON.stringify(MENU_CONTAINER_SELECTOR);
   const menuItemLiteral = JSON.stringify(MENU_ITEM_SELECTOR);
+  const targetLevelLiteral = JSON.stringify(level.toLowerCase());
 
   return `(async () => {
     ${buildClickDispatcher()}
 
     const MENU_CONTAINER_SELECTOR = ${menuContainerLiteral};
     const MENU_ITEM_SELECTOR = ${menuItemLiteral};
+    const TARGET_LEVEL = ${targetLevelLiteral};
 
     const CHIP_SELECTORS = [
       '[data-testid="composer-footer-actions"] button[aria-haspopup="menu"]',
@@ -159,11 +172,11 @@ function buildThinkingTimeExpression(): string {
         return null;
       };
 
-      const findExtendedOption = (menu) => {
+      const findTargetOption = (menu) => {
         const items = menu.querySelectorAll(MENU_ITEM_SELECTOR);
         for (const item of items) {
           const text = normalize(item.textContent ?? '');
-          if (text.includes('extended')) {
+          if (text.includes(TARGET_LEVEL)) {
             return item;
           }
         }
@@ -190,18 +203,18 @@ function buildThinkingTimeExpression(): string {
           return;
         }
 
-        const extendedOption = findExtendedOption(menu);
-        if (!extendedOption) {
-          resolve({ status: 'extended-not-found' });
+        const targetOption = findTargetOption(menu);
+        if (!targetOption) {
+          resolve({ status: 'option-not-found' });
           return;
         }
 
         const alreadySelected =
-          optionIsSelected(extendedOption) ||
-          optionIsSelected(extendedOption.querySelector?.('[aria-checked="true"], [data-state="checked"], [data-state="selected"]'));
-        const label = extendedOption.textContent?.trim?.() || null;
-        dispatchClickSequence(extendedOption);
-        resolve({ status: alreadySelected ? 'already-extended' : 'switched', label });
+          optionIsSelected(targetOption) ||
+          optionIsSelected(targetOption.querySelector?.('[aria-checked="true"], [data-state="checked"], [data-state="selected"]'));
+        const label = targetOption.textContent?.trim?.() || null;
+        dispatchClickSequence(targetOption);
+        resolve({ status: alreadySelected ? 'already-selected' : 'switched', label });
       };
 
       setTimeout(attempt, INITIAL_WAIT_MS);
@@ -209,6 +222,6 @@ function buildThinkingTimeExpression(): string {
   })()`;
 }
 
-export function buildThinkingTimeExpressionForTest(): string {
-  return buildThinkingTimeExpression();
+export function buildThinkingTimeExpressionForTest(level: ThinkingTimeLevel = 'extended'): string {
+  return buildThinkingTimeExpression(level);
 }

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -26,7 +26,6 @@ export const DEFAULT_BROWSER_CONFIG: ResolvedBrowserConfig = {
   remoteChrome: null,
   manualLogin: false,
   manualLoginProfileDir: null,
-  extendedThinking: false,
 };
 
 export function resolveBrowserConfig(config: BrowserAutomationConfig | undefined): ResolvedBrowserConfig {

--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -1,6 +1,7 @@
 import type CDP from 'chrome-remote-interface';
 import type Protocol from 'devtools-protocol';
 import type { BrowserRuntimeMetadata } from '../sessionStore.js';
+import type { ThinkingTimeLevel } from '../oracle/types.js';
 
 export type ChromeClient = Awaited<ReturnType<typeof CDP>>;
 export type CookieParam = Protocol.Network.CookieParam;
@@ -58,7 +59,8 @@ export interface BrowserAutomationConfig {
   remoteChrome?: { host: string; port: number } | null;
   manualLogin?: boolean;
   manualLoginProfileDir?: string | null;
-  extendedThinking?: boolean;
+  /** Thinking time intensity level for Thinking/Pro models: light, standard, extended, heavy */
+  thinkingTime?: ThinkingTimeLevel;
 }
 
 export interface BrowserRunOptions {
@@ -94,12 +96,13 @@ export interface BrowserRunResult {
 }
 
 export type ResolvedBrowserConfig = Required<
-  Omit<BrowserAutomationConfig, 'chromeProfile' | 'chromePath' | 'chromeCookiePath' | 'desiredModel' | 'remoteChrome'>
+  Omit<BrowserAutomationConfig, 'chromeProfile' | 'chromePath' | 'chromeCookiePath' | 'desiredModel' | 'remoteChrome' | 'thinkingTime'>
 > & {
   chromeProfile?: string | null;
   chromePath?: string | null;
   chromeCookiePath?: string | null;
   desiredModel?: string | null;
+  thinkingTime?: ThinkingTimeLevel;
   debugPort?: number | null;
   inlineCookiesSource?: string | null;
   remoteChrome?: { host: string; port: number } | null;

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -206,6 +206,13 @@ export function inferModelFromLabel(modelValue: string): ModelName {
   if ((normalized.includes('5.2') || normalized.includes('5_2')) && normalized.includes('pro')) {
     return 'gpt-5.2-pro';
   }
+  // Browser-only: pass through 5.2 thinking/instant variants for browser label mapping
+  if ((normalized.includes('5.2') || normalized.includes('5_2')) && normalized.includes('thinking')) {
+    return 'gpt-5.2-thinking' as ModelName;
+  }
+  if ((normalized.includes('5.2') || normalized.includes('5_2')) && normalized.includes('instant')) {
+    return 'gpt-5.2-instant';
+  }
   if (normalized.includes('5.0') || normalized.includes('5-pro')) {
     return 'gpt-5-pro';
   }
@@ -226,8 +233,11 @@ export function inferModelFromLabel(modelValue: string): ModelName {
   if (normalized.includes('5.1') || normalized.includes('5_1')) {
     return 'gpt-5.1';
   }
-  if (normalized.includes('instant') || normalized.includes('thinking') || normalized.includes('fast')) {
-    return 'gpt-5.1';
+  if (normalized.includes('thinking')) {
+    return 'gpt-5.2-thinking' as ModelName;
   }
-  return 'gpt-5.1';
+  if (normalized.includes('instant') || normalized.includes('fast')) {
+    return 'gpt-5.2-instant';
+  }
+  return 'gpt-5.2';
 }

--- a/src/oracle/types.ts
+++ b/src/oracle/types.ts
@@ -20,6 +20,8 @@ export type ProModelName = 'gpt-5.1-pro' | 'gpt-5-pro' | 'gpt-5.2-pro' | 'claude
 
 export type ReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
 
+export type ThinkingTimeLevel = 'light' | 'standard' | 'extended' | 'heavy';
+
 export interface AzureOptions {
   endpoint?: string;
   apiVersion?: string;

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -4,7 +4,7 @@ import { createWriteStream } from 'node:fs';
 import type { WriteStream } from 'node:fs';
 import net from 'node:net';
 import type { CookieParam } from './browser/types.js';
-import type { TransportFailureReason, AzureOptions, ModelName } from './oracle.js';
+import type { TransportFailureReason, AzureOptions, ModelName, ThinkingTimeLevel } from './oracle.js';
 import { DEFAULT_MODEL } from './oracle.js';
 import { safeModelSlug } from './oracle/modelResolver.js';
 import { getOracleHomeDir } from './oracleHome.js';
@@ -33,7 +33,8 @@ export interface BrowserSessionConfig {
   remoteChrome?: { host: string; port: number } | null;
   manualLogin?: boolean;
   manualLoginProfileDir?: string | null;
-  extendedThinking?: boolean;
+  /** Thinking time intensity: 'light', 'standard', 'extended', 'heavy' */
+  thinkingTime?: ThinkingTimeLevel;
 }
 
 export interface BrowserRuntimeMetadata {


### PR DESCRIPTION
Fixes #46

## Problem
The browser model selection was incorrectly mapping GPT-5.2 variants:
- `gpt-5.2-instant` was mapped to "Auto" instead of "Instant"
- `gpt-5.2-thinking` didn't exist as a CLI option
- `--browser-extended-thinking` only supported "Extended" level, not Light/Standard/Heavy
- The fuzzy matching algorithm would sometimes select the wrong variant (e.g., "Thinking" when "Auto" was requested)

Additionally, having fine-grained control over thinking time is useful when using oracle as a tool from AI coding agents (e.g., [pi](https://shittycodingagent.ai)). For quick web searches or simple queries, a minimal thinking budget keeps responses fast; for complex reasoning tasks, extended thinking is preferred (and don't always need to use Pro for those).

## Summary
⚠️ I haven't tested API modes, but _should_ be fine. The only file that could affect API is [`src/cli/options.ts`](https://github.com/steipete/oracle/pull/45/files#diff-7a5c1f7c5e6f8d2b0e3c4a5d6b7e8f9a) (changes to `inferModelFromLabel`).

- **Model Selection Fix**: Correctly select Auto/Thinking/Instant/Pro variants in ChatGPT UI
  - Order BROWSER_MODEL_LABELS by specificity (most specific first)
  - Add exact testid match bonus in scoring algorithm
  - Fix buttonMatchesTarget() to reject unwanted variants (e.g., don't accept "Thinking" when "Auto" requested)
  - Add scoring penalties for thinking/instant when not requested
- **Thinking Time Parameter**: Add `--browser-thinking-time <light|standard|extended|heavy>` option
- **Backward Compatibility**: Keep `--browser-extended-thinking` as deprecated alias mapping to `extended`
- **UI Stall Workaround**: Add page refresh after prompt submission to fix UI stalling with "thinking" indicator

## Test plan
- [x] `gpt-5.2` → ChatGPT 5.2 (Auto)
- [x] `gpt-5.2-thinking` → ChatGPT 5.2 Thinking
- [x] `gpt-5.2-instant` → ChatGPT 5.2 Instant
- [x] `gpt-5.2-pro` → ChatGPT 5.2 Pro
- [x] `--browser-extended-thinking` selects Extended thinking time (kept for backward compat, but could be removed as well)
- [x] `--browser-thinking-time extended` selects Extended thinking time
- [x] `--browser-thinking-time light` selects Light thinking time
- [x] `--browser-thinking-time heavy` selects Heavy thinking time
- [x] Build passes (`pnpm build`)