### PR TITLE
docs: add sk installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,16 @@ Engine auto-picks API when `OPENAI_API_KEY` is set, otherwise browser; browser i
   ```
 - Tip: set `browser.chatgptUrl` in config (or `--chatgpt-url`) to a dedicated ChatGPT project folder so browser runs don’t clutter your main history.
 
-**Codex skill**
+**Skills**
+
+Install via [sk](https://github.com/803/skills-supply) (supports Claude Code, Amp, Codex, OpenCode, etc.):
+```bash
+# Add --global flag to install in user-scope (defaults to project-scope)
+sk pkg add gh steipete/oracle --path skills
+sk sync
+```
+
+**Codex skill** (manual)
 - Copy the bundled skill from this repo to your Codex skills folder:
   - `mkdir -p ~/.codex/skills`
   - `cp -R skills/oracle ~/.codex/skills/oracle`


### PR DESCRIPTION
`sk` is a universal package manager for agent skills (npm/cargo for agents). it works across most coding agents, handles updates, and more. It installs skills using the native installation location for each coding agent. It also supports loading skills from claude-plugins (it'll extract the skill folders and put it into the right spot for other agents)

I proposed this PR because it solves a problem for me, and I do think it solves a for you for other users of this project. It’s annoying to use the same skills with multiple agents and keep them in updated (either globally in user-scope or for a specific project). It’s also tricky to distribute skills I or you have written, for multiple agents. This solves that.

Now if you feel it doesn’t solve it or you don’t care about the problem, I understand. I’d love some feedback for `sk`. Right now it just supports skills but I want to add support for commands and agent-specific things. It would be awesome to have a common container spec for agent extensions/packages/plugins, with some way to override for agent-specific tuning. That’s at least the direction I’m taking.

would you be open to adding this?
