### PR TITLE
feat(browser): add Grok automation parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 Oracle-specific notes:
 - ChatGPT project URLs: steipete@gmail.com -> https://chatgpt.com/g/g-p-691edc9fec088191b553a35093da1ea8-oracle/project; studpete@gmail.com -> https://chatgpt.com/g/g-p-69505ed97e3081918a275477a647a682/project. Prefer studpete URL if steipete project not found.
+- Grok browser runs: use `--grok-url https://grok.com` and `--browser-model-strategy ignore`; hard mode auto-enables when available.
 - Pro browser runs: allow up to 10 minutes; never click "Answer now"; keep at least 1–2 Pro live tests (reattach must stay Pro); move other tests to faster models where safe.
 - Live smoke tests: OpenAI live tests are opt-in. Run `ORACLE_LIVE_TEST=1 pnpm vitest run tests/live/openai-live.test.ts` with a real `OPENAI_API_KEY` when you need the background path; gpt-5-pro can take ~10 minutes.
 - Wait defaults: gpt-5-pro API runs detach by default; use `--wait` to stay attached. gpt-5.1 and browser runs block by default; every run prints `oracle session <id>` for reattach.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green?style=for-the-badge" alt="MIT License"></a>
 </p>
 
-Oracle bundles your prompt and files so another AI can answer with real context. It speaks GPT-5.1 Pro (default alias to GPT-5.2 Pro on the API), GPT-5.1 Codex (API-only), GPT-5.1, GPT-5.2, Gemini 3 Pro, Claude Sonnet 4.5, Claude Opus 4.1, and more—and it can ask one or multiple models in a single run. Browser automation is available; use `--browser-model-strategy current` to keep the active ChatGPT model (or `ignore` to skip the picker). API remains the most reliable path, and `--copy` is an easy manual fallback.
+Oracle bundles your prompt and files so another AI can answer with real context. It speaks GPT-5.1 Pro (default alias to GPT-5.2 Pro on the API), GPT-5.1 Codex (API-only), GPT-5.1, GPT-5.2, Gemini 3 Pro, Claude Sonnet 4.5, Claude Opus 4.1, and more—and it can ask one or multiple models in a single run. Browser automation is available for ChatGPT + Grok; use `--browser-model-strategy current` to keep the active ChatGPT model (or `ignore` for Grok to skip the picker). API remains the most reliable path, and `--copy` is an easy manual fallback.
 
 ## Quick start
 
@@ -36,6 +36,9 @@ npx -y @steipete/oracle --dry-run summary -p "Check release notes" --file docs/r
 # Browser run (no API key, will open ChatGPT)
 npx -y @steipete/oracle --engine browser -p "Walk through the UI smoke test" --file "src/**/*.ts"
 
+# Browser run (Grok)
+npx -y @steipete/oracle --engine browser --grok-url https://grok.com --browser-model-strategy ignore -p "Summarize the latest xAI update"
+
 # Gemini browser mode (no API key; uses Chrome cookies from gemini.google.com)
 npx -y @steipete/oracle --engine browser --model gemini-3-pro --prompt "a cute robot holding a banana" --generate-image out.jpg --aspect 1:1
 
@@ -54,6 +57,7 @@ Engine auto-picks API when `OPENAI_API_KEY` is set, otherwise browser; browser i
 **CLI**
 - API mode expects API keys in your environment: `OPENAI_API_KEY` (GPT-5.x), `GEMINI_API_KEY` (Gemini 3 Pro), `ANTHROPIC_API_KEY` (Claude Sonnet 4.5 / Opus 4.1).
 - Gemini browser mode uses Chrome cookies instead of an API key—just be logged into `gemini.google.com` in Chrome (no Python/venv required).
