### PR TITLE
fix(browser): prefer /tmp for hidden-home tmpdirs and redact inline cookies in debug logs

### DIFF
--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -2145,7 +2145,25 @@ async function resolveUserDataBaseDir(): Promise<string> {
       }
     }
   }
-  return os.tmpdir();
+
+  const tmpDir = os.tmpdir();
+  if (process.platform === "linux") {
+    const homeDir = os.homedir();
+    const relativeToHome =
+      homeDir && tmpDir.startsWith(homeDir + path.sep) ? tmpDir.slice(homeDir.length + 1) : "";
+    const firstSegment = relativeToHome.split(path.sep, 1)[0];
+    const isHiddenHomeTmp = Boolean(firstSegment?.startsWith("."));
+    if (isHiddenHomeTmp) {
+      try {
+        await mkdir("/tmp", { recursive: true });
+        return "/tmp";
+      } catch {
+        // Fall back to the inherited tmpdir if /tmp is unavailable.
+      }
+    }
+  }
+
+  return tmpDir;
 }
 
 function buildThinkingStatusExpression(): string {

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -64,6 +64,15 @@ export type { BrowserAutomationConfig, BrowserRunOptions, BrowserRunResult } fro
 export { CHATGPT_URL, DEFAULT_MODEL_STRATEGY, DEFAULT_MODEL_TARGET } from "./constants.js";
 export { parseDuration, delay, normalizeChatgptUrl, isTemporaryChatUrl } from "./utils.js";
 
+function redactBrowserConfigForDebugLog(config: Record<string, unknown>): Record<string, unknown> {
+  const redacted = { ...config };
+  if (Array.isArray(config.inlineCookies)) {
+    redacted.inlineCookies = `[redacted:${config.inlineCookies.length} cookies]`;
+    redacted.inlineCookieCount = config.inlineCookies.length;
+  }
+  return redacted;
+}
+
 function isCloudflareChallengeError(error: unknown): error is BrowserAutomationError {
   if (!(error instanceof BrowserAutomationError)) return false;
   return (error.details as { stage?: string } | undefined)?.stage === "cloudflare-challenge";
@@ -122,7 +131,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
   if (config.debug || process.env.CHATGPT_DEVTOOLS_TRACE === "1") {
     logger(
       `[browser-mode] config: ${JSON.stringify({
-        ...config,
+        ...redactBrowserConfigForDebugLog(config),
         promptLength: promptText.length,
       })}`,
     );


### PR DESCRIPTION
## Summary
- prefer `/tmp` for temporary browser profiles when Linux inherits a hidden tmpdir under `$HOME`
- redact inline cookie arrays from the low-level `[browser-mode] config:` debug logger

## Why
While validating native Oracle browser mode on a headless Linux host, I ran into two small but real issues in the Chrome/CDP path:

1. **Misleading launch failure from hidden-home tmpdirs**
   - On this host, `TMPDIR=/home/openclaw/.tmp`
   - Oracle created temporary browser profiles under that hidden home path
   - Chromium rejected the profile base and Oracle surfaced the outer symptom as:
     - `connect ECONNREFUSED 127.0.0.1:9222`
   - When the same run used `/tmp` instead, Chrome launched successfully and the run advanced to the real next blocker

2. **Verbose native logging still leaks inline cookie material**
   - higher-level session logging was already redacted
   - lower-level `[browser-mode] config:` logging still printed the full `inlineCookies` array

## What changed
### 1) tmpdir fallback for Linux hidden-home tmpdirs
In `resolveUserDataBaseDir()`, when `os.tmpdir()` resolves under `$HOME` and the first segment under `$HOME` is hidden (for example `.tmp`), prefer `/tmp` if available.

This keeps normal tmpdir behavior unchanged while avoiding a class of temporary browser-profile locations that can fail on some Linux/Chromium setups.

### 2) Redact `inlineCookies` in low-level browser-mode debug logs
The lower-level browser-mode config logger now redacts inline cookie arrays instead of printing raw values.

The redacted shape still preserves useful debugging context:
- `inlineCookies: "[redacted:N cookies]"`
- `inlineCookieCount: N`

## Validation
### Tmpdir split
Failing path:
```bash
oracle --engine browser \
  --browser-headless \
  --browser-no-cookie-sync \
  --browser-inline-cookies-file ~/.oracle/cookies.json \
  --prompt 'reply with exactly ORACLE_NATIVE_TMPDIR_SPLIT_OK' \
  --verbose
```
with inherited:
```bash
TMPDIR=/home/openclaw/.tmp
```

Observed:
- creates `/home/openclaw/.tmp/oracle-browser-*`
- fails with `connect ECONNREFUSED 127.0.0.1:9222`

Control run:
```bash
TMPDIR=/tmp oracle --engine browser \
  --browser-headless \
  --browser-no-cookie-sync \
  --browser-inline-cookies-file ~/.oracle/cookies.json \
  --prompt 'reply with exactly ORACLE_NATIVE_TMPDIR_SPLIT_OK' \
  --verbose
```

Observed:
- creates `/tmp/oracle-browser-*`
- launches Chrome successfully
- navigates to ChatGPT
- reaches the real next blocker:
  - `Cloudflare challenge detected in headless mode`

### Cookie redaction
Before this change:
- high-level browser config logging was redacted
- low-level `[browser-mode] config:` logging still leaked raw `inlineCookies`

After this change:
- both layers preserve debug usefulness without printing raw cookie values

## Risk notes
### Tmpdir heuristic
This is intentionally narrow, but it is still a heuristic:
- it changes behavior for Linux environments whose inherited tmpdir lives under a hidden path inside `$HOME`
- it does not probe Chromium directly; it avoids a proven-bad class of locations
- it only checks the first path segment under `$HOME`, by design, to stay conservative
- if `/tmp` is unavailable, it falls back to the inherited tmpdir

### Log redaction
Very low risk. The main tradeoff is losing raw inline-cookie visibility in verbose logs, which is desirable.

## What this does **not** do
- it does **not** make native headless Chrome bypass Cloudflare
- it does **not** change the practical recommendation for ChatGPT automation on hardened/headless hosts

The practical working path for that use case remains the Firefox/Camoufox flow; this PR just makes the native Chrome/CDP path more honest and safer to debug.

## AI assistance
This PR was prepared with AI assistance for investigation, patch packaging, and PR drafting, with human review before submission.

## Suggested commit split
1. `fix(browser): prefer /tmp for Linux hidden-home tmpdirs`
2. `fix(browser): redact inline cookies in browser-mode debug logs`