### PR TITLE
Add long-run flags and configurable timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 - Bridge: add the bridge workflow + MCP browser controls for remote ChatGPT sessions. Original PR #42 by Kyle McCleary (@kmccleary3301) — thank you!
+- CLI: add `--background`/`--no-background`, `--http-timeout`, `--zombie-timeout`, and `--zombie-last-activity` to support long-running API sessions.
+
+### Fixed
+- CLI: restore legacy `--[no-]notify`, `--[no-]notify-sound`, and `--[no-]background` flags as hidden aliases (Commander no longer accepts `[no-]` in `new Option()`).
+- Sessions: zombie detection now respects explicit timeouts and can optionally use last log activity to avoid false “zombie” status on long runs.
 
 ## 0.8.4 — 2026-01-04
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ npx -y @steipete/oracle oracle-mcp
 | `--browser-timeout`, `--browser-input-timeout` | Control overall/browser input timeouts (supports h/m/s/ms). |
 | `--render`, `--copy` | Print and/or copy the assembled markdown bundle. |
 | `--wait` | Block for background API runs (e.g., GPT‑5.1 Pro) instead of detaching. |
+| `--timeout <seconds\|auto>` | Overall API deadline (auto = 60m for pro, 120s otherwise). |
+| `--background`, `--no-background` | Force Responses API background mode (create + retrieve) for API runs. |
+| `--http-timeout <ms\|s\|m\|h>` | HTTP client timeout (default 20m). |
+| `--zombie-timeout <ms\|s\|m\|h>` | Override stale-session cutoff used by `oracle status`. |
+| `--zombie-last-activity` | Use last log activity to detect stale sessions. |
 | `--write-output <path>` | Save only the final answer (multi-model adds `.<model>`). |
 | `--files-report` | Print per-file token usage. |
 | `--dry-run [summary\|json\|full]` | Preview without sending. |
@@ -150,6 +155,7 @@ Advanced flags
 | Area | Flags |
 | --- | --- |
 | Browser | `--browser-manual-login`, `--browser-thinking-time`, `--browser-timeout`, `--browser-input-timeout`, `--browser-cookie-wait`, `--browser-inline-cookies[(-file)]`, `--browser-attachments`, `--browser-inline-files`, `--browser-bundle-files`, `--browser-keep-browser`, `--browser-headless`, `--browser-hide-window`, `--browser-no-cookie-sync`, `--browser-allow-cookie-errors`, `--browser-chrome-path`, `--browser-cookie-path`, `--chatgpt-url` |
+| Run control | `--background`, `--no-background`, `--http-timeout`, `--zombie-timeout`, `--zombie-last-activity` |
 | Azure/OpenAI | `--azure-endpoint`, `--azure-deployment`, `--azure-api-version`, `--base-url` |
 
 Remote browser example

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,5 +94,11 @@ Under the hood, pruning removes entire session directories (metadata + logs). Th
 ## API timeouts
 
 - `--timeout <seconds|auto>` controls the overall API deadline for a run.
+- `--http-timeout <ms|s|m|h>` overrides the HTTP client timeout for API requests (default 20m).
 - Defaults: `auto` = 60 m for `gpt-5.1-pro`; non-pro API models use `120s` if you don’t set a value.
 - Heartbeat messages print the live remaining time so you can see when the client-side deadline will fire.
+
+## Zombie/session staleness
+
+- `--zombie-timeout <ms|s|m|h>` overrides the stale-session cutoff used by `oracle status`.
+- `--zombie-last-activity` uses last log activity instead of start time to detect stale sessions.

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -1,4 +1,5 @@
 import { InvalidArgumentError, type Command } from 'commander';
+import { parseDuration } from '../browserMode.js';
 import path from 'node:path';
 import fg from 'fast-glob';
 import type { ModelName, PreviewMode } from '../oracle.js';
@@ -158,6 +159,19 @@ export function parseTimeoutOption(value: string | undefined): number | 'auto' |
   const parsed = Number.parseFloat(normalized);
   if (Number.isNaN(parsed) || parsed <= 0) {
     throw new InvalidArgumentError('Timeout must be a positive number of seconds or "auto".');
+  }
+  return parsed;
+}
+
+export function parseDurationOption(value: string | undefined, label: string): number | undefined {
+  if (value == null) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new InvalidArgumentError(`${label} must be a duration like 30m, 10s, 500ms, or 2h.`);
+  }
+  const parsed = parseDuration(trimmed, Number.NaN);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new InvalidArgumentError(`${label} must be a positive duration like 30m, 10s, 500ms, or 2h.`);
   }
   return parsed;
 }

