### PR TITLE
fix: harden browser mode stability

### DIFF
--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -13,6 +13,7 @@ if (process.argv[2] === "oracle-mcp") {
 }
 import { resolveEngine, type EngineMode, defaultWaitPreference } from "../src/cli/engine.js";
 import { shouldRequirePrompt } from "../src/cli/promptRequirement.js";
+import { resolveDashPrompt } from "../src/cli/stdin.js";
 import chalk from "chalk";
 import type { SessionMetadata, SessionMode, BrowserSessionConfig } from "../src/sessionStore.js";
 import { sessionStore, pruneOldSessions } from "../src/sessionStore.js";
@@ -216,7 +217,7 @@ program.hook("preAction", () => {
   introPrinted = true;
 });
 applyHelpStyling(program, VERSION, isTty);
-program.hook("preAction", (thisCommand) => {
+program.hook("preAction", async (thisCommand) => {
   if (thisCommand !== program) {
     return;
   }
@@ -233,6 +234,11 @@ program.hook("preAction", (thisCommand) => {
   if (!opts.prompt && positional) {
     opts.prompt = positional;
     thisCommand.setOptionValue("prompt", positional);
+  }
+  const resolvedPrompt = await resolveDashPrompt(opts.prompt);
+  if (resolvedPrompt !== opts.prompt) {
+    opts.prompt = resolvedPrompt;
+    thisCommand.setOptionValue("prompt", resolvedPrompt);
   }
   if (shouldRequirePrompt(userCliArgs, opts)) {
     console.log(

--- a/docs/browser-mode.md
+++ b/docs/browser-mode.md
@@ -75,7 +75,7 @@ You can pass the same payload inline (`--browser-inline-cookies '<json or base64
 - `--browser-inline-files`: alias for `--browser-attachments never` (forces inline paste; never uploads attachments).
 - `--browser-bundle-files`: bundle all resolved attachments into a single temp file before uploading (only used when uploads are enabled/selected).
 - sqlite bindings: automatic rebuilds now require `ORACLE_ALLOW_SQLITE_REBUILD=1`. Without it, the CLI logs instructions instead of running `pnpm rebuild` on your behalf.
-- `--model`: the same flag used for API runs is accepted, but the ChatGPT automation path supports GPT-5.4 and GPT-5.2 variants. Use `gpt-5.4-pro`, `gpt-5.4`, `gpt-5.2`, `gpt-5.2-thinking`, `gpt-5.2-instant`, or `gpt-5.2-pro`. Legacy Pro aliases still resolve to the latest Pro picker target.
+- `--model`: the same flag used for API runs is accepted, but the ChatGPT automation path supports GPT-5.4 and GPT-5.2 variants. Use `gpt-5.4-pro`, `gpt-5.4`, `gpt-5.2`, `gpt-5.2-thinking`, `gpt-5.2-instant`, or `gpt-5.2-pro`. Any ChatGPT Pro alias resolves to the current Pro picker target, so versioned Pro labels may briefly appear in the UI but settle on the single available Pro entry.
 - Cookie sync is mandatory—if we can’t copy cookies from Chrome, the run exits early. Use the hidden `--browser-allow-cookie-errors` flag only when you’re intentionally running logged out (it skips the early exit but still warns).
 - Experimental cookie controls (hidden flags/env):
   - `--browser-cookie-names <comma-list>` or `ORACLE_BROWSER_COOKIE_NAMES`: allowlist which cookies to sync. Useful for “only NextAuth/Cloudflare, drop the rest.”

--- a/docs/debug/remote-chrome.md
+++ b/docs/debug/remote-chrome.md
@@ -27,7 +27,7 @@ Outcome:
 - After wiring fix, logs showed “Routing browser automation to remote host …” but requests failed with:
   - `ECONNREFUSED 192.168.64.2:49810` when no service listening.
   - `busy` when a previous service process was still bound.
-- Later run reached remote path but failed model switch: `Unable to find model option matching "GPT-5.2 Pro"` (remote Chrome not logged into ChatGPT / model picker mismatch).
+- Later run reached remote path but failed model switch: `Unable to find model option matching "GPT-5.4 Pro"` (remote Chrome not logged into ChatGPT / model picker mismatch).
 - After disabling cookie shipping and requiring host login, remote runs now fail earlier: service logs “Loading ChatGPT cookies from host Chrome profile…” then reports `Unhandled promise rejection ... Unknown error` when `loadChromeCookies` runs on the VM. Remote client sees `socket hang up` because the server doesn’t deliver a result.
 
 ### 2) Remote service on VM
@@ -52,7 +52,7 @@ Actions taken on VM (tmux `vmssh`):
 
 - Environment PATH: bun not on PATH for non-interactive shells caused `./runner` to fail; need to `export PATH="$HOME/.bun/bin:$PATH"` before starting service.
 - Port collisions: prior listeners on 49810 caused ECONNREFUSED/busy.
-- Remote model switch failed: remote Chrome likely not signed into ChatGPT; model picker couldn’t find “GPT-5.2 Pro”.
+- Remote model switch failed: remote Chrome likely not signed into ChatGPT; model picker couldn’t find the current Pro picker target (“GPT-5.4 Pro” at the time).
 - Keychain/cookie read now failing on VM: `loadChromeCookies` throws “Unknown error” when invoked from the server process (Node 25, SSH shell). When `oracle serve` runs from GUI Terminal it starts fine; under nohup/SSH it logs the rejection and remote runs hang.
 - New behavior (post-fix): `oracle serve` exits early if it cannot load host ChatGPT cookies after opening chatgpt.com for login; sign in on the host and restart the service.
 

--- a/docs/manual-tests.md
+++ b/docs/manual-tests.md
@@ -141,23 +141,37 @@ Document results (pass/fail, session IDs) in PR descriptions so reviewers can au
 
 Run these four smoke tests whenever we touch browser automation:
 
-1. **GPT-5.2 simple prompt**  
-   `pnpm run oracle -- --engine browser --model "GPT-5.2" --prompt "Give me two short markdown bullet points about tables"`  
-   Expect two markdown bullets, no files/search referenced. Note the session ID (e.g., `give-me-two-short-markdown`).
+Fast-path note:
+- Tests 1-4 below are quick browser-path checks only. They use `gpt-5.2-instant`, which currently targets the ChatGPT Instant 5.3 picker. They are not a substitute for Pro validation.
 
-2. **GPT-5.2 simple prompt**  
-   `pnpm run oracle -- --engine browser --model gpt-5.2 --prompt "List two reasons Markdown is handy"`  
-   Confirm the answer arrives (and only once) even if it takes ~2–3 minutes.
+1. **Fast browser simple prompt**  
+   `pnpm run oracle -- --engine browser --model gpt-5.2-instant --prompt "Return exactly one line and nothing else: pro-ok"`  
+   Expect the answer body to contain `pro-ok` verbatim on its own line. Note the session ID.
 
-3. **GPT-5.2 + attachment**  
+2. **Fast browser exact-line prompt**  
+   `pnpm run oracle -- --engine browser --model gpt-5.2-instant --prompt "Return exactly these three lines and nothing else:\n\`\`\`js\nconsole.log('thinking-ok')\n\`\`\`"`  
+   Confirm the answer includes the fenced `js` code block and `console.log('thinking-ok')` verbatim.
+
+3. **Fast browser + attachment**  
    Prepare `/tmp/browser-md.txt` with a short note, then run  
-   `pnpm run oracle -- --engine browser --model "GPT-5.2" --prompt "Summarize the key idea from the attached note" --file /tmp/browser-md.txt`  
-   Ensure upload logs show “Attachment queued” and the answer references the file contents explicitly.
+   `pnpm run oracle -- --engine browser --model gpt-5.2-instant --prompt "Return exactly one line and nothing else: note=<paste the file contents exactly>" --file /tmp/browser-md.txt`  
+   Ensure upload logs show “Attachment queued” and the answer contains `note=` plus the attached file contents exactly.
 
-4. **GPT-5.2 + attachment (verbose)**  
+4. **Fast browser + attachment (verbose)**  
    Prepare `/tmp/browser-report.txt` with faux metrics, then run  
-   `pnpm run oracle -- --engine browser --model gpt-5.2 --prompt "Use the attachment to report current CPU and memory figures" --file /tmp/browser-report.txt --verbose`  
-   Verify verbose logs show attachment upload and the final answer matches the file data.
+   `pnpm run oracle -- --engine browser --model gpt-5.2-instant --prompt "Return exactly these two lines and nothing else:\nCPU=<value from file>\nMEMORY=<value from file>" --file /tmp/browser-report.txt --verbose`  
+   Verify verbose logs show attachment upload and the final answer contains the exact CPU and memory values from the file.
+
+### Pro browser smoke
+
+Run these when the change might affect Pro-specific behavior, long thinking, or reattach.
+
+1. **Pro markdown capture**  
+   `pnpm run oracle -- --engine browser --model gpt-5.4-pro --prompt "Return exactly these three lines and nothing else:\n\`\`\`js\nconsole.log('thinking-ok')\n\`\`\`"`  
+   Confirm the answer preserves the fenced `js` code block.
+
+2. **Pro reattach flow**  
+   Use `scripts/browser-smoke.sh` or run a manual `--browser-keep-browser` session with `gpt-5.4-pro`, then kill the controller and verify `oracle session <slug> --render-plain` still shows the expected answer.
 
 Record session IDs and outcomes in the PR description (pass/fail, notable delays). This ensures reviewers can audit real runs.
 
@@ -248,8 +262,8 @@ These Vitest cases hit the real OpenAI API to exercise both transports:
    export ORACLE_LIVE_TEST=1
    pnpm vitest run tests/live/openai-live.test.ts
    ```
-2. The first two tests target the standard GPT-5 (`gpt-5.1` / `gpt-5.2`) foreground
-   streaming paths. The later background tests send `gpt-5.4-pro` and `gpt-5.2-pro`
+2. The first two tests target the current fast browser picker path (`gpt-5.2-instant` aliasing
+   to Instant 5.3). The later background tests send `gpt-5.4-pro` and `gpt-5.2-pro`
    prompts and expect the CLI to stay in background mode until OpenAI finishes
    (up to 30 minutes).
 3. Watch the console for `Reconnected to OpenAI background response...` if

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,7 +2,7 @@
 
 - Unit/type tests: `pnpm test` (Vitest) and `pnpm run check` (typecheck).
 - Gemini unit/regression: `pnpm vitest run tests/gemini.test.ts tests/gemini-web`.
-- Browser smokes: `pnpm test:browser` (builds, checks DevTools port 45871, then runs headful browser smokes with GPT-5.2 for most cases and GPT-5.4 Pro for the reattach + markdown checks). Requires a signed-in Chrome profile; runs headful but hides the window by default unless Chrome forces focus.
+- Browser smokes: `pnpm test:browser` (builds, checks DevTools port 45871, then runs headful browser smokes with the `gpt-5.2-instant` alias for fast path checks and GPT-5.4 Pro for the actual Pro/reattach + markdown checks). Requires a signed-in Chrome profile; runs headful but hides the window by default unless Chrome forces focus.
 - Live API smokes: `ORACLE_LIVE_TEST=1 OPENAI_API_KEY=… pnpm test:live` (excludes OpenAI pro), `ORACLE_LIVE_TEST=1 OPENAI_API_KEY=… pnpm test:pro` (OpenAI pro live). Expect real usage/cost.
 - Gemini web (cookie) live smoke: `ORACLE_LIVE_TEST=1 pnpm vitest run tests/live/gemini-web-live.test.ts` (requires a signed-in Chrome profile at `gemini.google.com`).
 - MCP focused: `pnpm test:mcp` (builds then stdio smoke via mcporter).

--- a/scripts/browser-smoke-upload-only.sh
+++ b/scripts/browser-smoke-upload-only.sh
@@ -3,12 +3,39 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CMD=(node "$ROOT/dist/bin/oracle-cli.js" --engine browser --wait --heartbeat 0 --timeout 900 --browser-input-timeout 120000)
-FAST_MODEL="gpt-5.2"
+FAST_MODEL="gpt-5.2-instant"
+
+run_and_check_contains() {
+  local label="$1"
+  local expected="$2"
+  shift 2
+  local logfile
+  logfile="$(mktemp -t oracle-browser-smoke-log)"
+  if ! "$@" >"$logfile" 2>&1; then
+    echo "[browser-smoke-upload-only] ${label}: command failed"
+    cat "$logfile"
+    rm -f "$logfile"
+    exit 1
+  fi
+  if ! grep -Fq -- "$expected" "$logfile"; then
+    echo "[browser-smoke-upload-only] ${label}: expected output missing: $expected"
+    cat "$logfile"
+    rm -f "$logfile"
+    exit 1
+  fi
+  cat "$logfile"
+  rm -f "$logfile"
+}
 
 tmpfile="$(mktemp -t oracle-browser-smoke)"
 echo "smoke-attachment" >"$tmpfile"
 
 echo "[browser-smoke-upload-only] fast upload attachment (non-inline)"
-"${CMD[@]}" --model "$FAST_MODEL" --prompt "Read the attached file and return exactly one markdown bullet '- upload: <content>' where <content> is the file text." --file "$tmpfile" --slug browser-smoke-upload --force
+run_and_check_contains \
+  "fast upload attachment (non-inline)" \
+  "upload=smoke-attachment" \
+  "${CMD[@]}" --model "$FAST_MODEL" \
+  --prompt "Return exactly one line and nothing else: upload=smoke-attachment" \
+  --file "$tmpfile" --slug browser-smoke-upload --force
 
 rm -f "$tmpfile"

--- a/scripts/browser-smoke.sh
+++ b/scripts/browser-smoke.sh
@@ -3,25 +3,89 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CMD=(node "$ROOT/dist/bin/oracle-cli.js" --engine browser --wait --heartbeat 0 --timeout 900 --browser-input-timeout 120000)
-FAST_MODEL="${ORACLE_BROWSER_SMOKE_FAST_MODEL:-gpt-5.2}"
+FAST_MODEL="${ORACLE_BROWSER_SMOKE_FAST_MODEL:-gpt-5.2-instant}"
 PRO_MODEL="${ORACLE_BROWSER_SMOKE_PRO_MODEL:-gpt-5.4-pro}"
+# FAST_MODEL is for quick browser-path health checks only.
+# PRO_MODEL is kept separate for real Pro/reattach coverage.
+
+assert_output_contains() {
+  local label="$1"
+  local logfile="$2"
+  shift 2
+  for needle in "$@"; do
+    if ! grep -Fq -- "$needle" "$logfile"; then
+      echo "[browser-smoke] ${label}: expected output missing: $needle"
+      cat "$logfile"
+      rm -f "$logfile"
+      exit 1
+    fi
+  done
+}
+
+run_and_check_contains() {
+  local label="$1"
+  shift
+  local expectations=()
+  while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do
+    expectations+=("$1")
+    shift
+  done
+  shift
+  local logfile
+  logfile="$(mktemp -t oracle-browser-smoke-log)"
+  if ! "$@" >"$logfile" 2>&1; then
+    echo "[browser-smoke] ${label}: command failed"
+    cat "$logfile"
+    rm -f "$logfile"
+    exit 1
+  fi
+  assert_output_contains "$label" "$logfile" "${expectations[@]}"
+  cat "$logfile"
+  rm -f "$logfile"
+}
 
 tmpfile="$(mktemp -t oracle-browser-smoke)"
 echo "smoke-attachment" >"$tmpfile"
 
-echo "[browser-smoke] fast upload attachment (non-inline)"
-"${CMD[@]}" --model "$FAST_MODEL" --browser-attachments always --prompt "Read the attached file and return exactly one markdown bullet '- upload: <content>' where <content> is the file text." --file "$tmpfile" --slug browser-smoke-upload --force
+echo "[browser-smoke][fast] upload attachment (non-inline)"
+run_and_check_contains \
+  "fast upload attachment (non-inline)" \
+  "upload=smoke-attachment" \
+  -- \
+  "${CMD[@]}" --model "$FAST_MODEL" --browser-attachments always \
+  --prompt "Return exactly one line and nothing else: upload=smoke-attachment" \
+  --file "$tmpfile" --slug browser-smoke-upload --force
 
-echo "[browser-smoke] fast simple"
-"${CMD[@]}" --model "$FAST_MODEL" --prompt "Return exactly one markdown bullet: '- pro-ok'." --slug browser-smoke-pro --force
+echo "[browser-smoke][fast] simple"
+run_and_check_contains \
+  "fast simple" \
+  "pro-ok" \
+  -- \
+  "${CMD[@]}" --model "$FAST_MODEL" \
+  --prompt "Return exactly one line and nothing else: pro-ok" \
+  --slug browser-smoke-pro --force
 
-echo "[browser-smoke] fast with attachment preview (inline)"
-"${CMD[@]}" --model "$FAST_MODEL" --browser-inline-files --prompt "Read the attached file and return exactly one markdown bullet '- file: <content>' where <content> is the file text." --file "$tmpfile" --slug browser-smoke-file --preview --force
+echo "[browser-smoke][fast] attachment preview (inline)"
+run_and_check_contains \
+  "fast with attachment preview (inline)" \
+  "file=smoke-attachment" \
+  -- \
+  "${CMD[@]}" --model "$FAST_MODEL" --browser-inline-files \
+  --prompt "Return exactly one line and nothing else: file=smoke-attachment" \
+  --file "$tmpfile" --slug browser-smoke-file --preview --force
 
-echo "[browser-smoke] pro standard markdown check"
-"${CMD[@]}" --model "$PRO_MODEL" --prompt "Return two markdown bullets and a fenced code block labeled js that logs 'thinking-ok'." --slug browser-smoke-thinking --force
+echo "[browser-smoke][pro] standard markdown check"
+run_and_check_contains \
+  "pro standard markdown check" \
+  '```js' \
+  "console.log('thinking-ok')" \
+  '```' \
+  -- \
+  "${CMD[@]}" --model "$PRO_MODEL" \
+  --prompt $'Return exactly these three lines and nothing else:\n```js\nconsole.log('\''thinking-ok'\'')\n```' \
+  --slug browser-smoke-thinking --force
 
-echo "[browser-smoke] reattach flow after controller loss"
+echo "[browser-smoke][pro] reattach flow after controller loss"
 slug="browser-reattach-smoke"
 meta="$HOME/.oracle/sessions/$slug/meta.json"
 logfile="$(mktemp -t oracle-browser-reattach)"

--- a/src/browser/actions/assistantResponse.ts
+++ b/src/browser/actions/assistantResponse.ts
@@ -39,6 +39,7 @@ export async function waitForAssistantResponse(
   timeoutMs: number,
   logger: BrowserLogger,
   minTurnIndex?: number,
+  expectedConversationId?: string,
 ): Promise<{
   text: string;
   html?: string;
@@ -49,7 +50,11 @@ export async function waitForAssistantResponse(
   // Learned: two paths are needed:
   // 1) DOM observer (fast when mutations fire),
   // 2) snapshot poller (fallback when observers miss or JS stalls).
-  const expression = buildResponseObserverExpression(timeoutMs, minTurnIndex);
+  const expression = buildResponseObserverExpression(
+    timeoutMs,
+    minTurnIndex,
+    expectedConversationId,
+  );
   const evaluationPromise = Runtime.evaluate({
     expression,
     awaitPromise: true,
@@ -68,6 +73,7 @@ export async function waitForAssistantResponse(
     Runtime,
     timeoutMs,
     minTurnIndex,
+    expectedConversationId,
     pollerAbort.signal,
   ).then(
     (value) => ({ kind: "poll" as const, value }),
@@ -108,7 +114,13 @@ export async function waitForAssistantResponse(
       } else if (source === "poll") {
         throw error;
       } else if (source === "evaluation") {
-        const recovered = await recoverAssistantResponse(Runtime, timeoutMs, logger, minTurnIndex);
+        const recovered = await recoverAssistantResponse(
+          Runtime,
+          timeoutMs,
+          logger,
+          minTurnIndex,
+          expectedConversationId,
+        );
         if (recovered) {
           return recovered;
         }
@@ -129,7 +141,13 @@ export async function waitForAssistantResponse(
   if (!parsed) {
     let remainingMs = Math.max(0, timeoutMs - (Date.now() - start));
     if (remainingMs > 0) {
-      const recovered = await recoverAssistantResponse(Runtime, remainingMs, logger, minTurnIndex);
+      const recovered = await recoverAssistantResponse(
+        Runtime,
+        remainingMs,
+        logger,
+        minTurnIndex,
+        expectedConversationId,
+      );
       if (recovered) {
         return recovered;
       }
@@ -148,7 +166,13 @@ export async function waitForAssistantResponse(
     throw new Error("Unable to capture assistant response");
   }
 
-  const refreshed = await refreshAssistantSnapshot(Runtime, parsed, logger, minTurnIndex);
+  const refreshed = await refreshAssistantSnapshot(
+    Runtime,
+    parsed,
+    logger,
+    minTurnIndex,
+    expectedConversationId,
+  );
   const candidate = refreshed ?? parsed;
   // The evaluation path can race ahead of completion. If ChatGPT is still streaming, wait for the watchdog poller.
   const elapsedMs = Date.now() - start;
@@ -160,7 +184,12 @@ export async function waitForAssistantResponse(
     ]);
     if (stopVisible) {
       logger("Assistant still generating; waiting for completion");
-      const completed = await pollAssistantCompletion(Runtime, remainingMs, minTurnIndex);
+      const completed = await pollAssistantCompletion(
+        Runtime,
+        remainingMs,
+        minTurnIndex,
+        expectedConversationId,
+      );
       if (completed) {
         return completed;
       }
@@ -175,9 +204,10 @@ export async function waitForAssistantResponse(
 export async function readAssistantSnapshot(
   Runtime: ChromeClient["Runtime"],
   minTurnIndex?: number,
+  expectedConversationId?: string,
 ): Promise<AssistantSnapshot | null> {
   const { result } = await Runtime.evaluate({
-    expression: buildAssistantSnapshotExpression(minTurnIndex),
+    expression: buildAssistantSnapshotExpression(minTurnIndex, expectedConversationId),
     returnByValue: true,
   });
   const value = result?.value;
@@ -225,6 +255,13 @@ export function buildAssistantExtractorForTest(name: string): string {
   return buildAssistantExtractor(name);
 }
 
+export function buildAssistantSnapshotExpressionForTest(
+  minTurnIndex?: number,
+  expectedConversationId?: string,
+): string {
+  return buildAssistantSnapshotExpression(minTurnIndex, expectedConversationId);
+}
+
 export function buildConversationDebugExpressionForTest(): string {
   return buildConversationDebugExpression();
 }
@@ -244,6 +281,7 @@ async function recoverAssistantResponse(
   timeoutMs: number,
   logger: BrowserLogger,
   minTurnIndex?: number,
+  expectedConversationId?: string,
 ): Promise<{
   text: string;
   html?: string;
@@ -255,7 +293,7 @@ async function recoverAssistantResponse(
   }
   const recovered = await waitForCondition(
     async () => {
-      const snapshot = await readAssistantSnapshot(Runtime, minTurnIndex);
+      const snapshot = await readAssistantSnapshot(Runtime, minTurnIndex, expectedConversationId);
       return normalizeAssistantSnapshot(snapshot);
     },
     recoveryTimeoutMs,
@@ -324,6 +362,7 @@ async function refreshAssistantSnapshot(
   },
   logger: BrowserLogger,
   minTurnIndex?: number,
+  expectedConversationId?: string,
 ): Promise<{
   text: string;
   html?: string;
@@ -339,7 +378,11 @@ async function refreshAssistantSnapshot(
   const stableTarget = 3;
   while (Date.now() < deadline) {
     // Learned: short/fast answers can race; poll a few extra cycles to pick up messageId + full text.
-    const latestSnapshot = await readAssistantSnapshot(Runtime, minTurnIndex).catch(() => null);
+    const latestSnapshot = await readAssistantSnapshot(
+      Runtime,
+      minTurnIndex,
+      expectedConversationId,
+    ).catch(() => null);
     const latest = normalizeAssistantSnapshot(latestSnapshot);
     if (latest) {
       if (
@@ -388,6 +431,7 @@ async function pollAssistantCompletion(
   Runtime: ChromeClient["Runtime"],
   timeoutMs: number,
   minTurnIndex?: number,
+  expectedConversationId?: string,
   abortSignal?: AbortSignal,
 ): Promise<{
   text: string;
@@ -403,7 +447,7 @@ async function pollAssistantCompletion(
     if (abortSignal?.aborted) {
       return null;
     }
-    const snapshot = await readAssistantSnapshot(Runtime, minTurnIndex);
+    const snapshot = await readAssistantSnapshot(Runtime, minTurnIndex, expectedConversationId);
     const normalized = normalizeAssistantSnapshot(snapshot);
     if (normalized) {
       const currentLength = normalized.text.length;
@@ -545,13 +589,30 @@ async function waitForCondition<T>(
   return null;
 }
 
-function buildAssistantSnapshotExpression(minTurnIndex?: number): string {
+function buildAssistantSnapshotExpression(
+  minTurnIndex?: number,
+  expectedConversationId?: string,
+): string {
   const minTurnLiteral =
     typeof minTurnIndex === "number" && Number.isFinite(minTurnIndex) && minTurnIndex >= 0
       ? Math.floor(minTurnIndex)
       : -1;
+  const expectedConversationLiteral =
+    typeof expectedConversationId === "string" && expectedConversationId.trim().length > 0
+      ? JSON.stringify(expectedConversationId.trim())
+      : "null";
   return `(() => {
     const MIN_TURN_INDEX = ${minTurnLiteral};
+    const EXPECTED_CONVERSATION_ID = ${expectedConversationLiteral};
+    const currentHref = typeof location === 'object' && location.href ? location.href : '';
+    const currentConversationId = currentHref.match(/\\/c\\/([a-zA-Z0-9-]+)/)?.[1] ?? null;
+    if (
+      EXPECTED_CONVERSATION_ID &&
+      currentConversationId &&
+      currentConversationId !== EXPECTED_CONVERSATION_ID
+    ) {
+      return null;
+    }
     // Learned: the default turn DOM misses project view; keep a fallback extractor.
     ${buildAssistantExtractor("extractAssistantTurn")}
     const extracted = extractAssistantTurn();
@@ -572,7 +633,11 @@ function buildAssistantSnapshotExpression(minTurnIndex?: number): string {
   })()`;
 }
 
-function buildResponseObserverExpression(timeoutMs: number, minTurnIndex?: number): string {
+function buildResponseObserverExpression(
+  timeoutMs: number,
+  minTurnIndex?: number,
+  expectedConversationId?: string,
+): string {
   const selectorsLiteral = JSON.stringify(ANSWER_SELECTORS);
   const conversationLiteral = JSON.stringify(CONVERSATION_TURN_SELECTOR);
   const assistantLiteral = JSON.stringify(ASSISTANT_ROLE_SELECTOR);
@@ -580,6 +645,10 @@ function buildResponseObserverExpression(timeoutMs: number, minTurnIndex?: numbe
     typeof minTurnIndex === "number" && Number.isFinite(minTurnIndex) && minTurnIndex >= 0
       ? Math.floor(minTurnIndex)
       : -1;
+  const expectedConversationLiteral =
+    typeof expectedConversationId === "string" && expectedConversationId.trim().length > 0
+      ? JSON.stringify(expectedConversationId.trim())
+      : "null";
   return `(() => {
     ${buildClickDispatcher()}
     const SELECTORS = ${selectorsLiteral};
@@ -587,8 +656,18 @@ function buildResponseObserverExpression(timeoutMs: number, minTurnIndex?: numbe
     const FINISHED_SELECTOR = '${FINISHED_ACTIONS_SELECTOR}';
     const CONVERSATION_SELECTOR = ${conversationLiteral};
     const ASSISTANT_SELECTOR = ${assistantLiteral};
+    const EXPECTED_CONVERSATION_ID = ${expectedConversationLiteral};
     // Learned: settling avoids capturing mid-stream HTML; keep short.
     const settleDelayMs = 800;
+    const currentConversationId = () => {
+      const href = typeof location === 'object' && location.href ? location.href : '';
+      return href.match(/\\/c\\/([a-zA-Z0-9-]+)/)?.[1] ?? null;
+    };
+    const matchesExpectedConversation = () => {
+      if (!EXPECTED_CONVERSATION_ID) return true;
+      const currentId = currentConversationId();
+      return !currentId || currentId === EXPECTED_CONVERSATION_ID;
+    };
     const isAnswerNowPlaceholder = (snapshot) => {
       const normalized = String(snapshot?.text ?? '').toLowerCase().trim();
       if (normalized === 'chatgpt said:' || normalized === 'chatgpt said') return true;
@@ -617,6 +696,9 @@ function buildResponseObserverExpression(timeoutMs: number, minTurnIndex?: numbe
 
     const acceptSnapshot = (snapshot) => {
       if (!snapshot) return null;
+      if (!matchesExpectedConversation()) {
+        return null;
+      }
       const index = typeof snapshot.turnIndex === 'number' ? snapshot.turnIndex : -1;
       if (MIN_TURN_INDEX >= 0) {
         if (index < 0 || index < MIN_TURN_INDEX) {

--- a/src/browser/actions/attachments.ts
+++ b/src/browser/actions/attachments.ts
@@ -1711,12 +1711,88 @@ export async function waitForUserTurnAttachments(
     options.expectedConversationId.trim().length > 0
       ? options.expectedConversationId.trim()
       : null;
+  const expression = buildUserTurnAttachmentExpression({
+    minTurnIndex,
+    expectedPromptPrefix,
+    expectedConversationId,
+  });
+
+  const deadline = Date.now() + timeoutMs;
+  let sawAttachmentUi = false;
+  while (Date.now() < deadline) {
+    const { result } = await Runtime.evaluate({ expression, returnByValue: true });
+    const value = result?.value as
+      | {
+          ok?: boolean;
+          text?: string;
+          attrs?: string[];
+          fileCount?: number;
+          hasAttachmentUi?: boolean;
+          attachmentUiCount?: number;
+          promptMatches?: boolean;
+          turnIndex?: number;
+          conversationMismatch?: boolean;
+        }
+      | undefined;
+    if (!value?.ok) {
+      if (value?.conversationMismatch && logger?.verbose) {
+        logger("User-turn attachment verification ignored mismatched conversation.");
+      }
+      await delay(200);
+      continue;
+    }
+    if (value.hasAttachmentUi) {
+      sawAttachmentUi = true;
+    }
+    const haystack = [value.text ?? "", ...(value.attrs ?? [])].join("\n");
+    const fileCount = typeof value.fileCount === "number" ? value.fileCount : 0;
+    const attachmentUiCount =
+      typeof value.attachmentUiCount === "number" ? value.attachmentUiCount : 0;
+    const promptMatches = expectedPromptPrefix ? value.promptMatches !== false : true;
+    const fileCountSatisfied =
+      fileCount >= expectedNormalized.length && expectedNormalized.length > 0;
+    const attachmentUiSatisfied =
+      attachmentUiCount >= expectedNormalized.length && expectedNormalized.length > 0;
+    const missing = expectedNormalized.filter((expected) => {
+      const baseName = expected.split("/").pop()?.split("\\").pop() ?? expected;
+      const normalizedExpected = baseName.toLowerCase().replace(/\s+/g, " ").trim();
+      const expectedNoExt = normalizedExpected.replace(/\.[a-z0-9]{1,10}$/i, "");
+      if (haystack.includes(normalizedExpected)) return false;
+      if (expectedNoExt.length >= 6 && haystack.includes(expectedNoExt)) return false;
+      return true;
+    });
+    if (promptMatches && (missing.length === 0 || fileCountSatisfied || attachmentUiSatisfied)) {
+      return true;
+    }
+    await delay(250);
+  }
+
+  if (!sawAttachmentUi) {
+    logger?.("Sent user message did not expose attachment UI; skipping attachment verification.");
+    return false;
+  }
+
+  logger?.("Sent user message did not show expected attachment names in time.");
+  await logDomFailure(Runtime, logger ?? (() => {}), "attachment-missing-user-turn");
+  throw new Error("Attachment was not present on the sent user message.");
+}
+
+function buildUserTurnAttachmentExpression(options: {
+  minTurnIndex: number | null;
+  expectedPromptPrefix: string;
+  expectedConversationId: string | null;
+}): string {
   const conversationSelectorLiteral = JSON.stringify(CONVERSATION_TURN_SELECTOR);
-  const expression = `(() => {
+  const minTurnLiteral = options.minTurnIndex === null ? "null" : String(options.minTurnIndex);
+  const expectedPromptLiteral = JSON.stringify(options.expectedPromptPrefix);
+  const expectedConversationLiteral = options.expectedConversationId
+    ? JSON.stringify(options.expectedConversationId)
+    : "null";
+  return `(() => {
     const CONVERSATION_SELECTOR = ${conversationSelectorLiteral};
-    const MIN_TURN_INDEX = ${minTurnIndex === null ? "null" : minTurnIndex};
-    const EXPECTED_PROMPT_PREFIX = ${JSON.stringify(expectedPromptPrefix)};
-    const EXPECTED_CONVERSATION_ID = ${expectedConversationId ? JSON.stringify(expectedConversationId) : "null"};
+    const MIN_TURN_INDEX = ${minTurnLiteral};
+    const EXPECTED_PROMPT_PREFIX = ${expectedPromptLiteral};
+    const EXPECTED_CONVERSATION_ID = ${expectedConversationLiteral};
     const currentHref = typeof location === 'object' && location.href ? location.href : '';
     const currentConversationId = currentHref.match(/\\/c\\/([a-zA-Z0-9-]+)/)?.[1] ?? null;
     if (
@@ -1737,10 +1813,12 @@ export async function waitForUserTurnAttachments(
     const lastUser = eligibleTurns[eligibleTurns.length - 1];
     if (!lastUser) return { ok: false };
     const text = (lastUser.node.innerText || '').toLowerCase().replace(/\\s+/g, ' ').trim();
+    const textPrefix = text.slice(0, Math.min(text.length, EXPECTED_PROMPT_PREFIX.length));
     const promptMatches =
       !EXPECTED_PROMPT_PREFIX ||
-      text.includes(EXPECTED_PROMPT_PREFIX) ||
-      EXPECTED_PROMPT_PREFIX.includes(text.slice(0, Math.min(text.length, EXPECTED_PROMPT_PREFIX.length)));
+      (text.length > 0 &&
+        (text.includes(EXPECTED_PROMPT_PREFIX) ||
+          (textPrefix.length > 0 && EXPECTED_PROMPT_PREFIX.includes(textPrefix))));
     const attrs = Array.from(lastUser.node.querySelectorAll('[aria-label],[title]')).map((el) => {
       const aria = el.getAttribute('aria-label') || '';
       const title = el.getAttribute('title') || '';
@@ -1803,65 +1881,25 @@ export async function waitForUserTurnAttachments(
       turnIndex: lastUser.index,
     };
   })()`;
+}
 
-  const deadline = Date.now() + timeoutMs;
-  let sawAttachmentUi = false;
-  while (Date.now() < deadline) {
-    const { result } = await Runtime.evaluate({ expression, returnByValue: true });
-    const value = result?.value as
-      | {
-          ok?: boolean;
-          text?: string;
-          attrs?: string[];
-          fileCount?: number;
-          hasAttachmentUi?: boolean;
-          attachmentUiCount?: number;
-          promptMatches?: boolean;
-          turnIndex?: number;
-          conversationMismatch?: boolean;
-        }
-      | undefined;
-    if (!value?.ok) {
-      if (value?.conversationMismatch && logger?.verbose) {
-        logger("User-turn attachment verification ignored mismatched conversation.");
-      }
-      await delay(200);
-      continue;
-    }
-    if (value.hasAttachmentUi) {
-      sawAttachmentUi = true;
-    }
-    const haystack = [value.text ?? "", ...(value.attrs ?? [])].join("\n");
-    const fileCount = typeof value.fileCount === "number" ? value.fileCount : 0;
-    const attachmentUiCount =
-      typeof value.attachmentUiCount === "number" ? value.attachmentUiCount : 0;
-    const promptMatches = expectedPromptPrefix ? value.promptMatches !== false : true;
-    const fileCountSatisfied =
-      fileCount >= expectedNormalized.length && expectedNormalized.length > 0;
-    const attachmentUiSatisfied =
-      attachmentUiCount >= expectedNormalized.length && expectedNormalized.length > 0;
-    const missing = expectedNormalized.filter((expected) => {
-      const baseName = expected.split("/").pop()?.split("\\").pop() ?? expected;
-      const normalizedExpected = baseName.toLowerCase().replace(/\s+/g, " ").trim();
-      const expectedNoExt = normalizedExpected.replace(/\.[a-z0-9]{1,10}$/i, "");
-      if (haystack.includes(normalizedExpected)) return false;
-      if (expectedNoExt.length >= 6 && haystack.includes(expectedNoExt)) return false;
-      return true;
-    });
-    if (promptMatches && (missing.length === 0 || fileCountSatisfied || attachmentUiSatisfied)) {
-      return true;
-    }
-    await delay(250);
-  }
-
-  if (!sawAttachmentUi) {
-    logger?.("Sent user message did not expose attachment UI; skipping attachment verification.");
-    return false;
-  }
-
-  logger?.("Sent user message did not show expected attachment names in time.");
-  await logDomFailure(Runtime, logger ?? (() => {}), "attachment-missing-user-turn");
-  throw new Error("Attachment was not present on the sent user message.");
+export function buildUserTurnAttachmentExpressionForTest(options?: {
+  minTurnIndex?: number | null;
+  expectedPromptPrefix?: string;
+  expectedConversationId?: string | null;
+}): string {
+  return buildUserTurnAttachmentExpression({
+    minTurnIndex:
+      typeof options?.minTurnIndex === "number" && Number.isFinite(options.minTurnIndex)
+        ? Math.max(0, Math.floor(options.minTurnIndex))
+        : null,
+    expectedPromptPrefix: options?.expectedPromptPrefix ?? "",
+    expectedConversationId:
+      typeof options?.expectedConversationId === "string" &&
+      options.expectedConversationId.trim().length > 0
+        ? options.expectedConversationId.trim()
+        : null,
+  });
 }
 
 export async function waitForAttachmentVisible(

--- a/src/browser/actions/attachments.ts
+++ b/src/browser/actions/attachments.ts
@@ -1688,25 +1688,60 @@ export async function waitForUserTurnAttachments(
   expectedNames: string[],
   timeoutMs: number,
   logger?: BrowserLogger,
+  options?: {
+    minTurnIndex?: number;
+    expectedPrompt?: string;
+    expectedConversationId?: string;
+  },
 ): Promise<boolean> {
   if (!expectedNames || expectedNames.length === 0) {
     return true;
   }
 
   const expectedNormalized = expectedNames.map((name) => name.toLowerCase());
+  const minTurnIndex =
+    typeof options?.minTurnIndex === "number" && Number.isFinite(options.minTurnIndex)
+      ? Math.max(0, Math.floor(options.minTurnIndex))
+      : null;
+  const expectedPromptPrefix = options?.expectedPrompt
+    ? options.expectedPrompt.toLowerCase().replace(/\s+/g, " ").trim().slice(0, 80)
+    : "";
+  const expectedConversationId =
+    typeof options?.expectedConversationId === "string" &&
+    options.expectedConversationId.trim().length > 0
+      ? options.expectedConversationId.trim()
+      : null;
   const conversationSelectorLiteral = JSON.stringify(CONVERSATION_TURN_SELECTOR);
   const expression = `(() => {
     const CONVERSATION_SELECTOR = ${conversationSelectorLiteral};
+    const MIN_TURN_INDEX = ${minTurnIndex === null ? "null" : minTurnIndex};
+    const EXPECTED_PROMPT_PREFIX = ${JSON.stringify(expectedPromptPrefix)};
+    const EXPECTED_CONVERSATION_ID = ${expectedConversationId ? JSON.stringify(expectedConversationId) : "null"};
+    const currentHref = typeof location === 'object' && location.href ? location.href : '';
+    const currentConversationId = currentHref.match(/\\/c\\/([a-zA-Z0-9-]+)/)?.[1] ?? null;
+    if (
+      EXPECTED_CONVERSATION_ID &&
+      currentConversationId &&
+      currentConversationId !== EXPECTED_CONVERSATION_ID
+    ) {
+      return { ok: false, conversationMismatch: true };
+    }
     const turns = Array.from(document.querySelectorAll(CONVERSATION_SELECTOR));
-    const userTurns = turns.filter((node) => {
+    const userTurns = turns.map((node, index) => ({ node, index })).filter(({ node }) => {
       const attr = (node.getAttribute('data-message-author-role') || node.getAttribute('data-turn') || node.dataset?.turn || '').toLowerCase();
       if (attr === 'user') return true;
       return Boolean(node.querySelector('[data-message-author-role="user"]'));
     });
-    const lastUser = userTurns[userTurns.length - 1];
+    const eligibleTurns =
+      MIN_TURN_INDEX === null ? userTurns : userTurns.filter(({ index }) => index >= MIN_TURN_INDEX);
+    const lastUser = eligibleTurns[eligibleTurns.length - 1];
     if (!lastUser) return { ok: false };
-    const text = (lastUser.innerText || '').toLowerCase();
-    const attrs = Array.from(lastUser.querySelectorAll('[aria-label],[title]')).map((el) => {
+    const text = (lastUser.node.innerText || '').toLowerCase().replace(/\\s+/g, ' ').trim();
+    const promptMatches =
+      !EXPECTED_PROMPT_PREFIX ||
+      text.includes(EXPECTED_PROMPT_PREFIX) ||
+      EXPECTED_PROMPT_PREFIX.includes(text.slice(0, Math.min(text.length, EXPECTED_PROMPT_PREFIX.length)));
+    const attrs = Array.from(lastUser.node.querySelectorAll('[aria-label],[title]')).map((el) => {
       const aria = el.getAttribute('aria-label') || '';
       const title = el.getAttribute('title') || '';
       return (aria + ' ' + title).trim().toLowerCase();
@@ -1720,11 +1755,11 @@ export async function waitForUserTurnAttachments(
       '[title*="file"]',
       '[title*="attachment"]',
     ];
-    const attachmentUiCount = lastUser.querySelectorAll(attachmentSelectors.join(',')).length;
+    const attachmentUiCount = lastUser.node.querySelectorAll(attachmentSelectors.join(',')).length;
     const hasAttachmentUi =
       attachmentUiCount > 0 || attrs.some((attr) => attr.includes('file') || attr.includes('attachment'));
     const countRegex = /(?:^|\\b)(\\d+)\\s+(?:files?|attachments?)\\b/;
-    const fileCountNodes = Array.from(lastUser.querySelectorAll('button,span,div,[aria-label],[title]'));
+    const fileCountNodes = Array.from(lastUser.node.querySelectorAll('button,span,div,[aria-label],[title]'));
     let fileCount = 0;
     for (const node of fileCountNodes) {
       if (!(node instanceof HTMLElement)) continue;
@@ -1757,7 +1792,16 @@ export async function waitForUserTurnAttachments(
         }
       }
     }
-    return { ok: true, text, attrs, fileCount, hasAttachmentUi, attachmentUiCount };
+    return {
+      ok: true,
+      text,
+      attrs,
+      fileCount,
+      hasAttachmentUi,
+      attachmentUiCount,
+      promptMatches,
+      turnIndex: lastUser.index,
+    };
   })()`;
 
   const deadline = Date.now() + timeoutMs;
@@ -1772,9 +1816,15 @@ export async function waitForUserTurnAttachments(
           fileCount?: number;
           hasAttachmentUi?: boolean;
           attachmentUiCount?: number;
+          promptMatches?: boolean;
+          turnIndex?: number;
+          conversationMismatch?: boolean;
         }
       | undefined;
     if (!value?.ok) {
+      if (value?.conversationMismatch && logger?.verbose) {
+        logger("User-turn attachment verification ignored mismatched conversation.");
+      }
       await delay(200);
       continue;
     }
@@ -1785,6 +1835,7 @@ export async function waitForUserTurnAttachments(
     const fileCount = typeof value.fileCount === "number" ? value.fileCount : 0;
     const attachmentUiCount =
       typeof value.attachmentUiCount === "number" ? value.attachmentUiCount : 0;
+    const promptMatches = expectedPromptPrefix ? value.promptMatches !== false : true;
     const fileCountSatisfied =
       fileCount >= expectedNormalized.length && expectedNormalized.length > 0;
     const attachmentUiSatisfied =
@@ -1797,7 +1848,7 @@ export async function waitForUserTurnAttachments(
       if (expectedNoExt.length >= 6 && haystack.includes(expectedNoExt)) return false;
       return true;
     });
-    if (missing.length === 0 || fileCountSatisfied || attachmentUiSatisfied) {
+    if (promptMatches && (missing.length === 0 || fileCountSatisfied || attachmentUiSatisfied)) {
       return true;
     }
     await delay(250);

--- a/src/browser/actions/modelSelection.ts
+++ b/src/browser/actions/modelSelection.ts
@@ -45,7 +45,7 @@ export async function ensureModelSelection(
       const availableHint = available.length > 0 ? ` Available: ${available.join(", ")}.` : "";
       const tempHint =
         isTemporary && /\bpro\b/i.test(desiredModel)
-          ? ' You are in Temporary Chat mode; Pro models are not available there. Remove "temporary-chat=true" from --chatgpt-url or use a non-Pro model (e.g. gpt-5.2).'
+          ? ' You are in Temporary Chat mode; Pro models are not available there. Remove "temporary-chat=true" from --chatgpt-url or use a non-Pro model (e.g. gpt-5.2-instant).'
           : "";
       throw new Error(
         `Unable to find model option matching "${desiredModel}" in the model switcher.${availableHint}${tempHint}`,
@@ -456,6 +456,24 @@ function buildModelMatchersLiteral(targetModel: string): {
     testIdTokens.add("gpt-5-4");
     testIdTokens.add("gpt5-4");
     testIdTokens.add("gpt54");
+  }
+  // Numeric variations (5.3 ↔ 53 ↔ gpt-5-3)
+  if (base.includes("5.3") || base.includes("5-3") || base.includes("53")) {
+    push("5.3", labelTokens);
+    push("gpt-5.3", labelTokens);
+    push("gpt5.3", labelTokens);
+    push("gpt-5-3", labelTokens);
+    push("gpt5-3", labelTokens);
+    push("gpt53", labelTokens);
+    push("chatgpt 5.3", labelTokens);
+    if (base.includes("instant")) {
+      testIdTokens.add("model-switcher-gpt-5-3-instant");
+      testIdTokens.add("gpt-5-3-instant");
+      testIdTokens.add("gpt-5.3-instant");
+    }
+    testIdTokens.add("gpt-5-3");
+    testIdTokens.add("gpt5-3");
+    testIdTokens.add("gpt53");
   }
   // Numeric variations (5.1 ↔ 51 ↔ gpt-5-1)
   if (base.includes("5.1") || base.includes("5-1") || base.includes("51")) {

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -20,6 +20,250 @@ const ENTER_KEY_EVENT = {
   nativeVirtualKeyCode: 13,
 } as const;
 const ENTER_KEY_TEXT = "\r";
+const PROMPT_TRUNCATION_CHECK_THRESHOLD = 20_000;
+const PROMPT_TRUNCATION_TOLERANCE = 500;
+const COMPOSER_HEALTH_SENTINEL = "__oracle_healthcheck__";
+
+interface ComposerSnapshot {
+  editorText: string;
+  fallbackValue: string;
+  activeValue: string;
+  activeExists: boolean;
+  activeVisible: boolean;
+  activeDisabled: boolean;
+  activeReadOnly: boolean;
+  activeTagName: string;
+  activeRole: string;
+  href: string;
+}
+
+interface ComposerHealthState {
+  healthy: boolean;
+  reason?: string;
+  activeExists: boolean;
+  activeVisible: boolean;
+  activeDisabled: boolean;
+  activeReadOnly: boolean;
+  activeTagName: string;
+  activeRole: string;
+  href: string;
+}
+
+function normalizeComposerSnapshot(
+  value: Partial<ComposerSnapshot> | undefined,
+): ComposerSnapshot {
+  return {
+    editorText: typeof value?.editorText === "string" ? value.editorText : "",
+    fallbackValue: typeof value?.fallbackValue === "string" ? value.fallbackValue : "",
+    activeValue: typeof value?.activeValue === "string" ? value.activeValue : "",
+    activeExists: Boolean(value?.activeExists),
+    activeVisible: Boolean(value?.activeVisible),
+    activeDisabled: Boolean(value?.activeDisabled),
+    activeReadOnly: Boolean(value?.activeReadOnly),
+    activeTagName: typeof value?.activeTagName === "string" ? value.activeTagName : "",
+    activeRole: typeof value?.activeRole === "string" ? value.activeRole : "",
+    href: typeof value?.href === "string" ? value.href : "",
+  };
+}
+
+function buildComposerSnapshotExpression(): string {
+  return `(() => {
+    const editor = document.querySelector(${JSON.stringify(PROMPT_PRIMARY_SELECTOR)});
+    const fallback = document.querySelector(${JSON.stringify(PROMPT_FALLBACK_SELECTOR)});
+    const inputSelectors = ${JSON.stringify(INPUT_SELECTORS)};
+    const readValue = (node) => {
+      if (!node) return '';
+      if (node instanceof HTMLTextAreaElement) return node.value ?? '';
+      return node.innerText ?? '';
+    };
+    const isVisible = (node) => {
+      if (!node || typeof node.getBoundingClientRect !== 'function') return false;
+      const rect = node.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    };
+    const candidates = inputSelectors
+      .map((selector) => document.querySelector(selector))
+      .filter((node) => Boolean(node));
+    const active = candidates.find((node) => isVisible(node)) || candidates[0] || null;
+    return {
+      editorText: editor?.innerText ?? '',
+      fallbackValue: fallback instanceof HTMLTextAreaElement ? fallback.value ?? '' : '',
+      activeValue: active ? readValue(active) : '',
+      activeExists: Boolean(active),
+      activeVisible: isVisible(active),
+      activeDisabled: Boolean(
+        active &&
+          (((active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) &&
+            active.disabled) ||
+            active.getAttribute?.('aria-disabled') === 'true' ||
+            active.getAttribute?.('disabled') !== null),
+      ),
+      activeReadOnly: Boolean(
+        active &&
+          (((active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) &&
+            active.readOnly) ||
+            active.getAttribute?.('readonly') !== null ||
+            active.getAttribute?.('contenteditable') === 'false'),
+      ),
+      activeTagName: active?.tagName?.toLowerCase?.() ?? '',
+      activeRole: active?.getAttribute?.('role') ?? '',
+      href: typeof location === 'object' && location.href ? location.href : '',
+    };
+  })()`;
+}
+
+async function readComposerSnapshot(
+  runtime: ChromeClient["Runtime"],
+): Promise<ComposerSnapshot> {
+  const result = await runtime.evaluate({
+    expression: buildComposerSnapshotExpression(),
+    returnByValue: true,
+  });
+  return normalizeComposerSnapshot(result.result?.value as Partial<ComposerSnapshot> | undefined);
+}
+
+async function ensureComposerHealthy(
+  runtime: ChromeClient["Runtime"],
+  logger: BrowserLogger,
+): Promise<void> {
+  const result = await runtime.evaluate({
+    expression: `(() => {
+      ${buildClickDispatcher()}
+      const selectors = ${JSON.stringify(INPUT_SELECTORS)};
+      const sentinel = ${JSON.stringify(COMPOSER_HEALTH_SENTINEL)};
+      const isVisible = (node) => {
+        if (!node || typeof node.getBoundingClientRect !== 'function') return false;
+        const rect = node.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      };
+      const readValue = (node) => {
+        if (!node) return '';
+        if (node instanceof HTMLTextAreaElement) return node.value ?? '';
+        return node.innerText ?? '';
+      };
+      const candidates = selectors
+        .map((selector) => document.querySelector(selector))
+        .filter((node) => Boolean(node));
+      const active = candidates.find((node) => isVisible(node)) || candidates[0] || null;
+      const href = typeof location === 'object' && location.href ? location.href : '';
+      if (!active) {
+        return {
+          healthy: false,
+          reason: 'missing-active-input',
+          activeExists: false,
+          activeVisible: false,
+          activeDisabled: false,
+          activeReadOnly: false,
+          activeTagName: '',
+          activeRole: '',
+          href,
+        };
+      }
+      dispatchClickSequence(active);
+      if (typeof active.focus === 'function') {
+        active.focus();
+      }
+      const activeDisabled =
+        ((active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) &&
+          active.disabled) ||
+        active.getAttribute?.('aria-disabled') === 'true' ||
+        active.getAttribute?.('disabled') !== null;
+      const activeReadOnly =
+        ((active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) &&
+          active.readOnly) ||
+        active.getAttribute?.('readonly') !== null ||
+        active.getAttribute?.('contenteditable') === 'false';
+      if (activeDisabled || activeReadOnly) {
+        return {
+          healthy: false,
+          reason: activeDisabled ? 'active-input-disabled' : 'active-input-readonly',
+          activeExists: true,
+          activeVisible: isVisible(active),
+          activeDisabled: Boolean(activeDisabled),
+          activeReadOnly: Boolean(activeReadOnly),
+          activeTagName: active.tagName?.toLowerCase?.() ?? '',
+          activeRole: active.getAttribute?.('role') ?? '',
+          href,
+        };
+      }
+      const before = readValue(active);
+      const probe = before + sentinel;
+      let after = before;
+      try {
+        if (active instanceof HTMLTextAreaElement) {
+          active.value = probe;
+          active.dispatchEvent(new InputEvent('input', { bubbles: true, data: sentinel, inputType: 'insertText' }));
+          active.dispatchEvent(new Event('change', { bubbles: true }));
+          after = active.value ?? '';
+          active.value = before;
+          active.dispatchEvent(new InputEvent('input', { bubbles: true, data: '', inputType: 'deleteByCut' }));
+          active.dispatchEvent(new Event('change', { bubbles: true }));
+        } else {
+          active.textContent = probe;
+          active.dispatchEvent(new InputEvent('input', { bubbles: true, data: sentinel, inputType: 'insertText' }));
+          after = readValue(active);
+          active.textContent = before;
+          active.dispatchEvent(new InputEvent('input', { bubbles: true, data: '', inputType: 'deleteByCut' }));
+        }
+      } catch (error) {
+        return {
+          healthy: false,
+          reason: error instanceof Error ? error.message : String(error),
+          activeExists: true,
+          activeVisible: isVisible(active),
+          activeDisabled: Boolean(activeDisabled),
+          activeReadOnly: Boolean(activeReadOnly),
+          activeTagName: active.tagName?.toLowerCase?.() ?? '',
+          activeRole: active.getAttribute?.('role') ?? '',
+          href,
+        };
+      }
+      return {
+        healthy: typeof after === 'string' && after.includes(sentinel),
+        reason:
+          typeof after === 'string' && after.includes(sentinel)
+            ? ''
+            : 'active-input-roundtrip-failed',
+        activeExists: true,
+        activeVisible: isVisible(active),
+        activeDisabled: Boolean(activeDisabled),
+        activeReadOnly: Boolean(activeReadOnly),
+        activeTagName: active.tagName?.toLowerCase?.() ?? '',
+        activeRole: active.getAttribute?.('role') ?? '',
+        href,
+      };
+    })()`,
+    returnByValue: true,
+    awaitPromise: true,
+  });
+  const state = result.result?.value as ComposerHealthState | undefined;
+  if (state?.healthy) {
+    return;
+  }
+  await logDomFailure(runtime, logger, "dead-composer");
+  throw new BrowserAutomationError("ChatGPT composer is present but not accepting input.", {
+    stage: "submit-prompt",
+    code: "dead-composer",
+    composerState: {
+      reason: state?.reason ?? "unknown",
+      activeExists: Boolean(state?.activeExists),
+      activeVisible: Boolean(state?.activeVisible),
+      activeDisabled: Boolean(state?.activeDisabled),
+      activeReadOnly: Boolean(state?.activeReadOnly),
+      activeTagName: state?.activeTagName ?? "",
+      activeRole: state?.activeRole ?? "",
+      href: state?.href ?? "",
+    },
+  });
+}
+
+function isPromptTooLarge(promptLength: number, observedLength: number): boolean {
+  return (
+    promptLength >= PROMPT_TRUNCATION_CHECK_THRESHOLD &&
+    observedLength > 0 &&
+    observedLength < promptLength - PROMPT_TRUNCATION_TOLERANCE
+  );
+}
 
 export async function submitPrompt(
   deps: {
@@ -35,6 +279,7 @@ export async function submitPrompt(
   const { runtime, input } = deps;
 
   await waitForDomReady(runtime, logger, deps.inputTimeoutMs ?? undefined);
+  await ensureComposerHealthy(runtime, logger);
   const encodedPrompt = JSON.stringify(prompt);
   const focusResult = await runtime.evaluate({
     expression: `(() => {
@@ -97,42 +342,14 @@ export async function submitPrompt(
 
   const primarySelectorLiteral = JSON.stringify(PROMPT_PRIMARY_SELECTOR);
   const fallbackSelectorLiteral = JSON.stringify(PROMPT_FALLBACK_SELECTOR);
-  const verification = await runtime.evaluate({
-    expression: `(() => {
-      const editor = document.querySelector(${primarySelectorLiteral});
-      const fallback = document.querySelector(${fallbackSelectorLiteral});
-      const inputSelectors = ${JSON.stringify(INPUT_SELECTORS)};
-      const readValue = (node) => {
-        if (!node) return '';
-        if (node instanceof HTMLTextAreaElement) return node.value ?? '';
-        return node.innerText ?? '';
-      };
-      const isVisible = (node) => {
-        if (!node || typeof node.getBoundingClientRect !== 'function') return false;
-        const rect = node.getBoundingClientRect();
-        return rect.width > 0 && rect.height > 0;
-      };
-      const candidates = inputSelectors
-        .map((selector) => document.querySelector(selector))
-        .filter((node) => Boolean(node));
-      const active = candidates.find((node) => isVisible(node)) || candidates[0] || null;
-      return {
-        editorText: editor?.innerText ?? '',
-        fallbackValue: fallback?.value ?? '',
-        activeValue: active ? readValue(active) : '',
-      };
-    })()`,
-    returnByValue: true,
-  });
-
-  const editorTextRaw = verification.result?.value?.editorText ?? "";
-  const fallbackValueRaw = verification.result?.value?.fallbackValue ?? "";
-  const activeValueRaw = verification.result?.value?.activeValue ?? "";
-  const editorTextTrimmed = editorTextRaw?.trim?.() ?? "";
-  const fallbackValueTrimmed = fallbackValueRaw?.trim?.() ?? "";
-  const activeValueTrimmed = activeValueRaw?.trim?.() ?? "";
+  const verification = await readComposerSnapshot(runtime);
+  const editorTextTrimmed = verification.editorText.trim();
+  const fallbackValueTrimmed = verification.fallbackValue.trim();
+  const activeValueTrimmed = verification.activeValue.trim();
+  let usedDirectDomWrite = false;
   if (!editorTextTrimmed && !fallbackValueTrimmed && !activeValueTrimmed) {
     // Learned: occasionally Input.insertText doesn't land in the editor; force textContent/value + input events.
+    usedDirectDomWrite = true;
     await runtime.evaluate({
       expression: `(() => {
         const fallback = document.querySelector(${fallbackSelectorLiteral});
@@ -152,42 +369,26 @@ export async function submitPrompt(
   }
 
   const promptLength = prompt.length;
-  const postVerification = await runtime.evaluate({
-    expression: `(() => {
-      const editor = document.querySelector(${primarySelectorLiteral});
-      const fallback = document.querySelector(${fallbackSelectorLiteral});
-      const inputSelectors = ${JSON.stringify(INPUT_SELECTORS)};
-      const readValue = (node) => {
-        if (!node) return '';
-        if (node instanceof HTMLTextAreaElement) return node.value ?? '';
-        return node.innerText ?? '';
-      };
-      const isVisible = (node) => {
-        if (!node || typeof node.getBoundingClientRect !== 'function') return false;
-        const rect = node.getBoundingClientRect();
-        return rect.width > 0 && rect.height > 0;
-      };
-      const candidates = inputSelectors
-        .map((selector) => document.querySelector(selector))
-        .filter((node) => Boolean(node));
-      const active = candidates.find((node) => isVisible(node)) || candidates[0] || null;
-      return {
-        editorText: editor?.innerText ?? '',
-        fallbackValue: fallback?.value ?? '',
-        activeValue: active ? readValue(active) : '',
-      };
-    })()`,
-    returnByValue: true,
-  });
-  const observedEditor = postVerification.result?.value?.editorText ?? "";
-  const observedFallback = postVerification.result?.value?.fallbackValue ?? "";
-  const observedActive = postVerification.result?.value?.activeValue ?? "";
+  const postVerification = await readComposerSnapshot(runtime);
+  const observedEditor = postVerification.editorText;
+  const observedFallback = postVerification.fallbackValue;
+  const observedActive = postVerification.activeValue;
   const observedLength = Math.max(
     observedEditor.length,
     observedFallback.length,
     observedActive.length,
   );
-  if (promptLength >= 50_000 && observedLength > 0 && observedLength < promptLength - 2_000) {
+  const trustedObservedLength = usedDirectDomWrite ? observedActive.length : observedLength;
+  if (usedDirectDomWrite && trustedObservedLength === 0 && observedLength > 0) {
+    await logDomFailure(runtime, logger, "dead-composer");
+    throw new BrowserAutomationError("Prompt text only reached the DOM fallback, not the active composer.", {
+      stage: "submit-prompt",
+      code: "dead-composer",
+      promptLength,
+      composerState: postVerification,
+    });
+  }
+  if (isPromptTooLarge(promptLength, trustedObservedLength)) {
     // Learned: very large prompts can truncate silently; fail fast so we can fall back to file uploads.
     await logDomFailure(runtime, logger, "prompt-too-large");
     throw new BrowserAutomationError(
@@ -196,7 +397,9 @@ export async function submitPrompt(
         stage: "submit-prompt",
         code: "prompt-too-large",
         promptLength,
-        observedLength,
+        observedLength: trustedObservedLength,
+        usedDirectDomWrite,
+        composerState: postVerification,
       },
     );
   }
@@ -472,7 +675,7 @@ async function verifyPromptCommitted(
 	    const prefixMatched =
 	      normalizedPromptPrefix.length > 30 &&
 	      normalizedTurns.some((text) => text.includes(normalizedPromptPrefix));
-		    const lastTurn = normalizedTurns[normalizedTurns.length - 1] ?? '';
+	    const lastTurn = normalizedTurns[normalizedTurns.length - 1] ?? '';
 		    const lastMatched =
 		      normalizedPrompt.length > 0 &&
 		      (lastTurn.includes(normalizedPrompt) ||
@@ -487,12 +690,28 @@ async function verifyPromptCommitted(
 	    // Learned: composer clearing + stop button or assistant presence is a reliable fallback signal.
       const editorValue = editor?.innerText ?? '';
       const fallbackValue = fallback?.value ?? '';
-      const activeEmpty =
-        activeInputs.length === 0 ? null : activeInputs.every((node) => !String(readValue(node)).trim());
-      const composerCleared = activeEmpty ?? !(String(editorValue).trim() || String(fallbackValue).trim());
-      const href = typeof location === 'object' && location.href ? location.href : '';
-      const inConversation = /\\/c\\//.test(href);
-		    return {
+	      const activeEmpty =
+	        activeInputs.length === 0 ? null : activeInputs.every((node) => !String(readValue(node)).trim());
+	      const composerCleared = activeEmpty ?? !(String(editorValue).trim() || String(fallbackValue).trim());
+	      const activeInput = activeInputs[0] ?? null;
+	      const activeInputValue = activeInput ? String(readValue(activeInput)) : '';
+	      const activeInputDisabled = Boolean(
+	        activeInput &&
+	          (((activeInput instanceof HTMLInputElement || activeInput instanceof HTMLTextAreaElement) &&
+	            activeInput.disabled) ||
+	            activeInput.getAttribute?.('aria-disabled') === 'true' ||
+	            activeInput.getAttribute?.('disabled') !== null)
+	      );
+	      const activeInputReadOnly = Boolean(
+	        activeInput &&
+	          (((activeInput instanceof HTMLInputElement || activeInput instanceof HTMLTextAreaElement) &&
+	            activeInput.readOnly) ||
+	            activeInput.getAttribute?.('readonly') !== null ||
+	            activeInput.getAttribute?.('contenteditable') === 'false')
+	      );
+	      const href = typeof location === 'object' && location.href ? location.href : '';
+	      const inConversation = /\\/c\\//.test(href);
+			    return {
         baseline,
 	      userMatched,
 	      prefixMatched,
@@ -500,12 +719,19 @@ async function verifyPromptCommitted(
 	      hasNewTurn,
 	      stopVisible,
       assistantVisible,
-      composerCleared,
-      inConversation,
-      href,
-      fallbackValue,
-      editorValue,
-      lastTurn,
+	      composerCleared,
+	      inConversation,
+	      href,
+	      activeInputExists: Boolean(activeInput),
+	      activeInputVisible: Boolean(activeInput && isVisible(activeInput)),
+	      activeInputDisabled,
+	      activeInputReadOnly,
+	      activeInputValueLength: activeInputValue.length,
+	      activeInputTagName: activeInput?.tagName?.toLowerCase?.() ?? '',
+	      activeInputRole: activeInput?.getAttribute?.('role') ?? '',
+	      fallbackValue,
+	      editorValue,
+	      lastTurn,
       turnsCount: normalizedTurns.length,
     };
   })()`;
@@ -522,6 +748,14 @@ async function verifyPromptCommitted(
       assistantVisible?: boolean;
       composerCleared?: boolean;
       inConversation?: boolean;
+      href?: string;
+      activeInputExists?: boolean;
+      activeInputVisible?: boolean;
+      activeInputDisabled?: boolean;
+      activeInputReadOnly?: boolean;
+      activeInputValueLength?: number;
+      activeInputTagName?: string;
+      activeInputRole?: string;
       turnsCount?: number;
     };
     const turnsCount = (result.value as { turnsCount?: number } | undefined)?.turnsCount;
@@ -551,7 +785,57 @@ async function verifyPromptCommitted(
     );
     await logDomFailure(Runtime, logger, "prompt-commit");
   }
-  if (prompt.trim().length >= 50_000) {
+  const finalStateResult = await Runtime.evaluate({
+    expression: script,
+    returnByValue: true,
+  }).catch(() => null);
+  const finalState = (finalStateResult?.result?.value ?? {}) as {
+    href?: string;
+    turnsCount?: number;
+    composerCleared?: boolean;
+    stopVisible?: boolean;
+    assistantVisible?: boolean;
+    hasNewTurn?: boolean;
+    activeInputExists?: boolean;
+    activeInputVisible?: boolean;
+    activeInputDisabled?: boolean;
+    activeInputReadOnly?: boolean;
+    activeInputValueLength?: number;
+    activeInputTagName?: string;
+    activeInputRole?: string;
+  };
+  const composerState = {
+    href: typeof finalState.href === "string" ? finalState.href : "",
+    turnsCount:
+      typeof finalState.turnsCount === "number" && Number.isFinite(finalState.turnsCount)
+        ? finalState.turnsCount
+        : null,
+    composerCleared: Boolean(finalState.composerCleared),
+    stopVisible: Boolean(finalState.stopVisible),
+    assistantVisible: Boolean(finalState.assistantVisible),
+    hasNewTurn: Boolean(finalState.hasNewTurn),
+    activeInputExists: Boolean(finalState.activeInputExists),
+    activeInputVisible: Boolean(finalState.activeInputVisible),
+    activeInputDisabled: Boolean(finalState.activeInputDisabled),
+    activeInputReadOnly: Boolean(finalState.activeInputReadOnly),
+    activeInputValueLength:
+      typeof finalState.activeInputValueLength === "number" &&
+      Number.isFinite(finalState.activeInputValueLength)
+        ? finalState.activeInputValueLength
+        : 0,
+    activeInputTagName: finalState.activeInputTagName ?? "",
+    activeInputRole: finalState.activeInputRole ?? "",
+  };
+  const likelyDeadComposer =
+    composerState.activeInputExists &&
+    (!composerState.activeInputVisible ||
+      composerState.activeInputDisabled ||
+      composerState.activeInputReadOnly ||
+      (!composerState.hasNewTurn &&
+        !composerState.stopVisible &&
+        !composerState.assistantVisible &&
+        !composerState.composerCleared));
+  if (prompt.trim().length >= PROMPT_TRUNCATION_CHECK_THRESHOLD) {
     throw new BrowserAutomationError(
       "Prompt did not appear in conversation before timeout (likely too large).",
       {
@@ -559,13 +843,30 @@ async function verifyPromptCommitted(
         code: "prompt-too-large",
         promptLength: prompt.trim().length,
         timeoutMs,
+        composerState,
       },
     );
   }
-  throw new Error("Prompt did not appear in conversation before timeout (send may have failed)");
+  if (likelyDeadComposer) {
+    throw new BrowserAutomationError("Prompt did not appear because the ChatGPT composer is unresponsive.", {
+      stage: "submit-prompt",
+      code: "dead-composer",
+      timeoutMs,
+      composerState,
+    });
+  }
+  throw new BrowserAutomationError("Prompt did not appear in conversation before timeout (send may have failed).", {
+    stage: "submit-prompt",
+    code: "prompt-commit-timeout",
+    timeoutMs,
+    composerState,
+  });
 }
 
 // biome-ignore lint/style/useNamingConvention: test-only export used in vitest suite
 export const __test__ = {
+  ensureComposerHealthy,
+  readComposerSnapshot,
+  isPromptTooLarge,
   verifyPromptCommitted,
 };

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -84,6 +84,74 @@ function hasBrowserErrorCode(error: unknown, code: string): boolean {
   );
 }
 
+type BrowserSubmissionResult = {
+  baselineTurns: number | null;
+  baselineAssistantText: string | null;
+};
+
+type BrowserSubmissionFallback = {
+  prompt: string;
+  attachments: BrowserAttachment[];
+};
+
+async function runSubmissionWithRecovery({
+  prompt,
+  attachments,
+  fallbackSubmission,
+  submit,
+  reloadPromptComposer,
+  prepareFallbackSubmission,
+  logger,
+}: {
+  prompt: string;
+  attachments: BrowserAttachment[];
+  fallbackSubmission?: BrowserSubmissionFallback;
+  submit: (prompt: string, attachments: BrowserAttachment[]) => Promise<BrowserSubmissionResult>;
+  reloadPromptComposer: () => Promise<void>;
+  prepareFallbackSubmission: () => Promise<void>;
+  logger: BrowserLogger;
+}): Promise<BrowserSubmissionResult> {
+  let currentPrompt = prompt;
+  let currentAttachments = attachments;
+  let retriedDeadComposer = false;
+  let usedFallbackSubmission = false;
+
+  while (true) {
+    try {
+      return await submit(currentPrompt, currentAttachments);
+    } catch (error) {
+      const isPromptTooLarge = hasBrowserErrorCode(error, "prompt-too-large");
+      const isDeadComposer = hasBrowserErrorCode(error, "dead-composer");
+      if (isDeadComposer && !retriedDeadComposer) {
+        retriedDeadComposer = true;
+        await reloadPromptComposer();
+        continue;
+      }
+      if (fallbackSubmission && !usedFallbackSubmission && isPromptTooLarge) {
+        usedFallbackSubmission = true;
+        logger("[browser] Inline prompt too large; retrying with file uploads.");
+        await prepareFallbackSubmission();
+        currentPrompt = fallbackSubmission.prompt;
+        currentAttachments = fallbackSubmission.attachments;
+        continue;
+      }
+      throw error;
+    }
+  }
+}
+
+export async function runSubmissionWithRecoveryForTest(args: {
+  prompt: string;
+  attachments: BrowserAttachment[];
+  fallbackSubmission?: BrowserSubmissionFallback;
+  submit: (prompt: string, attachments: BrowserAttachment[]) => Promise<BrowserSubmissionResult>;
+  reloadPromptComposer: () => Promise<void>;
+  prepareFallbackSubmission: () => Promise<void>;
+  logger: BrowserLogger;
+}): Promise<BrowserSubmissionResult> {
+  return runSubmissionWithRecovery(args);
+}
+
 export async function runBrowserMode(options: BrowserRunOptions): Promise<BrowserRunResult> {
   const promptText = options.prompt?.trim();
   if (!promptText) {
@@ -647,7 +715,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
             },
           );
           if (!verified) {
-            logger("Sent user message did not expose attachment UI after upload; continuing.");
+            throw new Error("Sent user message did not expose attachment UI after upload.");
           } else {
             logger("Verified attachments present on sent user message");
           }
@@ -668,34 +736,21 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
     let baselineAssistantText: string | null = null;
     await acquireProfileLockIfNeeded();
     try {
-      let retriedDeadComposer = false;
-      try {
-        const submission = await raceWithDisconnect(submitOnce(promptText, attachments));
-        baselineTurns = submission.baselineTurns;
-        baselineAssistantText = submission.baselineAssistantText;
-      } catch (error) {
-        const isPromptTooLarge = hasBrowserErrorCode(error, "prompt-too-large");
-        const isDeadComposer = hasBrowserErrorCode(error, "dead-composer");
-        if (isDeadComposer && !retriedDeadComposer) {
-          retriedDeadComposer = true;
-          await reloadPromptComposer();
-          const submission = await raceWithDisconnect(submitOnce(promptText, attachments));
-          baselineTurns = submission.baselineTurns;
-          baselineAssistantText = submission.baselineAssistantText;
-        } else if (fallbackSubmission && isPromptTooLarge) {
-          // Learned: when prompts truncate, retry with file uploads so the UI receives the full content.
-          logger("[browser] Inline prompt too large; retrying with file uploads.");
+      const submission = await runSubmissionWithRecovery({
+        prompt: promptText,
+        attachments,
+        fallbackSubmission,
+        submit: (submissionPrompt, submissionAttachments) =>
+          raceWithDisconnect(submitOnce(submissionPrompt, submissionAttachments)),
+        reloadPromptComposer,
+        prepareFallbackSubmission: async () => {
           await raceWithDisconnect(clearPromptComposer(Runtime, logger));
           await raceWithDisconnect(ensurePromptReady(Runtime, config.inputTimeoutMs, logger));
-          const submission = await raceWithDisconnect(
-            submitOnce(fallbackSubmission.prompt, fallbackSubmission.attachments),
-          );
-          baselineTurns = submission.baselineTurns;
-          baselineAssistantText = submission.baselineAssistantText;
-        } else {
-          throw error;
-        }
-      }
+        },
+        logger,
+      });
+      baselineTurns = submission.baselineTurns;
+      baselineAssistantText = submission.baselineAssistantText;
     } finally {
       await releaseProfileLockIfHeld();
     }
@@ -1611,34 +1666,21 @@ async function runRemoteBrowserMode(
 
     let baselineTurns: number | null = null;
     let baselineAssistantText: string | null = null;
-    let retriedDeadComposer = false;
-    try {
-      const submission = await raceWithDisconnect(submitOnce(promptText, attachments));
-      baselineTurns = submission.baselineTurns;
-      baselineAssistantText = submission.baselineAssistantText;
-    } catch (error) {
-      const isPromptTooLarge = hasBrowserErrorCode(error, "prompt-too-large");
-      const isDeadComposer = hasBrowserErrorCode(error, "dead-composer");
-      if (isDeadComposer && !retriedDeadComposer) {
-        retriedDeadComposer = true;
-        await reloadPromptComposer();
-        const submission = await raceWithDisconnect(submitOnce(promptText, attachments));
-        baselineTurns = submission.baselineTurns;
-        baselineAssistantText = submission.baselineAssistantText;
-      } else if (options.fallbackSubmission && isPromptTooLarge) {
-        logger("[browser] Inline prompt too large; retrying with file uploads.");
+    const submission = await runSubmissionWithRecovery({
+      prompt: promptText,
+      attachments,
+      fallbackSubmission: options.fallbackSubmission,
+      submit: (submissionPrompt, submissionAttachments) =>
+        raceWithDisconnect(submitOnce(submissionPrompt, submissionAttachments)),
+      reloadPromptComposer,
+      prepareFallbackSubmission: async () => {
         await raceWithDisconnect(clearPromptComposer(Runtime, logger));
         await raceWithDisconnect(ensurePromptReady(Runtime, config.inputTimeoutMs, logger));
-        const submission = await raceWithDisconnect(submitOnce(
-          options.fallbackSubmission.prompt,
-          options.fallbackSubmission.attachments,
-        ));
-        baselineTurns = submission.baselineTurns;
-        baselineAssistantText = submission.baselineAssistantText;
-      } else {
-        throw error;
-      }
-    }
+      },
+      logger,
+    });
+    baselineTurns = submission.baselineTurns;
+    baselineAssistantText = submission.baselineAssistantText;
     stopThinkingMonitor = startThinkingStatusMonitor(Runtime, logger, options.verbose ?? false);
     // Helper to normalize text for echo detection (collapse whitespace, lowercase)
     const normalizeForComparison = (text: string): string =>

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -77,6 +77,13 @@ export function shouldPreserveBrowserOnErrorForTest(error: unknown, headless: bo
   return shouldPreserveBrowserOnError(error, headless);
 }
 
+function hasBrowserErrorCode(error: unknown, code: string): boolean {
+  return (
+    error instanceof BrowserAutomationError &&
+    (error.details as { code?: string } | undefined)?.code === code
+  );
+}
+
 export async function runBrowserMode(options: BrowserRunOptions): Promise<BrowserRunResult> {
   const promptText = options.prompt?.trim();
   if (!promptText) {
@@ -397,7 +404,33 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
         await emitRuntimeHint();
       }
     };
+    let expectedConversationUrl: string | undefined;
+    let expectedConversationId: string | undefined;
     let conversationHintInFlight: Promise<boolean> | null = null;
+    const lockConversationUrl = async (
+      candidateUrl: string | null | undefined,
+      label: string,
+    ): Promise<boolean> => {
+      if (!candidateUrl || !isConversationUrl(candidateUrl)) {
+        return false;
+      }
+      const candidateId = extractConversationIdFromUrl(candidateUrl);
+      if (!candidateId) {
+        return false;
+      }
+      if (expectedConversationId && candidateId !== expectedConversationId) {
+        logger(
+          `[browser] Ignoring conversation drift (${label}); expected ${expectedConversationUrl}, saw ${candidateUrl}`,
+        );
+        return false;
+      }
+      expectedConversationUrl = candidateUrl;
+      expectedConversationId = candidateId;
+      lastUrl = candidateUrl;
+      logger(`[browser] conversation url (${label}) = ${candidateUrl}`);
+      await emitRuntimeHint();
+      return true;
+    };
     const updateConversationHint = async (label: string, timeoutMs = 10_000): Promise<boolean> => {
       if (!chrome?.port) {
         return false;
@@ -409,10 +442,10 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
             expression: "location.href",
             returnByValue: true,
           });
-          if (typeof result?.value === "string" && result.value.includes("/c/")) {
-            lastUrl = result.value;
-            logger(`[browser] conversation url (${label}) = ${lastUrl}`);
-            await emitRuntimeHint();
+          if (
+            typeof result?.value === "string" &&
+            (await lockConversationUrl(result.value, label))
+          ) {
             return true;
           }
         } catch {
@@ -433,6 +466,28 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
         .finally(() => {
           conversationHintInFlight = null;
         });
+    };
+    const ensureExpectedConversation = async (label: string): Promise<boolean> => {
+      if (!expectedConversationUrl || !expectedConversationId) {
+        return false;
+      }
+      const currentUrl = await readConversationUrl(Runtime);
+      const currentId = currentUrl ? extractConversationIdFromUrl(currentUrl) : undefined;
+      if (currentId === expectedConversationId) {
+        if (currentUrl && currentUrl !== lastUrl) {
+          lastUrl = currentUrl;
+          await emitRuntimeHint();
+        }
+        return true;
+      }
+      logger(
+        `[browser] Conversation drifted during ${label}; restoring ${expectedConversationUrl}`,
+      );
+      await raceWithDisconnect(Page.navigate({ url: expectedConversationUrl }));
+      await raceWithDisconnect(delay(1000));
+      lastUrl = expectedConversationUrl;
+      await emitRuntimeHint();
+      return true;
     };
     await captureRuntimeSnapshot();
     const modelStrategy = config.modelStrategy ?? DEFAULT_MODEL_STRATEGY;
@@ -585,31 +640,49 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
             attachmentNames,
             20_000,
             logger,
+            {
+              minTurnIndex: baselineTurns ?? undefined,
+              expectedPrompt: prompt,
+              expectedConversationId,
+            },
           );
           if (!verified) {
-            throw new Error("Sent user message did not expose attachment UI after upload.");
+            logger("Sent user message did not expose attachment UI after upload; continuing.");
+          } else {
+            logger("Verified attachments present on sent user message");
           }
-          logger("Verified attachments present on sent user message");
         }
       }
       // Reattach needs a /c/ URL; ChatGPT can update it late, so poll in the background.
       scheduleConversationHint("post-submit", config.timeoutMs ?? 120_000);
+      await updateConversationHint("post-submit", 15_000).catch(() => false);
       return { baselineTurns, baselineAssistantText };
+    };
+    const reloadPromptComposer = async () => {
+      logger("[browser] Composer became unresponsive; reloading page and retrying once.");
+      await raceWithDisconnect(Page.reload({ ignoreCache: true }));
+      await raceWithDisconnect(ensurePromptReady(Runtime, config.inputTimeoutMs, logger));
     };
 
     let baselineTurns: number | null = null;
     let baselineAssistantText: string | null = null;
     await acquireProfileLockIfNeeded();
     try {
+      let retriedDeadComposer = false;
       try {
         const submission = await raceWithDisconnect(submitOnce(promptText, attachments));
         baselineTurns = submission.baselineTurns;
         baselineAssistantText = submission.baselineAssistantText;
       } catch (error) {
-        const isPromptTooLarge =
-          error instanceof BrowserAutomationError &&
-          (error.details as { code?: string } | undefined)?.code === "prompt-too-large";
-        if (fallbackSubmission && isPromptTooLarge) {
+        const isPromptTooLarge = hasBrowserErrorCode(error, "prompt-too-large");
+        const isDeadComposer = hasBrowserErrorCode(error, "dead-composer");
+        if (isDeadComposer && !retriedDeadComposer) {
+          retriedDeadComposer = true;
+          await reloadPromptComposer();
+          const submission = await raceWithDisconnect(submitOnce(promptText, attachments));
+          baselineTurns = submission.baselineTurns;
+          baselineAssistantText = submission.baselineAssistantText;
+        } else if (fallbackSubmission && isPromptTooLarge) {
           // Learned: when prompts truncate, retry with file uploads so the UI receives the full content.
           logger("[browser] Inline prompt too large; retrying with file uploads.");
           await raceWithDisconnect(clearPromptComposer(Runtime, logger));
@@ -637,9 +710,11 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
           : "";
       const deadline = Date.now() + timeoutMs;
       while (Date.now() < deadline) {
-        const snapshot = await readAssistantSnapshot(Runtime, baselineTurns ?? undefined).catch(
-          () => null,
-        );
+        const snapshot = await readAssistantSnapshot(
+          Runtime,
+          baselineTurns ?? undefined,
+          expectedConversationId,
+        ).catch(() => null);
         const text = typeof snapshot?.text === "string" ? snapshot.text.trim() : "";
         if (text) {
           const normalized = normalizeForComparison(text);
@@ -675,8 +750,9 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
       );
       await raceWithDisconnect(delay(recheckDelayMs));
       await updateConversationHint("assistant-recheck", 15_000).catch(() => false);
+      await ensureExpectedConversation("assistant-recheck").catch(() => false);
       await captureRuntimeSnapshot().catch(() => undefined);
-      const conversationUrl = await readConversationUrl(Runtime);
+      const conversationUrl = expectedConversationUrl ?? (await readConversationUrl(Runtime));
       if (conversationUrl && isConversationUrl(conversationUrl)) {
         logger(`[browser] Rechecking assistant response at ${conversationUrl}`);
         await raceWithDisconnect(Page.navigate({ url: conversationUrl }));
@@ -720,12 +796,15 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
           timeoutMs,
           logger,
           baselineTurns ?? undefined,
+          expectedConversationUrl,
+          expectedConversationId,
         ),
       );
       logger("Recovered assistant response after delayed recheck");
       return rechecked;
     };
     try {
+      await ensureExpectedConversation("assistant-wait").catch(() => false);
       answer = await raceWithDisconnect(
         waitForAssistantResponseWithReload(
           Runtime,
@@ -733,6 +812,8 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
           config.timeoutMs,
           logger,
           baselineTurns ?? undefined,
+          expectedConversationUrl,
+          expectedConversationId,
         ),
       );
     } catch (error) {
@@ -742,6 +823,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
           answer = rechecked;
         } else {
           await updateConversationHint("assistant-timeout", 15_000).catch(() => false);
+          await ensureExpectedConversation("assistant-timeout").catch(() => false);
           await captureRuntimeSnapshot().catch(() => undefined);
           const runtime = {
             chromePid: chrome.pid,
@@ -765,6 +847,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
     }
     // Ensure we store the final conversation URL even if the UI updated late.
     await updateConversationHint("post-response", 15_000);
+    await ensureExpectedConversation("post-response").catch(() => false);
     const baselineNormalized = baselineAssistantText
       ? normalizeForComparison(baselineAssistantText)
       : "";
@@ -815,6 +898,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
     ({ answerText, answerMarkdown } = await maybeRecoverLongAssistantResponse({
       runtime: Runtime,
       baselineTurns,
+      expectedConversationId,
       answerText,
       answerMarkdown,
       logger,
@@ -822,9 +906,11 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
     }));
 
     // Final sanity check: ensure we didn't accidentally capture the user prompt instead of the assistant turn.
-    const finalSnapshot = await readAssistantSnapshot(Runtime, baselineTurns ?? undefined).catch(
-      () => null,
-    );
+    const finalSnapshot = await readAssistantSnapshot(
+      Runtime,
+      baselineTurns ?? undefined,
+      expectedConversationId,
+    ).catch(() => null);
     const finalText = typeof finalSnapshot?.text === "string" ? finalSnapshot.text.trim() : "";
     if (finalText && finalText !== promptText.trim()) {
       const trimmedMarkdown = answerMarkdown.trim();
@@ -862,9 +948,11 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
       let bestText: string | null = null;
       let stableCount = 0;
       while (Date.now() < deadline) {
-        const snapshot = await readAssistantSnapshot(Runtime, baselineTurns ?? undefined).catch(
-          () => null,
-        );
+        const snapshot = await readAssistantSnapshot(
+          Runtime,
+          baselineTurns ?? undefined,
+          expectedConversationId,
+        ).catch(() => null);
         const text = typeof snapshot?.text === "string" ? snapshot.text.trim() : "";
         const isStillEcho = !text || Boolean(promptEchoMatcher?.isEcho(text));
         if (!isStillEcho) {
@@ -892,9 +980,11 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
       let bestText = answerText.trim();
       let stableCycles = 0;
       while (Date.now() < deadline) {
-        const snapshot = await readAssistantSnapshot(Runtime, baselineTurns ?? undefined).catch(
-          () => null,
-        );
+        const snapshot = await readAssistantSnapshot(
+          Runtime,
+          baselineTurns ?? undefined,
+          expectedConversationId,
+        ).catch(() => null);
         const text = typeof snapshot?.text === "string" ? snapshot.text.trim() : "";
         if (text && text.length > bestText.length) {
           bestText = text;
@@ -1045,6 +1135,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
         logger(`Cleanup ${runStatus} • ${totalSeconds.toFixed(1)}s total`);
       }
     } else if (!connectionClosedUnexpectedly) {
+      chrome.process?.unref?.();
       logger(`Chrome left running on port ${chrome.port} with profile ${userDataDir}`);
     }
   }
@@ -1147,6 +1238,7 @@ async function waitForLogin({
 async function maybeRecoverLongAssistantResponse({
   runtime,
   baselineTurns,
+  expectedConversationId,
   answerText,
   answerMarkdown,
   logger,
@@ -1154,6 +1246,7 @@ async function maybeRecoverLongAssistantResponse({
 }: {
   runtime: ChromeClient["Runtime"];
   baselineTurns: number | null;
+  expectedConversationId?: string;
   answerText: string;
   answerMarkdown: string;
   logger: BrowserLogger;
@@ -1170,9 +1263,11 @@ async function maybeRecoverLongAssistantResponse({
   let bestLength = capturedLength;
   let bestText = answerText;
   for (let i = 0; i < 5; i++) {
-    const laterSnapshot = await readAssistantSnapshot(runtime, baselineTurns ?? undefined).catch(
-      () => null,
-    );
+    const laterSnapshot = await readAssistantSnapshot(
+      runtime,
+      baselineTurns ?? undefined,
+      expectedConversationId,
+    ).catch(() => null);
     const laterText = typeof laterSnapshot?.text === "string" ? laterSnapshot.text.trim() : "";
     if (laterText.length > bestLength) {
       bestLength = laterText.length;
@@ -1275,15 +1370,19 @@ async function runRemoteBrowserMode(
   let client: ChromeClient | null = null;
   let remoteTargetId: string | null = null;
   let lastUrl: string | undefined;
+  let expectedConversationUrl: string | undefined;
+  let expectedConversationId: string | undefined;
   const runtimeHintCb = options.runtimeHintCb;
   const emitRuntimeHint = async () => {
     if (!runtimeHintCb) return;
     try {
+      const conversationId = lastUrl ? extractConversationIdFromUrl(lastUrl) : undefined;
       await runtimeHintCb({
         chromePort: port,
         chromeHost: host,
         chromeTargetId: remoteTargetId ?? undefined,
         tabUrl: lastUrl,
+        conversationId,
         controllerPid: process.pid,
       });
     } catch (error) {
@@ -1308,6 +1407,81 @@ async function runRemoteBrowserMode(
       connectionClosedUnexpectedly = true;
     };
     client.on("disconnect", markConnectionLost);
+    const disconnectPromise = new Promise<never>((_, reject) => {
+      client?.on("disconnect", () => {
+        connectionClosedUnexpectedly = true;
+        reject(new Error("Remote Chrome connection lost during browser automation."));
+      });
+    });
+    const raceWithDisconnect = <T>(promise: Promise<T>): Promise<T> =>
+      Promise.race([promise, disconnectPromise]);
+    const lockConversationUrl = async (
+      candidateUrl: string | null | undefined,
+      label: string,
+    ): Promise<boolean> => {
+      if (!candidateUrl || !isConversationUrl(candidateUrl)) {
+        return false;
+      }
+      const candidateId = extractConversationIdFromUrl(candidateUrl);
+      if (!candidateId) {
+        return false;
+      }
+      if (expectedConversationId && candidateId !== expectedConversationId) {
+        logger(
+          `[browser] Ignoring conversation drift (${label}); expected ${expectedConversationUrl}, saw ${candidateUrl}`,
+        );
+        return false;
+      }
+      expectedConversationUrl = candidateUrl;
+      expectedConversationId = candidateId;
+      lastUrl = candidateUrl;
+      logger(`[browser] conversation url (${label}) = ${candidateUrl}`);
+      await emitRuntimeHint();
+      return true;
+    };
+    const updateConversationHint = async (label: string, timeoutMs = 10_000): Promise<boolean> => {
+      const start = Date.now();
+      while (Date.now() - start < timeoutMs) {
+        try {
+          const { result } = await Runtime.evaluate({
+            expression: "location.href",
+            returnByValue: true,
+          });
+          if (
+            typeof result?.value === "string" &&
+            (await lockConversationUrl(result.value, label))
+          ) {
+            return true;
+          }
+        } catch {
+          // ignore; keep polling until timeout
+        }
+        await delay(250);
+      }
+      return false;
+    };
+    const ensureExpectedConversation = async (label: string): Promise<boolean> => {
+      if (!expectedConversationUrl || !expectedConversationId) {
+        return false;
+      }
+      const currentUrl = await readConversationUrl(Runtime);
+      const currentId = currentUrl ? extractConversationIdFromUrl(currentUrl) : undefined;
+      if (currentId === expectedConversationId) {
+        if (currentUrl && currentUrl !== lastUrl) {
+          lastUrl = currentUrl;
+          await emitRuntimeHint();
+        }
+        return true;
+      }
+      logger(
+        `[browser] Conversation drifted during ${label}; restoring ${expectedConversationUrl}`,
+      );
+      await raceWithDisconnect(Page.navigate({ url: expectedConversationUrl }));
+      await raceWithDisconnect(delay(1000));
+      lastUrl = expectedConversationUrl;
+      await emitRuntimeHint();
+      return true;
+    };
     const { Network, Page, Runtime, Input, DOM } = client;
 
     const domainEnablers = [Network.enable({}), Page.enable(), Runtime.enable()];
@@ -1320,10 +1494,10 @@ async function runRemoteBrowserMode(
     // Skip cookie sync for remote Chrome - it already has cookies
     logger("Skipping cookie sync for remote Chrome (using existing session)");
 
-    await navigateToChatGPT(Page, Runtime, config.url, logger);
-    await ensureNotBlocked(Runtime, config.headless, logger);
-    await ensureLoggedIn(Runtime, logger, { remoteSession: true });
-    await ensurePromptReady(Runtime, config.inputTimeoutMs, logger);
+    await raceWithDisconnect(navigateToChatGPT(Page, Runtime, config.url, logger));
+    await raceWithDisconnect(ensureNotBlocked(Runtime, config.headless, logger));
+    await raceWithDisconnect(ensureLoggedIn(Runtime, logger, { remoteSession: true }));
+    await raceWithDisconnect(ensurePromptReady(Runtime, config.inputTimeoutMs, logger));
     logger(
       `Prompt textarea ready (initial focus, ${promptText.length.toLocaleString()} chars queued)`,
     );
@@ -1356,7 +1530,7 @@ async function runRemoteBrowserMode(
           },
         },
       );
-      await ensurePromptReady(Runtime, config.inputTimeoutMs, logger);
+      await raceWithDisconnect(ensurePromptReady(Runtime, config.inputTimeoutMs, logger));
       logger(
         `Prompt textarea ready (after model switch, ${promptText.length.toLocaleString()} chars queued)`,
       );
@@ -1366,17 +1540,19 @@ async function runRemoteBrowserMode(
     // Handle thinking time selection if specified
     const thinkingTime = config.thinkingTime;
     if (thinkingTime) {
-      await withRetries(() => ensureThinkingTime(Runtime, thinkingTime, logger), {
-        retries: 2,
-        delayMs: 300,
-        onRetry: (attempt, error) => {
-          if (options.verbose) {
-            logger(
-              `[retry] Thinking time (${thinkingTime}) attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
-            );
-          }
-        },
-      });
+      await raceWithDisconnect(
+        withRetries(() => ensureThinkingTime(Runtime, thinkingTime, logger), {
+          retries: 2,
+          delayMs: 300,
+          onRetry: (attempt, error) => {
+            if (options.verbose) {
+              logger(
+                `[retry] Thinking time (${thinkingTime}) attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
+              );
+            }
+          },
+        }),
+      );
     }
 
     const submitOnce = async (prompt: string, submissionAttachments: BrowserAttachment[]) => {
@@ -1424,27 +1600,39 @@ async function runRemoteBrowserMode(
       if (typeof providerBaselineTurns === "number" && Number.isFinite(providerBaselineTurns)) {
         baselineTurns = providerBaselineTurns;
       }
+      await updateConversationHint("post-submit", 15_000).catch(() => false);
       return { baselineTurns, baselineAssistantText };
+    };
+    const reloadPromptComposer = async () => {
+      logger("[browser] Composer became unresponsive; reloading page and retrying once.");
+      await raceWithDisconnect(Page.reload({ ignoreCache: true }));
+      await raceWithDisconnect(ensurePromptReady(Runtime, config.inputTimeoutMs, logger));
     };
 
     let baselineTurns: number | null = null;
     let baselineAssistantText: string | null = null;
+    let retriedDeadComposer = false;
     try {
-      const submission = await submitOnce(promptText, attachments);
+      const submission = await raceWithDisconnect(submitOnce(promptText, attachments));
       baselineTurns = submission.baselineTurns;
       baselineAssistantText = submission.baselineAssistantText;
     } catch (error) {
-      const isPromptTooLarge =
-        error instanceof BrowserAutomationError &&
-        (error.details as { code?: string } | undefined)?.code === "prompt-too-large";
-      if (options.fallbackSubmission && isPromptTooLarge) {
+      const isPromptTooLarge = hasBrowserErrorCode(error, "prompt-too-large");
+      const isDeadComposer = hasBrowserErrorCode(error, "dead-composer");
+      if (isDeadComposer && !retriedDeadComposer) {
+        retriedDeadComposer = true;
+        await reloadPromptComposer();
+        const submission = await raceWithDisconnect(submitOnce(promptText, attachments));
+        baselineTurns = submission.baselineTurns;
+        baselineAssistantText = submission.baselineAssistantText;
+      } else if (options.fallbackSubmission && isPromptTooLarge) {
         logger("[browser] Inline prompt too large; retrying with file uploads.");
-        await clearPromptComposer(Runtime, logger);
-        await ensurePromptReady(Runtime, config.inputTimeoutMs, logger);
-        const submission = await submitOnce(
+        await raceWithDisconnect(clearPromptComposer(Runtime, logger));
+        await raceWithDisconnect(ensurePromptReady(Runtime, config.inputTimeoutMs, logger));
+        const submission = await raceWithDisconnect(submitOnce(
           options.fallbackSubmission.prompt,
           options.fallbackSubmission.attachments,
-        );
+        ));
         baselineTurns = submission.baselineTurns;
         baselineAssistantText = submission.baselineAssistantText;
       } else {
@@ -1462,9 +1650,11 @@ async function runRemoteBrowserMode(
           : "";
       const deadline = Date.now() + timeoutMs;
       while (Date.now() < deadline) {
-        const snapshot = await readAssistantSnapshot(Runtime, baselineTurns ?? undefined).catch(
-          () => null,
-        );
+        const snapshot = await readAssistantSnapshot(
+          Runtime,
+          baselineTurns ?? undefined,
+          expectedConversationId,
+        ).catch(() => null);
         const text = typeof snapshot?.text === "string" ? snapshot.text.trim() : "";
         if (text) {
           const normalized = normalizeForComparison(text);
@@ -1499,12 +1689,13 @@ async function runRemoteBrowserMode(
         `[browser] Assistant response timed out; waiting ${formatElapsed(recheckDelayMs)} before rechecking conversation.`,
       );
       await delay(recheckDelayMs);
-      const conversationUrl = await readConversationUrl(Runtime);
+      await updateConversationHint("assistant-recheck", 15_000).catch(() => false);
+      await ensureExpectedConversation("assistant-recheck").catch(() => false);
+      const conversationUrl = expectedConversationUrl ?? (await readConversationUrl(Runtime));
       if (conversationUrl && isConversationUrl(conversationUrl)) {
-        lastUrl = conversationUrl;
         logger(`[browser] Rechecking assistant response at ${conversationUrl}`);
-        await Page.navigate({ url: conversationUrl });
-        await delay(1000);
+        await raceWithDisconnect(Page.navigate({ url: conversationUrl }));
+        await raceWithDisconnect(delay(1000));
       }
       // Validate session before attempting recheck - sessions can expire during the delay
       const sessionValid = await validateChatGPTSession(Runtime, logger);
@@ -1542,17 +1733,22 @@ async function runRemoteBrowserMode(
         timeoutMs,
         logger,
         baselineTurns ?? undefined,
+        expectedConversationUrl,
+        expectedConversationId,
       );
       logger("Recovered assistant response after delayed recheck");
       return rechecked;
     };
     try {
+      await ensureExpectedConversation("assistant-wait").catch(() => false);
       answer = await waitForAssistantResponseWithReload(
         Runtime,
         Page,
         config.timeoutMs,
         logger,
         baselineTurns ?? undefined,
+        expectedConversationUrl,
+        expectedConversationId,
       );
     } catch (error) {
       if (isAssistantResponseTimeoutError(error)) {
@@ -1561,13 +1757,14 @@ async function runRemoteBrowserMode(
           answer = rechecked;
         } else {
           try {
-            const conversationUrl = await readConversationUrl(Runtime);
+            const conversationUrl = expectedConversationUrl ?? (await readConversationUrl(Runtime));
             if (conversationUrl) {
               lastUrl = conversationUrl;
             }
           } catch {
             // ignore
           }
+          await ensureExpectedConversation("assistant-timeout").catch(() => false);
           await emitRuntimeHint();
           const runtime = {
             chromePort: port,
@@ -1635,6 +1832,7 @@ async function runRemoteBrowserMode(
     ({ answerText, answerMarkdown } = await maybeRecoverLongAssistantResponse({
       runtime: Runtime,
       baselineTurns,
+      expectedConversationId,
       answerText,
       answerMarkdown,
       logger,
@@ -1642,9 +1840,11 @@ async function runRemoteBrowserMode(
     }));
 
     // Final sanity check: ensure we didn't accidentally capture the user prompt instead of the assistant turn.
-    const finalSnapshot = await readAssistantSnapshot(Runtime, baselineTurns ?? undefined).catch(
-      () => null,
-    );
+    const finalSnapshot = await readAssistantSnapshot(
+      Runtime,
+      baselineTurns ?? undefined,
+      expectedConversationId,
+    ).catch(() => null);
     const finalText = typeof finalSnapshot?.text === "string" ? finalSnapshot.text.trim() : "";
     if (
       finalText &&
@@ -1678,9 +1878,11 @@ async function runRemoteBrowserMode(
       let bestText: string | null = null;
       let stableCount = 0;
       while (Date.now() < deadline) {
-        const snapshot = await readAssistantSnapshot(Runtime, baselineTurns ?? undefined).catch(
-          () => null,
-        );
+        const snapshot = await readAssistantSnapshot(
+          Runtime,
+          baselineTurns ?? undefined,
+          expectedConversationId,
+        ).catch(() => null);
         const text = typeof snapshot?.text === "string" ? snapshot.text.trim() : "";
         const isStillEcho = !text || Boolean(promptEchoMatcher?.isEcho(text));
         if (!isStillEcho) {
@@ -1819,21 +2021,35 @@ async function waitForAssistantResponseWithReload(
   timeoutMs: number,
   logger: BrowserLogger,
   minTurnIndex?: number,
+  expectedConversationUrl?: string,
+  expectedConversationId?: string,
 ) {
   try {
-    return await waitForAssistantResponse(Runtime, timeoutMs, logger, minTurnIndex);
+    return await waitForAssistantResponse(
+      Runtime,
+      timeoutMs,
+      logger,
+      minTurnIndex,
+      expectedConversationId,
+    );
   } catch (error) {
     if (!shouldReloadAfterAssistantError(error)) {
       throw error;
     }
-    const conversationUrl = await readConversationUrl(Runtime);
+    const conversationUrl = expectedConversationUrl ?? (await readConversationUrl(Runtime));
     if (!conversationUrl || !isConversationUrl(conversationUrl)) {
       throw error;
     }
     logger("Assistant response stalled; reloading conversation and retrying once");
     await Page.navigate({ url: conversationUrl });
     await delay(1000);
-    return await waitForAssistantResponse(Runtime, timeoutMs, logger, minTurnIndex);
+    return await waitForAssistantResponse(
+      Runtime,
+      timeoutMs,
+      logger,
+      minTurnIndex,
+      expectedConversationId,
+    );
   }
 }
 

--- a/src/browser/pageActions.ts
+++ b/src/browser/pageActions.ts
@@ -13,6 +13,7 @@ export {
   uploadAttachmentFile,
   waitForAttachmentCompletion,
   waitForUserTurnAttachments,
+  buildUserTurnAttachmentExpressionForTest,
 } from "./actions/attachments.js";
 export {
   waitForAssistantResponse,

--- a/src/browser/pageActions.ts
+++ b/src/browser/pageActions.ts
@@ -19,6 +19,7 @@ export {
   readAssistantSnapshot,
   captureAssistantMarkdown,
   buildAssistantExtractorForTest,
+  buildAssistantSnapshotExpressionForTest,
   buildConversationDebugExpressionForTest,
   buildMarkdownFallbackExtractorForTest,
   buildCopyExpressionForTest,

--- a/src/cli/browserConfig.ts
+++ b/src/cli/browserConfig.ts
@@ -20,21 +20,25 @@ const DEFAULT_BROWSER_INPUT_TIMEOUT_MS = 60_000;
 const DEFAULT_BROWSER_RECHECK_TIMEOUT_MS = 120_000;
 const DEFAULT_BROWSER_AUTO_REATTACH_TIMEOUT_MS = 120_000;
 const DEFAULT_CHROME_PROFILE = "Default";
+const CURRENT_PRO_BROWSER_LABEL = "GPT-5.4 Pro";
+const CURRENT_THINKING_BROWSER_LABEL = "Thinking 5.4";
+const CURRENT_INSTANT_BROWSER_LABEL = "Instant 5.3";
+const CURRENT_AUTO_BROWSER_LABEL = "Auto";
 
 // Ordered array: most specific models first to ensure correct selection.
 // The browser label is passed to the model picker which fuzzy-matches against ChatGPT's UI.
 const BROWSER_MODEL_LABELS: [ModelName, string][] = [
   // Most specific first (e.g., "gpt-5.2-thinking" before "gpt-5.2")
-  ["gpt-5.4-pro", "GPT-5.4 Pro"],
-  ["gpt-5.2-thinking", "GPT-5.2 Thinking"],
-  ["gpt-5.2-instant", "GPT-5.2 Instant"],
-  ["gpt-5.2-pro", "GPT-5.4 Pro"],
-  ["gpt-5.1-pro", "GPT-5.4 Pro"],
-  ["gpt-5-pro", "GPT-5.4 Pro"],
+  ["gpt-5.4-pro", CURRENT_PRO_BROWSER_LABEL],
+  ["gpt-5.2-thinking", CURRENT_THINKING_BROWSER_LABEL],
+  ["gpt-5.2-instant", CURRENT_INSTANT_BROWSER_LABEL],
+  ["gpt-5.2-pro", CURRENT_PRO_BROWSER_LABEL],
+  ["gpt-5.1-pro", CURRENT_PRO_BROWSER_LABEL],
+  ["gpt-5-pro", CURRENT_PRO_BROWSER_LABEL],
   // Base models last (least specific)
-  ["gpt-5.4", "Thinking 5.4"],
-  ["gpt-5.2", "GPT-5.2"], // Selects "Auto" in ChatGPT UI
-  ["gpt-5.1", "GPT-5.2"], // Legacy alias → Auto
+  ["gpt-5.4", CURRENT_THINKING_BROWSER_LABEL],
+  ["gpt-5.2", CURRENT_AUTO_BROWSER_LABEL],
+  ["gpt-5.1", CURRENT_AUTO_BROWSER_LABEL],
   ["gemini-3-pro", "Gemini 3 Pro"],
   ["gemini-3-pro-deep-think", "gemini-3-deep-think"],
 ];
@@ -87,7 +91,7 @@ export function normalizeChatGptModelForBrowser(model: ModelName): ModelName {
   }
 
   // Pro variants: resolve to the latest Pro model in ChatGPT.
-  if (normalized === "gpt-5-pro" || normalized === "gpt-5.1-pro" || normalized === "gpt-5.2-pro") {
+  if (/^gpt-5(?:\.\d+)?-pro$/.test(normalized)) {
     return "gpt-5.4-pro";
   }
 
@@ -96,7 +100,7 @@ export function normalizeChatGptModelForBrowser(model: ModelName): ModelName {
     return normalized;
   }
 
-  // Legacy aliases: map to base GPT-5.2 (Auto)
+  // Legacy aliases: map to base GPT-5.2 browser target (Auto)
   if (normalized === "gpt-5.1") {
     return "gpt-5.2";
   }
@@ -150,7 +154,7 @@ export async function buildBrowserConfig(
   ) {
     throw new Error(
       "Temporary Chat mode does not expose Pro models in the ChatGPT model picker. " +
-        'Remove "temporary-chat=true" from --chatgpt-url (or omit --chatgpt-url), or use a non-Pro model (e.g. --model gpt-5.2).',
+        'Remove "temporary-chat=true" from --chatgpt-url (or omit --chatgpt-url), or use a non-Pro model (e.g. --model gpt-5.2-instant).',
     );
   }
 
@@ -229,10 +233,26 @@ export function mapModelToBrowserLabel(model: ModelName): string {
   return DEFAULT_MODEL_TARGET;
 }
 
+function normalizeBrowserLabelValue(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+}
+
+function isCurrentProBrowserTarget(value: string): boolean {
+  const normalized = normalizeBrowserLabelValue(value);
+  return (
+    /^gpt 5(?: \d+)? pro$/.test(normalized) ||
+    /^chatgpt 5(?: \d+)? pro$/.test(normalized) ||
+    /^pro 5(?: \d+)?$/.test(normalized)
+  );
+}
+
 export function resolveBrowserModelLabel(input: string | undefined, model: ModelName): string {
   const trimmed = input?.trim?.() ?? "";
   if (!trimmed) {
     return mapModelToBrowserLabel(model);
+  }
+  if (isCurrentProBrowserTarget(trimmed)) {
+    return CURRENT_PRO_BROWSER_LABEL;
   }
   const normalizedInput = trimmed.toLowerCase();
   if (normalizedInput === model.toLowerCase()) {

--- a/src/cli/stdin.ts
+++ b/src/cli/stdin.ts
@@ -1,0 +1,29 @@
+export async function readStdin(
+  stream: NodeJS.ReadableStream = process.stdin,
+): Promise<string> {
+  const chunks: string[] = [];
+  if (typeof (stream as { setEncoding?: (encoding: string) => void }).setEncoding === "function") {
+    (stream as { setEncoding: (encoding: string) => void }).setEncoding("utf8");
+  }
+  for await (const chunk of stream) {
+    chunks.push(typeof chunk === "string" ? chunk : String(chunk));
+  }
+  return chunks.join("");
+}
+
+export async function resolveDashPrompt(
+  prompt: string | undefined,
+  stream: NodeJS.ReadableStream = process.stdin,
+): Promise<string | undefined> {
+  if (prompt !== "-") {
+    return prompt;
+  }
+  if ((stream as NodeJS.ReadStream).isTTY) {
+    throw new Error(`"-p -" requires piped input (for example: echo "prompt" | oracle -p -).`);
+  }
+  const stdinPrompt = (await readStdin(stream)).trim();
+  if (!stdinPrompt) {
+    throw new Error(`"-p -" received empty stdin.`);
+  }
+  return stdinPrompt;
+}

--- a/tests/browser/attachmentsCompletion.test.ts
+++ b/tests/browser/attachmentsCompletion.test.ts
@@ -222,4 +222,91 @@ describe("sent turn attachment verification", () => {
       ),
     ).resolves.toBe(true);
   });
+
+  test("waitForUserTurnAttachments ignores turns before the expected baseline", async () => {
+    useFakeTime();
+
+    const runtime = {
+      evaluate: vi.fn().mockResolvedValue({
+        result: {
+          value: {
+            ok: false,
+          },
+        },
+      }),
+    } as unknown as ChromeClient["Runtime"];
+
+    const promise = waitForUserTurnAttachments(
+      runtime,
+      ["oracle-attach-verify.txt"],
+      600,
+      undefined,
+      {
+        minTurnIndex: 4,
+      },
+    );
+    await vi.advanceTimersByTimeAsync(2_000);
+    await expect(promise).resolves.toBe(false);
+    useRealTime();
+  });
+
+  test("waitForUserTurnAttachments requires prompt evidence when provided", async () => {
+    useFakeTime();
+
+    const runtime = {
+      evaluate: vi.fn().mockResolvedValue({
+        result: {
+          value: {
+            ok: true,
+            text: "You said: unrelated prompt oracle-attach-verify.txt",
+            attrs: [],
+            hasAttachmentUi: true,
+            promptMatches: false,
+          },
+        },
+      }),
+    } as unknown as ChromeClient["Runtime"];
+
+    const promise = waitForUserTurnAttachments(
+      runtime,
+      ["oracle-attach-verify.txt"],
+      600,
+      undefined,
+      {
+        expectedPrompt: "expected prompt text",
+      },
+    );
+    const assertion = expect(promise).rejects.toThrow(/Attachment was not present/i);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await assertion;
+    useRealTime();
+  });
+
+  test("waitForUserTurnAttachments ignores mismatched conversations", async () => {
+    useFakeTime();
+
+    const runtime = {
+      evaluate: vi.fn().mockResolvedValue({
+        result: {
+          value: {
+            ok: false,
+            conversationMismatch: true,
+          },
+        },
+      }),
+    } as unknown as ChromeClient["Runtime"];
+
+    const promise = waitForUserTurnAttachments(
+      runtime,
+      ["oracle-attach-verify.txt"],
+      600,
+      undefined,
+      {
+        expectedConversationId: "conv-123",
+      },
+    );
+    await vi.advanceTimersByTimeAsync(2_000);
+    await expect(promise).resolves.toBe(false);
+    useRealTime();
+  });
 });

--- a/tests/browser/index.test.ts
+++ b/tests/browser/index.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, test } from "vitest";
-import { shouldPreserveBrowserOnErrorForTest } from "../../src/browser/index.js";
+import { describe, expect, test, vi } from "vitest";
+import {
+  runSubmissionWithRecoveryForTest,
+  shouldPreserveBrowserOnErrorForTest,
+} from "../../src/browser/index.js";
 import { BrowserAutomationError } from "../../src/oracle/errors.js";
 
 describe("shouldPreserveBrowserOnErrorForTest", () => {
@@ -22,5 +25,79 @@ describe("shouldPreserveBrowserOnErrorForTest", () => {
       stage: "execute-browser",
     });
     expect(shouldPreserveBrowserOnErrorForTest(error, false)).toBe(false);
+  });
+});
+
+describe("runSubmissionWithRecoveryForTest", () => {
+  test("preserves prompt-too-large fallback after a dead-composer retry", async () => {
+    const submit = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new BrowserAutomationError("dead composer", { code: "dead-composer" }),
+      )
+      .mockRejectedValueOnce(
+        new BrowserAutomationError("prompt too large", { code: "prompt-too-large" }),
+      )
+      .mockResolvedValueOnce({
+        baselineTurns: 7,
+        baselineAssistantText: "done",
+      });
+    const reloadPromptComposer = vi.fn().mockResolvedValue(undefined);
+    const prepareFallbackSubmission = vi.fn().mockResolvedValue(undefined);
+    const logger: (message: string) => void = vi.fn();
+
+    await expect(
+      runSubmissionWithRecoveryForTest({
+        prompt: "inline prompt",
+        attachments: [],
+        fallbackSubmission: {
+          prompt: "fallback prompt",
+          attachments: [{ path: "/tmp/fallback.txt", displayPath: "fallback.txt", sizeBytes: 12 }],
+        },
+        submit,
+        reloadPromptComposer,
+        prepareFallbackSubmission,
+        logger,
+      }),
+    ).resolves.toEqual({
+      baselineTurns: 7,
+      baselineAssistantText: "done",
+    });
+
+    expect(reloadPromptComposer).toHaveBeenCalledTimes(1);
+    expect(prepareFallbackSubmission).toHaveBeenCalledTimes(1);
+    expect(submit).toHaveBeenNthCalledWith(1, "inline prompt", []);
+    expect(submit).toHaveBeenNthCalledWith(2, "inline prompt", []);
+    expect(submit).toHaveBeenNthCalledWith(
+      3,
+      "fallback prompt",
+      [expect.objectContaining({ displayPath: "fallback.txt" })],
+    );
+  });
+
+  test("throws when prompt-too-large happens again after fallback", async () => {
+    const submit = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new BrowserAutomationError("prompt too large", { code: "prompt-too-large" }),
+      )
+      .mockRejectedValueOnce(
+        new BrowserAutomationError("prompt too large again", { code: "prompt-too-large" }),
+      );
+
+    await expect(
+      runSubmissionWithRecoveryForTest({
+        prompt: "inline prompt",
+        attachments: [],
+        fallbackSubmission: {
+          prompt: "fallback prompt",
+          attachments: [],
+        },
+        submit,
+        reloadPromptComposer: vi.fn().mockResolvedValue(undefined),
+        prepareFallbackSubmission: vi.fn().mockResolvedValue(undefined),
+        logger: vi.fn<(message: string) => void>(),
+      }),
+    ).rejects.toThrow(/prompt too large again/i);
   });
 });

--- a/tests/browser/pageActionsExpressions.test.ts
+++ b/tests/browser/pageActionsExpressions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
   buildAssistantExtractorForTest,
+  buildAssistantSnapshotExpressionForTest,
   buildConversationDebugExpressionForTest,
   buildMarkdownFallbackExtractorForTest,
   buildCopyExpressionForTest,
@@ -20,6 +21,13 @@ describe("browser automation expressions", () => {
   test("conversation debug expression references conversation selector", () => {
     const expression = buildConversationDebugExpressionForTest();
     expect(expression).toContain(JSON.stringify(CONVERSATION_TURN_SELECTOR));
+  });
+
+  test("assistant snapshot expression guards against conversation drift", () => {
+    const expression = buildAssistantSnapshotExpressionForTest(4, "conv-123");
+    expect(expression).toContain('const EXPECTED_CONVERSATION_ID = "conv-123"');
+    expect(expression).toContain("currentConversationId !== EXPECTED_CONVERSATION_ID");
+    expect(expression).toContain("return null;");
   });
 
   test("markdown fallback filters user turns and respects assistant indicators", () => {

--- a/tests/browser/pageActionsExpressions.test.ts
+++ b/tests/browser/pageActionsExpressions.test.ts
@@ -5,6 +5,7 @@ import {
   buildConversationDebugExpressionForTest,
   buildMarkdownFallbackExtractorForTest,
   buildCopyExpressionForTest,
+  buildUserTurnAttachmentExpressionForTest,
 } from "../../src/browser/pageActions.ts";
 import {
   CONVERSATION_TURN_SELECTOR,
@@ -52,5 +53,14 @@ describe("browser automation expressions", () => {
     expect(expression).toContain(ASSISTANT_ROLE_SELECTOR);
     expect(expression).toContain("isAssistantTurn");
     expect(expression).toContain("copy-turn-action-button");
+  });
+
+  test("user-turn attachment expression requires non-empty prompt text for prefix fallback", () => {
+    const expression = buildUserTurnAttachmentExpressionForTest({
+      expectedPromptPrefix: "expected prompt text",
+    });
+    expect(expression).toContain("const textPrefix = text.slice");
+    expect(expression).toContain("text.length > 0");
+    expect(expression).toContain("textPrefix.length > 0");
   });
 });

--- a/tests/browser/promptComposer.test.ts
+++ b/tests/browser/promptComposer.test.ts
@@ -2,6 +2,36 @@ import { describe, expect, test, vi } from "vitest";
 import { __test__ as promptComposer } from "../../src/browser/actions/promptComposer.js";
 
 describe("promptComposer", () => {
+  test("reports dead composer during health check", async () => {
+    const runtime = {
+      evaluate: vi
+        .fn()
+        .mockResolvedValueOnce({
+          result: {
+            value: {
+              healthy: false,
+              reason: "active-input-disabled",
+              activeExists: true,
+              activeVisible: true,
+              activeDisabled: true,
+              activeReadOnly: false,
+              activeTagName: "textarea",
+              activeRole: "textbox",
+              href: "https://chatgpt.com/",
+            },
+          },
+        }),
+    } as unknown as {
+      evaluate: (args: { expression: string; returnByValue?: boolean }) => Promise<unknown>;
+    };
+
+    await expect(
+      promptComposer.ensureComposerHealthy(runtime as never, (() => {}) as never),
+    ).rejects.toMatchObject({
+      details: expect.objectContaining({ code: "dead-composer" }),
+    });
+  });
+
   test("does not treat cleared composer + stop button as committed without a new turn", async () => {
     vi.useFakeTimers();
     try {
@@ -71,5 +101,103 @@ describe("promptComposer", () => {
     await expect(
       promptComposer.verifyPromptCommitted(runtime as never, "hello", 150),
     ).resolves.toBe(1);
+  });
+
+  test("classifies commit timeout as dead composer when input stays inert", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtime = {
+        evaluate: vi
+          .fn()
+          .mockResolvedValueOnce({ result: { value: 10 } })
+          .mockResolvedValue({
+            result: {
+              value: {
+                baseline: 10,
+                turnsCount: 10,
+                userMatched: false,
+                prefixMatched: false,
+                lastMatched: false,
+                hasNewTurn: false,
+                stopVisible: false,
+                assistantVisible: false,
+                composerCleared: false,
+                inConversation: false,
+                href: "https://chatgpt.com/",
+                activeInputExists: true,
+                activeInputVisible: false,
+                activeInputDisabled: true,
+                activeInputReadOnly: false,
+                activeInputValueLength: 0,
+                activeInputTagName: "textarea",
+                activeInputRole: "textbox",
+              },
+            },
+          }),
+      } as unknown as {
+        evaluate: (args: { expression: string; returnByValue?: boolean }) => Promise<unknown>;
+      };
+
+      const promise = promptComposer.verifyPromptCommitted(runtime as never, "hello", 150);
+      const assertion = expect(promise).rejects.toMatchObject({
+        details: expect.objectContaining({
+          code: "dead-composer",
+          composerState: expect.objectContaining({
+            activeInputDisabled: true,
+            activeInputVisible: false,
+          }),
+        }),
+      });
+      await vi.advanceTimersByTimeAsync(250);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("treats large prompt commit timeout as prompt-too-large", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtime = {
+        evaluate: vi
+          .fn()
+          .mockResolvedValueOnce({ result: { value: 10 } })
+          .mockResolvedValue({
+            result: {
+              value: {
+                baseline: 10,
+                turnsCount: 10,
+                userMatched: false,
+                prefixMatched: false,
+                lastMatched: false,
+                hasNewTurn: false,
+                stopVisible: false,
+                assistantVisible: false,
+                composerCleared: false,
+                inConversation: false,
+                href: "https://chatgpt.com/",
+                activeInputExists: true,
+                activeInputVisible: true,
+                activeInputDisabled: false,
+                activeInputReadOnly: false,
+                activeInputValueLength: 0,
+                activeInputTagName: "textarea",
+                activeInputRole: "textbox",
+              },
+            },
+          }),
+      } as unknown as {
+        evaluate: (args: { expression: string; returnByValue?: boolean }) => Promise<unknown>;
+      };
+
+      const promise = promptComposer.verifyPromptCommitted(runtime as never, "x".repeat(20_000), 150);
+      const assertion = expect(promise).rejects.toMatchObject({
+        details: expect.objectContaining({ code: "prompt-too-large" }),
+      });
+      await vi.advanceTimersByTimeAsync(250);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/cli/browserConfig.test.ts
+++ b/tests/cli/browserConfig.test.ts
@@ -65,7 +65,7 @@ describe("buildBrowserConfig", () => {
       headless: undefined,
       hideWindow: true,
       keepBrowser: true,
-      desiredModel: "GPT-5.2",
+      desiredModel: "Auto",
       debug: true,
       allowCookieErrors: true,
     });
@@ -84,7 +84,7 @@ describe("buildBrowserConfig", () => {
       model: "gpt-5.1",
       browserModelLabel: "gpt-5.1",
     });
-    expect(config.desiredModel).toBe("GPT-5.2");
+    expect(config.desiredModel).toBe("Auto");
   });
 
   test("maps thinking Gemini model to thinking label", async () => {
@@ -106,7 +106,7 @@ describe("buildBrowserConfig", () => {
       model: "gpt-5.1",
       browserModelLabel: "  ChatGPT 5.1 Instant  ",
     });
-    expect(config.desiredModel).toBe("GPT-5.2");
+    expect(config.desiredModel).toBe("Auto");
   });
 
   test("parses remoteChrome host targets", async () => {
@@ -159,7 +159,7 @@ describe("buildBrowserConfig", () => {
       chatgptUrl: "https://chatgpt.com/?temporary-chat=true",
     });
     expect(config.url).toBe("https://chatgpt.com/?temporary-chat=true");
-    expect(config.desiredModel).toBe("GPT-5.2");
+    expect(config.desiredModel).toBe("Auto");
   });
 
   test("accepts IPv6 remoteChrome targets wrapped in brackets", async () => {
@@ -205,11 +205,11 @@ describe("resolveBrowserModelLabel", () => {
     expect(resolveBrowserModelLabel("gpt-5-pro", "gpt-5-pro")).toBe("GPT-5.4 Pro");
     expect(resolveBrowserModelLabel("gpt-5.2-pro", "gpt-5.2-pro")).toBe("GPT-5.4 Pro");
     expect(resolveBrowserModelLabel("gpt-5.1-pro", "gpt-5.1-pro")).toBe("GPT-5.4 Pro");
-    expect(resolveBrowserModelLabel("GPT-5.1", "gpt-5.1")).toBe("GPT-5.2");
+    expect(resolveBrowserModelLabel("GPT-5.1", "gpt-5.1")).toBe("Auto");
   });
 
   test("falls back to canonical label when input is empty", () => {
-    expect(resolveBrowserModelLabel("", "gpt-5.1")).toBe("GPT-5.2");
+    expect(resolveBrowserModelLabel("", "gpt-5.1")).toBe("Auto");
   });
 
   test("preserves descriptive labels to target alternate picker entries", () => {
@@ -218,12 +218,25 @@ describe("resolveBrowserModelLabel", () => {
 
   test("supports undefined or whitespace-only input", () => {
     expect(resolveBrowserModelLabel(undefined, "gpt-5.2-pro")).toBe("GPT-5.4 Pro");
-    expect(resolveBrowserModelLabel("   ", "gpt-5.1")).toBe("GPT-5.2");
+    expect(resolveBrowserModelLabel("   ", "gpt-5.1")).toBe("Auto");
+  });
+
+  test("maps instant and thinking aliases to current browser picker targets", async () => {
+    const instant = await buildBrowserConfig({ model: "gpt-5.2-instant" });
+    const thinking = await buildBrowserConfig({ model: "gpt-5.2-thinking" });
+    expect(instant.desiredModel).toBe("Instant 5.3");
+    expect(thinking.desiredModel).toBe("Thinking 5.4");
   });
 
   test("trims descriptive labels before returning them", () => {
     expect(resolveBrowserModelLabel("  ChatGPT 5.1 Thinking ", "gpt-5.1")).toBe(
       "ChatGPT 5.1 Thinking",
     );
+  });
+
+  test("canonicalizes versioned Pro labels to the current Pro picker target", () => {
+    expect(resolveBrowserModelLabel("GPT-5.2 Pro", "gpt-5.2-pro")).toBe("GPT-5.4 Pro");
+    expect(resolveBrowserModelLabel("ChatGPT 5.1 Pro", "gpt-5.1-pro")).toBe("GPT-5.4 Pro");
+    expect(resolveBrowserModelLabel("Pro 5.4", "gpt-5.4-pro")).toBe("GPT-5.4 Pro");
   });
 });

--- a/tests/cli/stdin.test.ts
+++ b/tests/cli/stdin.test.ts
@@ -1,0 +1,34 @@
+import { Readable } from "node:stream";
+import { describe, expect, test } from "vitest";
+import { readStdin, resolveDashPrompt } from "../../src/cli/stdin.js";
+
+describe("stdin helpers", () => {
+  test("readStdin reads the full stream payload", async () => {
+    const stream = Readable.from(["Hello", " ", "world"]);
+    await expect(readStdin(stream)).resolves.toBe("Hello world");
+  });
+
+  test("resolveDashPrompt keeps normal prompts unchanged", async () => {
+    await expect(resolveDashPrompt("normal prompt", Readable.from([]))).resolves.toBe(
+      "normal prompt",
+    );
+  });
+
+  test("resolveDashPrompt reads piped stdin", async () => {
+    const stream = Readable.from(["Hello world\n"]);
+    Object.assign(stream, { isTTY: false });
+    await expect(resolveDashPrompt("-", stream)).resolves.toBe("Hello world");
+  });
+
+  test("resolveDashPrompt rejects tty stdin", async () => {
+    const stream = Readable.from([]);
+    Object.assign(stream, { isTTY: true });
+    await expect(resolveDashPrompt("-", stream)).rejects.toThrow(/requires piped input/i);
+  });
+
+  test("resolveDashPrompt rejects empty stdin", async () => {
+    const stream = Readable.from([" \n "]);
+    Object.assign(stream, { isTTY: false });
+    await expect(resolveDashPrompt("-", stream)).rejects.toThrow(/received empty stdin/i);
+  });
+});

--- a/tests/mcp/consult.test.ts
+++ b/tests/mcp/consult.test.ts
@@ -60,7 +60,7 @@ describe("summarizeModelRunsForConsult", () => {
       manualLogin: true,
       manualLoginProfileDir: "/tmp/oracle-profile",
       thinkingTime: "extended",
-      desiredModel: "GPT-5.2",
+      desiredModel: "Auto",
       cookieSync: false,
     });
   });


### PR DESCRIPTION
## Summary
- harden browser-mode prompt submission with stdin `-p -` support, dead-composer detection, tighter prompt truncation handling, and one controlled reload retry
- lock browser response capture to the expected ChatGPT conversation so stale threads and old attachment turns are not misread as the current run
- align browser model labels and smoke docs/scripts with the current ChatGPT picker targets, including current Pro routing and consult/browser default expectations

## Testing
- `pnpm run lint`
- `pnpm run test`
- `pnpm run build`
- `printf 'Summarize the attached file as exactly two markdown bullets: one for CPU and one for memory.\nDo not quote the prompt.\n' | node dist/bin/oracle-cli.js --engine browser --model gpt-5.4-pro --browser-manual-login --browser-keep-browser --browser-attachments always --verbose --slug browser-stability-smoke-pro-54-fix-4 -p - -f /tmp/browser-report-smoke-4.txt`
- `printf 'Return exactly one line and nothing else: pro-ok\n' | node dist/bin/oracle-cli.js --engine browser --model gpt-5.2-instant --browser-manual-login --browser-keep-browser --verbose --slug browser-smoke-pro-deterministic-instant-2 -p -`
