### PR TITLE
Fix Gemini browser profile dir resolution

### DIFF
--- a/src/gemini-web/browserSessionManager.ts
+++ b/src/gemini-web/browserSessionManager.ts
@@ -31,16 +31,17 @@ export async function openGeminiBrowserSession(
   input: OpenGeminiBrowserSessionInput,
 ): Promise<GeminiBrowserSession> {
   const { browserConfig, keepBrowserDefault, purpose, log } = input;
-  const profileDir =
-    browserConfig?.manualLoginProfileDir ?? path.join(os.homedir(), ".oracle", "browser-profile");
-  await mkdir(profileDir, { recursive: true });
-
   const resolvedConfig = resolveBrowserConfig({
     ...browserConfig,
     manualLogin: true,
-    manualLoginProfileDir: profileDir,
     keepBrowser: browserConfig?.keepBrowser ?? keepBrowserDefault,
   });
+  const profileDir =
+    resolvedConfig.manualLoginProfileDir ??
+    browserConfig?.manualLoginProfileDir ??
+    process.env.ORACLE_BROWSER_PROFILE_DIR ??
+    path.join(os.homedir(), ".oracle", "browser-profile");
+  await mkdir(profileDir, { recursive: true });
   const keepBrowser = Boolean(resolvedConfig.keepBrowser);
 
   let port = await readDevToolsPort(profileDir);

--- a/src/gemini-web/browserSessionManager.ts
+++ b/src/gemini-web/browserSessionManager.ts
@@ -36,11 +36,11 @@ export async function openGeminiBrowserSession(
     manualLogin: true,
     keepBrowser: browserConfig?.keepBrowser ?? keepBrowserDefault,
   });
-  const profileDir =
-    resolvedConfig.manualLoginProfileDir ??
-    browserConfig?.manualLoginProfileDir ??
-    process.env.ORACLE_BROWSER_PROFILE_DIR ??
-    path.join(os.homedir(), ".oracle", "browser-profile");
+  const profileDir = resolveGeminiProfileDir(
+    resolvedConfig.manualLoginProfileDir,
+    browserConfig?.manualLoginProfileDir,
+    process.env.ORACLE_BROWSER_PROFILE_DIR,
+  );
   await mkdir(profileDir, { recursive: true });
   const keepBrowser = Boolean(resolvedConfig.keepBrowser);
 
@@ -112,4 +112,17 @@ export async function openGeminiBrowserSession(
     targetId: targetId ?? undefined,
     close,
   };
+}
+
+function resolveGeminiProfileDir(
+  ...candidates: Array<string | null | undefined>
+): string {
+  for (const candidate of candidates) {
+    if (typeof candidate !== "string") continue;
+    const normalized = candidate.trim();
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return path.join(os.homedir(), ".oracle", "browser-profile");
 }

--- a/tests/gemini-web/browserSessionManager.test.ts
+++ b/tests/gemini-web/browserSessionManager.test.ts
@@ -128,4 +128,31 @@ describe("openGeminiBrowserSession", () => {
 
     await session.close();
   });
+
+  it("ignores blank ORACLE_BROWSER_PROFILE_DIR values", async () => {
+    process.env.ORACLE_BROWSER_PROFILE_DIR = "   ";
+
+    const { openGeminiBrowserSession } = await import(
+      "../../src/gemini-web/browserSessionManager.js"
+    );
+
+    const session = await openGeminiBrowserSession({
+      browserConfig: {},
+      keepBrowserDefault: false,
+      purpose: "test blank env profile",
+      log: () => {},
+    });
+
+    const expectedDefault = path.join(os.homedir(), ".oracle", "browser-profile");
+    expect(session.profileDir).toBe(expectedDefault);
+    expect(launchChrome).toHaveBeenCalledWith(
+      expect.objectContaining({
+        manualLogin: true,
+      }),
+      expectedDefault,
+      expect.any(Function),
+    );
+
+    await session.close();
+  });
 });

