### PR TITLE
feat(cli): add follow-up session chaining and lineage-aware status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Gemini web: include upload MIME metadata so image attachments keep working for image analysis, with regression coverage for image and non-image payloads. (#104) — thanks @DK625.
 - API: route Gemini and Claude through chat/completions-compatible proxies when `--base-url` targets OpenRouter or another OpenAI-style endpoint, and keep explicit Claude base URLs from being overwritten by env defaults. (#95) — thanks @thesobercoder.
 - MCP: let `consult` inherit browser defaults from `~/.oracle/config.json` while still honoring explicit tool-call overrides. (#109) — thanks @doodaaatimmy-creator.
+- CLI: scope `--followup` to the OpenAI/Azure Responses path so Gemini, Claude, and custom `--base-url` adapters fail fast instead of silently starting a fresh run. (#105) — thanks @cheulyop.
 
 ### Changed
 - OpenAI: switch the default Pro target from `gpt-5.2-pro` to `gpt-5.4-pro`, add explicit `gpt-5.4` support, roll `gpt-5.1-pro` and `gpt-5.2-pro` forward to `gpt-5.4-pro`, keep provider-qualified custom ids intact, and map browser default Pro selection to ChatGPT `GPT-5.4 Pro` (#107, thanks @jameskraus).

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ npx -y @steipete/oracle -p "Write a concise architecture note for the storage ad
 # Multi-model API run
 npx -y @steipete/oracle -p "Cross-check the data layer assumptions" --models gpt-5.1-pro,gemini-3-pro --file "src/**/*.ts"
 
+# Follow up from an existing session id
+npx -y @steipete/oracle --engine api --model gpt-5.2-pro --followup release-readiness-audit --followup-model gpt-5.2-pro -p "Re-evaluate with this new context" --file "src/**/*.ts"
+
+# Follow up directly from a Responses API id
+npx -y @steipete/oracle --engine api --model gpt-5.2-pro --followup resp_abc1234567890 -p "Continue from this response" --file docs/notes.md
+
 # Preview without spending tokens
 npx -y @steipete/oracle --dry-run summary -p "Check release notes" --file docs/release-notes.md
 
@@ -96,10 +102,41 @@ npx -y @steipete/oracle oracle-mcp
 - Multi-model API runs with aggregated cost/usage, including OpenRouter IDs alongside first-party models.
 - Render/copy bundles for manual paste into ChatGPT when automation is blocked.
 - GPT‑5 Pro API runs detach by default; reattach via `oracle session <id>` / `oracle status` or block with `--wait`.
+- Follow-up API runs can continue from `--followup <sessionId|responseId>`; for multi-model parents, add `--followup-model <model>`.
 - Azure endpoints supported via `--azure-endpoint/--azure-deployment/--azure-api-version` or `AZURE_OPENAI_*` envs.
 - File safety: globs/excludes, size guards, `--files-report`.
 - Sessions you can replay (`oracle status`, `oracle session <id> --render`).
 - Session logs and bundles live in `~/.oracle/sessions` (override with `ORACLE_HOME_DIR`).
+
+## Follow-up and lineage
+
+Use `--followup` to continue an existing API run with additional context/files:
+
+```bash
+oracle \
+  --engine api \
+  --model gpt-5.2-pro \
+  --followup <existing-session-id-or-resp_id> \
+  --followup-model gpt-5.2-pro \
+  --slug "my-followup-run" \
+  --wait \
+  -p "Follow-up: re-evaluate the previous recommendation with the attached files." \
+  --file "server/src/strategy/plan.ts" \
+  --file "server/src/strategy/executor.ts"
+```
+
+When the parent session used `--models`, `--followup-model` picks which model's response id to chain from.
+
+`oracle status` shows parent/child lineage in tree form:
+
+```text
+Recent Sessions
+Status    Model         Mode    Timestamp           Chars    Cost  Slug
+completed gpt-5.2-pro   api     03/01/2026 09:00 AM  1800  $2.110  architecture-review-parent
+completed gpt-5.2-pro   api     03/01/2026 09:14 AM  2200  $2.980  ├─ architecture-review-followup
+running   gpt-5.2-pro   api     03/01/2026 09:22 AM  1400       -  │  └─ architecture-review-implementation-pass
+pending   gpt-5.2-pro   api     03/01/2026 09:25 AM   900       -  └─ architecture-review-risk-check
+```
 
 ## Browser auto-reattach (long Pro runs)
 
@@ -128,6 +165,8 @@ oracle --engine browser \
 | `-e, --engine <api\|browser>` | Choose API or browser (browser is experimental). |
 | `-m, --model <name>` | Built-ins (`gpt-5.4-pro` default, `gpt-5.4`, `gpt-5.1-pro`, `gpt-5-pro`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5.2`, `gpt-5.2-instant`, `gpt-5.2-pro`, `gemini-3-pro`, `claude-4.5-sonnet`, `claude-4.1-opus`) plus any OpenRouter id (e.g., `minimax/minimax-m2`, `openai/gpt-4o-mini`). |
 | `--models <list>` | Comma-separated API models (mix built-ins and OpenRouter ids) for multi-model runs. |
+| `--followup <sessionId\|responseId>` | Continue an API run from a stored oracle session or `resp_...` response id. |
+| `--followup-model <model>` | For multi-model parent sessions, choose which model response to continue from. |
 | `--base-url <url>` | Point API runs at LiteLLM/Azure/OpenRouter/etc. |
 | `--chatgpt-url <url>` | Target a ChatGPT workspace/folder (browser). |
 | `--browser-model-strategy <select\|current\|ignore>` | Control ChatGPT model selection in browser mode (current keeps the active model; ignore skips the picker). |

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ npx -y @steipete/oracle -p "Write a concise architecture note for the storage ad
 # Multi-model API run
 npx -y @steipete/oracle -p "Cross-check the data layer assumptions" --models gpt-5.1-pro,gemini-3-pro --file "src/**/*.ts"
 
-# Follow up from an existing session id
+# Follow up from an existing OpenAI/Azure session id
 npx -y @steipete/oracle --engine api --model gpt-5.2-pro --followup release-readiness-audit --followup-model gpt-5.2-pro -p "Re-evaluate with this new context" --file "src/**/*.ts"
 
-# Follow up directly from a Responses API id
+# Follow up directly from an OpenAI Responses API id
 npx -y @steipete/oracle --engine api --model gpt-5.2-pro --followup resp_abc1234567890 -p "Continue from this response" --file docs/notes.md
 
 # Preview without spending tokens
@@ -102,7 +102,7 @@ npx -y @steipete/oracle oracle-mcp
 - Multi-model API runs with aggregated cost/usage, including OpenRouter IDs alongside first-party models.
 - Render/copy bundles for manual paste into ChatGPT when automation is blocked.
 - GPT‑5 Pro API runs detach by default; reattach via `oracle session <id>` / `oracle status` or block with `--wait`.
-- Follow-up API runs can continue from `--followup <sessionId|responseId>`; for multi-model parents, add `--followup-model <model>`.
+- OpenAI/Azure follow-up API runs can continue from `--followup <sessionId|responseId>`; for multi-model parents, add `--followup-model <model>`.
 - Azure endpoints supported via `--azure-endpoint/--azure-deployment/--azure-api-version` or `AZURE_OPENAI_*` envs.
 - File safety: globs/excludes, size guards, `--files-report`.
 - Sessions you can replay (`oracle status`, `oracle session <id> --render`).
@@ -110,7 +110,7 @@ npx -y @steipete/oracle oracle-mcp
 
 ## Follow-up and lineage
 
-Use `--followup` to continue an existing API run with additional context/files:
+Use `--followup` to continue an existing OpenAI/Azure Responses API run with additional context/files:
 
 ```bash
 oracle \
@@ -126,6 +126,7 @@ oracle \
 ```
 
 When the parent session used `--models`, `--followup-model` picks which model's response id to chain from.
+Custom `--base-url` providers plus Gemini/Claude API runs are excluded here because they do not preserve `previous_response_id` in Oracle.
 
 `oracle status` shows parent/child lineage in tree form:
 
@@ -165,8 +166,8 @@ oracle --engine browser \
 | `-e, --engine <api\|browser>` | Choose API or browser (browser is experimental). |
 | `-m, --model <name>` | Built-ins (`gpt-5.4-pro` default, `gpt-5.4`, `gpt-5.1-pro`, `gpt-5-pro`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5.2`, `gpt-5.2-instant`, `gpt-5.2-pro`, `gemini-3-pro`, `claude-4.5-sonnet`, `claude-4.1-opus`) plus any OpenRouter id (e.g., `minimax/minimax-m2`, `openai/gpt-4o-mini`). |
 | `--models <list>` | Comma-separated API models (mix built-ins and OpenRouter ids) for multi-model runs. |
-| `--followup <sessionId\|responseId>` | Continue an API run from a stored oracle session or `resp_...` response id. |
-| `--followup-model <model>` | For multi-model parent sessions, choose which model response to continue from. |
+| `--followup <sessionId\|responseId>` | Continue an OpenAI/Azure Responses API run from a stored oracle session or `resp_...` response id. |
+| `--followup-model <model>` | For multi-model OpenAI/Azure parent sessions, choose which model response to continue from. |
 | `--base-url <url>` | Point API runs at LiteLLM/Azure/OpenRouter/etc. |
 | `--chatgpt-url <url>` | Target a ChatGPT workspace/folder (browser). |
 | `--browser-model-strategy <select\|current\|ignore>` | Control ChatGPT model selection in browser mode (current keeps the active model; ignore skips the picker). |

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -98,6 +98,8 @@ interface CliOptions extends OptionValues {
   apiKey?: string;
   session?: string;
   execSession?: string;
+  followup?: string;
+  followupModel?: string;
   notify?: boolean;
   notifySound?: boolean;
   renderMarkdown?: boolean;
@@ -168,6 +170,7 @@ type ResolvedCliOptions = Omit<CliOptions, 'model'> & {
   models?: ModelName[];
   effectiveModelId?: string;
   writeOutputPath?: string;
+  previousResponseId?: string;
 };
 
 interface RestartCommandOptions {
@@ -232,6 +235,14 @@ program
   .argument('[prompt]', 'Prompt text (shorthand for --prompt).')
   .option('-p, --prompt <text>', 'User prompt to send to the model.')
   .addOption(new Option('--message <text>', 'Alias for --prompt.').hideHelp())
+  .option(
+    '--followup <sessionId|responseId>',
+    'Continue an API run from a stored Responses API response id (resp_...) or from a stored oracle session id.',
+  )
+  .option(
+    '--followup-model <model>',
+    'When following up a multi-model session, choose which model response to continue from.',
+  )
   .option(
     '-f, --file <paths...>',
     'Files/directories or glob patterns to attach (prefix with !pattern to exclude). Files larger than 1 MB are rejected automatically.',
@@ -739,6 +750,7 @@ function buildRunOptions(options: ResolvedCliOptions, overrides: Partial<RunOrac
     prompt: options.prompt,
     model: options.model,
     models: overrides.models ?? options.models,
+    previousResponseId: overrides.previousResponseId ?? options.previousResponseId,
     effectiveModelId: overrides.effectiveModelId ?? options.effectiveModelId ?? options.model,
     file: overrides.file ?? options.file ?? [],
     slug: overrides.slug ?? options.slug,
@@ -787,12 +799,79 @@ function resolveHeartbeatIntervalMs(seconds: number | undefined): number | undef
   return Math.round(seconds * 1000);
 }
 
+async function resolveFollowupResponseId(value: string, followupModel?: string): Promise<string> {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new Error('--followup requires a session id or response id.');
+  }
+  if (trimmed.startsWith('resp_')) {
+    return trimmed;
+  }
+
+  // Treat as oracle session id (slug).
+  const meta = await sessionStore.readSession(trimmed);
+  if (!meta) {
+    throw new Error(`No session found with ID ${trimmed}`);
+  }
+  const fromMetadata = extractResponseIdFromSession(meta, followupModel);
+  if (fromMetadata) {
+    return fromMetadata;
+  }
+
+  // Fallback: scrape the log for a response id (covers older sessions / edge cases).
+  const logText = await sessionStore.readLog(trimmed).catch(() => '');
+  const matches = logText.match(/resp_[A-Za-z0-9]+/g) ?? [];
+  const last = matches.length > 0 ? matches[matches.length - 1] : null;
+  if (last) {
+    return last;
+  }
+
+  throw new Error(
+    `Session ${trimmed} does not contain a stored response id. Ensure the original run produced a Responses API response id (background/store helps).`,
+  );
+}
+
+function extractResponseIdFromSession(meta: SessionMetadata, followupModel?: string): string | null {
+  // Single-model sessions store response metadata at the session root.
+  const rootResponse = (meta as unknown as { response?: Record<string, unknown> | null }).response ?? null;
+  const rootResponseId =
+    (rootResponse?.responseId as string | undefined) ?? (rootResponse?.id as string | undefined);
+  if (rootResponseId && rootResponseId.startsWith('resp_')) {
+    return rootResponseId;
+  }
+
+  const runs = Array.isArray(meta.models) ? meta.models : [];
+  if (runs.length === 0) {
+    return null;
+  }
+  const pickRun = (): (typeof runs)[number] | null => {
+    if (followupModel) {
+      return runs.find((r) => r.model === followupModel) ?? null;
+    }
+    return runs.length === 1 ? runs[0] : null;
+  };
+  const chosen = pickRun();
+  if (!chosen) {
+    const models = runs.map((r) => r.model).join(', ');
+    throw new Error(
+      followupModel
+        ? `Session ${meta.id} has no model named ${followupModel}. Available: ${models}`
+        : `Session ${meta.id} has multiple model runs. Re-run with --followup-model. Available: ${models}`,
+    );
+  }
+  const runResponse = (chosen as unknown as { response?: Record<string, unknown> | null }).response ?? null;
+  const runResponseId =
+    (runResponse?.responseId as string | undefined) ?? (runResponse?.id as string | undefined);
+  return runResponseId && runResponseId.startsWith('resp_') ? runResponseId : null;
+}
+
 function buildRunOptionsFromMetadata(metadata: SessionMetadata): RunOracleOptions {
   const stored = metadata.options ?? {};
   return {
     prompt: stored.prompt ?? '',
     model: (stored.model as ModelName) ?? DEFAULT_MODEL,
     models: stored.models as ModelName[] | undefined,
+    previousResponseId: stored.previousResponseId,
     effectiveModelId: stored.effectiveModelId ?? stored.model,
     file: stored.file ?? [],
     slug: stored.slug,
@@ -1111,6 +1190,15 @@ async function runRootCommand(options: CliOptions): Promise<void> {
       options.prompt = `${options.prompt.trim()}\n${userConfig.promptSuffix}`;
     }
     resolvedOptions.prompt = options.prompt;
+    if (options.followup) {
+      if (engine !== 'api') {
+        throw new Error('--followup requires --engine api.');
+      }
+      if (normalizedMultiModels.length > 0) {
+        throw new Error('--followup cannot be combined with --models.');
+      }
+      resolvedOptions.previousResponseId = await resolveFollowupResponseId(options.followup, options.followupModel);
+    }
     const runOptions = buildRunOptions(resolvedOptions, { preview: true, previewMode, baseUrl: resolvedBaseUrl });
     if (engine === 'browser') {
       await runBrowserPreview(
@@ -1160,6 +1248,15 @@ async function runRootCommand(options: CliOptions): Promise<void> {
     options.prompt = `${options.prompt.trim()}\n${userConfig.promptSuffix}`;
   }
   resolvedOptions.prompt = options.prompt;
+  if (options.followup) {
+    if (engine !== 'api') {
+      throw new Error('--followup requires --engine api.');
+    }
+    if (normalizedMultiModels.length > 0) {
+      throw new Error('--followup cannot be combined with --models.');
+    }
+    resolvedOptions.previousResponseId = await resolveFollowupResponseId(options.followup, options.followupModel);
+  }
 
   const duplicateBlocked = await shouldBlockDuplicatePrompt({
     prompt: resolvedOptions.prompt,

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -171,6 +171,8 @@ type ResolvedCliOptions = Omit<CliOptions, 'model'> & {
   effectiveModelId?: string;
   writeOutputPath?: string;
   previousResponseId?: string;
+  followupSessionId?: string;
+  followupModel?: string;
 };
 
 interface RestartCommandOptions {
@@ -799,13 +801,18 @@ function resolveHeartbeatIntervalMs(seconds: number | undefined): number | undef
   return Math.round(seconds * 1000);
 }
 
-async function resolveFollowupResponseId(value: string, followupModel?: string): Promise<string> {
+interface FollowupResolution {
+  responseId: string;
+  sessionId?: string;
+}
+
+async function resolveFollowupReference(value: string, followupModel?: string): Promise<FollowupResolution> {
   const trimmed = value.trim();
   if (trimmed.length === 0) {
     throw new Error('--followup requires a session id or response id.');
   }
   if (trimmed.startsWith('resp_')) {
-    return trimmed;
+    return { responseId: trimmed };
   }
 
   // Treat as oracle session id (slug).
@@ -815,7 +822,7 @@ async function resolveFollowupResponseId(value: string, followupModel?: string):
   }
   const fromMetadata = extractResponseIdFromSession(meta, followupModel);
   if (fromMetadata) {
-    return fromMetadata;
+    return { responseId: fromMetadata, sessionId: meta.id };
   }
 
   // Fallback: scrape the log for a response id (covers older sessions / edge cases).
@@ -823,7 +830,7 @@ async function resolveFollowupResponseId(value: string, followupModel?: string):
   const matches = logText.match(/resp_[A-Za-z0-9]+/g) ?? [];
   const last = matches.length > 0 ? matches[matches.length - 1] : null;
   if (last) {
-    return last;
+    return { responseId: last, sessionId: meta.id };
   }
 
   throw new Error(
@@ -1197,7 +1204,10 @@ async function runRootCommand(options: CliOptions): Promise<void> {
       if (normalizedMultiModels.length > 0) {
         throw new Error('--followup cannot be combined with --models.');
       }
-      resolvedOptions.previousResponseId = await resolveFollowupResponseId(options.followup, options.followupModel);
+      const followup = await resolveFollowupReference(options.followup, options.followupModel);
+      resolvedOptions.previousResponseId = followup.responseId;
+      resolvedOptions.followupSessionId = followup.sessionId;
+      resolvedOptions.followupModel = options.followupModel;
     }
     const runOptions = buildRunOptions(resolvedOptions, { preview: true, previewMode, baseUrl: resolvedBaseUrl });
     if (engine === 'browser') {
@@ -1255,7 +1265,10 @@ async function runRootCommand(options: CliOptions): Promise<void> {
     if (normalizedMultiModels.length > 0) {
       throw new Error('--followup cannot be combined with --models.');
     }
-    resolvedOptions.previousResponseId = await resolveFollowupResponseId(options.followup, options.followupModel);
+    const followup = await resolveFollowupReference(options.followup, options.followupModel);
+    resolvedOptions.previousResponseId = followup.responseId;
+    resolvedOptions.followupSessionId = followup.sessionId;
+    resolvedOptions.followupModel = options.followupModel;
   }
 
   const duplicateBlocked = await shouldBlockDuplicatePrompt({
@@ -1360,6 +1373,8 @@ async function runRootCommand(options: CliOptions): Promise<void> {
       ...baseRunOptions,
       mode: sessionMode,
       browserConfig,
+      followupSessionId: resolvedOptions.followupSessionId,
+      followupModel: resolvedOptions.followupModel,
       waitPreference,
       youtube: options.youtube,
       generateImage: options.generateImage,
@@ -1603,6 +1618,8 @@ async function restartSession(sessionId: string, options: RestartCommandOptions)
       ...runOptions,
       mode: sessionMode,
       browserConfig,
+      followupSessionId: storedOptions.followupSessionId,
+      followupModel: storedOptions.followupModel,
       waitPreference,
       youtube: storedOptions.youtube,
       generateImage: storedOptions.generateImage,

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -239,7 +239,7 @@ program
   .addOption(new Option('--message <text>', 'Alias for --prompt.').hideHelp())
   .option(
     '--followup <sessionId|responseId>',
-    'Continue an API run from a stored Responses API response id (resp_...) or from a stored oracle session id.',
+    'Continue an OpenAI/Azure Responses API run from a stored response id (resp_...) or from a stored oracle session id.',
   )
   .option(
     '--followup-model <model>',
@@ -806,6 +806,32 @@ interface FollowupResolution {
   sessionId?: string;
 }
 
+function assertFollowupSupported({
+  engine,
+  model,
+  baseUrl,
+  azureEndpoint,
+}: {
+  engine: EngineMode;
+  model: ModelName;
+  baseUrl?: string;
+  azureEndpoint?: string;
+}): void {
+  if (engine !== 'api') {
+    throw new Error('--followup requires --engine api.');
+  }
+  if (model.startsWith('gemini') || model.startsWith('claude')) {
+    throw new Error(
+      `--followup is only supported for OpenAI Responses API runs. Model ${model} uses a provider client without previous_response_id support.`,
+    );
+  }
+  if (baseUrl && !azureEndpoint) {
+    throw new Error(
+      '--followup is only supported for the default OpenAI Responses API or Azure OpenAI Responses. Custom --base-url providers are not supported.',
+    );
+  }
+}
+
 function levenshteinDistance(a: string, b: string): number {
   if (a === b) return 0;
   if (a.length === 0) return b.length;
@@ -1256,9 +1282,12 @@ async function runRootCommand(options: CliOptions): Promise<void> {
     }
     resolvedOptions.prompt = options.prompt;
     if (options.followup) {
-      if (engine !== 'api') {
-        throw new Error('--followup requires --engine api.');
-      }
+      assertFollowupSupported({
+        engine,
+        model: resolvedModel,
+        baseUrl: resolvedBaseUrl,
+        azureEndpoint: resolvedOptions.azure?.endpoint,
+      });
       if (normalizedMultiModels.length > 0) {
         throw new Error('--followup cannot be combined with --models.');
       }
@@ -1317,9 +1346,12 @@ async function runRootCommand(options: CliOptions): Promise<void> {
   }
   resolvedOptions.prompt = options.prompt;
   if (options.followup) {
-    if (engine !== 'api') {
-      throw new Error('--followup requires --engine api.');
-    }
+    assertFollowupSupported({
+      engine,
+      model: resolvedModel,
+      baseUrl: resolvedBaseUrl,
+      azureEndpoint: resolvedOptions.azure?.endpoint,
+    });
     if (normalizedMultiModels.length > 0) {
       throw new Error('--followup cannot be combined with --models.');
     }

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -806,6 +806,59 @@ interface FollowupResolution {
   sessionId?: string;
 }
 
+function levenshteinDistance(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  const previous = new Array<number>(b.length + 1);
+  const current = new Array<number>(b.length + 1);
+  for (let j = 0; j <= b.length; j += 1) {
+    previous[j] = j;
+  }
+  for (let i = 1; i <= a.length; i += 1) {
+    current[0] = i;
+    for (let j = 1; j <= b.length; j += 1) {
+      const substitutionCost = a[i - 1] === b[j - 1] ? 0 : 1;
+      current[j] = Math.min(previous[j] + 1, current[j - 1] + 1, previous[j - 1] + substitutionCost);
+    }
+    for (let j = 0; j <= b.length; j += 1) {
+      previous[j] = current[j];
+    }
+  }
+  return previous[b.length];
+}
+
+function scoreSessionSimilarity(input: string, candidate: string): number {
+  if (input === candidate) return 1;
+  if (candidate.startsWith(input) || input.startsWith(candidate)) return 0.95;
+  if (candidate.includes(input) || input.includes(candidate)) return 0.8;
+  const distance = levenshteinDistance(input, candidate);
+  const maxLength = Math.max(input.length, candidate.length);
+  if (maxLength === 0) return 0;
+  return Math.max(0, 1 - distance / maxLength);
+}
+
+async function suggestFollowupSessionIds(input: string, limit = 3): Promise<string[]> {
+  const normalizedInput = input.trim().toLowerCase();
+  if (!normalizedInput) return [];
+  const sessions = await sessionStore.listSessions().catch(() => []);
+  const seen = new Set<string>();
+  const ranked = sessions
+    .map((meta) => meta.id)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0)
+    .filter((id) => {
+      if (seen.has(id)) return false;
+      seen.add(id);
+      return true;
+    })
+    .map((id) => ({ id, score: scoreSessionSimilarity(normalizedInput, id.toLowerCase()) }))
+    .filter((entry) => entry.score >= 0.45)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+  return ranked.map((entry) => entry.id);
+}
+
 async function resolveFollowupReference(value: string, followupModel?: string): Promise<FollowupResolution> {
   const trimmed = value.trim();
   if (trimmed.length === 0) {
@@ -818,7 +871,12 @@ async function resolveFollowupReference(value: string, followupModel?: string): 
   // Treat as oracle session id (slug).
   const meta = await sessionStore.readSession(trimmed);
   if (!meta) {
-    throw new Error(`No session found with ID ${trimmed}`);
+    const suggestions = await suggestFollowupSessionIds(trimmed);
+    const suggestionText =
+      suggestions.length > 0 ? ` Did you mean: ${suggestions.map((id) => `"${id}"`).join(', ')}?` : '';
+    throw new Error(
+      `No session found with ID ${trimmed}.${suggestionText} Run "oracle status --hours 72 --limit 20" to list recent sessions.`,
+    );
   }
   const fromMetadata = extractResponseIdFromSession(meta, followupModel);
   if (fromMetadata) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,6 +92,26 @@ Each invocation can optionally prune cached sessions before starting new work:
 
 Under the hood, pruning removes entire session directories (metadata + logs). The command-line cleanup command (`oracle session --clear`) still exists when you need to wipe everything manually.
 
+## Follow-up chaining
+
+`--followup` and `--followup-model` are CLI run flags (not persisted defaults in `config.json`).
+
+- `--followup <sessionId|responseId>` continues an API run from either a stored Oracle session id or a `resp_...` Responses API id.
+- For multi-model parent sessions, add `--followup-model <model>` to choose which parent model response to chain from.
+- If the session id is wrong, Oracle now prints actionable guidance and suggests close matches from local session history.
+
+Example:
+
+```bash
+oracle \
+  --engine api \
+  --model gpt-5.2-pro \
+  --followup release-readiness-audit \
+  --followup-model gpt-5.2-pro \
+  -p "Follow-up: revise the plan with these files." \
+  --file "src/**/*.ts"
+```
+
 ## API timeouts
 
 - `--timeout <seconds|auto>` controls the overall API deadline for a run.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,8 +96,9 @@ Under the hood, pruning removes entire session directories (metadata + logs). Th
 
 `--followup` and `--followup-model` are CLI run flags (not persisted defaults in `config.json`).
 
-- `--followup <sessionId|responseId>` continues an API run from either a stored Oracle session id or a `resp_...` Responses API id.
-- For multi-model parent sessions, add `--followup-model <model>` to choose which parent model response to chain from.
+- `--followup <sessionId|responseId>` continues an OpenAI/Azure Responses API run from either a stored Oracle session id or a `resp_...` Responses API id.
+- For multi-model OpenAI/Azure parent sessions, add `--followup-model <model>` to choose which parent model response to chain from.
+- Gemini/Claude API runs and custom `--base-url` providers are intentionally excluded because Oracle cannot preserve `previous_response_id` through those adapters.
 - If the session id is wrong, Oracle now prints actionable guidance and suggests close matches from local session history.
 
 Example:

--- a/src/cli/detach.ts
+++ b/src/cli/detach.ts
@@ -3,10 +3,10 @@ import type { ModelName } from '../oracle.js';
 import { isProModel } from '../oracle/modelResolver.js';
 
 export function shouldDetachSession({
-  // Params kept for future policy tweaks; currently only model/disableDetachEnv matter.
+  // Params kept for policy tweaks.
   engine,
   model,
-  waitPreference: _waitPreference,
+  waitPreference,
   disableDetachEnv,
 }: {
   engine: EngineMode;
@@ -15,6 +15,8 @@ export function shouldDetachSession({
   disableDetachEnv: boolean;
 }): boolean {
   if (disableDetachEnv) return false;
+  // Explicit --wait means "stay attached", regardless of model defaults.
+  if (waitPreference) return false;
   // Only Pro-tier API runs should start detached by default; browser runs stay inline so failures surface.
   if (isProModel(model) && engine === 'api') return true;
   return false;

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -72,7 +72,7 @@ function renderHelpFooter(program: Command, colors: HelpColors): string {
     `${colors.bullet('•')} Spell out the project + platform + version requirements (repo name, target OS/toolchain versions, API dependencies) so Oracle doesn’t guess defaults.`,
     `${colors.bullet('•')} When comparing multiple repos/files, spell out each repo + path + role (e.g., “Project A SettingsView → apps/project-a/Sources/SettingsView.swift; Project B SettingsView → ../project-b/mac/...”) so the model knows exactly which file is which.`,
     `${colors.bullet('•')} Best results: 6–30 sentences plus key source files; very short prompts often yield generic answers.`,
-    `${colors.bullet('•')} Oracle is one-shot: it does not remember prior runs, so start fresh each time with full context.`,
+    `${colors.bullet('•')} Oracle is one-shot by default. For API runs, you can chain follow-ups by passing ${colors.accent('--followup <sessionId|responseId>')} (continues via Responses API previous_response_id).`,
     `${colors.bullet('•')} Run ${colors.accent('--files-report')} to inspect token spend before hitting the API.`,
     `${colors.bullet('•')} Non-preview runs spawn detached sessions (especially gpt-5.4-pro API). If the CLI times out, do not re-run — reattach with ${colors.accent('oracle session <slug>')} to resume/inspect the existing run.`,
     `${colors.bullet('•')} Set a memorable 3–5 word slug via ${colors.accent('--slug "<words>"')} to keep session IDs tidy.`,

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -72,7 +72,7 @@ function renderHelpFooter(program: Command, colors: HelpColors): string {
     `${colors.bullet('•')} Spell out the project + platform + version requirements (repo name, target OS/toolchain versions, API dependencies) so Oracle doesn’t guess defaults.`,
     `${colors.bullet('•')} When comparing multiple repos/files, spell out each repo + path + role (e.g., “Project A SettingsView → apps/project-a/Sources/SettingsView.swift; Project B SettingsView → ../project-b/mac/...”) so the model knows exactly which file is which.`,
     `${colors.bullet('•')} Best results: 6–30 sentences plus key source files; very short prompts often yield generic answers.`,
-    `${colors.bullet('•')} Oracle is one-shot by default. For API runs, you can chain follow-ups by passing ${colors.accent('--followup <sessionId|responseId>')} (continues via Responses API previous_response_id).`,
+    `${colors.bullet('•')} Oracle is one-shot by default. For OpenAI/Azure API runs, you can chain follow-ups by passing ${colors.accent('--followup <sessionId|responseId>')} (continues via Responses API previous_response_id).`,
     `${colors.bullet('•')} Run ${colors.accent('--files-report')} to inspect token spend before hitting the API.`,
     `${colors.bullet('•')} Non-preview runs spawn detached sessions (especially gpt-5.4-pro API). If the CLI times out, do not re-run — reattach with ${colors.accent('oracle session <slug>')} to resume/inspect the existing run.`,
     `${colors.bullet('•')} Set a memorable 3–5 word slug via ${colors.accent('--slug "<words>"')} to keep session IDs tidy.`,

--- a/src/cli/sessionDisplay.ts
+++ b/src/cli/sessionDisplay.ts
@@ -578,7 +578,7 @@ function buildStatusTreeRows(
     }
     visited.add(entry.id);
     const children = childMap.get(entry.id) ?? [];
-    const nodeBranch = children.length > 0 ? (isLast ? '└┬ ' : '├┬ ') : isLast ? '└─ ' : '├─ ';
+    const nodeBranch = isLast ? '└─ ' : '├─ ';
     const prefix = `${ancestorHasMore.map((hasMore) => (hasMore ? '│  ' : '   ')).join('')}${nodeBranch}`;
     rows.push({ entry, displaySlug: `${prefix}${entry.id}` });
 
@@ -598,8 +598,7 @@ function buildStatusTreeRows(
         ? `${lineage.parentSessionId} (${abbreviateResponseId(lineage.parentResponseId)})`
         : undefined;
     const children = childMap.get(entry.id) ?? [];
-    const displaySlug = children.length > 0 ? `┬ ${entry.id}` : entry.id;
-    rows.push({ entry, displaySlug, detachedParentLabel: hiddenParent });
+    rows.push({ entry, displaySlug: entry.id, detachedParentLabel: hiddenParent });
     children.forEach((child, index) => {
       walkChild(child, [], index === children.length - 1);
     });

--- a/src/cli/sessionDisplay.ts
+++ b/src/cli/sessionDisplay.ts
@@ -73,10 +73,16 @@ export async function showStatus({
   }
   console.log(chalk.bold('Recent Sessions'));
   console.log(formatSessionTableHeader(richTty));
-  for (const entry of filteredEntries) {
-    const row = formatSessionTableRow(entry, { rich: richTty });
-    const lineage = formatStatusLineage(entry, responseOwners, richTty);
-    console.log(`${row}${lineage}`);
+  const treeRows = buildStatusTreeRows(filteredEntries, responseOwners);
+  for (const row of treeRows) {
+    const line = formatSessionTableRow(row.entry, { rich: richTty, displaySlug: row.displaySlug });
+    const detachedParent =
+      row.detachedParentLabel != null
+        ? richTty
+          ? chalk.gray(` <- ${row.detachedParentLabel}`)
+          : ` <- ${row.detachedParentLabel}`
+        : '';
+    console.log(`${line}${detachedParent}`);
   }
   if (truncated) {
     const sessionsDir = sessionStore.sessionsDir();
@@ -533,20 +539,79 @@ function matchesModel(entry: SessionMetadata, filter: string): boolean {
   return models.includes(normalized);
 }
 
-function formatStatusLineage(
-  entry: SessionMetadata,
+interface StatusTreeRow {
+  entry: SessionMetadata;
+  displaySlug: string;
+  detachedParentLabel?: string;
+}
+
+function buildStatusTreeRows(
+  entries: SessionMetadata[],
   responseOwners: ReadonlyMap<string, string>,
-  rich: boolean,
-): string {
-  const lineage = resolveSessionLineage(entry, responseOwners);
-  if (!lineage) {
-    return '';
+): StatusTreeRow[] {
+  const entryById = new Map(entries.map((entry) => [entry.id, entry]));
+  const orderIndex = new Map(entries.map((entry, index) => [entry.id, index]));
+  const lineageById = new Map<string, ReturnType<typeof resolveSessionLineage>>();
+  const childMap = new Map<string, SessionMetadata[]>();
+
+  for (const entry of entries) {
+    const lineage = resolveSessionLineage(entry, responseOwners);
+    lineageById.set(entry.id, lineage);
+    const parentId = lineage?.parentSessionId;
+    if (parentId && parentId !== entry.id && entryById.has(parentId)) {
+      const siblings = childMap.get(parentId) ?? [];
+      siblings.push(entry);
+      childMap.set(parentId, siblings);
+    }
   }
-  const parentLabel = lineage.parentSessionId
-    ? `${lineage.parentSessionId} (${abbreviateResponseId(lineage.parentResponseId)})`
-    : abbreviateResponseId(lineage.parentResponseId);
-  const suffix = ` <- ${parentLabel}`;
-  return rich ? chalk.gray(suffix) : suffix;
+
+  for (const siblings of childMap.values()) {
+    siblings.sort((a, b) => (orderIndex.get(a.id) ?? 0) - (orderIndex.get(b.id) ?? 0));
+  }
+
+  const rows: StatusTreeRow[] = [];
+  const visited = new Set<string>();
+
+  const walkChild = (entry: SessionMetadata, ancestorHasMore: boolean[], isLast: boolean): void => {
+    if (visited.has(entry.id)) {
+      return;
+    }
+    visited.add(entry.id);
+    const prefix = `${ancestorHasMore.map((hasMore) => (hasMore ? '│  ' : '   ')).join('')}${isLast ? '└─ ' : '├─ '}`;
+    rows.push({ entry, displaySlug: `${prefix}${entry.id}` });
+
+    const children = childMap.get(entry.id) ?? [];
+    children.forEach((child, index) => {
+      walkChild(child, [...ancestorHasMore, !isLast], index === children.length - 1);
+    });
+  };
+
+  const walkRoot = (entry: SessionMetadata): void => {
+    if (visited.has(entry.id)) {
+      return;
+    }
+    visited.add(entry.id);
+    const lineage = lineageById.get(entry.id);
+    const hiddenParent =
+      lineage?.parentSessionId && !entryById.has(lineage.parentSessionId)
+        ? `${lineage.parentSessionId} (${abbreviateResponseId(lineage.parentResponseId)})`
+        : undefined;
+    rows.push({ entry, displaySlug: entry.id, detachedParentLabel: hiddenParent });
+
+    const children = childMap.get(entry.id) ?? [];
+    children.forEach((child, index) => {
+      walkChild(child, [], index === children.length - 1);
+    });
+  };
+
+  const roots = entries.filter((entry) => {
+    const parentId = lineageById.get(entry.id)?.parentSessionId;
+    return !(parentId && parentId !== entry.id && entryById.has(parentId));
+  });
+
+  roots.forEach((entry) => walkRoot(entry));
+  entries.forEach((entry) => walkRoot(entry));
+  return rows;
 }
 
 async function buildSessionChainLine(metadata: SessionMetadata): Promise<string | null> {

--- a/src/cli/sessionDisplay.ts
+++ b/src/cli/sessionDisplay.ts
@@ -609,8 +609,12 @@ function buildStatusTreeRows(
     return !(parentId && parentId !== entry.id && entryById.has(parentId));
   });
 
-  roots.forEach((entry) => walkRoot(entry));
-  entries.forEach((entry) => walkRoot(entry));
+  roots.forEach((entry) => {
+    walkRoot(entry);
+  });
+  entries.forEach((entry) => {
+    walkRoot(entry);
+  });
   return rows;
 }
 

--- a/src/cli/sessionDisplay.ts
+++ b/src/cli/sessionDisplay.ts
@@ -14,6 +14,11 @@ import type { BrowserLogger } from '../browser/types.js';
 import { resumeBrowserSession } from '../browser/reattach.js';
 import { estimateTokenCount } from '../browser/utils.js';
 import { formatSessionTableHeader, formatSessionTableRow, resolveSessionCost } from './sessionTable.js';
+import {
+  abbreviateResponseId,
+  buildResponseOwnerIndex,
+  resolveSessionLineage,
+} from './sessionLineage.js';
 
 const isTty = (): boolean => Boolean(process.stdout.isTTY);
 const dim = (text: string): string => (isTty() ? kleur.dim(text) : text);
@@ -58,6 +63,7 @@ export async function showStatus({
   const { entries, truncated, total } = sessionStore.filterSessions(metas, { hours, includeAll, limit });
   const filteredEntries = modelFilter ? entries.filter((entry) => matchesModel(entry, modelFilter)) : entries;
   const richTty = process.stdout.isTTY && chalk.level > 0;
+  const responseOwners = buildResponseOwnerIndex(metas);
   if (!filteredEntries.length) {
     console.log(CLEANUP_TIP);
     if (showExamples) {
@@ -68,7 +74,9 @@ export async function showStatus({
   console.log(chalk.bold('Recent Sessions'));
   console.log(formatSessionTableHeader(richTty));
   for (const entry of filteredEntries) {
-    console.log(formatSessionTableRow(entry, { rich: richTty }));
+    const row = formatSessionTableRow(entry, { rich: richTty });
+    const lineage = formatStatusLineage(entry, responseOwners, richTty);
+    console.log(`${row}${lineage}`);
   }
   if (truncated) {
     const sessionsDir = sessionStore.sessionsDir();
@@ -204,6 +212,10 @@ export async function attachSession(sessionId: string, options?: AttachSessionOp
     const reattachLine = buildReattachLine(metadata);
     if (reattachLine) {
       console.log(chalk.blue(reattachLine));
+    }
+    const chainLine = await buildSessionChainLine(metadata);
+    if (chainLine) {
+      console.log(dim(`Chain: ${chainLine}`));
     }
     console.log(`Created: ${metadata.createdAt}`);
     console.log(`Status: ${metadata.status}`);
@@ -519,6 +531,41 @@ function matchesModel(entry: SessionMetadata, filter: string): boolean {
   const models =
     entry.models?.map((model) => model.model.toLowerCase()) ?? (entry.model ? [entry.model.toLowerCase()] : []);
   return models.includes(normalized);
+}
+
+function formatStatusLineage(
+  entry: SessionMetadata,
+  responseOwners: ReadonlyMap<string, string>,
+  rich: boolean,
+): string {
+  const lineage = resolveSessionLineage(entry, responseOwners);
+  if (!lineage) {
+    return '';
+  }
+  const parentLabel = lineage.parentSessionId
+    ? `${lineage.parentSessionId} (${abbreviateResponseId(lineage.parentResponseId)})`
+    : abbreviateResponseId(lineage.parentResponseId);
+  const suffix = ` <- ${parentLabel}`;
+  return rich ? chalk.gray(suffix) : suffix;
+}
+
+async function buildSessionChainLine(metadata: SessionMetadata): Promise<string | null> {
+  const lineageWithoutLookup = resolveSessionLineage(metadata);
+  if (!lineageWithoutLookup) {
+    return `root -> ${metadata.id}`;
+  }
+  if (lineageWithoutLookup.parentSessionId) {
+    return `${lineageWithoutLookup.parentSessionId} (${abbreviateResponseId(lineageWithoutLookup.parentResponseId)}) -> ${
+      metadata.id
+    }`;
+  }
+  const sessions = await sessionStore.listSessions().catch(() => []);
+  const responseOwners = buildResponseOwnerIndex(sessions);
+  const lineage = resolveSessionLineage(metadata, responseOwners) ?? lineageWithoutLookup;
+  if (lineage.parentSessionId) {
+    return `${lineage.parentSessionId} (${abbreviateResponseId(lineage.parentResponseId)}) -> ${metadata.id}`;
+  }
+  return `${abbreviateResponseId(lineage.parentResponseId)} -> ${metadata.id}`;
 }
 
 async function buildSessionLogForDisplay(

--- a/src/cli/sessionDisplay.ts
+++ b/src/cli/sessionDisplay.ts
@@ -577,10 +577,11 @@ function buildStatusTreeRows(
       return;
     }
     visited.add(entry.id);
-    const prefix = `${ancestorHasMore.map((hasMore) => (hasMore ? '│  ' : '   ')).join('')}${isLast ? '└─ ' : '├─ '}`;
+    const children = childMap.get(entry.id) ?? [];
+    const nodeBranch = children.length > 0 ? (isLast ? '└┬ ' : '├┬ ') : isLast ? '└─ ' : '├─ ';
+    const prefix = `${ancestorHasMore.map((hasMore) => (hasMore ? '│  ' : '   ')).join('')}${nodeBranch}`;
     rows.push({ entry, displaySlug: `${prefix}${entry.id}` });
 
-    const children = childMap.get(entry.id) ?? [];
     children.forEach((child, index) => {
       walkChild(child, [...ancestorHasMore, !isLast], index === children.length - 1);
     });
@@ -596,9 +597,9 @@ function buildStatusTreeRows(
       lineage?.parentSessionId && !entryById.has(lineage.parentSessionId)
         ? `${lineage.parentSessionId} (${abbreviateResponseId(lineage.parentResponseId)})`
         : undefined;
-    rows.push({ entry, displaySlug: entry.id, detachedParentLabel: hiddenParent });
-
     const children = childMap.get(entry.id) ?? [];
+    const displaySlug = children.length > 0 ? `┬ ${entry.id}` : entry.id;
+    rows.push({ entry, displaySlug, detachedParentLabel: hiddenParent });
     children.forEach((child, index) => {
       walkChild(child, [], index === children.length - 1);
     });

--- a/src/cli/sessionLineage.ts
+++ b/src/cli/sessionLineage.ts
@@ -1,0 +1,72 @@
+import type { SessionMetadata } from '../sessionStore.js';
+
+type ResponseRecord = { responseId?: unknown; id?: unknown };
+
+export interface SessionLineage {
+  parentResponseId: string;
+  parentSessionId?: string;
+}
+
+function readResponseId(record: ResponseRecord | undefined | null): string | null {
+  if (!record) return null;
+  const candidate =
+    typeof record.responseId === 'string' ? record.responseId : typeof record.id === 'string' ? record.id : null;
+  if (!candidate || !candidate.startsWith('resp_')) {
+    return null;
+  }
+  return candidate;
+}
+
+export function collectSessionResponseIds(meta: SessionMetadata): string[] {
+  const ids = new Set<string>();
+  const rootResponse = readResponseId(meta.response as ResponseRecord | undefined);
+  if (rootResponse) {
+    ids.add(rootResponse);
+  }
+  const runs = Array.isArray(meta.models) ? meta.models : [];
+  for (const run of runs) {
+    const runResponse = readResponseId((run as unknown as { response?: ResponseRecord | null }).response);
+    if (runResponse) {
+      ids.add(runResponse);
+    }
+  }
+  return [...ids];
+}
+
+export function buildResponseOwnerIndex(sessions: SessionMetadata[]): Map<string, string> {
+  const byResponse = new Map<string, string>();
+  for (const session of sessions) {
+    for (const responseId of collectSessionResponseIds(session)) {
+      if (!byResponse.has(responseId)) {
+        byResponse.set(responseId, session.id);
+      }
+    }
+  }
+  return byResponse;
+}
+
+export function resolveSessionLineage(
+  meta: SessionMetadata,
+  responseOwners?: ReadonlyMap<string, string>,
+): SessionLineage | null {
+  const previous = meta.options?.previousResponseId?.trim();
+  if (!previous) {
+    return null;
+  }
+  let parentSessionId = meta.options?.followupSessionId?.trim();
+  if (!parentSessionId && responseOwners) {
+    parentSessionId = responseOwners.get(previous);
+  }
+  if (parentSessionId === meta.id) {
+    parentSessionId = undefined;
+  }
+  return { parentResponseId: previous, parentSessionId };
+}
+
+export function abbreviateResponseId(responseId: string, max = 18): string {
+  if (responseId.length <= max) {
+    return responseId;
+  }
+  const head = Math.max(8, max - 7);
+  return `${responseId.slice(0, head)}...${responseId.slice(-4)}`;
+}

--- a/src/cli/sessionTable.ts
+++ b/src/cli/sessionTable.ts
@@ -14,6 +14,11 @@ export const TIMESTAMP_PAD = 19;
 export const CHARS_PAD = 5;
 export const COST_PAD = 7;
 
+interface FormatSessionTableRowOptions {
+  rich?: boolean;
+  displaySlug?: string;
+}
+
 export function formatSessionTableHeader(rich?: boolean): string {
   const header = `${'Status'.padEnd(STATUS_PAD)} ${'Model'.padEnd(MODEL_PAD)} ${'Mode'.padEnd(
     MODE_PAD,
@@ -21,7 +26,7 @@ export function formatSessionTableHeader(rich?: boolean): string {
   return dim(header, isRich(rich));
 }
 
-export function formatSessionTableRow(meta: SessionMetadata, options?: { rich?: boolean }): string {
+export function formatSessionTableRow(meta: SessionMetadata, options?: FormatSessionTableRowOptions): string {
   const rich = isRich(options?.rich);
   const status = colorStatus(meta.status ?? 'unknown', rich);
   const modelLabel = (meta.model ?? 'n/a').padEnd(MODEL_PAD);
@@ -36,7 +41,8 @@ export function formatSessionTableRow(meta: SessionMetadata, options?: { rich?: 
   const costValue = resolveSessionCost(meta);
   const costRaw = costValue != null ? formatCostTable(costValue) : `${''.padStart(COST_PAD - 1)}-`;
   const cost = rich ? chalk.gray(costRaw) : costRaw;
-  const slug = rich ? chalk.cyan(meta.id) : meta.id;
+  const slugValue = options?.displaySlug ?? meta.id;
+  const slug = rich ? chalk.cyan(slugValue) : slugValue;
   return `${status} ${model} ${mode} ${timestamp} ${chars} ${cost}  ${slug}`;
 }
 

--- a/src/oracle/request.ts
+++ b/src/oracle/request.ts
@@ -29,10 +29,12 @@ export function buildRequestBody({
   maxOutputTokens,
   background,
   storeResponse,
+  previousResponseId,
 }: BuildRequestBodyParams): OracleRequestBody {
   const searchToolType: ToolConfig['type'] = modelConfig.searchToolType ?? 'web_search_preview';
   return {
     model: modelConfig.apiModel ?? modelConfig.model,
+    previous_response_id: previousResponseId ? previousResponseId : undefined,
     instructions: systemPrompt,
     input: [
       {

--- a/src/oracle/run.ts
+++ b/src/oracle/run.ts
@@ -251,6 +251,9 @@ export async function runOracle(options: RunOracleOptions, deps: RunOracleDeps =
     (options.model.startsWith('gemini')
       ? resolveGeminiModelId(options.model)
       : (modelConfig.apiModel ?? modelConfig.model));
+  if (!isPreview && options.previousResponseId) {
+    log(dim(`Continuing from response ${options.previousResponseId}`));
+  }
   const requestBody = buildRequestBody({
     modelConfig,
     systemPrompt,
@@ -258,7 +261,9 @@ export async function runOracle(options: RunOracleOptions, deps: RunOracleDeps =
     searchEnabled,
     maxOutputTokens: options.maxOutput,
     background: useBackground,
-    storeResponse: useBackground,
+    // Storing makes follow-ups possible (Responses API chaining relies on stored response state).
+    storeResponse: useBackground || Boolean(options.previousResponseId),
+    previousResponseId: options.previousResponseId,
   });
   const estimatedInputTokens = estimateRequestTokens(requestBody, modelConfig);
   const tokenLabel = formatTokenEstimate(

--- a/src/oracle/types.ts
+++ b/src/oracle/types.ts
@@ -128,6 +128,14 @@ export interface RunOracleOptions {
   prompt: string;
   model: ModelName;
   models?: ModelName[];
+  /**
+   * Continue an OpenAI Responses API conversation by chaining from a prior response id.
+   * This maps to the Responses API field `previous_response_id`.
+   *
+   * Note: Responses API does not carry forward `instructions`, so callers must still
+   * send instructions each turn (Oracle does).
+   */
+  previousResponseId?: string;
   file?: string[];
   slug?: string;
   filesReport?: boolean;
@@ -220,6 +228,7 @@ export interface BuildRequestBodyParams {
   maxOutputTokens?: number;
   background?: boolean;
   storeResponse?: boolean;
+  previousResponseId?: string;
 }
 
 export interface ToolConfig {
@@ -228,6 +237,8 @@ export interface ToolConfig {
 
 export interface OracleRequestBody {
   model: string;
+  // biome-ignore lint/style/useNamingConvention: field name provided by OpenAI Responses API
+  previous_response_id?: string;
   instructions: string;
   input: Array<{
     role: 'user';

--- a/src/oracle/types.ts
+++ b/src/oracle/types.ts
@@ -237,7 +237,6 @@ export interface ToolConfig {
 
 export interface OracleRequestBody {
   model: string;
-  // biome-ignore lint/style/useNamingConvention: field name provided by OpenAI Responses API
   previous_response_id?: string;
   instructions: string;
   input: Array<{

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -93,6 +93,8 @@ export interface StoredRunOptions {
   file?: string[];
   model?: string;
   models?: ModelName[];
+  /** Responses API chaining (maps to `previous_response_id`). */
+  previousResponseId?: string;
   maxInput?: number;
   system?: string;
   maxOutput?: number;

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -95,6 +95,10 @@ export interface StoredRunOptions {
   models?: ModelName[];
   /** Responses API chaining (maps to `previous_response_id`). */
   previousResponseId?: string;
+  /** Optional session slug that provided the parent response when using `--followup <sessionId>`. */
+  followupSessionId?: string;
+  /** Optional model selector used with --followup-model for multi-model parent sessions. */
+  followupModel?: string;
   maxInput?: number;
   system?: string;
   maxOutput?: number;
@@ -407,6 +411,9 @@ export async function initializeSession(
       file: options.file ?? [],
       model: options.model,
       models: modelList,
+      previousResponseId: options.previousResponseId,
+      followupSessionId: options.followupSessionId,
+      followupModel: options.followupModel,
       effectiveModelId: options.effectiveModelId,
       maxInput: options.maxInput,
       system: options.system,

--- a/tests/cli/detach.test.ts
+++ b/tests/cli/detach.test.ts
@@ -38,11 +38,21 @@ describe('shouldDetachSession', () => {
     expect(standard).toBe(false);
   });
 
-  test('allows detach for pro models when env permits', () => {
+  test('does not detach when wait preference is true, even for pro models', () => {
     const pro52 = shouldDetachSession({
       engine: 'api',
       model: 'gpt-5.2-pro',
       waitPreference: true,
+      disableDetachEnv: false,
+    });
+    expect(pro52).toBe(false);
+  });
+
+  test('allows detach for pro models when wait preference is false and env permits', () => {
+    const pro52 = shouldDetachSession({
+      engine: 'api',
+      model: 'gpt-5.2-pro',
+      waitPreference: false,
       disableDetachEnv: false,
     });
     expect(pro52).toBe(true);

--- a/tests/cli/integrationCli.test.ts
+++ b/tests/cli/integrationCli.test.ts
@@ -127,6 +127,169 @@ describe('oracle CLI integration', () => {
     await rm(oracleHome, { recursive: true, force: true });
   }, INTEGRATION_TIMEOUT);
 
+  test('accepts direct response ids in --followup and persists chain metadata', async () => {
+    const oracleHome = await mkdtemp(path.join(os.tmpdir(), 'oracle-followup-resp-'));
+    const env = {
+      ...process.env,
+      // biome-ignore lint/style/useNamingConvention: env var name
+      OPENAI_API_KEY: 'sk-integration',
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_HOME_DIR: oracleHome,
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_CLIENT_FACTORY: CLIENT_FACTORY,
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_NO_DETACH: '1',
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_DISABLE_KEYTAR: '1',
+    };
+    const directResponseId = 'resp_direct_followup_12345';
+
+    await execFileAsync(
+      process.execPath,
+      [
+        '--import',
+        'tsx',
+        CLI_ENTRY,
+        '--prompt',
+        'Child from direct response id',
+        '--model',
+        'gpt-5.1',
+        '--followup',
+        directResponseId,
+      ],
+      { env },
+    );
+
+    const sessionsDir = path.join(oracleHome, 'sessions');
+    const [sessionId] = await readdir(sessionsDir);
+    expect(sessionId).toBeTruthy();
+    const metadata = JSON.parse(await readFile(path.join(sessionsDir, sessionId, 'meta.json'), 'utf8'));
+    expect(metadata.options?.previousResponseId).toBe(directResponseId);
+    expect(metadata.options?.followupSessionId).toBeUndefined();
+    expect(metadata.options?.followupModel).toBeUndefined();
+
+    await rm(oracleHome, { recursive: true, force: true });
+  }, INTEGRATION_TIMEOUT);
+
+  test('requires --followup-model when parent session has multiple model runs', async () => {
+    const oracleHome = await mkdtemp(path.join(os.tmpdir(), 'oracle-followup-multi-error-'));
+    const env = {
+      ...process.env,
+      // biome-ignore lint/style/useNamingConvention: env var name
+      OPENAI_API_KEY: 'sk-integration',
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_HOME_DIR: oracleHome,
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_CLIENT_FACTORY: CLIENT_FACTORY,
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_NO_DETACH: '1',
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_DISABLE_KEYTAR: '1',
+    };
+
+    await execFileAsync(
+      process.execPath,
+      ['--import', 'tsx', CLI_ENTRY, '--prompt', 'Parent multi followup', '--models', 'gpt-5.1,gpt-5.2'],
+      { env },
+    );
+
+    const sessionsDir = path.join(oracleHome, 'sessions');
+    const [parentId] = await readdir(sessionsDir);
+    expect(parentId).toBeTruthy();
+
+    try {
+      await execFileAsync(
+        process.execPath,
+        [
+          '--import',
+          'tsx',
+          CLI_ENTRY,
+          '--prompt',
+          'Child missing followup model',
+          '--model',
+          'gpt-5.1',
+          '--followup',
+          parentId,
+        ],
+        { env },
+      );
+      throw new Error('Expected oracle CLI to fail but it succeeded.');
+    } catch (error) {
+      const stderr =
+        error && typeof error === 'object' && error !== null && 'stderr' in error
+          ? String((error as { stderr?: unknown }).stderr ?? '')
+          : '';
+      expect(stderr).toMatch(/multiple model runs/i);
+      expect(stderr).toMatch(/--followup-model/i);
+    }
+
+    await rm(oracleHome, { recursive: true, force: true });
+  }, INTEGRATION_TIMEOUT);
+
+  test('uses --followup-model to continue from the selected parent model response', async () => {
+    const oracleHome = await mkdtemp(path.join(os.tmpdir(), 'oracle-followup-multi-select-'));
+    const env = {
+      ...process.env,
+      // biome-ignore lint/style/useNamingConvention: env var name
+      OPENAI_API_KEY: 'sk-integration',
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_HOME_DIR: oracleHome,
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_CLIENT_FACTORY: CLIENT_FACTORY,
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_NO_DETACH: '1',
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_DISABLE_KEYTAR: '1',
+    };
+
+    await execFileAsync(
+      process.execPath,
+      ['--import', 'tsx', CLI_ENTRY, '--prompt', 'Parent multi followup select', '--models', 'gpt-5.1,gpt-5.2'],
+      { env },
+    );
+
+    const sessionsDir = path.join(oracleHome, 'sessions');
+    const [parentId] = await readdir(sessionsDir);
+    expect(parentId).toBeTruthy();
+
+    const parentMeta = JSON.parse(await readFile(path.join(sessionsDir, parentId, 'meta.json'), 'utf8'));
+    const selectedRun = (
+      (parentMeta.models as Array<{ model: string; response?: { responseId?: string } }> | undefined) ?? []
+    ).find((run) => run.model === 'gpt-5.2');
+    const selectedResponseId = selectedRun?.response?.responseId;
+    expect(selectedResponseId).toBeTruthy();
+    expect(String(selectedResponseId).startsWith('resp_')).toBe(true);
+
+    await execFileAsync(
+      process.execPath,
+      [
+        '--import',
+        'tsx',
+        CLI_ENTRY,
+        '--prompt',
+        'Child with followup model select',
+        '--model',
+        'gpt-5.1',
+        '--followup',
+        parentId,
+        '--followup-model',
+        'gpt-5.2',
+      ],
+      { env },
+    );
+
+    const allSessions = await readdir(sessionsDir);
+    expect(allSessions.length).toBe(2);
+    const childId = allSessions.find((id) => id !== parentId);
+    expect(childId).toBeTruthy();
+    const childMeta = JSON.parse(await readFile(path.join(sessionsDir, childId as string, 'meta.json'), 'utf8'));
+    expect(childMeta.options?.previousResponseId).toBe(selectedResponseId);
+    expect(childMeta.options?.followupSessionId).toBe(parentId);
+    expect(childMeta.options?.followupModel).toBe('gpt-5.2');
+
+    await rm(oracleHome, { recursive: true, force: true });
+  }, INTEGRATION_TIMEOUT);
+
   test('rejects mixing --model and --models regardless of source', async () => {
     const oracleHome = await mkdtemp(path.join(os.tmpdir(), 'oracle-multi-conflict-'));
     const env = {

--- a/tests/cli/integrationCli.test.ts
+++ b/tests/cli/integrationCli.test.ts
@@ -59,6 +59,74 @@ describe('oracle CLI integration', () => {
     await rm(oracleHome, { recursive: true, force: true });
   }, INTEGRATION_TIMEOUT);
 
+  test('persists followup lineage and reuses previous_response_id during --exec-session', async () => {
+    const oracleHome = await mkdtemp(path.join(os.tmpdir(), 'oracle-followup-'));
+    const env = {
+      ...process.env,
+      // biome-ignore lint/style/useNamingConvention: env var name
+      OPENAI_API_KEY: 'sk-integration',
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_HOME_DIR: oracleHome,
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_CLIENT_FACTORY: CLIENT_FACTORY,
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_NO_DETACH: '1',
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_DISABLE_KEYTAR: '1',
+    };
+
+    await execFileAsync(
+      process.execPath,
+      ['--import', 'tsx', CLI_ENTRY, '--prompt', 'Parent run', '--model', 'gpt-5.1'],
+      { env },
+    );
+
+    const sessionsDir = path.join(oracleHome, 'sessions');
+    const [parentId] = await readdir(sessionsDir);
+    expect(parentId).toBeTruthy();
+    const parentMeta = JSON.parse(await readFile(path.join(sessionsDir, parentId, 'meta.json'), 'utf8'));
+    const parentResponseId = String(parentMeta.response?.responseId ?? '');
+    expect(parentResponseId.startsWith('resp_')).toBe(true);
+
+    await execFileAsync(
+      process.execPath,
+      [
+        '--import',
+        'tsx',
+        CLI_ENTRY,
+        '--prompt',
+        'Child run',
+        '--model',
+        'gpt-5.1',
+        '--followup',
+        parentId,
+      ],
+      { env },
+    );
+
+    const allSessions = await readdir(sessionsDir);
+    expect(allSessions.length).toBe(2);
+    const childId = allSessions.find((id) => id !== parentId);
+    expect(childId).toBeTruthy();
+    const childMeta = JSON.parse(await readFile(path.join(sessionsDir, childId as string, 'meta.json'), 'utf8'));
+    expect(childMeta.options?.previousResponseId).toBe(parentResponseId);
+    expect(childMeta.options?.followupSessionId).toBe(parentId);
+
+    await execFileAsync(
+      process.execPath,
+      ['--import', 'tsx', CLI_ENTRY, '--exec-session', childId as string],
+      {
+        env: {
+          ...env,
+          // biome-ignore lint/style/useNamingConvention: env var name
+          ORACLE_TEST_REQUIRE_PREV: '1',
+        },
+      },
+    );
+
+    await rm(oracleHome, { recursive: true, force: true });
+  }, INTEGRATION_TIMEOUT);
+
   test('rejects mixing --model and --models regardless of source', async () => {
     const oracleHome = await mkdtemp(path.join(os.tmpdir(), 'oracle-multi-conflict-'));
     const env = {

--- a/tests/cli/integrationCli.test.ts
+++ b/tests/cli/integrationCli.test.ts
@@ -171,6 +171,123 @@ describe('oracle CLI integration', () => {
     await rm(oracleHome, { recursive: true, force: true });
   }, INTEGRATION_TIMEOUT);
 
+  test('rejects --followup for Gemini API runs', async () => {
+    const oracleHome = await mkdtemp(path.join(os.tmpdir(), 'oracle-followup-gemini-unsupported-'));
+    const env = {
+      ...process.env,
+      // biome-ignore lint/style/useNamingConvention: env var name
+      GEMINI_API_KEY: 'gk-integration',
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_HOME_DIR: oracleHome,
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_DISABLE_KEYTAR: '1',
+    };
+
+    try {
+      await execFileAsync(
+        process.execPath,
+        ['--import', 'tsx', CLI_ENTRY, '--prompt', 'Gemini followup', '--model', 'gemini-3-pro', '--followup', 'resp_parent_1234'],
+        { env },
+      );
+      throw new Error('Expected oracle CLI to fail but it succeeded.');
+    } catch (error) {
+      const stderr =
+        error && typeof error === 'object' && error !== null && 'stderr' in error
+          ? String((error as { stderr?: unknown }).stderr ?? '')
+          : '';
+      expect(stderr).toMatch(/only supported for OpenAI Responses API runs/i);
+      expect(stderr).toMatch(/gemini-3-pro/i);
+    }
+
+    await rm(oracleHome, { recursive: true, force: true });
+  }, INTEGRATION_TIMEOUT);
+
+  test('rejects --followup for Claude API runs', async () => {
+    const oracleHome = await mkdtemp(path.join(os.tmpdir(), 'oracle-followup-claude-unsupported-'));
+    const env = {
+      ...process.env,
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ANTHROPIC_API_KEY: 'ak-integration',
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_HOME_DIR: oracleHome,
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_DISABLE_KEYTAR: '1',
+    };
+
+    try {
+      await execFileAsync(
+        process.execPath,
+        [
+          '--import',
+          'tsx',
+          CLI_ENTRY,
+          '--prompt',
+          'Claude followup',
+          '--model',
+          'claude-4.5-sonnet',
+          '--followup',
+          'resp_parent_1234',
+        ],
+        { env },
+      );
+      throw new Error('Expected oracle CLI to fail but it succeeded.');
+    } catch (error) {
+      const stderr =
+        error && typeof error === 'object' && error !== null && 'stderr' in error
+          ? String((error as { stderr?: unknown }).stderr ?? '')
+          : '';
+      expect(stderr).toMatch(/only supported for OpenAI Responses API runs/i);
+      expect(stderr).toMatch(/claude-4.5-sonnet/i);
+    }
+
+    await rm(oracleHome, { recursive: true, force: true });
+  }, INTEGRATION_TIMEOUT);
+
+  test('rejects --followup for custom --base-url providers', async () => {
+    const oracleHome = await mkdtemp(path.join(os.tmpdir(), 'oracle-followup-baseurl-unsupported-'));
+    const env = {
+      ...process.env,
+      // biome-ignore lint/style/useNamingConvention: env var name
+      OPENAI_API_KEY: 'sk-integration',
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_HOME_DIR: oracleHome,
+      // biome-ignore lint/style/useNamingConvention: env var name
+      OPENROUTER_API_KEY: 'or-integration',
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_DISABLE_KEYTAR: '1',
+    };
+
+    try {
+      await execFileAsync(
+        process.execPath,
+        [
+          '--import',
+          'tsx',
+          CLI_ENTRY,
+          '--prompt',
+          'OpenRouter followup',
+          '--model',
+          'gpt-5.1',
+          '--base-url',
+          'https://openrouter.ai/api/v1',
+          '--followup',
+          'resp_parent_1234',
+        ],
+        { env },
+      );
+      throw new Error('Expected oracle CLI to fail but it succeeded.');
+    } catch (error) {
+      const stderr =
+        error && typeof error === 'object' && error !== null && 'stderr' in error
+          ? String((error as { stderr?: unknown }).stderr ?? '')
+          : '';
+      expect(stderr).toMatch(/default OpenAI Responses API or Azure OpenAI Responses/i);
+      expect(stderr).toMatch(/Custom --base-url providers are not supported/i);
+    }
+
+    await rm(oracleHome, { recursive: true, force: true });
+  }, INTEGRATION_TIMEOUT);
+
   test('prints actionable guidance when --followup session id is missing', async () => {
     const oracleHome = await mkdtemp(path.join(os.tmpdir(), 'oracle-followup-missing-id-'));
     const env = {
@@ -226,7 +343,7 @@ describe('oracle CLI integration', () => {
           ? String((error as { stderr?: unknown }).stderr ?? '')
           : '';
       expect(stderr).toMatch(/No session found with ID release-readiness-audti/i);
-      expect(stderr).toMatch(/Did you mean:\s+\"release-readiness-audit\"/i);
+      expect(stderr).toMatch(/Did you mean:\s+"release-readiness-audit"/i);
       expect(stderr).toMatch(/oracle status --hours 72 --limit 20/i);
     }
 

--- a/tests/cli/integrationCli.test.ts
+++ b/tests/cli/integrationCli.test.ts
@@ -171,6 +171,68 @@ describe('oracle CLI integration', () => {
     await rm(oracleHome, { recursive: true, force: true });
   }, INTEGRATION_TIMEOUT);
 
+  test('prints actionable guidance when --followup session id is missing', async () => {
+    const oracleHome = await mkdtemp(path.join(os.tmpdir(), 'oracle-followup-missing-id-'));
+    const env = {
+      ...process.env,
+      // biome-ignore lint/style/useNamingConvention: env var name
+      OPENAI_API_KEY: 'sk-integration',
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_HOME_DIR: oracleHome,
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_CLIENT_FACTORY: CLIENT_FACTORY,
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_NO_DETACH: '1',
+      // biome-ignore lint/style/useNamingConvention: env var name
+      ORACLE_DISABLE_KEYTAR: '1',
+    };
+
+    await execFileAsync(
+      process.execPath,
+      [
+        '--import',
+        'tsx',
+        CLI_ENTRY,
+        '--prompt',
+        'Parent run for followup suggestions',
+        '--model',
+        'gpt-5.1',
+        '--slug',
+        'release-readiness-audit',
+      ],
+      { env },
+    );
+
+    try {
+      await execFileAsync(
+        process.execPath,
+        [
+          '--import',
+          'tsx',
+          CLI_ENTRY,
+          '--prompt',
+          'Child with typo followup id',
+          '--model',
+          'gpt-5.1',
+          '--followup',
+          'release-readiness-audti',
+        ],
+        { env },
+      );
+      throw new Error('Expected oracle CLI to fail but it succeeded.');
+    } catch (error) {
+      const stderr =
+        error && typeof error === 'object' && error !== null && 'stderr' in error
+          ? String((error as { stderr?: unknown }).stderr ?? '')
+          : '';
+      expect(stderr).toMatch(/No session found with ID release-readiness-audti/i);
+      expect(stderr).toMatch(/Did you mean:\s+\"release-readiness-audit\"/i);
+      expect(stderr).toMatch(/oracle status --hours 72 --limit 20/i);
+    }
+
+    await rm(oracleHome, { recursive: true, force: true });
+  }, INTEGRATION_TIMEOUT);
+
   test('requires --followup-model when parent session has multiple model runs', async () => {
     const oracleHome = await mkdtemp(path.join(os.tmpdir(), 'oracle-followup-multi-error-'));
     const env = {

--- a/tests/cli/sessionDisplay.coverage.test.ts
+++ b/tests/cli/sessionDisplay.coverage.test.ts
@@ -84,7 +84,7 @@ describe('sessionDisplay helpers', () => {
     const { showStatus } = await import('../../src/cli/sessionDisplay.js');
     await showStatus({ hours: 24, includeAll: false, limit: 5 });
 
-    expect(log).toHaveBeenCalledWith(expect.stringMatching(/┬ parent-session/));
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/parent-session/));
     expect(log).toHaveBeenCalledWith(expect.stringMatching(/└─ child-session/));
     log.mockRestore();
   }, 15_000);
@@ -131,8 +131,8 @@ describe('sessionDisplay helpers', () => {
     const { showStatus } = await import('../../src/cli/sessionDisplay.js');
     await showStatus({ hours: 24, includeAll: false, limit: 10 });
 
-    expect(log).toHaveBeenCalledWith(expect.stringMatching(/┬ parent-session/));
-    expect(log).toHaveBeenCalledWith(expect.stringMatching(/├┬ child-a/));
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/parent-session/));
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/├─ child-a/));
     expect(log).toHaveBeenCalledWith(expect.stringMatching(/│  └─ grandchild-a1/));
     expect(log).toHaveBeenCalledWith(expect.stringMatching(/└─ child-b/));
     log.mockRestore();

--- a/tests/cli/sessionDisplay.coverage.test.ts
+++ b/tests/cli/sessionDisplay.coverage.test.ts
@@ -133,7 +133,7 @@ describe('sessionDisplay helpers', () => {
 
     expect(log).toHaveBeenCalledWith(expect.stringMatching(/parent-session/));
     expect(log).toHaveBeenCalledWith(expect.stringMatching(/├─ child-a/));
-    expect(log).toHaveBeenCalledWith(expect.stringMatching(/│  └─ grandchild-a1/));
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/│ {2}└─ grandchild-a1/));
     expect(log).toHaveBeenCalledWith(expect.stringMatching(/└─ child-b/));
     log.mockRestore();
   }, 15_000);

--- a/tests/cli/sessionDisplay.coverage.test.ts
+++ b/tests/cli/sessionDisplay.coverage.test.ts
@@ -84,7 +84,7 @@ describe('sessionDisplay helpers', () => {
     const { showStatus } = await import('../../src/cli/sessionDisplay.js');
     await showStatus({ hours: 24, includeAll: false, limit: 5 });
 
-    expect(log).toHaveBeenCalledWith(expect.stringMatching(/child-session.*<- parent-session/));
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/└─ child-session/));
     log.mockRestore();
   }, 15_000);
 

--- a/tests/cli/sessionDisplay.coverage.test.ts
+++ b/tests/cli/sessionDisplay.coverage.test.ts
@@ -61,6 +61,33 @@ describe('sessionDisplay helpers', () => {
     log.mockRestore();
   }, 15_000);
 
+  it('shows follow-up lineage in status rows', async () => {
+    const parent = {
+      id: 'parent-session',
+      status: 'completed',
+      createdAt: '2025-11-20T00:00:00.000Z',
+      model: 'gpt-5.1',
+      options: { prompt: 'parent' },
+      response: { responseId: 'resp_parent_1234' },
+    };
+    const child = {
+      id: 'child-session',
+      status: 'completed',
+      createdAt: '2025-11-20T00:01:00.000Z',
+      model: 'gpt-5.1',
+      options: { prompt: 'child', previousResponseId: 'resp_parent_1234', followupSessionId: 'parent-session' },
+    };
+    mockSessionStore.listSessions.mockResolvedValue([child, parent]);
+    mockSessionStore.filterSessions.mockReturnValue({ entries: [child, parent], truncated: false, total: 2 });
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { showStatus } = await import('../../src/cli/sessionDisplay.js');
+    await showStatus({ hours: 24, includeAll: false, limit: 5 });
+
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/child-session.*<- parent-session/));
+    log.mockRestore();
+  }, 15_000);
+
   it('formats metadata and completion summaries', async () => {
     const {
       formatResponseMetadata,

--- a/tests/cli/sessionDisplay.coverage.test.ts
+++ b/tests/cli/sessionDisplay.coverage.test.ts
@@ -84,7 +84,57 @@ describe('sessionDisplay helpers', () => {
     const { showStatus } = await import('../../src/cli/sessionDisplay.js');
     await showStatus({ hours: 24, includeAll: false, limit: 5 });
 
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/┬ parent-session/));
     expect(log).toHaveBeenCalledWith(expect.stringMatching(/└─ child-session/));
+    log.mockRestore();
+  }, 15_000);
+
+  it('renders nested follow-up branches with stable tree connectors', async () => {
+    const parent = {
+      id: 'parent-session',
+      status: 'completed',
+      createdAt: '2025-11-20T00:00:00.000Z',
+      model: 'gpt-5.1',
+      options: { prompt: 'parent' },
+      response: { responseId: 'resp_parent_1234' },
+    };
+    const childA = {
+      id: 'child-a',
+      status: 'completed',
+      createdAt: '2025-11-20T00:01:00.000Z',
+      model: 'gpt-5.1',
+      options: { prompt: 'child-a', previousResponseId: 'resp_parent_1234', followupSessionId: 'parent-session' },
+      response: { responseId: 'resp_child_a_1234' },
+    };
+    const childB = {
+      id: 'child-b',
+      status: 'completed',
+      createdAt: '2025-11-20T00:02:00.000Z',
+      model: 'gpt-5.1',
+      options: { prompt: 'child-b', previousResponseId: 'resp_parent_1234', followupSessionId: 'parent-session' },
+    };
+    const grandchild = {
+      id: 'grandchild-a1',
+      status: 'completed',
+      createdAt: '2025-11-20T00:03:00.000Z',
+      model: 'gpt-5.1',
+      options: { prompt: 'grandchild', previousResponseId: 'resp_child_a_1234', followupSessionId: 'child-a' },
+    };
+    mockSessionStore.listSessions.mockResolvedValue([parent, childA, childB, grandchild]);
+    mockSessionStore.filterSessions.mockReturnValue({
+      entries: [parent, childA, childB, grandchild],
+      truncated: false,
+      total: 4,
+    });
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { showStatus } = await import('../../src/cli/sessionDisplay.js');
+    await showStatus({ hours: 24, includeAll: false, limit: 10 });
+
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/┬ parent-session/));
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/├┬ child-a/));
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/│  └─ grandchild-a1/));
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/└─ child-b/));
     log.mockRestore();
   }, 15_000);
 

--- a/tests/cli/sessionDisplay.test.ts
+++ b/tests/cli/sessionDisplay.test.ts
@@ -156,6 +156,24 @@ describe('attachSession rendering', () => {
     readSessionRequestMock.mockReset();
   });
 
+  test('prints chain metadata for follow-up sessions', async () => {
+    const followupMeta: SessionMetadata = {
+      ...baseMeta,
+      options: {
+        previousResponseId: 'resp_parent_1234',
+        followupSessionId: 'parent-session',
+      },
+    } as SessionMetadata;
+    readSessionMetadataMock.mockResolvedValue(followupMeta);
+    readSessionLogMock.mockResolvedValue('Answer:\nchild output');
+    readSessionRequestMock.mockResolvedValue({ prompt: 'Prompt here' });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await attachSession('sess', { renderMarkdown: false });
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Chain: parent-session (resp_parent_1234) -> sess'));
+  });
+
 	  test('prints all model runs with status and tokens', async () => {
 	    const multiMeta: SessionMetadata = {
 	      ...baseMeta,

--- a/tests/fixtures/mockClientFactory.cjs
+++ b/tests/fixtures/mockClientFactory.cjs
@@ -34,12 +34,18 @@ class MockStream {
   abort() {}
 }
 
+let responseCounter = 0;
+
 function mockClientFactory() {
   return {
     responses: {
       stream: async (body) => {
+        if (process.env.ORACLE_TEST_REQUIRE_PREV === '1' && !body.previous_response_id) {
+          throw new Error('MISSING_PREVIOUS_RESPONSE_ID');
+        }
+        responseCounter += 1;
         const response = {
-          id: 'mock-response',
+          id: `resp_mock${Date.now()}${responseCounter}`,
           status: 'completed',
           usage: {
             input_tokens: 12,

--- a/tests/sessionManager.test.ts
+++ b/tests/sessionManager.test.ts
@@ -69,9 +69,12 @@ describe('session lifecycle', () => {
 	      {
 	        prompt: 'Inspect code',
 	        model: 'gpt-5.2-pro',
-	        file: ['notes.md'],
-	        maxInput: 123,
-	        system: 'SYS',
+        file: ['notes.md'],
+        previousResponseId: 'resp-parent-123',
+        followupSessionId: 'parent-session',
+        followupModel: 'gpt-5.1',
+        maxInput: 123,
+        system: 'SYS',
         maxOutput: 456,
         silent: false,
         filesReport: true,
@@ -82,6 +85,9 @@ describe('session lifecycle', () => {
 	    const baseDir = path.join(sessionModule.getSessionsDir(), metadata.id);
 	    const storedMeta = JSON.parse(await readFile(path.join(baseDir, 'meta.json'), 'utf8'));
 	    expect(storedMeta.options.file).toEqual(['notes.md']);
+      expect(storedMeta.options.previousResponseId).toBe('resp-parent-123');
+      expect(storedMeta.options.followupSessionId).toBe('parent-session');
+      expect(storedMeta.options.followupModel).toBe('gpt-5.1');
 	    await expect(readFile(path.join(baseDir, 'request.json'), 'utf8')).rejects.toThrow();
 	    const modelMeta = JSON.parse(await readFile(path.join(baseDir, 'models', 'gpt-5.2-pro.json'), 'utf8'));
 	    expect(modelMeta.status).toBe('pending');


### PR DESCRIPTION
## Summary
- add follow-up support for existing sessions so new runs can continue from prior response context
- persist follow-up lineage metadata in session state for restart/status/session flows
- render session relationships in `oracle status` using a tree-style lineage view
- ensure `--wait` is honored by detach policy so pro/background runs can remain inline when requested
- polish lineage connectors in status output for clearer parent/child readability

## What changed
- CLI/options + run orchestration: follow-up id plumbed through request/run types
- session manager: parent/child lineage persistence + metadata propagation
- status/session display: tree-style lineage rendering and connector normalization
- detach policy: wait preference now prevents unintended detach behavior
- follow-up UX: missing/typo session ids now return actionable guidance with close-match suggestions + `oracle status` hint
- docs: README follow-up examples and generalized lineage sample output
- docs/configuration: add a dedicated follow-up chaining section and CLI examples

## Sample `oracle status` output
```text
Recent Sessions
Status    Model         Mode    Timestamp           Chars    Cost  Slug
completed gpt-5.2-pro   api     03/01/2026 09:00 AM  1800  $2.110  architecture-review-parent
completed gpt-5.2-pro   api     03/01/2026 09:14 AM  2200  $2.980  ├─ architecture-review-followup
running   gpt-5.2-pro   api     03/01/2026 09:22 AM  1400       -  │  └─ architecture-review-implementation-pass
pending   gpt-5.2-pro   api     03/01/2026 09:25 AM   900       -  └─ architecture-review-risk-check
```

## Sample follow-up command
```bash
oracle \
  --engine api \
  --model gpt-5.2-pro \
  --followup <existing-session-id-or-resp_id> \
  --followup-model gpt-5.2-pro \
  --slug "my-followup-run" \
  --wait \
  -p "Follow-up: re-evaluate the previous recommendation with the attached files." \
  --file "server/src/strategy/plan.ts" \
  --file "server/src/strategy/executor.ts"
```

Use `--followup-model` when the parent session was multi-model; otherwise it can be omitted.

## Tests
- `pnpm test -- tests/cli/detach.test.ts tests/cli/sessionDisplay.test.ts tests/cli/sessionDisplay.coverage.test.ts tests/sessionManager.test.ts tests/cli/integrationCli.test.ts`
- Result: 101 files passed, 15 skipped; 584 tests passed, 33 skipped

## Notes
- Includes follow-up chain persistence, status tree UX, wait/detach fix, docs refresh, and follow-up error-message hardening.
