### PR TITLE
fix(browser): harden composer send + commit detection

### DIFF
--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -36,16 +36,29 @@ export async function submitPrompt(
 
   await waitForDomReady(runtime, logger, deps.inputTimeoutMs ?? undefined);
   const encodedPrompt = JSON.stringify(prompt);
+  const inputSelectorsLiteral = JSON.stringify(INPUT_SELECTORS);
+  const sendSelectorsLiteral = JSON.stringify(SEND_BUTTON_SELECTORS);
   const focusResult = await runtime.evaluate({
     expression: `(() => {
       ${buildClickDispatcher()}
-      const SELECTORS = ${JSON.stringify(INPUT_SELECTORS)};
+      const SELECTORS = ${inputSelectorsLiteral};
+      const SEND_SELECTORS = ${sendSelectorsLiteral};
       const isVisible = (node) => {
         if (!node || typeof node.getBoundingClientRect !== 'function') {
           return false;
         }
         const rect = node.getBoundingClientRect();
         return rect.width > 0 && rect.height > 0;
+      };
+      const hasComposerSendButton = (node) => {
+        let current = node;
+        while (current && current !== document.body) {
+          if (SEND_SELECTORS.some((selector) => current.querySelector(selector))) {
+            return true;
+          }
+          current = current.parentElement;
+        }
+        return false;
       };
       const focusNode = (node) => {
         if (!node) {
@@ -75,7 +88,10 @@ export async function submitPrompt(
           candidates.push(node);
         }
       }
-      const preferred = candidates.find((node) => isVisible(node)) || candidates[0];
+      const preferred =
+        candidates.find((node) => isVisible(node) && hasComposerSendButton(node)) ||
+        candidates.find((node) => isVisible(node)) ||
+        candidates[0];
       if (preferred && focusNode(preferred)) {
         return { focused: true };
       }
@@ -101,7 +117,8 @@ export async function submitPrompt(
     expression: `(() => {
       const editor = document.querySelector(${primarySelectorLiteral});
       const fallback = document.querySelector(${fallbackSelectorLiteral});
-      const inputSelectors = ${JSON.stringify(INPUT_SELECTORS)};
+      const inputSelectors = ${inputSelectorsLiteral};
+      const sendSelectors = ${sendSelectorsLiteral};
       const readValue = (node) => {
         if (!node) return '';
         if (node instanceof HTMLTextAreaElement) return node.value ?? '';
@@ -112,10 +129,24 @@ export async function submitPrompt(
         const rect = node.getBoundingClientRect();
         return rect.width > 0 && rect.height > 0;
       };
+      const hasComposerSendButton = (node) => {
+        let current = node;
+        while (current && current !== document.body) {
+          if (sendSelectors.some((selector) => current.querySelector(selector))) {
+            return true;
+          }
+          current = current.parentElement;
+        }
+        return false;
+      };
       const candidates = inputSelectors
         .map((selector) => document.querySelector(selector))
         .filter((node) => Boolean(node));
-      const active = candidates.find((node) => isVisible(node)) || candidates[0] || null;
+      const active =
+        candidates.find((node) => isVisible(node) && hasComposerSendButton(node)) ||
+        candidates.find((node) => isVisible(node)) ||
+        candidates[0] ||
+        null;
       return {
         editorText: editor?.innerText ?? '',
         fallbackValue: fallback?.value ?? '',
@@ -135,6 +166,23 @@ export async function submitPrompt(
     // Learned: occasionally Input.insertText doesn't land in the editor; force textContent/value + input events.
     await runtime.evaluate({
       expression: `(() => {
+        const inputSelectors = ${inputSelectorsLiteral};
+        const candidates = inputSelectors
+          .map((selector) => document.querySelector(selector))
+          .filter((node) => Boolean(node));
+        for (const node of candidates) {
+          if (!node) continue;
+          if (node instanceof HTMLTextAreaElement) {
+            node.value = ${encodedPrompt};
+            node.dispatchEvent(new InputEvent('input', { bubbles: true, data: ${encodedPrompt}, inputType: 'insertFromPaste' }));
+            node.dispatchEvent(new Event('change', { bubbles: true }));
+            continue;
+          }
+          if (node.isContentEditable || node.getAttribute?.('contenteditable') === 'true') {
+            node.textContent = ${encodedPrompt};
+            node.dispatchEvent(new InputEvent('input', { bubbles: true, data: ${encodedPrompt}, inputType: 'insertFromPaste' }));
+          }
+        }
         const fallback = document.querySelector(${fallbackSelectorLiteral});
         if (fallback) {
           fallback.value = ${encodedPrompt};
@@ -156,7 +204,8 @@ export async function submitPrompt(
     expression: `(() => {
       const editor = document.querySelector(${primarySelectorLiteral});
       const fallback = document.querySelector(${fallbackSelectorLiteral});
-      const inputSelectors = ${JSON.stringify(INPUT_SELECTORS)};
+      const inputSelectors = ${inputSelectorsLiteral};
+      const sendSelectors = ${sendSelectorsLiteral};
       const readValue = (node) => {
         if (!node) return '';
         if (node instanceof HTMLTextAreaElement) return node.value ?? '';
@@ -167,10 +216,24 @@ export async function submitPrompt(
         const rect = node.getBoundingClientRect();
         return rect.width > 0 && rect.height > 0;
       };
+      const hasComposerSendButton = (node) => {
+        let current = node;
+        while (current && current !== document.body) {
+          if (sendSelectors.some((selector) => current.querySelector(selector))) {
+            return true;
+          }
+          current = current.parentElement;
+        }
+        return false;
+      };
       const candidates = inputSelectors
         .map((selector) => document.querySelector(selector))
         .filter((node) => Boolean(node));
-      const active = candidates.find((node) => isVisible(node)) || candidates[0] || null;
+      const active =
+        candidates.find((node) => isVisible(node) && hasComposerSendButton(node)) ||
+        candidates.find((node) => isVisible(node)) ||
+        candidates[0] ||
+        null;
       return {
         editorText: editor?.innerText ?? '',
         fallbackValue: fallback?.value ?? '',
@@ -511,10 +574,8 @@ async function verifyPromptCommitted(
     if (matchesPrompt && (baselineUnknown || info?.hasNewTurn)) {
       return typeof turnsCount === 'number' && Number.isFinite(turnsCount) ? turnsCount : null;
     }
-    const fallbackCommit =
-      info?.composerCleared &&
-      Boolean(info?.hasNewTurn) &&
-      ((info?.stopVisible ?? false) || info?.assistantVisible || info?.inConversation);
+    // Keep fallback commit strict: only trust it when ChatGPT is actively generating.
+    const fallbackCommit = info?.composerCleared && Boolean(info?.hasNewTurn) && Boolean(info?.stopVisible);
     if (fallbackCommit) {
       return typeof turnsCount === 'number' && Number.isFinite(turnsCount) ? turnsCount : null;
     }

--- a/src/browser/constants.ts
+++ b/src/browser/constants.ts
@@ -67,7 +67,6 @@ export const STOP_BUTTON_SELECTOR = '[data-testid="stop-button"]';
 export const SEND_BUTTON_SELECTORS = [
   'button[data-testid="send-button"]',
   'button[data-testid*="composer-send"]',
-  'form button[type="submit"]',
   'button[type="submit"][data-testid*="send"]',
   'button[aria-label*="Send"]',
 ];

--- a/tests/browser/promptComposer.test.ts
+++ b/tests/browser/promptComposer.test.ts
@@ -66,4 +66,40 @@ describe('promptComposer', () => {
 
     await expect(promptComposer.verifyPromptCommitted(runtime as never, 'hello', 150)).resolves.toBe(1);
   });
+
+  test('does not treat assistant-visible fallback as committed when stop button is absent', async () => {
+    vi.useFakeTimers();
+    try {
+      const runtime = {
+        evaluate: vi
+          .fn()
+          // Baseline read (turn count)
+          .mockResolvedValueOnce({ result: { value: 5 } })
+          // Polls (repeat)
+          .mockResolvedValue({
+            result: {
+              value: {
+                baseline: 5,
+                turnsCount: 6,
+                userMatched: false,
+                prefixMatched: false,
+                lastMatched: false,
+                hasNewTurn: true,
+                stopVisible: false,
+                assistantVisible: true,
+                composerCleared: true,
+                inConversation: true,
+              },
+            },
+          }),
+      } as unknown as { evaluate: (args: { expression: string; returnByValue?: boolean }) => Promise<unknown> };
+
+      const promise = promptComposer.verifyPromptCommitted(runtime as never, 'hello', 150);
+      const assertion = expect(promise).rejects.toThrow(/prompt did not appear/i);
+      await vi.advanceTimersByTimeAsync(250);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- remove overly broad `form button[type="submit"]` selector to avoid clicking non-composer controls (for example, "Answer now")
- prefer composer inputs that are colocated with a valid send button when focusing and reading the active prompt field
- strengthen insert fallback by writing prompt text across candidate composer inputs (`textarea` and `contenteditable`)
- tighten fallback commit detection to require a visible stop button (active generation), preventing stale-turn false positives
- add regression test for assistant-visible fallback without stop button

## Validation
- `pnpm run typecheck`
- `pnpm vitest run tests/browser/promptComposer.test.ts tests/browser/promptComposerExpressions.test.ts`
