### PR TITLE
fix: honor --no-wait for Commander --no- flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## Unreleased
 
+### Added
+- Sessions: add `oracle restart <id>` to re-run a stored session as a new session (clones options) (#84, thanks @enki).
+
 ### Fixed
 - Browser: fix markdown fallback extractor TDZ crash in browser mode (#90, thanks @julianknutsen).
+- CLI: honor `--no-wait` for Commander `--no-` flags (fixes restart wait preference) (#84, thanks @enki).
 
 ## 0.8.5 — 2026-01-19
 

--- a/tests/sessionManager.test.ts
+++ b/tests/sessionManager.test.ts
@@ -135,6 +135,20 @@ describe('session lifecycle', () => {
     expect(second.id).toBe('alpha-beta-gamma-2');
   });
 
+  test('initializeSession can restart from a base slug override and appends suffix on conflict', async () => {
+    const first = await sessionModule.initializeSession(
+      { prompt: 'Original', model: 'gpt-5.2-pro', slug: 'alpha beta gamma' },
+      '/tmp/cwd',
+    );
+    const restarted = await sessionModule.initializeSession(
+      { prompt: 'Restarted', model: 'gpt-5.2-pro' },
+      '/tmp/cwd',
+      undefined,
+      first.id,
+    );
+    expect(restarted.id).toBe('alpha-beta-gamma-2');
+  });
+
   test('marks stale running sessions as zombies after 60 minutes', async () => {
 	    const meta = await sessionModule.initializeSession({ prompt: 'Zombie', model: 'gpt-5.2-pro' }, '/tmp/cwd');
     const staleStarted = new Date(Date.now() - sessionModule.ZOMBIE_MAX_AGE_MS - 60_000).toISOString();

--- a/tests/sessionStore.test.ts
+++ b/tests/sessionStore.test.ts
@@ -32,6 +32,32 @@ describe('sessionStore', () => {
     expect(request?.prompt).toBe('Inspect me');
   });
 
+  test('persists waitPreference and gemini browser metadata for restarts', async () => {
+    const meta = await store.createSession(
+      {
+        prompt: 'Persist me',
+        model: 'gemini-3-pro',
+        mode: 'browser',
+        waitPreference: false,
+        youtube: 'https://example.com/video',
+        generateImage: 'in.png',
+        editImage: 'edit.png',
+        outputPath: 'out.png',
+        aspectRatio: '1:1',
+        geminiShowThoughts: true,
+      },
+      process.cwd(),
+    );
+    const fetched = await store.readSession(meta.id);
+    expect(fetched?.options.waitPreference).toBe(false);
+    expect(fetched?.options.youtube).toBe('https://example.com/video');
+    expect(fetched?.options.generateImage).toBe('in.png');
+    expect(fetched?.options.editImage).toBe('edit.png');
+    expect(fetched?.options.outputPath).toBe('out.png');
+    expect(fetched?.options.aspectRatio).toBe('1:1');
+    expect(fetched?.options.geminiShowThoughts).toBe(true);
+  });
+
   test('writes per-model logs and aggregates combined log', async () => {
     const meta = await store.createSession(
       {


### PR DESCRIPTION
Follow-up for #84: Commander negated flags set `wait=false` (not `noWait=true`), so `--no-wait` was ignored for root + `oracle restart`.

- Fix: treat `--[no-]wait` as tri-state (true/false/undefined)
- Restart: remote browser host forces `--wait`
- Tests: add restart base slug override + persisted waitPreference/Gemini metadata

Gate: `pnpm docs:list && pnpm lint && pnpm typecheck && pnpm build && pnpm test`
