### PR TITLE
Open browser runs on the requested ChatGPT URL

### DIFF
--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -224,7 +224,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
   try {
     try {
       const strictTabIsolation = Boolean(manualLogin && reusedChrome);
-      const connection = await connectWithNewTab(chrome.port, logger, undefined, chromeHost, {
+      const connection = await connectWithNewTab(chrome.port, logger, config.url, chromeHost, {
         fallbackToDefault: !strictTabIsolation,
         retries: strictTabIsolation ? 3 : 0,
         retryDelayMs: 500,


### PR DESCRIPTION
## Summary
- pass the configured ChatGPT URL into the local browser tab attach path
- avoid launching a transient about:blank tab before navigation starts

## Why
On local browser runs, the current attach path opens a fresh tab with no initial URL and navigates later. In practice that makes failures look like Oracle ignored the requested conversation URL and can leave the user staring at about:blank when the browser session dies early.

Passing  into  makes the initial tab match the requested ChatGPT target immediately.

## Validation
- Lockfile is up to date, resolution step is skipped
Already up to date

╭ Warning ─────────────────────────────────────────────────────────────────────╮
│                                                                              │
│   Ignored build scripts: protobufjs.                                         │
│   Run "pnpm approve-builds" to pick which dependencies should be allowed     │
│   to run scripts.                                                            │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯


> @steipete/oracle@0.9.0 prepare /Users/Matthew/Projects/oracle
> pnpm run build


> @steipete/oracle@0.9.0 build /Users/Matthew/Projects/oracle
> tsc -p tsconfig.build.json && pnpm run build:vendor


> @steipete/oracle@0.9.0 build:vendor /Users/Matthew/Projects/oracle
> node -e "const fs=require('fs'); const path=require('path'); const vendorRoot=path.join('dist','vendor'); fs.rmSync(vendorRoot,{recursive:true,force:true}); const vendors=[['oracle-notifier']]; vendors.forEach(([name])=>{const src=path.join('vendor',name); const dest=path.join(vendorRoot,name); fs.mkdirSync(dest,{recursive:true}); if(fs.existsSync(src)){fs.cpSync(src,dest,{recursive:true,force:true});}});"

Done in 4.2s using pnpm v10.23.0 (which ran  / 
> @steipete/oracle@0.9.0 build /Users/Matthew/Projects/oracle
> tsc -p tsconfig.build.json && pnpm run build:vendor


> @steipete/oracle@0.9.0 build:vendor /Users/Matthew/Projects/oracle
> node -e "const fs=require('fs'); const path=require('path'); const vendorRoot=path.join('dist','vendor'); fs.rmSync(vendorRoot,{recursive:true,force:true}); const vendors=[['oracle-notifier']]; vendors.forEach(([name])=>{const src=path.join('vendor',name); const dest=path.join(vendorRoot,name); fs.mkdirSync(dest,{recursive:true}); if(fs.existsSync(src)){fs.cpSync(src,dest,{recursive:true,force:true});}});")
- verified the one-line source diff in 
