### PR TITLE
feat: restart stored sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ npx -y @steipete/oracle --engine browser --model gemini-3-pro --prompt "a cute r
 # Sessions (list and replay)
 npx -y @steipete/oracle status --hours 72
 npx -y @steipete/oracle session <id> --render
+npx -y @steipete/oracle restart <id>
 
 # TUI (interactive, only for humans)
 npx -y @steipete/oracle tui

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -137,6 +137,12 @@ interface CliOptions extends OptionValues {
   browserDebugPort?: number;
   remoteHost?: string;
   remoteToken?: string;
+  youtube?: string;
+  generateImage?: string;
+  editImage?: string;
+  output?: string;
+  aspect?: string;
+  geminiShowThoughts?: boolean;
   copyMarkdown?: boolean;
   copy?: boolean;
   verbose?: boolean;
@@ -162,6 +168,13 @@ type ResolvedCliOptions = Omit<CliOptions, 'model'> & {
   effectiveModelId?: string;
   writeOutputPath?: string;
 };
+
+interface RestartCommandOptions {
+  wait?: boolean;
+  noWait?: boolean;
+  remoteHost?: string;
+  remoteToken?: string;
+}
 
 const VERSION = getCliVersion();
 const CLI_ENTRYPOINT = fileURLToPath(import.meta.url);
@@ -651,6 +664,18 @@ const statusCommand = program
       limit: statusOptions.limit,
       showExamples,
     });