--- a/src/oracle/background.ts
+++ b/src/oracle/background.ts
@@ -10,7 +10,6 @@ import {
 } from './errors.js';
 import type { ClientLike, OracleResponse, OracleRequestBody } from './types.js';
 
-const BACKGROUND_MAX_WAIT_MS = 30 * 60 * 1000;
 const BACKGROUND_POLL_INTERVAL_MS = 5000;
 const BACKGROUND_RETRY_BASE_MS = 3000;
 const BACKGROUND_RETRY_MAX_MS = 15000;
@@ -42,7 +41,7 @@ export async function executeBackgroundResponse(params: BackgroundExecutionParam
   log(
     chalk.dim(
       `API scheduled background response ${responseId} (status=${initialResponse.status ?? 'unknown'}). Monitoring up to ${Math.round(
-        BACKGROUND_MAX_WAIT_MS / 60000,
+        maxWaitMs / 60000,
       )} minutes for completion...`,
     ),
   );

--- a/src/oracle/run.ts
+++ b/src/oracle/run.ts
@@ -371,6 +371,7 @@ export async function runOracle(options: RunOracleOptions, deps: RunOracleDeps =
         : modelConfig.model.startsWith('gemini')
           ? resolveGeminiModelId(effectiveModelId as ModelName)
           : effectiveModelId,
+      httpTimeoutMs: options.httpTimeoutMs,
     });
   logVerbose('Dispatching request to API...');
   if (options.verbose) {

--- a/src/oracle/types.ts
+++ b/src/oracle/types.ts
@@ -30,7 +30,13 @@ export interface AzureOptions {
 
 export type ClientFactory = (
   apiKey: string,
-  options?: { baseUrl?: string; azure?: AzureOptions; model?: ModelName; resolvedModelId?: string },
+  options?: {
+    baseUrl?: string;
+    azure?: AzureOptions;
+    model?: ModelName;
+    resolvedModelId?: string;
+    httpTimeoutMs?: number;
+  },
 ) => ClientLike;
 
 export interface ModelConfig {
@@ -143,6 +149,12 @@ export interface RunOracleOptions {
   writeOutputPath?: string;
   /** Number of seconds to wait before timing out, or 'auto' to use model defaults. */
   timeoutSeconds?: number | 'auto';
+  /** Override HTTP client timeout (milliseconds). */
+  httpTimeoutMs?: number;
+  /** Override zombie timeout for the session (milliseconds). */
+  zombieTimeoutMs?: number;
+  /** Use last log activity to detect stale sessions. */
+  zombieUseLastActivity?: boolean;
   /** Render plain text instead of ANSI-rendered markdown when printing answers to a rich TTY. */
   renderPlain?: boolean;
   /** Suppress the per-run header log line (used for multi-model logs where a model header is already printed). */


### PR DESCRIPTION
## Summary\n- Add CLI flags for long-running API sessions (background, http-timeout, zombie-timeout, zombie-last-activity).\n- Make HTTP client timeout configurable.\n- Improve zombie detection for long runs (optional last-activity + auto-extend to run timeout).\n- Restore legacy [no-] flags as hidden aliases due to Commander incompatibility with new Option().\n- Update docs/changelog.\n\n## Testing\n- 
> @steipete/oracle@0.8.4 build /Users/paul/Documents/GitHub/oracle
> tsc -p tsconfig.build.json && pnpm run build:vendor


> @steipete/oracle@0.8.4 build:vendor /Users/paul/Documents/GitHub/oracle
> node -e "const fs=require('fs'); const path=require('path'); const vendorRoot=path.join('dist','vendor'); fs.rmSync(vendorRoot,{recursive:true,force:true}); const vendors=[['oracle-notifier']]; vendors.forEach(([name])=>{const src=path.join('vendor',name); const dest=path.join(vendorRoot,name); fs.mkdirSync(dest,{recursive:true}); if(fs.existsSync(src)){fs.cpSync(src,dest,{recursive:true,force:true});}});"