+- Grok browser mode uses the shared Chrome session on `grok.com`; pass `--grok-url https://grok.com` and `--browser-model-strategy ignore`. File uploads are not supported in Grok browser runs.
 - If your Gemini account can’t access “Pro”, Oracle auto-falls back to a supported model for web runs (and logs the fallback in verbose mode).
 - Prefer API mode or `--copy` + manual paste; browser automation is experimental.
 - Browser support: stable on macOS; works on Linux (add `--browser-chrome-path/--browser-cookie-path` when needed) and Windows (manual-login or inline cookies recommended when app-bound cookies block decryption).
@@ -63,7 +67,7 @@ Engine auto-picks API when `OPENAI_API_KEY` is set, otherwise browser; browser i
   - Oracle bundles a prompt plus the right files so another AI (GPT 5 Pro + more) can answer. Use when stuck/bugs/reviewing.
   - Run `npx -y @steipete/oracle --help` once per session before first use.
   ```
-- Tip: set `browser.chatgptUrl` in config (or `--chatgpt-url`) to a dedicated ChatGPT project folder so browser runs don’t clutter your main history.
+- Tip: set `browser.chatgptUrl` in config (or `--chatgpt-url`) to a dedicated ChatGPT project folder so browser runs don’t clutter your main history. For Grok, use `browser.grokUrl` (or `--grok-url`).
 
 **Codex skill**
 - Copy the bundled skill from this repo to your Codex skills folder:
@@ -94,6 +98,7 @@ npx -y @steipete/oracle oracle-mcp
 - Bundle once, reuse anywhere (API or experimental browser).
 - Multi-model API runs with aggregated cost/usage, including OpenRouter IDs alongside first-party models.
 - Render/copy bundles for manual paste into ChatGPT when automation is blocked.
+- Grok browser automation support (with hard-mode toggle when available).
 - GPT‑5 Pro API runs detach by default; reattach via `oracle session <id>` / `oracle status` or block with `--wait`.
 - Azure endpoints supported via `--azure-endpoint/--azure-deployment/--azure-api-version` or `AZURE_OPENAI_*` envs.
 - File safety: globs/excludes, size guards, `--files-report`.
@@ -111,7 +116,8 @@ npx -y @steipete/oracle oracle-mcp
 | `--models <list>` | Comma-separated API models (mix built-ins and OpenRouter ids) for multi-model runs. |
 | `--base-url <url>` | Point API runs at LiteLLM/Azure/OpenRouter/etc. |
 | `--chatgpt-url <url>` | Target a ChatGPT workspace/folder (browser). |
-| `--browser-model-strategy <select\|current\|ignore>` | Control ChatGPT model selection in browser mode (current keeps the active model; ignore skips the picker). |
+| `--grok-url <url>` | Target Grok in browser mode. |
+| `--browser-model-strategy <select\|current\|ignore>` | Control ChatGPT model selection in browser mode (current keeps the active model; ignore skips the picker; ignored for Grok/Gemini). |
 | `--browser-port <port>` | Pin the Chrome DevTools port (WSL/Windows firewall helper). |
 | `--browser-inline-cookies[(-file)] <payload|path>` | Supply cookies without Chrome/Keychain (browser). |
 | `--browser-timeout`, `--browser-input-timeout` | Control overall/browser input timeouts (supports h/m/s/ms). |
@@ -136,18 +142,19 @@ Put defaults in `~/.oracle/config.json` (JSON5). Example:
   engine: "api",
   filesReport: true,
   browser: {
-    chatgptUrl: "https://chatgpt.com/g/g-p-691edc9fec088191b553a35093da1ea8-oracle/project"
+    chatgptUrl: "https://chatgpt.com/g/g-p-691edc9fec088191b553a35093da1ea8-oracle/project",
+    grokUrl: null // set to https://grok.com to target Grok browser runs
   }
 }
 ```
-Use `browser.chatgptUrl` (or the legacy alias `browser.url`) to target a specific ChatGPT workspace/folder for browser automation.
+Use `browser.chatgptUrl` (or the legacy alias `browser.url`) to target a specific ChatGPT workspace/folder for browser automation. Use `browser.grokUrl` to target Grok.
 See [docs/configuration.md](docs/configuration.md) for precedence and full schema.
 
 Advanced flags
 
 | Area | Flags |
 | --- | --- |