+  });
+
+program
+  .command('restart <id>')
+  .description('Re-run a stored session as a new session (clones options).')
+  .addOption(new Option('--wait').default(undefined))
+  .addOption(new Option('--no-wait').default(undefined).hideHelp())
+  .option('--remote-host <host:port>', 'Delegate browser runs to a remote `oracle serve` instance.')
+  .option('--remote-token <token>', 'Access token for the remote `oracle serve` instance.')
+  .action(async (sessionId: string, _options: RestartCommandOptions, cmd: Command) => {
+    const restartOptions = cmd.opts<RestartCommandOptions>();
+    await restartSession(sessionId, restartOptions);
   });
 
 function buildRunOptions(options: ResolvedCliOptions, overrides: Partial<RunOracleOptions> = {}): RunOracleOptions {
@@ -1196,6 +1221,13 @@ async function runRootCommand(options: CliOptions): Promise<void> {
       ...baseRunOptions,
       mode: sessionMode,
       browserConfig,
+      waitPreference,
+      youtube: options.youtube,
+      generateImage: options.generateImage,
+      editImage: options.editImage,
+      outputPath: options.output,
+      aspectRatio: options.aspect,
+      geminiShowThoughts: options.geminiShowThoughts,
     },
     process.cwd(),
     notifications,
@@ -1265,6 +1297,7 @@ async function runInteractiveSession(
   userConfig?: UserConfig,
   suppressSummary = false,
   browserDeps?: BrowserSessionRunnerDeps,
+  cwd: string = process.cwd(),
 ): Promise<void> {
   const { logLine, writeChunk, stream } = sessionStore.createLogWriter(sessionMeta.id);
   let headerAugmented = false;
@@ -1293,7 +1326,7 @@ async function runInteractiveSession(
       runOptions,
       mode,
       browserConfig,
-      cwd: process.cwd(),
+      cwd,
       log: combinedLog,
       write: combinedWrite,
       version: VERSION,
@@ -1334,6 +1367,166 @@ async function launchDetachedSession(sessionId: string): Promise<boolean> {
       reject(error);
     }
   });
+}
+
+async function restartSession(sessionId: string, options: RestartCommandOptions): Promise<void> {
+  const metadata = await sessionStore.readSession(sessionId);
+  if (!metadata) {
+    console.error(chalk.red(`No session found with ID ${sessionId}`));
+    process.exitCode = 1;
+    return;
+  }
+
+  const runOptions = buildRunOptionsFromMetadata(metadata);
+  if (!runOptions.prompt) {
+    console.error(chalk.red(`Session ${sessionId} has no stored prompt; cannot restart.`));
+    process.exitCode = 1;
+    return;
+  }
+
+  const sessionMode = getSessionMode(metadata);
+  const engine: EngineMode = sessionMode === 'browser' ? 'browser' : 'api';
+  const browserConfig = getBrowserConfigFromMetadata(metadata);
+  if (sessionMode === 'browser' && !browserConfig) {
+    console.error(chalk.red(`Session ${sessionId} is missing browser config; cannot restart.`));
+    process.exitCode = 1;
+    return;
+  }
+
+  const userConfig = (await loadUserConfig()).config;
+  const cwd = metadata.cwd ?? process.cwd();
+  const storedOptions = metadata.options ?? {};
+
+  if (runOptions.file && runOptions.file.length > 0) {
+    const isBrowserMode = engine === 'browser';
+    const filesToValidate = isBrowserMode ? runOptions.file.filter((f) => !isMediaFile(f)) : runOptions.file;
+    if (filesToValidate.length > 0) {
+      await readFiles(filesToValidate, { cwd });
+    }
+  }
+
+  enforceBrowserSearchFlag(runOptions, sessionMode, console.log);
+
+  const waitPreference = resolveRestartWaitPreference({
+    waitFlag: options.wait,
+    noWaitFlag: options.noWait,
+    storedPreference: storedOptions.waitPreference,
+    model: runOptions.model,
+    engine,
+  });
+
+  const remoteConfig = resolveRemoteServiceConfig({
+    cliHost: options.remoteHost,
+    cliToken: options.remoteToken,
+    userConfig,
+    env: process.env,
+  });
+  const remoteHost = remoteConfig.host;
+  const remoteToken = remoteConfig.token;
+  if (remoteHost && engine !== 'browser') {
+    throw new Error('--remote-host requires a browser session.');
+  }
+  if (remoteHost) {
+    console.log(chalk.dim(`Remote browser host detected: ${remoteHost}`));
+  }
+
+  let browserDeps: BrowserSessionRunnerDeps | undefined;
+  if (browserConfig && remoteHost) {
+    browserDeps = {
+      executeBrowser: createRemoteBrowserExecutor({ host: remoteHost, token: remoteToken }),
+    };
+    console.log(chalk.dim(`Routing browser automation to remote host ${remoteHost}`));
+  } else if (browserConfig && runOptions.model.startsWith('gemini')) {
+    browserDeps = {
+      executeBrowser: createGeminiWebExecutor({
+        youtube: storedOptions.youtube,
+        generateImage: storedOptions.generateImage,
+        editImage: storedOptions.editImage,
+        outputPath: storedOptions.outputPath,
+        aspectRatio: storedOptions.aspectRatio,
+        showThoughts: storedOptions.geminiShowThoughts,
+      }),
+    };
+    console.log(chalk.dim('Using Gemini web client for browser automation'));
+    if (browserConfig.modelStrategy && browserConfig.modelStrategy !== 'select') {
+      console.log(chalk.dim('Browser model strategy is ignored for Gemini web runs.'));
+    }
+  }
+  const remoteExecutionActive = Boolean(browserDeps);
+
+  await sessionStore.ensureStorage();
+  const notifications = deriveNotificationSettingsFromMetadata(metadata, process.env, userConfig.notify);
+  const sessionMeta = await sessionStore.createSession(
+    {
+      ...runOptions,
+      mode: sessionMode,
+      browserConfig,
+      waitPreference,
+      youtube: storedOptions.youtube,
+      generateImage: storedOptions.generateImage,
+      editImage: storedOptions.editImage,
+      outputPath: storedOptions.outputPath,
+      aspectRatio: storedOptions.aspectRatio,
+      geminiShowThoughts: storedOptions.geminiShowThoughts,
+    },
+    cwd,
+    notifications,
+    sessionId,
+  );
+
+  const liveRunOptions: RunOracleOptions = {
+    ...runOptions,
+    sessionId: sessionMeta.id,
+    effectiveModelId: resolveEffectiveModelIdForRun(runOptions.model, runOptions.effectiveModelId),
+  };
+
+  const disableDetachEnv = process.env.ORACLE_NO_DETACH === '1';
+  const detachAllowed = remoteExecutionActive
+    ? false
+    : shouldDetachSession({
+        engine,
+        model: runOptions.model,
+        waitPreference,
+        disableDetachEnv,
+      });
+  const detached = !detachAllowed
+    ? false
+    : await launchDetachedSession(sessionMeta.id).catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        console.log(chalk.yellow(`Unable to detach session runner (${message}). Running inline...`));
+        return false;
+      });
+
+  if (!waitPreference) {
+    if (!detached) {
+      console.log(chalk.red('Unable to start in background; use --wait to run inline.'));
+      process.exitCode = 1;
+      return;
+    }
+    console.log(chalk.blue(`Session running in background. Reattach via: oracle session ${sessionMeta.id}`));
+    console.log(chalk.dim('Pro runs can take up to 60 minutes (usually 10-15). Add --wait to stay attached.'));
+    return;
+  }
+
+  if (detached === false) {
+    await runInteractiveSession(
+      sessionMeta,
+      liveRunOptions,
+      sessionMode,
+      browserConfig,
+      false,
+      notifications,
+      userConfig,
+      true,
+      browserDeps,
+      cwd,
+    );
+    return;
+  }
+  if (detached) {
+    console.log(chalk.blue(`Reattach via: oracle session ${sessionMeta.id}`));
+    await attachSession(sessionMeta.id, { suppressMetadata: true });
+  }
 }
 
 async function executeSession(sessionId: string) {
@@ -1418,6 +1611,33 @@ function resolveWaitFlag({
   if (waitFlag === true) return true;
   if (noWaitFlag === true) return false;
   return defaultWaitPreference(model, engine);
+}
+
+function resolveRestartWaitPreference({
+  waitFlag,
+  noWaitFlag,
+  storedPreference,
+  model,
+  engine,
+}: {
+  waitFlag?: boolean;
+  noWaitFlag?: boolean;
+  storedPreference?: boolean;
+  model: ModelName;
+  engine: EngineMode;
+}): boolean {
+  if (waitFlag === true) return true;
+  if (noWaitFlag === true) return false;
+  if (typeof storedPreference === 'boolean') return storedPreference;
+  return defaultWaitPreference(model, engine);
+}
+
+function resolveEffectiveModelIdForRun(model: ModelName, stored?: string): string {
+  if (stored) return stored;
+  if (model.startsWith('gemini')) {
+    return resolveGeminiModelId(model);
+  }
+  return isKnownModel(model) ? MODEL_CONFIGS[model].apiModel ?? model : model;
 }
 
 program.action(async function (this: Command) {

--- a/docs/browser-mode.md
+++ b/docs/browser-mode.md
@@ -79,7 +79,7 @@ You can pass the same payload inline (`--browser-inline-cookies '<json or base64
     ]
     ```
 
-All options are persisted with the session so reruns (`oracle exec <id>`) reuse the same automation settings.
+All options are persisted with the session so restarts (`oracle restart <id>`) reuse the same automation settings.
 
 ### Manual login mode (persistent profile, no cookie copy)
 

--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -491,6 +491,7 @@ async function askOracleFlow(version: string, userConfig: UserConfig): Promise<v
       ...runOptions,
       mode,
       browserConfig,
+      waitPreference: true,
     },
     process.cwd(),
     notifications,

--- a/src/mcp/tools/consult.ts
+++ b/src/mcp/tools/consult.ts
@@ -263,6 +263,7 @@ export function registerConsultTool(server: McpServer): void {
           mode: resolvedEngine,
           slug,
           browserConfig,
+          waitPreference: true,
         },
         cwd,
         notifications,

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -103,6 +103,14 @@ export interface StoredRunOptions {
   httpTimeoutMs?: number;
   zombieTimeoutMs?: number;
   zombieUseLastActivity?: boolean;
+  /** Whether the run preferred to stay attached (true) or detach (false). */
+  waitPreference?: boolean;
+  youtube?: string;
+  generateImage?: string;
+  editImage?: string;
+  outputPath?: string;
+  aspectRatio?: string;
+  geminiShowThoughts?: boolean;
 }
 
 export interface SessionMetadata {
@@ -348,9 +356,10 @@ export async function initializeSession(
   options: InitializeSessionOptions,
   cwd: string,
   notifications?: SessionNotifications,
+  baseSlugOverride?: string,
 ): Promise<SessionMetadata> {
   await ensureSessionStorage();
-  const baseSlug = createSessionId(options.prompt || DEFAULT_SLUG, options.slug);
+  const baseSlug = baseSlugOverride || createSessionId(options.prompt || DEFAULT_SLUG, options.slug);
   const sessionId = await ensureUniqueSessionId(baseSlug);
   const dir = sessionDir(sessionId);
   await ensureDir(dir);
@@ -405,6 +414,13 @@ export async function initializeSession(
       zombieTimeoutMs: options.zombieTimeoutMs,
       zombieUseLastActivity: options.zombieUseLastActivity,
       writeOutputPath: options.writeOutputPath,
+      waitPreference: options.waitPreference,
+      youtube: options.youtube,
+      generateImage: options.generateImage,
+      editImage: options.editImage,
+      outputPath: options.outputPath,
+      aspectRatio: options.aspectRatio,
+      geminiShowThoughts: options.geminiShowThoughts,
     },
   };
   await ensureDir(modelsDir(sessionId));

--- a/src/sessionStore.ts
+++ b/src/sessionStore.ts
@@ -23,6 +23,7 @@ export interface SessionStore {
     options: InitializeSessionOptionsType,
     cwd: string,
     notifications?: SessionNotifications,
+    baseSlugOverride?: string,
   ): Promise<SessionMetadata>;
   readSession(sessionId: string): Promise<SessionMetadata | null>;
   updateSession(sessionId: string, updates: Partial<SessionMetadata>): Promise<SessionMetadata>;
@@ -50,8 +51,9 @@ class FileSessionStore implements SessionStore {
     options: InitializeSessionOptionsType,
     cwd: string,
     notifications?: SessionNotifications,
+    baseSlugOverride?: string,
   ): Promise<SessionMetadata> {
-    return initializeSession(options, cwd, notifications);
+    return initializeSession(options, cwd, notifications, baseSlugOverride);
   }
 
   readSession(sessionId: string): Promise<SessionMetadata | null> {


### PR DESCRIPTION
## Summary
- add `oracle restart <id>` to rerun stored sessions with cloned options
- persist wait preference + Gemini/browser options in session metadata for restarts
- reuse stored cwd and enforce wait in TUI/consult runs; update docs

## Testing
- not run (not requested)