--- a/tests/gemini-web/browserSessionManager.test.ts
+++ b/tests/gemini-web/browserSessionManager.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const {
+  launchChrome,
+  connectWithNewTab,
+  closeTab,
+  readDevToolsPort,
+  writeDevToolsActivePort,
+  writeChromePid,
+  cleanupStaleProfileState,
+  verifyDevToolsReachable,
+} = vi.hoisted(() => ({
+  launchChrome: vi.fn(),
+  connectWithNewTab: vi.fn(),
+  closeTab: vi.fn(async () => undefined),
+  readDevToolsPort: vi.fn(async () => null),
+  writeDevToolsActivePort: vi.fn(async () => undefined),
+  writeChromePid: vi.fn(async () => undefined),
+  cleanupStaleProfileState: vi.fn(async () => undefined),
+  verifyDevToolsReachable: vi.fn(async () => ({ ok: false, error: "unreachable" })),
+}));
+
+vi.mock("../../src/browser/chromeLifecycle.js", () => ({
+  launchChrome,
+  connectWithNewTab,
+  closeTab,
+}));
+
+vi.mock("../../src/browser/profileState.js", () => ({
+  readDevToolsPort,
+  writeDevToolsActivePort,
+  writeChromePid,
+  cleanupStaleProfileState,
+  verifyDevToolsReachable,
+}));
+
+describe("openGeminiBrowserSession", () => {
+  const tempDirs: string[] = [];
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    launchChrome.mockResolvedValue({
+      port: 9222,
+      pid: 12345,
+      kill: vi.fn(),
+    });
+    connectWithNewTab.mockResolvedValue({
+      targetId: "target-1",
+      client: {
+        close: vi.fn(async () => undefined),
+      },
+    });
+    readDevToolsPort.mockResolvedValue(null);
+    verifyDevToolsReachable.mockResolvedValue({ ok: false, error: "unreachable" });
+    delete process.env.ORACLE_BROWSER_PROFILE_DIR;
+  });
+
+  afterEach(async () => {
+    delete process.env.ORACLE_BROWSER_PROFILE_DIR;
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (dir) {
+        await rm(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("prefers explicit manualLoginProfileDir over ORACLE_BROWSER_PROFILE_DIR", async () => {
+    const explicitDir = await mkdtemp(path.join(os.tmpdir(), "oracle-gemini-explicit-"));
+    const envDir = await mkdtemp(path.join(os.tmpdir(), "oracle-gemini-env-"));
+    tempDirs.push(explicitDir, envDir);
+    process.env.ORACLE_BROWSER_PROFILE_DIR = envDir;
+
+    const { openGeminiBrowserSession } = await import(
+      "../../src/gemini-web/browserSessionManager.js"
+    );
+
+    const session = await openGeminiBrowserSession({
+      browserConfig: { manualLoginProfileDir: explicitDir },
+      keepBrowserDefault: false,
+      purpose: "test explicit profile",
+      log: () => {},
+    });
+
+    expect(session.profileDir).toBe(explicitDir);
+    expect(launchChrome).toHaveBeenCalledWith(
+      expect.objectContaining({
+        manualLogin: true,
+        manualLoginProfileDir: explicitDir,
+      }),
+      explicitDir,
+      expect.any(Function),
+    );
+
+    await session.close();
+  });
+
+  it("uses ORACLE_BROWSER_PROFILE_DIR when manualLoginProfileDir is not set", async () => {
+    const envDir = await mkdtemp(path.join(os.tmpdir(), "oracle-gemini-env-"));
+    tempDirs.push(envDir);
+    process.env.ORACLE_BROWSER_PROFILE_DIR = envDir;
+
+    const { openGeminiBrowserSession } = await import(
+      "../../src/gemini-web/browserSessionManager.js"
+    );
+
+    const session = await openGeminiBrowserSession({
+      browserConfig: {},
+      keepBrowserDefault: false,
+      purpose: "test env profile",
+      log: () => {},
+    });
+
+    expect(session.profileDir).toBe(envDir);
+    expect(launchChrome).toHaveBeenCalledWith(
+      expect.objectContaining({
+        manualLogin: true,
+        manualLoginProfileDir: envDir,
+      }),
+      envDir,
+      expect.any(Function),
+    );
+
+    await session.close();
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes a narrow Gemini browser-session bug: `openGeminiBrowserSession()` was choosing the profile directory before browser config resolution, so Gemini manual-login / Deep Think runs could ignore configured browser profile defaults.

## Intent

The intent of this PR is strictly to make Gemini browser sessions honor the same resolved profile-dir precedence that the rest of browser config uses:

1. explicit `manualLoginProfileDir`
2. `ORACLE_BROWSER_PROFILE_DIR`
3. default `~/.oracle/browser-profile`

This PR is intentionally separate from the Grok browser/provider refactor work. It does not change Grok, ChatGPT, or shared browser runtime behavior.

## How we got into this bug

We found this while reviewing a separate browser-provider refactor branch. Review surfaced that Gemini browser runs were not respecting configured persistent profile directories unless `browserConfig.manualLoginProfileDir` was passed explicitly.

The root cause was local to `src/gemini-web/browserSessionManager.ts`:

- it picked `profileDir` up front from `browserConfig?.manualLoginProfileDir ?? ~/.oracle/browser-profile`
- only after that did it call `resolveBrowserConfig()`
- that meant resolved defaults like `ORACLE_BROWSER_PROFILE_DIR` never got a chance to influence the actual Gemini Chrome profile path

In practice, users with a configured browser profile dir could silently launch the wrong Gemini profile and miss their signed-in session.

## Why this solution is right

This fix keeps the scope intentionally small:

- `openGeminiBrowserSession()` now resolves browser config first
- it then derives `profileDir` from `resolvedConfig.manualLoginProfileDir`
- a defensive fallback remains for explicit config / env / default path so existing mocked tests and unexpected call sites stay safe

Why this is the correct behavior:

- `resolveBrowserConfig()` is already the source of truth for browser config precedence
- Gemini should not reimplement its own earlier, narrower profile-dir resolution path
- the change is isolated to Gemini session setup and does not alter shared provider/runtime logic

## Tests

Added focused coverage for Gemini session manager profile resolution:

- explicit `manualLoginProfileDir` wins over `ORACLE_BROWSER_PROFILE_DIR`
- `ORACLE_BROWSER_PROFILE_DIR` is honored when explicit config is absent

Validation run on this branch:

- `pnpm test`
- `pnpm run typecheck`
- `pnpm run build`