-| Browser | `--browser-timeout`, `--browser-input-timeout`, `--browser-inline-cookies[(-file)]`, `--browser-attachments`, `--browser-inline-files`, `--browser-bundle-files`, `--browser-keep-browser`, `--browser-headless`, `--browser-hide-window`, `--browser-no-cookie-sync`, `--browser-allow-cookie-errors`, `--browser-chrome-path`, `--browser-cookie-path`, `--chatgpt-url` |
+| Browser | `--browser-timeout`, `--browser-input-timeout`, `--browser-inline-cookies[(-file)]`, `--browser-attachments`, `--browser-inline-files`, `--browser-bundle-files`, `--browser-keep-browser`, `--browser-headless`, `--browser-hide-window`, `--browser-no-cookie-sync`, `--browser-allow-cookie-errors`, `--browser-chrome-path`, `--browser-cookie-path`, `--chatgpt-url`, `--grok-url` |
 | Azure/OpenAI | `--azure-endpoint`, `--azure-deployment`, `--azure-api-version`, `--base-url` |
 
 Remote browser example

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -107,6 +107,7 @@ interface CliOptions extends OptionValues {
   browserChromePath?: string;
   browserCookiePath?: string;
   chatgptUrl?: string;
+  grokUrl?: string;
   browserUrl?: string;
   browserTimeout?: string;
   browserInputTimeout?: string;
@@ -342,6 +343,12 @@ program
       `Override the ChatGPT web URL (e.g., workspace/folder like https://chatgpt.com/g/.../project; default ${CHATGPT_URL}).`,
     ),
   )
+  .addOption(
+    new Option(
+      '--grok-url <url>',
+      'Override the Grok web URL (default https://grok.com).',
+    ),
+  )
   .addOption(new Option('--browser-url <url>', `Alias for --chatgpt-url (default ${CHATGPT_URL}).`).hideHelp())
   .addOption(new Option('--browser-timeout <ms|s|m>', 'Maximum time to wait for an answer (default 1200s / 20m).').hideHelp())
   .addOption(
@@ -365,7 +372,7 @@ program
   .addOption(
     new Option(
       '--browser-manual-login',
-      'Skip cookie copy; reuse a persistent automation profile and wait for manual ChatGPT login.',
+      'Skip cookie copy; reuse a persistent automation profile and wait for manual ChatGPT/Grok login.',
     ).hideHelp(),
   )
   .addOption(new Option('--browser-headless', 'Launch Chrome in headless mode.').hideHelp())
@@ -374,7 +381,7 @@ program
   .addOption(
     new Option(
       '--browser-model-strategy <mode>',
-      'ChatGPT model picker strategy: select (default) switches to the requested model, current keeps the active model, ignore skips the picker entirely.',
+      'ChatGPT model picker strategy: select (default) switches to the requested model, current keeps the active model, ignore skips the picker entirely (ignored for Grok/Gemini).',
     ).choices(['select', 'current', 'ignore']),
   )
   .addOption(
@@ -1259,6 +1266,7 @@ function printDebugHelp(cliName: string): void {
   console.log(chalk.bold('Browser Options'));
   printDebugOptionGroup([
     ['--chatgpt-url <url>', 'Override the ChatGPT web URL (workspace/folder targets).'],
+    ['--grok-url <url>', 'Override the Grok web URL (browser mode).'],
     ['--browser-chrome-profile <name>', 'Reuse cookies from a specific Chrome profile.'],
     ['--browser-chrome-path <path>', 'Point to a custom Chrome/Chromium binary.'],
     ['--browser-cookie-path <path>', 'Use a specific Chrome/Chromium cookie store file.'],
@@ -1266,7 +1274,7 @@ function printDebugHelp(cliName: string): void {
     ['--browser-timeout <ms|s|m>', 'Cap total wait time for the assistant response.'],
     ['--browser-input-timeout <ms|s|m>', 'Cap how long we wait for the composer textarea.'],
     ['--browser-no-cookie-sync', 'Skip copying cookies from your main profile.'],
-    ['--browser-manual-login', 'Skip cookie copy; reuse a persistent automation profile and log in manually.'],
+    ['--browser-manual-login', 'Skip cookie copy; reuse a persistent automation profile and log in manually (ChatGPT/Grok).'],
     ['--browser-headless', 'Launch Chrome in headless mode.'],
     ['--browser-hide-window', 'Hide the Chrome window (macOS headful only).'],
     ['--browser-keep-browser', 'Leave Chrome running after completion.'],

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,11 +22,12 @@ Oracle reads an optional per-user config from `~/.oracle/config.json`. The file 
     chromePath: null,
     chromeCookiePath: null,
     chatgptUrl: "https://chatgpt.com/", // root is fine; folder URLs also work
+    grokUrl: null, // set to https://grok.com to target Grok browser runs
     url: null, // alias for chatgptUrl (kept for back-compat)
     debugPort: null,          // fixed DevTools port (env: ORACLE_BROWSER_PORT / ORACLE_BROWSER_DEBUG_PORT)
     timeoutMs: 1200000,
     inputTimeoutMs: 30000,
-    modelStrategy: "select", // select | current | ignore (ChatGPT only; ignored for Gemini web)
+    modelStrategy: "select", // select | current | ignore (ChatGPT only; ignored for Grok/Gemini)
     headless: false,
     hideWindow: false,
     keepBrowser: false,
@@ -65,6 +66,7 @@ CLI flags → `config.json` → environment → built-in defaults.
 - `ORACLE_NOTIFY*` env vars still layer on top of the config’s `notify` block.
 - `sessionRetentionHours` controls the default value for `--retain-hours`. When unset, `ORACLE_RETAIN_HOURS` (if present) becomes the fallback, and the CLI flag still wins over both.
 - `browser.chatgptUrl` accepts either the root ChatGPT URL (`https://chatgpt.com/`) or a folder/workspace URL (e.g., `https://chatgpt.com/g/.../project`); `browser.url` remains as a legacy alias.
+- `browser.grokUrl` targets Grok browser runs (e.g., `https://grok.com/`).
 
 If the config is missing or invalid, Oracle falls back to defaults and prints a warning for parse errors.
 

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -12,4 +12,6 @@ Owner: Oracle CLI
 
 Notes:
 - If you supply `--base-url`, it overrides the default xAI endpoint.
-- Browser engine is not supported for Grok; Oracle coerces `--engine browser` to `api`.
+- Browser engine is supported for Grok via `--grok-url https://grok.com` (automation via Chrome). Use `--browser-model-strategy ignore` to skip the ChatGPT picker logic.
+- Grok browser mode auto-enables hard mode when `DeepSearch` / `Think Harder` is available.
+- Grok browser mode currently does not upload file attachments.

--- a/docs/manual-tests.md
+++ b/docs/manual-tests.md
@@ -34,6 +34,21 @@ Prereqs:
    `pnpm run oracle -- --engine browser --model gemini-3-pro --prompt "add sunglasses" --edit-image /tmp/gemini-gen.jpg --output /tmp/gemini-edit.jpg --wait --verbose`
    - Confirm `/tmp/gemini-edit.jpg` exists.
 
+### Grok browser mode (Grok web)
+
+Run this whenever you touch Grok selectors, prompt submission, or response extraction.
+
+Prereqs:
+- Chrome profile is signed into `grok.com` (or at least has a session that can chat anonymously).
+
+1. Basic prompt:
+   `pnpm run oracle -- --engine browser --grok-url https://grok.com --browser-model-strategy ignore --prompt "Reply with OK" --wait --verbose`
+   - Confirm the answer text is captured in the CLI.
+2. Hard mode toggle:
+   - If the Grok UI shows `DeepSearch` or `Think Harder`, confirm the log line "Enabled Grok hard mode" appears before sending.
+
+Note: Grok browser mode currently skips file uploads; keep prompts text-only.
+
 ### Multi-Model CLI fan-out
 
 Run this whenever you touch the session store, CLI session views, or TUI wiring for multi-model runs.

--- a/skills/oracle/SKILL.md
+++ b/skills/oracle/SKILL.md
@@ -37,6 +37,9 @@ Recommended defaults:
 
 - Browser run (main path; long-running is normal):
   - `npx -y @steipete/oracle --engine browser --model gpt-5.2-pro -p "<task>" --file "src/**"`
+- Browser run (Grok):
+  - `npx -y @steipete/oracle --engine browser --grok-url https://grok.com --browser-model-strategy ignore -p "<task>"`
+  - Note: Grok browser mode currently does not upload file attachments.
 
 - Manual paste fallback (assemble bundle, copy to clipboard):
   - `npx -y @steipete/oracle --render --copy -p "<task>" --file "src/**"`
@@ -70,7 +73,7 @@ Recommended defaults:
 ## Engines (API vs browser)
 
 - Auto-pick: uses `api` when `OPENAI_API_KEY` is set, otherwise `browser`.
-- Browser engine supports GPT + Gemini only; use `--engine api` for Claude/Grok/Codex or multi-model runs.
+- Browser engine supports ChatGPT (GPT-*) + Grok (`--grok-url`) + Gemini web; use `--engine api` for Claude/Codex or multi-model runs.
 - **API runs require explicit user consent** before starting because they incur usage costs.
 - Browser attachments:
   - `--browser-attachments auto|never|always` (auto pastes inline up to ~60k chars then uploads).

--- a/src/browser/constants.ts
+++ b/src/browser/constants.ts
@@ -1,11 +1,13 @@
 import type { BrowserModelStrategy } from './types.js';
 
 export const CHATGPT_URL = 'https://chatgpt.com/';
+export const GROK_URL = 'https://grok.com/';
 export const DEFAULT_MODEL_TARGET = 'GPT-5.2 Pro';
 export const DEFAULT_MODEL_STRATEGY: BrowserModelStrategy = 'select';
-export const COOKIE_URLS = ['https://chatgpt.com', 'https://chat.openai.com', 'https://atlas.openai.com'];
+export const COOKIE_URLS = ['https://chatgpt.com', 'https://chat.openai.com', 'https://atlas.openai.com', 'https://grok.com'];
 
 export const INPUT_SELECTORS = [
+  'textarea[aria-label="Ask Grok anything"]',
   'textarea[data-id="prompt-textarea"]',
   'textarea[placeholder*="Send a message"]',
   'textarea[aria-label="Message ChatGPT"]',
@@ -13,10 +15,14 @@ export const INPUT_SELECTORS = [
   'textarea[name="prompt-textarea"]',
   '#prompt-textarea',
   '.ProseMirror',
+  '[contenteditable="true"]',
   '[contenteditable="true"][data-virtualkeyboard="true"]',
 ];
 
 export const ANSWER_SELECTORS = [
+  '.message-bubble .response-content-markdown',
+  '.message-bubble .markdown',
+  '.message-bubble',
   'article[data-testid^="conversation-turn"][data-message-author-role="assistant"]',
   'article[data-testid^="conversation-turn"][data-turn="assistant"]',
   'article[data-testid^="conversation-turn"] [data-message-author-role="assistant"]',
@@ -31,8 +37,12 @@ export const ANSWER_SELECTORS = [
 export const CONVERSATION_TURN_SELECTOR =
   'article[data-testid^="conversation-turn"], div[data-testid^="conversation-turn"], section[data-testid^="conversation-turn"], ' +
   'article[data-message-author-role], div[data-message-author-role], section[data-message-author-role], ' +
-  'article[data-turn], div[data-turn], section[data-turn]';
-export const ASSISTANT_ROLE_SELECTOR = '[data-message-author-role="assistant"], [data-turn="assistant"]';
+  'article[data-turn], div[data-turn], section[data-turn], ' +
+  'div[class*="message-bubble"]'; // Grok uses .message-bubble directly
+
+export const ASSISTANT_ROLE_SELECTOR =
+  '[data-message-author-role="assistant"], [data-turn="assistant"], .message-assistant, ' +
+  '.message-bubble:not(.bg-surface-l1):not(.text-primary-inverse)'; // Grok user bubbles use surface background
 export const CLOUDFLARE_SCRIPT_SELECTOR = 'script[src*="/challenge-platform/"]';
 export const CLOUDFLARE_TITLE = 'just a moment';
 export const PROMPT_PRIMARY_SELECTOR = '#prompt-textarea';
@@ -63,17 +73,20 @@ export const UPLOAD_STATUS_SELECTORS = [
   '[aria-live="assertive"]',
 ];
 
-export const STOP_BUTTON_SELECTOR = '[data-testid="stop-button"]';
+export const STOP_BUTTON_SELECTOR =
+  '[data-testid="stop-button"], button[aria-label*="Stop"], button[aria-label*="Cancel"], button[aria-label*="Abort"]';
 export const SEND_BUTTON_SELECTORS = [
   'button[data-testid="send-button"]',
   'button[data-testid*="composer-send"]',
   'form button[type="submit"]',
   'button[type="submit"][data-testid*="send"]',
   'button[aria-label*="Send"]',
+  'button[aria-label="Submit"]', // Grok
 ];
 export const SEND_BUTTON_SELECTOR = SEND_BUTTON_SELECTORS[0];
-export const MODEL_BUTTON_SELECTOR = '[data-testid="model-switcher-dropdown-button"]';
-export const COPY_BUTTON_SELECTOR = 'button[data-testid="copy-turn-action-button"]';
+export const MODEL_BUTTON_SELECTOR = '[data-testid="model-switcher-dropdown-button"], button[aria-label="Model select"]';
+export const COPY_BUTTON_SELECTOR =
+  'button[data-testid="copy-turn-action-button"], button[aria-label="Copy"], button[aria-label*="Copy"]';
 // Action buttons that only appear once a turn has finished rendering.
 export const FINISHED_ACTIONS_SELECTOR =
-  'button[data-testid="copy-turn-action-button"], button[data-testid="good-response-turn-action-button"], button[data-testid="bad-response-turn-action-button"], button[aria-label="Share"]';
+  'button[data-testid="copy-turn-action-button"], button[data-testid="good-response-turn-action-button"], button[data-testid="bad-response-turn-action-button"], button[aria-label="Share"], button[aria-label="Copy"], button[aria-label*="Copy"], button[aria-label="Regenerate"]';

--- a/src/browser/cookies.ts
+++ b/src/browser/cookies.ts
@@ -30,7 +30,7 @@ export async function syncCookies(
       const cookieWithUrl = attachUrl(cookie, url);
       try {
         // Learned: CDP will silently drop cookies without a url; always attach one.
-        const result = await Network.setCookie(cookieWithUrl);
+        const result = await Network.setCookie(cookieWithUrl as any);
         if (result?.success) {
           applied += 1;
         }

--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -24,6 +24,7 @@ export interface BrowserAutomationConfig {
   chromeCookiePath?: string | null;
   url?: string;
   chatgptUrl?: string | null;
+  grokUrl?: string | null;
   timeoutMs?: number;
   debugPort?: number | null;
   inputTimeoutMs?: number;

--- a/src/browser/utils.ts
+++ b/src/browser/utils.ts
@@ -98,10 +98,14 @@ export function formatBytes(size: number): string {
 }
 
 /**
- * Normalizes a ChatGPT URL, ensuring it is absolute, uses http/https, and trims whitespace.
+ * Normalizes a browser URL, ensuring it is absolute, uses http/https, and trims whitespace.
  * Falls back to the provided default when input is empty/undefined.
  */
-export function normalizeChatgptUrl(raw: string | null | undefined, fallback: string): string {
+export function normalizeBrowserUrl(
+  raw: string | null | undefined,
+  fallback: string,
+  label: string,
+): string {
   const candidate = raw?.trim();
   if (!candidate) {
     return fallback;
@@ -112,13 +116,27 @@ export function normalizeChatgptUrl(raw: string | null | undefined, fallback: st
   try {
     parsed = new URL(withScheme);
   } catch {
-    throw new Error(`Invalid ChatGPT URL: "${raw}". Provide an absolute http(s) URL.`);
+    throw new Error(`Invalid ${label} URL: "${raw}". Provide an absolute http(s) URL.`);
   }
   if (!/^https?:$/i.test(parsed.protocol)) {
-    throw new Error(`Invalid ChatGPT URL protocol: "${parsed.protocol}". Use http or https.`);
+    throw new Error(`Invalid ${label} URL protocol: "${parsed.protocol}". Use http or https.`);
   }
   // Preserve user-provided path/query; URL#toString will normalize trailing slashes appropriately.
   return parsed.toString();
+}
+
+/**
+ * Normalizes a ChatGPT URL, ensuring it is absolute, uses http/https, and trims whitespace.
+ */
+export function normalizeChatgptUrl(raw: string | null | undefined, fallback: string): string {
+  return normalizeBrowserUrl(raw, fallback, 'ChatGPT');
+}
+
+/**
+ * Normalizes a Grok URL, ensuring it is absolute, uses http/https, and trims whitespace.
+ */
+export function normalizeGrokUrl(raw: string | null | undefined, fallback: string): string {
+  return normalizeBrowserUrl(raw, fallback, 'Grok');
 }
 
 export function isTemporaryChatUrl(url: string): boolean {
@@ -126,6 +144,15 @@ export function isTemporaryChatUrl(url: string): boolean {
     const parsed = new URL(url);
     const value = (parsed.searchParams.get('temporary-chat') ?? '').trim().toLowerCase();
     return value === 'true' || value === '1' || value === 'yes';
+  } catch {
+    return false;
+  }
+}
+
+export function isGrokUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname.endsWith('grok.com');
   } catch {
     return false;
   }

--- a/src/browserMode.ts
+++ b/src/browserMode.ts
@@ -7,9 +7,12 @@ export type {
 export {
   runBrowserMode,
   CHATGPT_URL,
+  GROK_URL,
   DEFAULT_MODEL_STRATEGY,
   DEFAULT_MODEL_TARGET,
   parseDuration,
+  normalizeBrowserUrl,
   normalizeChatgptUrl,
+  normalizeGrokUrl,
   isTemporaryChatUrl,
 } from './browser/index.js';

--- a/src/cli/browserConfig.ts
+++ b/src/cli/browserConfig.ts
@@ -2,7 +2,16 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { BrowserSessionConfig } from '../sessionStore.js';
 import type { ModelName, ThinkingTimeLevel } from '../oracle.js';
-import { CHATGPT_URL, DEFAULT_MODEL_STRATEGY, DEFAULT_MODEL_TARGET, isTemporaryChatUrl, normalizeChatgptUrl, parseDuration } from '../browserMode.js';
+import {
+  CHATGPT_URL,
+  GROK_URL,
+  DEFAULT_MODEL_STRATEGY,
+  DEFAULT_MODEL_TARGET,
+  isTemporaryChatUrl,
+  normalizeChatgptUrl,
+  normalizeGrokUrl,
+  parseDuration,
+} from '../browserMode.js';
 import { normalizeBrowserModelStrategy } from '../browser/modelStrategy.js';
 import type { BrowserModelStrategy } from '../browser/types.js';
 import type { CookieParam } from '../browser/types.js';
@@ -32,6 +41,7 @@ export interface BrowserFlagOptions {
   browserChromePath?: string;
   browserCookiePath?: string;
   chatgptUrl?: string;
+  grokUrl?: string;
   browserUrl?: string;
   browserTimeout?: string;
   browserInputTimeout?: string;
@@ -103,6 +113,7 @@ export async function buildBrowserConfig(options: BrowserFlagOptions): Promise<B
   if (options.remoteChrome) {
     remoteChrome = parseRemoteChromeTarget(options.remoteChrome);
   }
+  const grokUrl = options.grokUrl ? normalizeGrokUrl(options.grokUrl, GROK_URL) : undefined;
   const rawUrl = options.chatgptUrl ?? options.browserUrl;
   const url = rawUrl ? normalizeChatgptUrl(rawUrl, CHATGPT_URL) : undefined;
 
@@ -124,6 +135,7 @@ export async function buildBrowserConfig(options: BrowserFlagOptions): Promise<B
     chromePath: options.browserChromePath ?? null,
     chromeCookiePath: options.browserCookiePath ?? null,
     url,
+    grokUrl,
     debugPort: selectBrowserPort(options),
     timeoutMs: options.browserTimeout ? parseDuration(options.browserTimeout, DEFAULT_BROWSER_TIMEOUT_MS) : undefined,
     inputTimeoutMs: options.browserInputTimeout

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -16,6 +16,7 @@ export interface BrowserSessionConfig {
   chromePath?: string | null;
   chromeCookiePath?: string | null;
   chatgptUrl?: string | null;
+  grokUrl?: string | null;
   url?: string;
   timeoutMs?: number;
   debugPort?: number | null;

--- a/tests/browser/config.test.ts
+++ b/tests/browser/config.test.ts
@@ -35,6 +35,15 @@ describe('resolveBrowserConfig', () => {
     expect(resolved.debug).toBe(true);
   });
 
+  test('uses grokUrl when provided', () => {
+    const resolved = resolveBrowserConfig({
+      grokUrl: 'https://grok.com',
+    });
+    expect(resolved.url).toBe('https://grok.com/');
+    expect(resolved.grokUrl).toBe('https://grok.com/');
+    expect(resolved.chatgptUrl).toBe('https://grok.com/');
+  });
+
   test('rejects temporary chat URLs when desiredModel is Pro', () => {
     expect(() =>
       resolveBrowserConfig({

--- a/tests/cli/browserConfig.test.ts
+++ b/tests/cli/browserConfig.test.ts
@@ -109,6 +109,15 @@ describe('buildBrowserConfig', () => {
     expect(config.url).toBe('https://chatgpt.example.com/workspace');
   });
 
+  test('passes grokUrl through', async () => {
+    const config = await buildBrowserConfig({
+      model: 'gpt-5.2-pro',
+      grokUrl: 'https://grok.com',
+    });
+    expect(config.grokUrl).toBe('https://grok.com/');
+    expect(config.url).toBeUndefined();
+  });
+
   test('rejects invalid chatgpt URL protocols', async () => {
     await expect(
       buildBrowserConfig({


### PR DESCRIPTION
## Summary
- Add Grok browser automation parity (selectors, prompt submission, response capture, stop handling, reattach).
- Wire Grok URL config + CLI options; skip ChatGPT-only flows; allow no-cookie Grok runs; block attachments with clear error.
- Document Grok browser mode usage and add manual test coverage.

## Testing
- npm run build
- npm run test -- tests/cli/browserConfig.test.ts tests/browser/config.test.ts
- npm run test -- tests/browser/reattach.test.ts
- node dist/bin/oracle-cli.js --engine browser --remote-chrome localhost:9223 --grok-url https://grok.com --browser-model-strategy ignore --prompt "Reply with OK" --force