### PR TITLE
feat: native ChatGPT image download in browser mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ npx -y @steipete/oracle --engine browser -p "Walk through the UI smoke test" --f
 # Gemini browser mode (no API key; uses Chrome cookies from gemini.google.com)
 npx -y @steipete/oracle --engine browser --model gemini-3-pro --prompt "a cute robot holding a banana" --generate-image out.jpg --aspect 1:1
 
+# ChatGPT browser mode image generation/editing, saving the generated originals locally
+npx -y @steipete/oracle --engine browser --browser-manual-login --browser-attachments always \
+  --file product-front.png --file product-side.jpg \
+  --generate-image out.png \
+  --prompt "Turn these into a 1:1 4K pure white background ecommerce hero image"
+
 # Sessions (list and replay)
 npx -y @steipete/oracle status --hours 72
 npx -y @steipete/oracle session <id> --render
@@ -95,6 +101,7 @@ Engine auto-picks API when `OPENAI_API_KEY` is set, otherwise browser; browser i
 
 - API mode expects API keys in your environment: `OPENAI_API_KEY` (GPT-5.x), `GEMINI_API_KEY` (Gemini 3.1 Pro / Gemini 3 Pro), `ANTHROPIC_API_KEY` (Claude Sonnet 4.5 / Opus 4.1).
 - Gemini browser mode uses Chrome cookies instead of an API key—just be logged into `gemini.google.com` in Chrome (no Python/venv required).
+- ChatGPT browser mode can also save generated image originals locally via `--generate-image <file>`. When the assistant returns multiple images, Oracle saves the first one to the requested path and additional images as numbered siblings (for example `out.2.png`, `out.3.png`).
 - If your Gemini account can’t access “Pro”, Oracle auto-falls back to a supported model for web runs (and logs the fallback in verbose mode).
 - Prefer API mode or `--copy` + manual paste; browser automation is experimental.
 - Browser support: stable on macOS; works on Linux (add `--browser-chrome-path/--browser-cookie-path` when needed) and Windows (manual-login or inline cookies recommended when app-bound cookies block decryption).
@@ -213,7 +220,7 @@ oracle --engine browser \
 | `--browser-manual-login`                                        | Skip cookie copy; reuse a persistent automation profile and wait for manual ChatGPT login.                                                                                                                                                                                                                      |
 | `--browser-thinking-time <light\|standard\|extended\|heavy>`    | Set ChatGPT thinking-time intensity (browser; Thinking/Pro models only).                                                                                                                                                                                                                                        |
 | `--browser-port <port>`                                         | Pin the Chrome DevTools port (WSL/Windows firewall helper).                                                                                                                                                                                                                                                     |
-| `--browser-inline-cookies[(-file)] <payload \| path>`          | Supply cookies without Chrome/Keychain (browser).                                                                                                                                                                                                                                                               |
+| `--browser-inline-cookies[(-file)] <payload \| path>`           | Supply cookies without Chrome/Keychain (browser).                                                                                                                                                                                                                                                               |
 | `--browser-timeout`, `--browser-input-timeout`                  | Control overall/browser input timeouts (supports h/m/s/ms).                                                                                                                                                                                                                                                     |
 | `--browser-recheck-delay`, `--browser-recheck-timeout`          | Delayed recheck for long Pro runs: wait then retry capture after timeout (supports h/m/s/ms).                                                                                                                                                                                                                   |
 | `--browser-reuse-wait`                                          | Wait for a shared Chrome profile before launching (parallel browser runs).                                                                                                                                                                                                                                      |
@@ -231,8 +238,8 @@ oracle --engine browser \
 | `--remote-host`, `--remote-token`                               | Use a remote `oracle serve` host (browser).                                                                                                                                                                                                                                                                     |
 | `--remote-chrome <host:port>`                                   | Attach to an existing remote Chrome session (browser).                                                                                                                                                                                                                                                          |
 | `--youtube <url>`                                               | YouTube video URL to analyze (Gemini browser mode).                                                                                                                                                                                                                                                             |
-| `--generate-image <file>`                                       | Generate image and save to file (Gemini browser mode).                                                                                                                                                                                                                                                          |
-| `--edit-image <file>`                                           | Edit existing image with `--output` (Gemini browser mode).                                                                                                                                                                                                                                                      |
+| `--generate-image <file>`                                       | Save generated image output to a file. Supports Gemini browser mode natively and ChatGPT browser mode when the assistant response contains downloadable images. Extra images save as numbered siblings.                                                                                                         |
+| `--edit-image <file>`                                           | Edit existing image with `--output` (Gemini browser mode). For ChatGPT browser mode, attach source images with `--file` and use `--generate-image` for the output path.                                                                                                                                         |
 | `--azure-endpoint`, `--azure-deployment`, `--azure-api-version` | Target Azure OpenAI endpoints (picks Azure client automatically).                                                                                                                                                                                                                                               |
 
 ## Configuration

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -642,19 +642,19 @@ program
   .addOption(
     new Option(
       "--generate-image <file>",
-      "Generate image and save to file (Gemini web/cookie mode only; requires gemini.google.com Chrome cookies).",
+      "Generate image and save to file. Supports Gemini web/cookie mode and ChatGPT browser mode when the assistant returns downloadable image artifacts.",
     ),
   )
   .addOption(
     new Option(
       "--edit-image <file>",
-      "Edit existing image (use with --output, Gemini web/cookie mode only).",
+      "Edit existing image (use with --output, Gemini web/cookie mode only). For ChatGPT browser mode, attach source images with --file and use --generate-image for the output path.",
     ),
   )
   .addOption(
     new Option(
       "--output <file>",
-      "Output file path for image operations (Gemini web/cookie mode only).",
+      "Output file path for image operations. Gemini uses it for edit flows; ChatGPT browser mode also honors it as an image-save target when downloadable images are returned.",
     ),
   )
   .addOption(
@@ -966,6 +966,8 @@ function buildRunOptions(
     background: overrides.background ?? undefined,
     renderPlain: overrides.renderPlain ?? options.renderPlain ?? false,
     writeOutputPath: overrides.writeOutputPath ?? options.writeOutputPath,
+    generateImage: overrides.generateImage ?? options.generateImage,
+    outputPath: overrides.outputPath ?? options.output,
   };
 }
 
@@ -1191,6 +1193,8 @@ function buildRunOptionsFromMetadata(metadata: SessionMetadata): RunOracleOption
     background: stored.background,
     renderPlain: stored.renderPlain,
     writeOutputPath: stored.writeOutputPath,
+    generateImage: stored.generateImage,
+    outputPath: stored.outputPath,
   };
 }
 

--- a/skills/oracle/SKILL.md
+++ b/skills/oracle/SKILL.md
@@ -43,6 +43,19 @@ Recommended defaults:
   - `npx -y @steipete/oracle --render --copy -p "<task>" --file "src/**"`
   - Note: `--copy` is a hidden alias for `--copy-markdown`.
 
+## Image output (`--generate-image`, `--edit-image`)
+
+- The flag is `--generate-image <file>` (not `--image-generate`).
+- Gemini browser mode:
+  - Generate: `npx -y @steipete/oracle --engine browser --model gemini-3-pro -p "<image prompt>" --generate-image out.png --aspect 1:1`
+  - Edit: `npx -y @steipete/oracle --engine browser --model gemini-3-pro -p "<edit instructions>" --edit-image source.png --output edited.png`
+- ChatGPT browser mode:
+  - Save generated/downloadable image output locally with `--generate-image out.png`.
+  - For edits or reference-image workflows, attach source images with `--file ...` and keep `--generate-image` as the output path.
+  - If ChatGPT returns multiple downloadable images, the first saves to the requested path and extras save as numbered siblings like `out.2.png`, `out.3.png`.
+- Practical ChatGPT example:
+  - `npx -y @steipete/oracle --engine browser --browser-manual-login --browser-attachments always --file source-front.png --file source-side.jpg --generate-image out.png -p "Turn these into a 1:1 clean white-background ecommerce hero image"`
+
 ## Attaching files (`--file`)
 
 `--file` accepts files, directories, and globs. You can pass it multiple times; entries can be comma-separated.
@@ -75,6 +88,9 @@ Recommended defaults:
 - **API runs require explicit user consent** before starting because they incur usage costs.
 - Browser attachments:
   - `--browser-attachments auto|never|always` (auto pastes inline up to ~60k chars then uploads).
+- Image-output notes:
+  - Gemini: native browser-mode image generation/editing via `--generate-image`, `--edit-image`, `--output`, `--aspect`.
+  - ChatGPT: `--generate-image` works when the assistant returns downloadable image artifacts.
 - Remote browser host (signed-in machine runs automation):
   - Host: `oracle serve --host 0.0.0.0 --port 9473 --token <secret>`
   - Client: `oracle --engine browser --remote-host <host:port> --remote-token <secret> -p "<task>" --file "src/**"`

--- a/src/browser/actions/assistantResponse.ts
+++ b/src/browser/actions/assistantResponse.ts
@@ -16,6 +16,26 @@ import {
 import { buildClickDispatcher } from "./domEvents.js";
 
 const ASSISTANT_POLL_TIMEOUT_ERROR = "assistant-response-watchdog-timeout";
+const GENERATED_IMAGE_URL_FRAGMENT = "/backend-api/estuary/content?id=file_";
+const IMAGE_GENERATION_PLACEHOLDER_PATTERNS = [
+  "generating a more detailed image",
+  "generating image",
+  "creating image",
+  "rendering image",
+  "hang tight",
+] as const;
+
+interface AssistantTurnStatus {
+  text: string;
+  html?: string;
+  turnId?: string | null;
+  messageId?: string | null;
+  turnIndex?: number | null;
+  hasFinishedActions: boolean;
+  hasDoneMarkdown: boolean;
+  generatedImageCount: number;
+  imageGenerationPending: boolean;
+}
 
 function isAnswerNowPlaceholderText(normalized: string): boolean {
   const text = normalized.trim();
@@ -32,6 +52,47 @@ function isAnswerNowPlaceholderText(normalized: string): boolean {
   return (
     text.includes("answer now") && (text.includes("pro thinking") || text.includes("chatgpt said"))
   );
+}
+
+function isImageGenerationPlaceholderText(normalized: string): boolean {
+  const text = normalized.trim();
+  if (!text) return false;
+  return IMAGE_GENERATION_PLACEHOLDER_PATTERNS.some((pattern) => text.includes(pattern));
+}
+
+function isGeneratedImageControlsText(text: string | null | undefined): boolean {
+  const normalized = String(text ?? "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+  if (!normalized || normalized.length > 64) return false;
+  return [
+    "thinking preview",
+    "thinking edit",
+    "stopped thinking preview",
+    "stopped thinking edit",
+    "preview edit",
+    "preview",
+    "edit",
+    "generated image",
+  ].includes(normalized);
+}
+
+export function isGeneratedImageControlsTextForTest(text: string | null | undefined): boolean {
+  return isGeneratedImageControlsText(text);
+}
+
+async function readPageGeneratedImageCount(Runtime: ChromeClient["Runtime"]): Promise<number> {
+  try {
+    const { result } = await Runtime.evaluate({
+      expression: `document.querySelectorAll('img[src*="${GENERATED_IMAGE_URL_FRAGMENT}"]').length`,
+      returnByValue: true,
+    });
+    const value = Number(result?.value);
+    return Number.isFinite(value) && value > 0 ? value : 0;
+  } catch {
+    return 0;
+  }
 }
 
 export async function waitForAssistantResponse(
@@ -154,12 +215,20 @@ export async function waitForAssistantResponse(
   const elapsedMs = Date.now() - start;
   const remainingMs = Math.max(0, timeoutMs - elapsedMs);
   if (remainingMs > 0) {
-    const [stopVisible, completionVisible] = await Promise.all([
+    const [stopVisible, completionStatus] = await Promise.all([
       isStopButtonVisible(Runtime),
-      isCompletionVisible(Runtime),
+      readAssistantTurnStatus(Runtime, minTurnIndex),
     ]);
+    const completionVisible = isAssistantTurnComplete(completionStatus);
+    const imageGenerationPending = Boolean(completionStatus?.imageGenerationPending);
     if (stopVisible) {
       logger("Assistant still generating; waiting for completion");
+      const completed = await pollAssistantCompletion(Runtime, remainingMs, minTurnIndex);
+      if (completed) {
+        return completed;
+      }
+    } else if (imageGenerationPending) {
+      logger("Image generation still in progress; waiting for downloadable image artifacts");
       const completed = await pollAssistantCompletion(Runtime, remainingMs, minTurnIndex);
       if (completed) {
         return completed;
@@ -297,19 +366,22 @@ async function parseAssistantEvaluationResult(
       typeof (result.value as { messageId?: unknown }).messageId === "string"
         ? ((result.value as { messageId?: string }).messageId ?? undefined)
         : undefined;
-    const text = cleanAssistantText(String((result.value as { text: unknown }).text ?? ""));
-    const normalized = text.toLowerCase();
-    if (isAnswerNowPlaceholderText(normalized)) {
-      return null;
-    }
-    return { text, html, meta: { turnId, messageId } };
+  const text = cleanAssistantText(String((result.value as { text: unknown }).text ?? ""));
+  const normalized = text.toLowerCase();
+  if (isAnswerNowPlaceholderText(normalized) || isImageGenerationPlaceholderText(normalized)) {
+    return null;
+  }
+  return { text, html, meta: { turnId, messageId } };
   }
   const fallbackText =
     typeof result.value === "string" ? cleanAssistantText(result.value as string) : "";
   if (!fallbackText) {
     return null;
   }
-  if (isAnswerNowPlaceholderText(fallbackText.toLowerCase())) {
+  if (
+    isAnswerNowPlaceholderText(fallbackText.toLowerCase()) ||
+    isImageGenerationPlaceholderText(fallbackText.toLowerCase())
+  ) {
     return null;
   }
   return { text: fallbackText, html: undefined, meta: {} };
@@ -403,8 +475,25 @@ async function pollAssistantCompletion(
     if (abortSignal?.aborted) {
       return null;
     }
-    const snapshot = await readAssistantSnapshot(Runtime, minTurnIndex);
-    const normalized = normalizeAssistantSnapshot(snapshot);
+    const [snapshot, turnStatus, stopVisible] = await Promise.all([
+      readAssistantSnapshot(Runtime, minTurnIndex),
+      readAssistantTurnStatus(Runtime, minTurnIndex),
+      isStopButtonVisible(Runtime),
+    ]);
+    const normalized = normalizeAssistantSnapshot(snapshot, turnStatus ?? undefined);
+    if (turnStatus?.generatedImageCount) {
+      if (normalized) {
+        return normalized;
+      }
+      return {
+        text: turnStatus.text || "Generated image",
+        html: turnStatus.html,
+        meta: {
+          turnId: turnStatus.turnId ?? undefined,
+          messageId: turnStatus.messageId ?? undefined,
+        },
+      };
+    }
     if (normalized) {
       const currentLength = normalized.text.length;
       if (currentLength > previousLength) {
@@ -414,10 +503,8 @@ async function pollAssistantCompletion(
       } else {
         stableCycles += 1;
       }
-      const [stopVisible, completionVisible] = await Promise.all([
-        isStopButtonVisible(Runtime),
-        isCompletionVisible(Runtime),
-      ]);
+      const completionVisible = isAssistantTurnComplete(turnStatus);
+      const imageGenerationPending = Boolean(turnStatus?.imageGenerationPending);
       const shortAnswer = currentLength > 0 && currentLength < 16;
       const mediumAnswer = currentLength >= 16 && currentLength < 40;
       const longAnswer = currentLength >= 40 && currentLength < 500;
@@ -430,10 +517,19 @@ async function pollAssistantCompletion(
       const minStableMs = shortAnswer ? 8000 : mediumAnswer ? 1200 : longAnswer ? 2000 : 3000;
       // Require stop button to disappear before treating completion as final.
       if (!stopVisible) {
+        const pageGeneratedImageCount =
+          isGeneratedImageControlsText(turnStatus?.text ?? normalized.text) &&
+          !imageGenerationPending &&
+          stableMs >= 1200
+            ? await readPageGeneratedImageCount(Runtime)
+            : 0;
+        if (pageGeneratedImageCount > 0) {
+          return normalized;
+        }
         const stableEnough = stableCycles >= requiredStableCycles && stableMs >= minStableMs;
         const completionEnough =
           completionVisible && stableCycles >= completionStableTarget && stableMs >= minStableMs;
-        if (completionEnough || stableEnough) {
+        if (completionEnough || (stableEnough && !imageGenerationPending)) {
           return normalized;
         }
       }
@@ -458,52 +554,108 @@ async function isStopButtonVisible(Runtime: ChromeClient["Runtime"]): Promise<bo
   }
 }
 
-async function isCompletionVisible(Runtime: ChromeClient["Runtime"]): Promise<boolean> {
+function isAssistantTurnComplete(status: AssistantTurnStatus | null): boolean {
+  return Boolean(
+    status &&
+      (status.hasFinishedActions || status.hasDoneMarkdown || status.generatedImageCount > 0),
+  );
+}
+
+function buildAssistantTurnStatusExpression(minTurnIndex?: number): string {
+  const minTurnLiteral =
+    typeof minTurnIndex === "number" && Number.isFinite(minTurnIndex) && minTurnIndex >= 0
+      ? Math.floor(minTurnIndex)
+      : -1;
+  return `(() => {
+    const MIN_TURN_INDEX = ${minTurnLiteral};
+    const GENERATED_IMAGE_URL_FRAGMENT = ${JSON.stringify(GENERATED_IMAGE_URL_FRAGMENT)};
+    const IMAGE_PLACEHOLDER_PATTERNS = ${JSON.stringify(IMAGE_GENERATION_PLACEHOLDER_PATTERNS)};
+    const ASSISTANT_SELECTOR = '${ASSISTANT_ROLE_SELECTOR}';
+    const FINISHED_SELECTOR = '${FINISHED_ACTIONS_SELECTOR}';
+    const CONVERSATION_SELECTOR = '${CONVERSATION_TURN_SELECTOR}';
+    const isAssistantTurn = (node) => {
+      if (!(node instanceof HTMLElement)) return false;
+      const turnAttr = (node.getAttribute('data-turn') || node.dataset?.turn || '').toLowerCase();
+      if (turnAttr === 'assistant') return true;
+      const role = (node.getAttribute('data-message-author-role') || node.dataset?.messageAuthorRole || '').toLowerCase();
+      if (role === 'assistant') return true;
+      const testId = (node.getAttribute('data-testid') || '').toLowerCase();
+      if (testId.includes('assistant')) return true;
+      return Boolean(node.querySelector(ASSISTANT_SELECTOR) || node.querySelector('[data-testid*="assistant"]'));
+    };
+
+    const turns = Array.from(document.querySelectorAll(CONVERSATION_SELECTOR));
+    let lastAssistantTurn = null;
+    let turnIndex = null;
+    for (let index = turns.length - 1; index >= 0; index -= 1) {
+      if (!isAssistantTurn(turns[index])) continue;
+      if (MIN_TURN_INDEX >= 0 && index < MIN_TURN_INDEX) continue;
+      lastAssistantTurn = turns[index];
+      turnIndex = index;
+      break;
+    }
+    if (!lastAssistantTurn) return null;
+    const messageRoot = lastAssistantTurn.querySelector(ASSISTANT_SELECTOR) || lastAssistantTurn;
+    const text = (messageRoot.innerText || messageRoot.textContent || '').trim();
+    const html = messageRoot.innerHTML || '';
+    const generatedImages = Array.from(messageRoot.querySelectorAll('img')).filter((img) => {
+      const src = img.getAttribute('src') || '';
+      return src.includes(GENERATED_IMAGE_URL_FRAGMENT);
+    });
+    const markdowns = lastAssistantTurn.querySelectorAll('.markdown');
+    const normalizedText = text.toLowerCase();
+    return {
+      text,
+      html,
+      turnId: messageRoot.getAttribute('data-testid'),
+      messageId: messageRoot.getAttribute('data-message-id'),
+      turnIndex,
+      hasFinishedActions: Boolean(lastAssistantTurn.querySelector(FINISHED_SELECTOR)),
+      hasDoneMarkdown: Array.from(markdowns).some((n) => (n.textContent || '').trim() === 'Done'),
+      generatedImageCount: generatedImages.length,
+      imageGenerationPending:
+        generatedImages.length === 0 &&
+        IMAGE_PLACEHOLDER_PATTERNS.some((pattern) => normalizedText.includes(pattern)),
+    };
+  })()`;
+}
+
+async function readAssistantTurnStatus(
+  Runtime: ChromeClient["Runtime"],
+  minTurnIndex?: number,
+): Promise<AssistantTurnStatus | null> {
   try {
     const { result } = await Runtime.evaluate({
-      expression: `(() => {
-        // Find the LAST assistant turn to check completion status
-        // Must match the same logic as buildAssistantExtractor for consistency
-        const ASSISTANT_SELECTOR = '${ASSISTANT_ROLE_SELECTOR}';
-        const isAssistantTurn = (node) => {
-          if (!(node instanceof HTMLElement)) return false;
-          const turnAttr = (node.getAttribute('data-turn') || node.dataset?.turn || '').toLowerCase();
-          if (turnAttr === 'assistant') return true;
-          const role = (node.getAttribute('data-message-author-role') || node.dataset?.messageAuthorRole || '').toLowerCase();
-          if (role === 'assistant') return true;
-          const testId = (node.getAttribute('data-testid') || '').toLowerCase();
-          if (testId.includes('assistant')) return true;
-          return Boolean(node.querySelector(ASSISTANT_SELECTOR) || node.querySelector('[data-testid*="assistant"]'));
-        };
-
-        const turns = Array.from(document.querySelectorAll('${CONVERSATION_TURN_SELECTOR}'));
-        let lastAssistantTurn = null;
-        for (let i = turns.length - 1; i >= 0; i--) {
-          if (isAssistantTurn(turns[i])) {
-            lastAssistantTurn = turns[i];
-            break;
-          }
-        }
-        if (!lastAssistantTurn) {
-          return false;
-        }
-        // Check if the last assistant turn has finished action buttons (copy, thumbs up/down, share)
-        if (lastAssistantTurn.querySelector('${FINISHED_ACTIONS_SELECTOR}')) {
-          return true;
-        }
-        // Also check for "Done" text in the last assistant turn's markdown
-        const markdowns = lastAssistantTurn.querySelectorAll('.markdown');
-        return Array.from(markdowns).some((n) => (n.textContent || '').trim() === 'Done');
-      })()`,
+      expression: buildAssistantTurnStatusExpression(minTurnIndex),
       returnByValue: true,
     });
-    return Boolean(result?.value);
+    const value = result?.value;
+    if (!value || typeof value !== "object") {
+      return null;
+    }
+    return value as AssistantTurnStatus;
   } catch {
-    return false;
+    return null;
   }
 }
 
 function normalizeAssistantSnapshot(snapshot: AssistantSnapshot | null): {
+  text: string;
+  html?: string;
+  meta: { turnId?: string | null; messageId?: string | null };
+} | null;
+function normalizeAssistantSnapshot(
+  snapshot: AssistantSnapshot | null,
+  status: AssistantTurnStatus | null | undefined,
+): {
+  text: string;
+  html?: string;
+  meta: { turnId?: string | null; messageId?: string | null };
+} | null;
+function normalizeAssistantSnapshot(
+  snapshot: AssistantSnapshot | null,
+  status?: AssistantTurnStatus | null,
+): {
   text: string;
   html?: string;
   meta: { turnId?: string | null; messageId?: string | null };
@@ -516,6 +668,9 @@ function normalizeAssistantSnapshot(snapshot: AssistantSnapshot | null): {
   // "Pro thinking" often renders a placeholder turn containing an "Answer now" gate.
   // Treat it as incomplete so browser mode keeps waiting for the real assistant text.
   if (isAnswerNowPlaceholderText(normalized)) {
+    return null;
+  }
+  if (isImageGenerationPlaceholderText(normalized) && !status?.generatedImageCount) {
     return null;
   }
   // Ignore user echo turns that can show up in project view fallbacks.

--- a/src/browser/actions/navigation.ts
+++ b/src/browser/actions/navigation.ts
@@ -196,6 +196,21 @@ export async function ensureLoggedIn(
     returnByValue: true,
   });
   const probe = normalizeLoginProbe(outcome.result?.value);
+  if (probe.pageUnavailable) {
+    const message = formatPageUnavailableMessage({
+      unavailable: true,
+      title: probe.pageTitle,
+      pageUrl: probe.pageUrl,
+      errorCode: probe.pageErrorCode,
+    });
+    logger(message);
+    throw new BrowserAutomationError(message, {
+      stage: "page-unavailable",
+      pageUrl: probe.pageUrl ?? null,
+      pageTitle: probe.pageTitle ?? null,
+      errorCode: probe.pageErrorCode ?? null,
+    });
+  }
   if (probe.ok) {
     logger(
       `Login check passed (status=${probe.status}, domLoginCta=${Boolean(probe.domLoginCta)})`,
@@ -347,6 +362,24 @@ export async function ensurePromptReady(
         return;
       }
     }
+    const unavailable = await readPageUnavailableState(Runtime).catch(
+      (): PageUnavailableState => ({
+        unavailable: false,
+        pageUrl: null,
+        title: null,
+        errorCode: null,
+      }),
+    );
+    if (unavailable.unavailable) {
+      const message = formatPageUnavailableMessage(unavailable);
+      logger(message);
+      throw new BrowserAutomationError(message, {
+        stage: "page-unavailable",
+        pageUrl: unavailable.pageUrl ?? null,
+        pageTitle: unavailable.title ?? null,
+        errorCode: unavailable.errorCode ?? null,
+      });
+    }
     await logDomFailure(Runtime, logger, "prompt-textarea");
     throw new Error("Prompt textarea did not appear before timeout");
   }
@@ -441,6 +474,9 @@ type LoginProbeResult = {
   pageUrl?: string | null;
   domLoginCta?: boolean;
   onAuthPage?: boolean;
+  pageUnavailable?: boolean;
+  pageTitle?: string | null;
+  pageErrorCode?: string | null;
 };
 
 function buildLoginProbeExpression(timeoutMs: number): string {
@@ -449,10 +485,30 @@ function buildLoginProbeExpression(timeoutMs: number): string {
     // Some UIs render without a session; use DOM + network for a robust answer.
     const timer = setTimeout(() => {}, ${timeoutMs});
     const pageUrl = typeof location === 'object' && location?.href ? location.href : null;
+    const pageTitle = typeof document === 'object' && document?.title ? document.title : '';
+    const bodyText =
+      typeof document === 'object' && document?.body
+        ? String(document.body.innerText || document.body.textContent || '')
+        : '';
     const onAuthPage =
       typeof location === 'object' &&
       typeof location.pathname === 'string' &&
       /^\\/(auth|login|signin)/i.test(location.pathname);
+    const normalizedTitle = String(pageTitle || '').toLowerCase();
+    const normalizedBody = String(bodyText || '').toLowerCase();
+    const errorCodeMatch = String(bodyText || '').match(/\\b(ERR_[A-Z0-9_]+)\\b/);
+    const pageErrorCode = errorCodeMatch ? errorCodeMatch[1] : null;
+    const pageUnavailable =
+      Boolean(pageUrl && String(pageUrl).startsWith('chrome-error://')) ||
+      normalizedTitle.includes("this site can't be reached") ||
+      normalizedTitle.includes("site can't be reached") ||
+      normalizedTitle.includes('problem loading page') ||
+      normalizedBody.includes("this site can't be reached") ||
+      normalizedBody.includes("site can't be reached") ||
+      normalizedBody.includes('your internet access is blocked') ||
+      normalizedBody.includes('check if there is a typo') ||
+      normalizedBody.includes('dns_probe') ||
+      normalizedBody.includes('err_');
 
     const hasLoginCta = () => {
       const candidates = Array.from(
@@ -517,7 +573,7 @@ function buildLoginProbeExpression(timeoutMs: number): string {
     const loginSignals = domLoginCta || onAuthPage;
     clearTimeout(timer);
     return {
-      ok: !loginSignals && (status === 0 || status === 200),
+      ok: !loginSignals && !pageUnavailable && status === 200,
       status,
       redirected: false,
       url: pageUrl,
@@ -525,6 +581,9 @@ function buildLoginProbeExpression(timeoutMs: number): string {
       domLoginCta,
       onAuthPage,
       error,
+      pageUnavailable,
+      pageTitle,
+      pageErrorCode,
     };
   })()`;
 }
@@ -551,5 +610,65 @@ function normalizeLoginProbe(raw: unknown): LoginProbeResult {
     pageUrl: typeof value.pageUrl === "string" ? value.pageUrl : null,
     domLoginCta: Boolean(value.domLoginCta),
     onAuthPage: Boolean(value.onAuthPage),
+    pageUnavailable: Boolean(value.pageUnavailable),
+    pageTitle: typeof value.pageTitle === "string" ? value.pageTitle : null,
+    pageErrorCode: typeof value.pageErrorCode === "string" ? value.pageErrorCode : null,
   };
+}
+
+type PageUnavailableState = {
+  unavailable: boolean;
+  title?: string | null;
+  pageUrl?: string | null;
+  errorCode?: string | null;
+};
+
+async function readPageUnavailableState(
+  Runtime: ChromeClient["Runtime"],
+): Promise<PageUnavailableState> {
+  const outcome = await Runtime.evaluate({
+    expression: `(() => {
+      const pageUrl = typeof location === 'object' && location?.href ? location.href : null;
+      const title = typeof document === 'object' && document?.title ? document.title : '';
+      const bodyText =
+        typeof document === 'object' && document?.body
+          ? String(document.body.innerText || document.body.textContent || '')
+          : '';
+      const normalizedTitle = String(title || '').toLowerCase();
+      const normalizedBody = String(bodyText || '').toLowerCase();
+      const errorCodeMatch = String(bodyText || '').match(/\\b(ERR_[A-Z0-9_]+)\\b/);
+      const errorCode = errorCodeMatch ? errorCodeMatch[1] : null;
+      const unavailable =
+        Boolean(pageUrl && String(pageUrl).startsWith('chrome-error://')) ||
+        normalizedTitle.includes("this site can't be reached") ||
+        normalizedTitle.includes("site can't be reached") ||
+        normalizedTitle.includes('problem loading page') ||
+        normalizedBody.includes("this site can't be reached") ||
+        normalizedBody.includes("site can't be reached") ||
+        normalizedBody.includes('your internet access is blocked') ||
+        normalizedBody.includes('check if there is a typo') ||
+        normalizedBody.includes('dns_probe') ||
+        normalizedBody.includes('err_');
+      return { unavailable, title, pageUrl, errorCode };
+    })()`,
+    returnByValue: true,
+  });
+  const value = outcome.result?.value as Record<string, unknown> | undefined;
+  return {
+    unavailable: Boolean(value?.unavailable),
+    title: typeof value?.title === "string" ? value.title : null,
+    pageUrl: typeof value?.pageUrl === "string" ? value.pageUrl : null,
+    errorCode: typeof value?.errorCode === "string" ? value.errorCode : null,
+  };
+}
+
+function formatPageUnavailableMessage(state: PageUnavailableState): string {
+  const parts = [
+    state.title ? `title=${state.title}` : null,
+    state.errorCode ? `code=${state.errorCode}` : null,
+    state.pageUrl ? `url=${state.pageUrl}` : null,
+  ].filter(Boolean);
+  return parts.length > 0
+    ? `ChatGPT page is unavailable (${parts.join(", ")}).`
+    : "ChatGPT page is unavailable.";
 }

--- a/src/browser/chatgptImages.ts
+++ b/src/browser/chatgptImages.ts
@@ -1,0 +1,194 @@
+import path from "node:path";
+import fs from "node:fs/promises";
+import type {
+  ChromeClient,
+  BrowserGeneratedImage,
+  BrowserLogger,
+  SavedBrowserImage,
+} from "./types.js";
+import { CONVERSATION_TURN_SELECTOR, ASSISTANT_ROLE_SELECTOR } from "./constants.js";
+
+function extractFileId(url: string): string | undefined {
+  try {
+    return new URL(url).searchParams.get("id") ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function dedupeImages(images: BrowserGeneratedImage[]): BrowserGeneratedImage[] {
+  const best = new Map<string, BrowserGeneratedImage>();
+  for (const image of images) {
+    const key = image.fileId ?? image.url;
+    const currentArea = (image.width ?? 0) * (image.height ?? 0);
+    const existing = best.get(key);
+    const existingArea = existing ? (existing.width ?? 0) * (existing.height ?? 0) : -1;
+    if (!existing || currentArea >= existingArea) {
+      best.set(key, image);
+    }
+  }
+  return [...best.values()];
+}
+
+function buildAssistantImageExpression(minTurnIndex?: number): string {
+  const minTurnLiteral =
+    typeof minTurnIndex === "number" && Number.isFinite(minTurnIndex) && minTurnIndex >= 0
+      ? Math.floor(minTurnIndex)
+      : -1;
+  const conversationLiteral = JSON.stringify(CONVERSATION_TURN_SELECTOR);
+  const assistantLiteral = JSON.stringify(ASSISTANT_ROLE_SELECTOR);
+  return `(() => {
+    const MIN_TURN_INDEX = ${minTurnLiteral};
+    const CONVERSATION_SELECTOR = ${conversationLiteral};
+    const ASSISTANT_SELECTOR = ${assistantLiteral};
+    const isAssistantTurn = (node) => {
+      if (!(node instanceof HTMLElement)) return false;
+      const turnAttr = (node.getAttribute('data-turn') || node.dataset?.turn || '').toLowerCase();
+      if (turnAttr === 'assistant') return true;
+      const role = (node.getAttribute('data-message-author-role') || node.dataset?.messageAuthorRole || '').toLowerCase();
+      if (role === 'assistant') return true;
+      const testId = (node.getAttribute('data-testid') || '').toLowerCase();
+      if (testId.includes('assistant')) return true;
+      return Boolean(node.querySelector(ASSISTANT_SELECTOR) || node.querySelector('[data-testid*="assistant"]'));
+    };
+    const turns = Array.from(document.querySelectorAll(CONVERSATION_SELECTOR));
+    for (let index = turns.length - 1; index >= 0; index -= 1) {
+      const turn = turns[index];
+      if (!isAssistantTurn(turn)) continue;
+      if (MIN_TURN_INDEX >= 0 && index < MIN_TURN_INDEX) continue;
+      const messageRoot = turn.querySelector(ASSISTANT_SELECTOR) || turn;
+      const images = Array.from(messageRoot.querySelectorAll('img')).map((img) => ({
+        url: img.src || '',
+        alt: img.alt || '',
+        width: img.naturalWidth || 0,
+        height: img.naturalHeight || 0,
+      })).filter((img) => img.url && img.url.includes('/backend-api/estuary/content?id=file_'));
+      return images;
+    }
+    return [];
+  })()`;
+}
+
+export async function readAssistantGeneratedImages(
+  Runtime: ChromeClient["Runtime"],
+  minTurnIndex?: number,
+): Promise<BrowserGeneratedImage[]> {
+  const { result } = await Runtime.evaluate({
+    expression: buildAssistantImageExpression(minTurnIndex),
+    returnByValue: true,
+  });
+  const raw = Array.isArray(result?.value) ? result.value : [];
+  const normalized = raw
+    .map((item) => ({
+      url: typeof item?.url === "string" ? item.url : "",
+      alt: typeof item?.alt === "string" ? item.alt : undefined,
+      width: typeof item?.width === "number" ? item.width : undefined,
+      height: typeof item?.height === "number" ? item.height : undefined,
+      fileId: typeof item?.url === "string" ? extractFileId(item.url) : undefined,
+    }))
+    .filter((item) => item.url.length > 0);
+  return dedupeImages(normalized);
+}
+
+function contentTypeToExtension(contentType: string | null): string {
+  const value = String(contentType ?? "").toLowerCase();
+  if (value.includes("png")) return "png";
+  if (value.includes("jpeg") || value.includes("jpg")) return "jpg";
+  if (value.includes("webp")) return "webp";
+  if (value.includes("gif")) return "gif";
+  if (value.includes("svg")) return "svg";
+  return "bin";
+}
+
+function resolveSiblingImagePath(basePath: string, index: number, extension: string): string {
+  const ext = path.extname(basePath);
+  const dir = path.dirname(basePath);
+  const stem = ext ? path.basename(basePath, ext) : path.basename(basePath);
+  if (index === 0) {
+    return ext ? basePath : path.join(dir, `${stem}.${extension}`);
+  }
+  const suffix = ext ? `${stem}.${index + 1}${ext}` : `${stem}.${index + 1}.${extension}`;
+  return path.join(dir, suffix);
+}
+
+async function buildCookieHeader(Network: ChromeClient["Network"]): Promise<string> {
+  const response = await Network.getCookies({ urls: ["https://chatgpt.com/"] });
+  return (response.cookies ?? [])
+    .filter((cookie) => cookie.name && typeof cookie.value === "string")
+    .map((cookie) => `${cookie.name}=${cookie.value}`)
+    .join("; ");
+}
+
+export async function saveChatGptGeneratedImages(params: {
+  Network: ChromeClient["Network"];
+  images: BrowserGeneratedImage[];
+  outputPath: string;
+  logger?: BrowserLogger;
+}): Promise<{
+  saved: boolean;
+  imageCount: number;
+  savedImages: SavedBrowserImage[];
+  errors: string[];
+}> {
+  const { Network, images, outputPath, logger } = params;
+  if (!images.length) return { saved: false, imageCount: 0, savedImages: [], errors: [] };
+
+  const cookieHeader = await buildCookieHeader(Network);
+  if (!cookieHeader) {
+    return {
+      saved: false,
+      imageCount: images.length,
+      savedImages: [],
+      errors: ["Missing ChatGPT cookies for image download."],
+    };
+  }
+
+  const savedImages: SavedBrowserImage[] = [];
+  const errors: string[] = [];
+  await fs.mkdir(path.dirname(path.resolve(outputPath)), { recursive: true });
+
+  for (let index = 0; index < images.length; index += 1) {
+    const image = images[index];
+    try {
+      const response = await fetch(image.url, {
+        headers: {
+          cookie: cookieHeader,
+          "user-agent": "Mozilla/5.0",
+        },
+        redirect: "follow",
+      });
+      if (!response.ok) {
+        throw new Error(`download failed: ${response.status} ${response.statusText}`);
+      }
+      const contentType = response.headers.get("content-type");
+      const extension = contentTypeToExtension(contentType);
+      const targetPath = resolveSiblingImagePath(path.resolve(outputPath), index, extension);
+      const buffer = Buffer.from(await response.arrayBuffer());
+      await fs.writeFile(targetPath, buffer);
+      savedImages.push({
+        path: targetPath,
+        url: image.url,
+        finalUrl: response.url,
+        alt: image.alt,
+        width: image.width,
+        height: image.height,
+        fileId: image.fileId,
+        contentType: contentType ?? undefined,
+        sizeBytes: buffer.length,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      errors.push(`${image.fileId ?? image.url}: ${message}`);
+      logger?.(
+        `[browser] Failed to save generated image ${index + 1}/${images.length}: ${message}`,
+      );
+    }
+  }
+
+  return {
+    saved: savedImages.length > 0,
+    imageCount: images.length,
+    savedImages,
+    errors,
+  };
+}

--- a/src/browser/chatgptImages.ts
+++ b/src/browser/chatgptImages.ts
@@ -7,6 +7,12 @@ import type {
   SavedBrowserImage,
 } from "./types.js";
 import { CONVERSATION_TURN_SELECTOR, ASSISTANT_ROLE_SELECTOR } from "./constants.js";
+import { delay } from "./utils.js";
+import { readAssistantSnapshot } from "./pageActions.js";
+import { getOracleHomeDir } from "../oracleHome.js";
+
+const GENERATED_IMAGE_WAIT_MIN_MS = 15_000;
+const GENERATED_IMAGE_WAIT_MAX_MS = 15 * 60_000;
 
 function extractFileId(url: string): string | undefined {
   try {
@@ -90,6 +96,48 @@ export async function readAssistantGeneratedImages(
   return dedupeImages(normalized);
 }
 
+async function readAssistantGeneratedImagesWithFallback(
+  Runtime: ChromeClient["Runtime"],
+  minTurnIndex?: number | null,
+): Promise<BrowserGeneratedImage[]> {
+  const filteredImages = await readAssistantGeneratedImages(
+    Runtime,
+    minTurnIndex ?? undefined,
+  ).catch(() => []);
+  if (
+    filteredImages.length > 0 ||
+    typeof minTurnIndex !== "number" ||
+    !Number.isFinite(minTurnIndex)
+  ) {
+    return filteredImages;
+  }
+
+  const [fallbackImages, fallbackSnapshot] = await Promise.all([
+    readAssistantGeneratedImages(Runtime).catch(() => []),
+    readAssistantSnapshot(Runtime).catch(() => null),
+  ]);
+  const fallbackTurnIndex =
+    typeof fallbackSnapshot?.turnIndex === "number" ? fallbackSnapshot.turnIndex : null;
+  const nearBoundary =
+    fallbackTurnIndex !== null && fallbackTurnIndex + 1 >= Math.floor(minTurnIndex);
+  return fallbackImages.length > 0 && nearBoundary ? fallbackImages : [];
+}
+
+function resolveGeneratedImageWaitTimeoutMs(waitTimeoutMs?: number): number {
+  const requestedTimeout =
+    typeof waitTimeoutMs === "number" && Number.isFinite(waitTimeoutMs)
+      ? waitTimeoutMs
+      : GENERATED_IMAGE_WAIT_MAX_MS;
+  return Math.max(
+    GENERATED_IMAGE_WAIT_MIN_MS,
+    Math.min(requestedTimeout, GENERATED_IMAGE_WAIT_MAX_MS),
+  );
+}
+
+export function resolveGeneratedImageWaitTimeoutMsForTest(waitTimeoutMs?: number): number {
+  return resolveGeneratedImageWaitTimeoutMs(waitTimeoutMs);
+}
+
 function contentTypeToExtension(contentType: string | null): string {
   const value = String(contentType ?? "").toLowerCase();
   if (value.includes("png")) return "png";
@@ -109,6 +157,25 @@ function resolveSiblingImagePath(basePath: string, index: number, extension: str
   }
   const suffix = ext ? `${stem}.${index + 1}${ext}` : `${stem}.${index + 1}.${extension}`;
   return path.join(dir, suffix);
+}
+
+function sanitizeGeneratedImageStem(value: string): string {
+  return value
+    .replace(/[^a-zA-Z0-9_-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 48);
+}
+
+function resolveDefaultGeneratedImagePath(images: BrowserGeneratedImage[]): string {
+  const primary = images[0];
+  const stemSource =
+    primary?.fileId ||
+    primary?.alt ||
+    primary?.url ||
+    `generated-${Date.now().toString(36)}`;
+  const stem = sanitizeGeneratedImageStem(stemSource) || `generated-${Date.now().toString(36)}`;
+  return path.join(getOracleHomeDir(), ".temp", `${stem}.png`);
 }
 
 async function buildCookieHeader(Network: ChromeClient["Network"]): Promise<string> {
@@ -190,5 +257,109 @@ export async function saveChatGptGeneratedImages(params: {
     imageCount: images.length,
     savedImages,
     errors,
+  };
+}
+
+export async function collectGeneratedImageArtifacts(params: {
+  Runtime: ChromeClient["Runtime"];
+  Network: ChromeClient["Network"];
+  logger?: BrowserLogger;
+  minTurnIndex?: number | null;
+  generateImagePath?: string;
+  outputPath?: string;
+  answerText: string;
+  waitTimeoutMs?: number;
+}): Promise<{
+  generatedImages: BrowserGeneratedImage[];
+  savedImages: SavedBrowserImage[];
+  imageCount: number;
+  markdownSuffix: string;
+  answerText: string;
+}> {
+  const explicitTargetPath = params.generateImagePath ?? params.outputPath;
+  let generatedImages = await readAssistantGeneratedImagesWithFallback(
+    params.Runtime,
+    params.minTurnIndex ?? undefined,
+  );
+  let latestAnswerText = params.answerText;
+
+  if (explicitTargetPath && generatedImages.length === 0) {
+    const deadline = Date.now() + resolveGeneratedImageWaitTimeoutMs(params.waitTimeoutMs);
+    while (Date.now() < deadline) {
+      await delay(1500);
+      generatedImages = await readAssistantGeneratedImagesWithFallback(
+        params.Runtime,
+        params.minTurnIndex ?? undefined,
+      );
+      if (generatedImages.length > 0) {
+        break;
+      }
+      const latestSnapshot = await readAssistantSnapshot(
+        params.Runtime,
+        params.minTurnIndex ?? undefined,
+      ).catch(() => null);
+      const snapshotText =
+        typeof latestSnapshot?.text === "string" ? latestSnapshot.text.trim() : "";
+      if (snapshotText) {
+        latestAnswerText = snapshotText;
+      }
+    }
+  }
+
+  const imageCount = generatedImages.length;
+  if (explicitTargetPath && imageCount === 0) {
+    throw new Error(`No images generated. Response text:\n${latestAnswerText || "(empty response)"}`);
+  }
+  if (imageCount === 0) {
+    return {
+      generatedImages,
+      savedImages: [],
+      imageCount,
+      markdownSuffix: imageCount > 0 ? `\n\n*Generated ${imageCount} image(s).*` : "",
+      answerText: latestAnswerText,
+    };
+  }
+
+  const targetPath = explicitTargetPath ?? resolveDefaultGeneratedImagePath(generatedImages);
+  if (!explicitTargetPath) {
+    params.logger?.(`[browser] Auto-saving generated images to ${targetPath}`);
+  }
+
+  const saved = await saveChatGptGeneratedImages({
+    Network: params.Network,
+    images: generatedImages,
+    outputPath: targetPath,
+    logger: params.logger,
+  });
+  if (!saved.saved) {
+    const detail = saved.errors.length > 0 ? `\n${saved.errors.join("\n")}` : "";
+    if (explicitTargetPath) {
+      throw new Error(
+        `No images generated. Response text:\n${latestAnswerText || "(empty response)"}${detail}`,
+      );
+    }
+    params.logger?.(
+      `[browser] Auto-save for generated images failed; returning metadata only.${detail}`,
+    );
+    return {
+      generatedImages,
+      savedImages: [],
+      imageCount,
+      markdownSuffix: `\n\n*Generated ${imageCount} image(s).*`,
+      answerText: latestAnswerText,
+    };
+  }
+
+  const primaryPath = saved.savedImages[0]?.path ?? targetPath;
+  const suffix =
+    saved.savedImages.length > 1
+      ? `\n\n*Generated ${saved.imageCount} image(s). Saved ${saved.savedImages.length} file(s) starting at: ${primaryPath}*`
+      : `\n\n*Generated ${saved.imageCount} image(s). Saved to: ${primaryPath}*`;
+  return {
+    generatedImages,
+    savedImages: saved.savedImages,
+    imageCount: saved.imageCount,
+    markdownSuffix: suffix,
+    answerText: latestAnswerText,
   };
 }

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -59,7 +59,7 @@ import {
 } from "./profileState.js";
 import { runProviderSubmissionFlow } from "./providerDomFlow.js";
 import { chatgptDomProvider } from "./providers/index.js";
-import { readAssistantGeneratedImages, saveChatGptGeneratedImages } from "./chatgptImages.js";
+import { collectGeneratedImageArtifacts, readAssistantGeneratedImages } from "./chatgptImages.js";
 
 export type { BrowserAutomationConfig, BrowserRunOptions, BrowserRunResult } from "./types.js";
 export { CHATGPT_URL, DEFAULT_MODEL_STRATEGY, DEFAULT_MODEL_TARGET } from "./constants.js";
@@ -78,93 +78,45 @@ export function shouldPreserveBrowserOnErrorForTest(error: unknown, headless: bo
   return shouldPreserveBrowserOnError(error, headless);
 }
 
-async function maybePersistChatGptGeneratedImages(params: {
-  Runtime: ChromeClient["Runtime"];
-  Network: ChromeClient["Network"];
-  logger: BrowserLogger;
-  baselineTurns?: number | null;
-  generateImagePath?: string;
-  outputPath?: string;
-  answerText: string;
-  waitTimeoutMs?: number;
-}): Promise<{
-  generatedImages: Awaited<ReturnType<typeof readAssistantGeneratedImages>>;
-  savedImages: Awaited<ReturnType<typeof saveChatGptGeneratedImages>>["savedImages"];
-  imageCount: number;
-  markdownSuffix: string;
-  answerText: string;
-}> {
-  const targetPath = params.generateImagePath ?? params.outputPath;
-  let generatedImages = await readAssistantGeneratedImages(
-    params.Runtime,
-    params.baselineTurns ?? undefined,
-  ).catch(() => []);
-  let latestAnswerText = params.answerText;
+const DEFAULT_IMAGE_RESPONSE_RECOVERY_TIMEOUT_MS = 120_000;
+const GENERATED_IMAGE_URL_FRAGMENT = "/backend-api/estuary/content?id=file_";
 
-  if (targetPath && generatedImages.length === 0) {
-    const deadline = Date.now() + Math.max(15_000, params.waitTimeoutMs ?? 180_000);
-    let stableCycles = 0;
-    while (Date.now() < deadline) {
-      await delay(1500);
-      generatedImages = await readAssistantGeneratedImages(
-        params.Runtime,
-        params.baselineTurns ?? undefined,
-      ).catch(() => []);
-      if (generatedImages.length > 0) {
-        break;
-      }
-      const latestSnapshot = await readAssistantSnapshot(
-        params.Runtime,
-        params.baselineTurns ?? undefined,
-      ).catch(() => null);
-      const snapshotText =
-        typeof latestSnapshot?.text === "string" ? latestSnapshot.text.trim() : "";
-      if (snapshotText && snapshotText !== latestAnswerText) {
-        latestAnswerText = snapshotText;
-        stableCycles = 0;
-      } else {
-        stableCycles += 1;
-      }
-      if (latestAnswerText.length >= 24 && stableCycles >= 4) {
-        break;
-      }
-    }
+function resolveAssistantResponseTimeoutMs(
+  configuredTimeoutMs: number,
+  imageOutputMode: boolean,
+): number {
+  if (!imageOutputMode) {
+    return configuredTimeoutMs;
   }
+  return Math.min(configuredTimeoutMs, DEFAULT_IMAGE_RESPONSE_RECOVERY_TIMEOUT_MS);
+}
 
-  const imageCount = generatedImages.length;
-  if (!targetPath || imageCount === 0) {
-    return {
-      generatedImages,
-      savedImages: [],
-      imageCount,
-      markdownSuffix: imageCount > 0 ? `\n\n*Generated ${imageCount} image(s).*` : "",
-      answerText: latestAnswerText,
-    };
+export function resolveAssistantResponseTimeoutMsForTest(
+  configuredTimeoutMs: number,
+  imageOutputMode: boolean,
+): number {
+  return resolveAssistantResponseTimeoutMs(configuredTimeoutMs, imageOutputMode);
+}
+
+function shouldSkipMarkdownCaptureForGeneratedImage(answer: {
+  text?: string | null;
+  html?: string | null;
+}): boolean {
+  if (typeof answer.html === "string" && answer.html.includes(GENERATED_IMAGE_URL_FRAGMENT)) {
+    return true;
   }
-  const saved = await saveChatGptGeneratedImages({
-    Network: params.Network,
-    images: generatedImages,
-    outputPath: targetPath,
-    logger: params.logger,
-  });
-  if (!saved.saved) {
-    const errorDetail = saved.errors.length > 0 ? `\n${saved.errors.join("\n")}` : "";
-    throw new Error(
-      `No images generated. Response text did not include downloadable image bytes.${errorDetail}`,
-    );
-  }
-  const primaryPath = saved.savedImages[0]?.path ?? targetPath;
-  const suffix =
-    saved.savedImages.length > 1
-      ? `\n\n*Generated ${saved.imageCount} image(s). Saved ${saved.savedImages.length} file(s) starting at: ${primaryPath}*`
-      : `\n\n*Generated ${saved.imageCount} image(s). Saved to: ${primaryPath}*`;
-  return {
-    generatedImages,
-    savedImages: saved.savedImages,
-    imageCount: saved.imageCount,
-    markdownSuffix: suffix,
-    answerText: latestAnswerText,
-  };
+  const normalizedText = String(answer.text ?? "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+  return normalizedText === "generated image";
+}
+
+export function shouldSkipMarkdownCaptureForGeneratedImageForTest(answer: {
+  text?: string | null;
+  html?: string | null;
+}): boolean {
+  return shouldSkipMarkdownCaptureForGeneratedImage(answer);
 }
 
 export async function runBrowserMode(options: BrowserRunOptions): Promise<BrowserRunResult> {
@@ -187,6 +139,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
   const runtimeHintCb = options.runtimeHintCb;
   let lastTargetId: string | undefined;
   let lastUrl: string | undefined;
+  const imageOutputMode = Boolean(options.generateImagePath || options.outputPath);
   const emitRuntimeHint = async (): Promise<void> => {
     if (!runtimeHintCb || !chrome?.port) {
       return;
@@ -639,8 +592,9 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
           }
         }
       }
-      let baselineTurns = await readConversationTurnCount(Runtime, logger);
-      // Learned: return baselineTurns so assistant polling can ignore earlier content.
+      let baselineTurns = await readConversationTurnIndex(Runtime, logger);
+      // Learned: use the last existing turn index, not the raw turn count, so new
+      // image-only assistant turns are not filtered out when the DOM pre-renders wrappers.
       const sendAttachmentNames = attachmentWaitTimedOut ? [] : attachmentNames;
       const providerState: Record<string, unknown> = {
         runtime: Runtime,
@@ -809,7 +763,10 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
           },
         );
       }
-      const timeoutMs = recheckTimeoutMs > 0 ? recheckTimeoutMs : config.timeoutMs;
+      const timeoutMs = resolveAssistantResponseTimeoutMs(
+        recheckTimeoutMs > 0 ? recheckTimeoutMs : config.timeoutMs,
+        imageOutputMode,
+      );
       const rechecked = await raceWithDisconnect(
         waitForAssistantResponseWithReload(
           Runtime,
@@ -827,7 +784,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
         waitForAssistantResponseWithReload(
           Runtime,
           Page,
-          config.timeoutMs,
+          resolveAssistantResponseTimeoutMs(config.timeoutMs, imageOutputMode),
           logger,
           baselineTurns ?? undefined,
         ),
@@ -884,28 +841,34 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
     }
     answerText = answer.text;
     answerHtml = answer.html ?? "";
-    const copiedMarkdown = await raceWithDisconnect(
-      withRetries(
-        async () => {
-          const attempt = await captureAssistantMarkdown(Runtime, answer.meta, logger);
-          if (!attempt) {
-            throw new Error("copy-missing");
-          }
-          return attempt;
-        },
-        {
-          retries: 2,
-          delayMs: 350,
-          onRetry: (attempt, error) => {
-            if (options.verbose) {
-              logger(
-                `[retry] Markdown capture attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
-              );
-            }
-          },
-        },
-      ),
-    ).catch(() => null);
+    const skipMarkdownCapture = shouldSkipMarkdownCaptureForGeneratedImage(answer);
+    if (skipMarkdownCapture) {
+      logger("Skipping markdown capture for generated-image response");
+    }
+    const copiedMarkdown = skipMarkdownCapture
+      ? null
+      : await raceWithDisconnect(
+          withRetries(
+            async () => {
+              const attempt = await captureAssistantMarkdown(Runtime, answer.meta, logger);
+              if (!attempt) {
+                throw new Error("copy-missing");
+              }
+              return attempt;
+            },
+            {
+              retries: 2,
+              delayMs: 350,
+              onRetry: (attempt, error) => {
+                if (options.verbose) {
+                  logger(
+                    `[retry] Markdown capture attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
+                  );
+                }
+              },
+            },
+          ),
+        ).catch(() => null);
     answerMarkdown = copiedMarkdown ?? answerText;
 
     const promptEchoMatcher = buildPromptEchoMatcher(promptText);
@@ -1016,20 +979,17 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
     }
     stopThinkingMonitor?.();
     runStatus = "complete";
-    const imageArtifacts = await maybePersistChatGptGeneratedImages({
+    const imageArtifacts = await collectGeneratedImageArtifacts({
       Runtime,
       Network,
       logger,
-      baselineTurns,
+      minTurnIndex: baselineTurns,
       generateImagePath: options.generateImagePath,
       outputPath: options.outputPath,
       answerText,
-      waitTimeoutMs: Math.min(config.timeoutMs, 180_000),
+      waitTimeoutMs: options.config?.timeoutMs,
     });
     answerText = imageArtifacts.answerText || answerText;
-    if ((options.generateImagePath || options.outputPath) && imageArtifacts.imageCount === 0) {
-      throw new Error(`No images generated. Response text:\n${answerText || "(empty response)"}`);
-    }
     if (imageArtifacts.markdownSuffix) {
       answerMarkdown += imageArtifacts.markdownSuffix;
     }
@@ -1392,6 +1352,7 @@ async function runRemoteBrowserMode(
   let client: ChromeClient | null = null;
   let remoteTargetId: string | null = null;
   let lastUrl: string | undefined;
+  const imageOutputMode = Boolean(options.generateImagePath || options.outputPath);
   const runtimeHintCb = options.runtimeHintCb;
   const emitRuntimeHint = async () => {
     if (!runtimeHintCb) return;
@@ -1520,7 +1481,7 @@ async function runRemoteBrowserMode(
         await waitForAttachmentCompletion(Runtime, waitBudget, attachmentNames, logger);
         logger("All attachments uploaded");
       }
-      let baselineTurns = await readConversationTurnCount(Runtime, logger);
+      let baselineTurns = await readConversationTurnIndex(Runtime, logger);
       const providerState: Record<string, unknown> = {
         runtime: Runtime,
         input: Input,
@@ -1652,7 +1613,10 @@ async function runRemoteBrowserMode(
         );
       }
       await emitRuntimeHint();
-      const timeoutMs = recheckTimeoutMs > 0 ? recheckTimeoutMs : config.timeoutMs;
+      const timeoutMs = resolveAssistantResponseTimeoutMs(
+        recheckTimeoutMs > 0 ? recheckTimeoutMs : config.timeoutMs,
+        imageOutputMode,
+      );
       const rechecked = await waitForAssistantResponseWithReload(
         Runtime,
         Page,
@@ -1667,7 +1631,7 @@ async function runRemoteBrowserMode(
       answer = await waitForAssistantResponseWithReload(
         Runtime,
         Page,
-        config.timeoutMs,
+        resolveAssistantResponseTimeoutMs(config.timeoutMs, imageOutputMode),
         logger,
         baselineTurns ?? undefined,
       );
@@ -1726,27 +1690,32 @@ async function runRemoteBrowserMode(
     }
     answerText = answer.text;
     answerHtml = answer.html ?? "";
-
-    const copiedMarkdown = await withRetries(
-      async () => {
-        const attempt = await captureAssistantMarkdown(Runtime, answer.meta, logger);
-        if (!attempt) {
-          throw new Error("copy-missing");
-        }
-        return attempt;
-      },
-      {
-        retries: 2,
-        delayMs: 350,
-        onRetry: (attempt, error) => {
-          if (options.verbose) {
-            logger(
-              `[retry] Markdown capture attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
-            );
-          }
-        },
-      },
-    ).catch(() => null);
+    const skipMarkdownCapture = shouldSkipMarkdownCaptureForGeneratedImage(answer);
+    if (skipMarkdownCapture) {
+      logger("Skipping markdown capture for generated-image response");
+    }
+    const copiedMarkdown = skipMarkdownCapture
+      ? null
+      : await withRetries(
+          async () => {
+            const attempt = await captureAssistantMarkdown(Runtime, answer.meta, logger);
+            if (!attempt) {
+              throw new Error("copy-missing");
+            }
+            return attempt;
+          },
+          {
+            retries: 2,
+            delayMs: 350,
+            onRetry: (attempt, error) => {
+              if (options.verbose) {
+                logger(
+                  `[retry] Markdown capture attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
+                );
+              }
+            },
+          },
+        ).catch(() => null);
 
     answerMarkdown = copiedMarkdown ?? answerText;
     ({ answerText, answerMarkdown } = await maybeRecoverLongAssistantResponse({
@@ -1821,20 +1790,17 @@ async function runRemoteBrowserMode(
     }
     stopThinkingMonitor?.();
 
-    const imageArtifacts = await maybePersistChatGptGeneratedImages({
+    const imageArtifacts = await collectGeneratedImageArtifacts({
       Runtime,
       Network,
       logger,
-      baselineTurns,
+      minTurnIndex: baselineTurns,
       generateImagePath: options.generateImagePath,
       outputPath: options.outputPath,
       answerText,
-      waitTimeoutMs: Math.min(config.timeoutMs, 180_000),
+      waitTimeoutMs: options.config?.timeoutMs,
     });
     answerText = imageArtifacts.answerText || answerText;
-    if ((options.generateImagePath || options.outputPath) && imageArtifacts.imageCount === 0) {
-      throw new Error(`No images generated. Response text:\n${answerText || "(empty response)"}`);
-    }
     if (imageArtifacts.markdownSuffix) {
       answerMarkdown += imageArtifacts.markdownSuffix;
     }
@@ -1970,6 +1936,14 @@ async function waitForAssistantResponseWithReload(
     logger("Assistant response stalled; reloading conversation and retrying once");
     await Page.navigate({ url: conversationUrl });
     await delay(1000);
+    const recoveredGeneratedImage = await recoverGeneratedImageAnswerAfterReload(
+      Runtime,
+      minTurnIndex,
+    );
+    if (recoveredGeneratedImage) {
+      logger("Recovered generated image artifacts after reloading conversation");
+      return recoveredGeneratedImage;
+    }
     return await waitForAssistantResponse(Runtime, timeoutMs, logger, minTurnIndex);
   }
 }
@@ -2133,7 +2107,85 @@ function buildSessionValidationExpression(): string {
   })()`;
 }
 
-async function readConversationTurnCount(
+function resolveBaselineTurnIndex(rawTurnCount: number): number {
+  return Math.max(0, Math.floor(rawTurnCount) - 1);
+}
+
+export function resolveBaselineTurnIndexForTest(rawTurnCount: number): number {
+  return resolveBaselineTurnIndex(rawTurnCount);
+}
+
+async function recoverGeneratedImageAnswerAfterReload(
+  Runtime: ChromeClient["Runtime"],
+  minTurnIndex?: number,
+): Promise<{
+  text: string;
+  html?: string;
+  meta: { turnId?: string | null; messageId?: string | null };
+} | null> {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    const [images, snapshot] = await Promise.all([
+      readAssistantGeneratedImages(Runtime, minTurnIndex).catch(() => []),
+      readAssistantSnapshot(Runtime, minTurnIndex).catch(() => null),
+    ]);
+    if (images.length > 0) {
+      const text =
+        typeof snapshot?.text === "string" && snapshot.text.trim()
+          ? snapshot.text.trim()
+          : "Generated image";
+      return {
+        text,
+        html: typeof snapshot?.html === "string" ? snapshot.html : undefined,
+        meta: {
+          turnId: snapshot?.turnId ?? undefined,
+          messageId: snapshot?.messageId ?? undefined,
+        },
+      };
+    }
+
+    if (typeof minTurnIndex === "number" && Number.isFinite(minTurnIndex)) {
+      const [fallbackImages, fallbackSnapshot] = await Promise.all([
+        readAssistantGeneratedImages(Runtime).catch(() => []),
+        readAssistantSnapshot(Runtime).catch(() => null),
+      ]);
+      const fallbackTurnIndex =
+        typeof fallbackSnapshot?.turnIndex === "number" ? fallbackSnapshot.turnIndex : null;
+      const nearBoundary =
+        fallbackTurnIndex !== null && fallbackTurnIndex + 1 >= Math.floor(minTurnIndex);
+      if (fallbackImages.length > 0 && nearBoundary) {
+        const text =
+          typeof fallbackSnapshot?.text === "string" && fallbackSnapshot.text.trim()
+            ? fallbackSnapshot.text.trim()
+            : "Generated image";
+        return {
+          text,
+          html: typeof fallbackSnapshot?.html === "string" ? fallbackSnapshot.html : undefined,
+          meta: {
+            turnId: fallbackSnapshot?.turnId ?? undefined,
+            messageId: fallbackSnapshot?.messageId ?? undefined,
+          },
+        };
+      }
+    }
+
+    await delay(500);
+  }
+  return null;
+}
+
+export async function recoverGeneratedImageAnswerAfterReloadForTest(
+  Runtime: ChromeClient["Runtime"],
+  minTurnIndex?: number,
+): Promise<{
+  text: string;
+  html?: string;
+  meta: { turnId?: string | null; messageId?: string | null };
+} | null> {
+  return recoverGeneratedImageAnswerAfterReload(Runtime, minTurnIndex);
+}
+
+async function readConversationTurnIndex(
   Runtime: ChromeClient["Runtime"],
   logger?: BrowserLogger,
 ): Promise<number | null> {
@@ -2149,7 +2201,7 @@ async function readConversationTurnCount(
       if (!Number.isFinite(raw)) {
         throw new Error("Turn count not numeric");
       }
-      return Math.max(0, Math.floor(raw));
+      return resolveBaselineTurnIndex(raw);
     } catch (error) {
       if (attempt < attempts - 1) {
         await delay(150);
@@ -2157,7 +2209,7 @@ async function readConversationTurnCount(
       }
       if (logger?.verbose) {
         logger(
-          `Failed to read conversation turn count: ${error instanceof Error ? error.message : String(error)}`,
+          `Failed to read conversation turn index: ${error instanceof Error ? error.message : String(error)}`,
         );
       }
       return null;

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -59,6 +59,7 @@ import {
 } from "./profileState.js";
 import { runProviderSubmissionFlow } from "./providerDomFlow.js";
 import { chatgptDomProvider } from "./providers/index.js";
+import { readAssistantGeneratedImages, saveChatGptGeneratedImages } from "./chatgptImages.js";
 
 export type { BrowserAutomationConfig, BrowserRunOptions, BrowserRunResult } from "./types.js";
 export { CHATGPT_URL, DEFAULT_MODEL_STRATEGY, DEFAULT_MODEL_TARGET } from "./constants.js";
@@ -75,6 +76,95 @@ function shouldPreserveBrowserOnError(error: unknown, headless: boolean): boolea
 
 export function shouldPreserveBrowserOnErrorForTest(error: unknown, headless: boolean): boolean {
   return shouldPreserveBrowserOnError(error, headless);
+}
+
+async function maybePersistChatGptGeneratedImages(params: {
+  Runtime: ChromeClient["Runtime"];
+  Network: ChromeClient["Network"];
+  logger: BrowserLogger;
+  baselineTurns?: number | null;
+  generateImagePath?: string;
+  outputPath?: string;
+  answerText: string;
+  waitTimeoutMs?: number;
+}): Promise<{
+  generatedImages: Awaited<ReturnType<typeof readAssistantGeneratedImages>>;
+  savedImages: Awaited<ReturnType<typeof saveChatGptGeneratedImages>>["savedImages"];
+  imageCount: number;
+  markdownSuffix: string;
+  answerText: string;
+}> {
+  const targetPath = params.generateImagePath ?? params.outputPath;
+  let generatedImages = await readAssistantGeneratedImages(
+    params.Runtime,
+    params.baselineTurns ?? undefined,
+  ).catch(() => []);
+  let latestAnswerText = params.answerText;
+
+  if (targetPath && generatedImages.length === 0) {
+    const deadline = Date.now() + Math.max(15_000, params.waitTimeoutMs ?? 180_000);
+    let stableCycles = 0;
+    while (Date.now() < deadline) {
+      await delay(1500);
+      generatedImages = await readAssistantGeneratedImages(
+        params.Runtime,
+        params.baselineTurns ?? undefined,
+      ).catch(() => []);
+      if (generatedImages.length > 0) {
+        break;
+      }
+      const latestSnapshot = await readAssistantSnapshot(
+        params.Runtime,
+        params.baselineTurns ?? undefined,
+      ).catch(() => null);
+      const snapshotText =
+        typeof latestSnapshot?.text === "string" ? latestSnapshot.text.trim() : "";
+      if (snapshotText && snapshotText !== latestAnswerText) {
+        latestAnswerText = snapshotText;
+        stableCycles = 0;
+      } else {
+        stableCycles += 1;
+      }
+      if (latestAnswerText.length >= 24 && stableCycles >= 4) {
+        break;
+      }
+    }
+  }
+
+  const imageCount = generatedImages.length;
+  if (!targetPath || imageCount === 0) {
+    return {
+      generatedImages,
+      savedImages: [],
+      imageCount,
+      markdownSuffix: imageCount > 0 ? `\n\n*Generated ${imageCount} image(s).*` : "",
+      answerText: latestAnswerText,
+    };
+  }
+  const saved = await saveChatGptGeneratedImages({
+    Network: params.Network,
+    images: generatedImages,
+    outputPath: targetPath,
+    logger: params.logger,
+  });
+  if (!saved.saved) {
+    const errorDetail = saved.errors.length > 0 ? `\n${saved.errors.join("\n")}` : "";
+    throw new Error(
+      `No images generated. Response text did not include downloadable image bytes.${errorDetail}`,
+    );
+  }
+  const primaryPath = saved.savedImages[0]?.path ?? targetPath;
+  const suffix =
+    saved.savedImages.length > 1
+      ? `\n\n*Generated ${saved.imageCount} image(s). Saved ${saved.savedImages.length} file(s) starting at: ${primaryPath}*`
+      : `\n\n*Generated ${saved.imageCount} image(s). Saved to: ${primaryPath}*`;
+  return {
+    generatedImages,
+    savedImages: saved.savedImages,
+    imageCount: saved.imageCount,
+    markdownSuffix: suffix,
+    answerText: latestAnswerText,
+  };
 }
 
 export async function runBrowserMode(options: BrowserRunOptions): Promise<BrowserRunResult> {
@@ -587,9 +677,16 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
             logger,
           );
           if (!verified) {
-            throw new Error("Sent user message did not expose attachment UI after upload.");
+            if (options.generateImagePath || options.outputPath) {
+              logger(
+                "Attachment UI did not render on the sent user message; continuing because image-output mode is enabled.",
+              );
+            } else {
+              throw new Error("Sent user message did not expose attachment UI after upload.");
+            }
+          } else {
+            logger("Verified attachments present on sent user message");
           }
-          logger("Verified attachments present on sent user message");
         }
       }
       // Reattach needs a /c/ URL; ChatGPT can update it late, so poll in the background.
@@ -919,6 +1016,23 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
     }
     stopThinkingMonitor?.();
     runStatus = "complete";
+    const imageArtifacts = await maybePersistChatGptGeneratedImages({
+      Runtime,
+      Network,
+      logger,
+      baselineTurns,
+      generateImagePath: options.generateImagePath,
+      outputPath: options.outputPath,
+      answerText,
+      waitTimeoutMs: Math.min(config.timeoutMs, 180_000),
+    });
+    answerText = imageArtifacts.answerText || answerText;
+    if ((options.generateImagePath || options.outputPath) && imageArtifacts.imageCount === 0) {
+      throw new Error(`No images generated. Response text:\n${answerText || "(empty response)"}`);
+    }
+    if (imageArtifacts.markdownSuffix) {
+      answerMarkdown += imageArtifacts.markdownSuffix;
+    }
     const durationMs = Date.now() - startedAt;
     const answerChars = answerText.length;
     const answerTokens = estimateTokenCount(answerMarkdown);
@@ -926,6 +1040,8 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
       answerText,
       answerMarkdown,
       answerHtml: answerHtml.length > 0 ? answerHtml : undefined,
+      generatedImages: imageArtifacts.generatedImages,
+      savedImages: imageArtifacts.savedImages,
       tookMs: durationMs,
       answerTokens,
       answerChars,
@@ -935,6 +1051,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
       userDataDir,
       chromeTargetId: lastTargetId,
       tabUrl: lastUrl,
+      conversationId: lastUrl ? extractConversationIdFromUrl(lastUrl) : undefined,
       controllerPid: process.pid,
     };
   } catch (error) {
@@ -1704,6 +1821,23 @@ async function runRemoteBrowserMode(
     }
     stopThinkingMonitor?.();
 
+    const imageArtifacts = await maybePersistChatGptGeneratedImages({
+      Runtime,
+      Network,
+      logger,
+      baselineTurns,
+      generateImagePath: options.generateImagePath,
+      outputPath: options.outputPath,
+      answerText,
+      waitTimeoutMs: Math.min(config.timeoutMs, 180_000),
+    });
+    answerText = imageArtifacts.answerText || answerText;
+    if ((options.generateImagePath || options.outputPath) && imageArtifacts.imageCount === 0) {
+      throw new Error(`No images generated. Response text:\n${answerText || "(empty response)"}`);
+    }
+    if (imageArtifacts.markdownSuffix) {
+      answerMarkdown += imageArtifacts.markdownSuffix;
+    }
     const durationMs = Date.now() - startedAt;
     const answerChars = answerText.length;
     const answerTokens = estimateTokenCount(answerMarkdown);
@@ -1712,6 +1846,8 @@ async function runRemoteBrowserMode(
       answerText,
       answerMarkdown,
       answerHtml: answerHtml.length > 0 ? answerHtml : undefined,
+      generatedImages: imageArtifacts.generatedImages,
+      savedImages: imageArtifacts.savedImages,
       tookMs: durationMs,
       answerTokens,
       answerChars,
@@ -1721,6 +1857,7 @@ async function runRemoteBrowserMode(
       userDataDir: undefined,
       chromeTargetId: remoteTargetId ?? undefined,
       tabUrl: lastUrl,
+      conversationId: lastUrl ? extractConversationIdFromUrl(lastUrl) : undefined,
       controllerPid: process.pid,
     };
   } catch (error) {

--- a/src/browser/pageActions.ts
+++ b/src/browser/pageActions.ts
@@ -22,4 +22,5 @@ export {
   buildConversationDebugExpressionForTest,
   buildMarkdownFallbackExtractorForTest,
   buildCopyExpressionForTest,
+  isGeneratedImageControlsTextForTest,
 } from "./actions/assistantResponse.js";

--- a/src/browser/reattach.ts
+++ b/src/browser/reattach.ts
@@ -11,13 +11,13 @@ import {
   ensureLoggedIn,
   ensurePromptReady,
 } from "./pageActions.js";
-import { readAssistantGeneratedImages, saveChatGptGeneratedImages } from "./chatgptImages.js";
+import { collectGeneratedImageArtifacts } from "./chatgptImages.js";
 import type { BrowserLogger, ChromeClient } from "./types.js";
 import { launchChrome, connectToChrome, hideChromeWindow } from "./chromeLifecycle.js";
 import { resolveBrowserConfig } from "./config.js";
 import { syncCookies } from "./cookies.js";
 import { CHATGPT_URL } from "./constants.js";
-import { cleanupStaleProfileState } from "./profileState.js";
+import { cleanupStaleProfileState, readChromePid } from "./profileState.js";
 import {
   pickTarget,
   extractConversationIdFromUrl,
@@ -52,58 +52,13 @@ export interface ReattachResult {
   answerMarkdown: string;
 }
 
-async function maybeSaveReattachedImages(params: {
-  Runtime: ChromeClient["Runtime"];
-  Network: ChromeClient["Network"];
-  logger: BrowserLogger;
-  minTurnIndex?: number | null;
-  generateImagePath?: string;
-  outputPath?: string;
-  answerText: string;
-  answerMarkdown: string;
-}): Promise<{ answerText: string; answerMarkdown: string }> {
-  const targetPath = params.generateImagePath ?? params.outputPath;
-  if (!targetPath) {
-    return { answerText: params.answerText, answerMarkdown: params.answerMarkdown };
-  }
-  const images = await readAssistantGeneratedImages(
-    params.Runtime,
-    params.minTurnIndex ?? undefined,
-  ).catch(() => []);
-  if (!images.length) {
-    throw new Error(
-      `No images generated. Response text:\n${params.answerText || "(empty response)"}`,
-    );
-  }
-  const saved = await saveChatGptGeneratedImages({
-    Network: params.Network,
-    images,
-    outputPath: targetPath,
-    logger: params.logger,
-  });
-  if (!saved.saved) {
-    const detail = saved.errors.length > 0 ? `\n${saved.errors.join("\n")}` : "";
-    throw new Error(
-      `No images generated. Response text:\n${params.answerText || "(empty response)"}${detail}`,
-    );
-  }
-  const primaryPath = saved.savedImages[0]?.path ?? targetPath;
-  const suffix =
-    saved.savedImages.length > 1
-      ? `\n\n*Generated ${saved.imageCount} image(s). Saved ${saved.savedImages.length} file(s) starting at: ${primaryPath}*`
-      : `\n\n*Generated ${saved.imageCount} image(s). Saved to: ${primaryPath}*`;
-  return {
-    answerText: params.answerText,
-    answerMarkdown: `${params.answerMarkdown}${suffix}`,
-  };
-}
-
 export async function resumeBrowserSession(
   runtime: BrowserRuntimeMetadata,
   config: BrowserSessionConfig | undefined,
   logger: BrowserLogger,
   deps: ReattachDeps = {},
 ): Promise<ReattachResult> {
+  const resolved = resolveBrowserConfig(config ?? {});
   const recoverSession =
     deps.recoverSession ??
     (async (runtimeMeta, configMeta) =>
@@ -194,14 +149,14 @@ export async function resumeBrowserSession(
       minTurnIndex,
       timeoutMs,
     );
-    const markdown =
-      (await withTimeout(
-        captureMarkdown(Runtime, recovered.meta, logger),
-        15_000,
+      const markdown =
+        (await withTimeout(
+          captureMarkdown(Runtime, recovered.meta, logger),
+          15_000,
         "Reattach markdown capture timed out",
       )) ?? recovered.text;
     const aligned = alignPromptEchoMarkdown(recovered.text, markdown, promptEcho, logger);
-    const withImages = await maybeSaveReattachedImages({
+    const imageArtifacts = await collectGeneratedImageArtifacts({
       Runtime,
       Network,
       logger,
@@ -209,24 +164,88 @@ export async function resumeBrowserSession(
       generateImagePath: deps.generateImagePath,
       outputPath: deps.outputPath,
       answerText: aligned.answerText,
-      answerMarkdown: aligned.answerMarkdown,
+      waitTimeoutMs: config?.timeoutMs,
     });
+      const withImages = {
+        answerText: imageArtifacts.answerText,
+        answerMarkdown: `${aligned.answerMarkdown}${imageArtifacts.markdownSuffix}`,
+      };
 
-    if (client && typeof client.close === "function") {
+      await closeExistingReattachChrome(client, runtime, resolved, logger);
+
+      return { answerText: withImages.answerText, answerMarkdown: withImages.answerMarkdown };
+    } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger(
+      `Existing Chrome reattach failed (${message}); reopening browser to locate the session.`,
+    );
+    return recoverSession(runtime, config);
+  }
+}
+
+async function closeExistingReattachChrome(
+  client: ChromeClient,
+  runtime: BrowserRuntimeMetadata,
+  config: ReturnType<typeof resolveBrowserConfig>,
+  logger: BrowserLogger,
+): Promise<void> {
+  if (config.keepBrowser) {
+    if (typeof client.close === "function") {
       try {
         await client.close();
       } catch {
         // ignore
       }
     }
+    return;
+  }
 
-    return { answerText: withImages.answerText, answerMarkdown: withImages.answerMarkdown };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    logger(
-      `Existing Chrome reattach failed (${message}); reopening browser to locate the session.`,
+  let browserClosed = false;
+  const browserDomain = (
+    client as ChromeClient & {
+      Browser?: {
+        close?: () => Promise<void>;
+      };
+    }
+  ).Browser;
+  if (browserDomain && typeof browserDomain.close === "function") {
+    try {
+      await browserDomain.close();
+      browserClosed = true;
+    } catch (error) {
+      logger(
+        `Failed to close reattached Chrome via CDP: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  if (!browserClosed) {
+    const pid =
+      runtime.chromePid ??
+      (runtime.userDataDir ? await readChromePid(runtime.userDataDir).catch(() => null) : null);
+    if (pid) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  if (typeof client.close === "function") {
+    try {
+      await client.close();
+    } catch {
+      // ignore
+    }
+  }
+
+  if (config.manualLogin && runtime.userDataDir) {
+    await cleanupStaleProfileState(runtime.userDataDir, logger, { lockRemovalMode: "never" }).catch(
+      () => undefined,
     );
-    return recoverSession(runtime, config);
+  } else if (runtime.userDataDir) {
+    await rm(runtime.userDataDir, { recursive: true, force: true }).catch(() => undefined);
   }
 }
 
@@ -325,7 +344,7 @@ async function resumeBrowserSessionViaNewChrome(
   );
   const markdown = (await captureMarkdown(Runtime, recovered.meta, logger)) ?? recovered.text;
   const aligned = alignPromptEchoMarkdown(recovered.text, markdown, promptEcho, logger);
-  const withImages = await maybeSaveReattachedImages({
+  const imageArtifacts = await collectGeneratedImageArtifacts({
     Runtime,
     Network,
     logger,
@@ -333,8 +352,12 @@ async function resumeBrowserSessionViaNewChrome(
     generateImagePath: deps.generateImagePath,
     outputPath: deps.outputPath,
     answerText: aligned.answerText,
-    answerMarkdown: aligned.answerMarkdown,
+    waitTimeoutMs: config?.timeoutMs,
   });
+  const withImages = {
+    answerText: imageArtifacts.answerText,
+    answerMarkdown: `${aligned.answerMarkdown}${imageArtifacts.markdownSuffix}`,
+  };
 
   if (client && typeof client.close === "function") {
     try {

--- a/src/browser/reattach.ts
+++ b/src/browser/reattach.ts
@@ -11,6 +11,7 @@ import {
   ensureLoggedIn,
   ensurePromptReady,
 } from "./pageActions.js";
+import { readAssistantGeneratedImages, saveChatGptGeneratedImages } from "./chatgptImages.js";
 import type { BrowserLogger, ChromeClient } from "./types.js";
 import { launchChrome, connectToChrome, hideChromeWindow } from "./chromeLifecycle.js";
 import { resolveBrowserConfig } from "./config.js";
@@ -42,11 +43,59 @@ export interface ReattachDeps {
     config: BrowserSessionConfig | undefined,
   ) => Promise<ReattachResult>;
   promptPreview?: string;
+  generateImagePath?: string;
+  outputPath?: string;
 }
 
 export interface ReattachResult {
   answerText: string;
   answerMarkdown: string;
+}
+
+async function maybeSaveReattachedImages(params: {
+  Runtime: ChromeClient["Runtime"];
+  Network: ChromeClient["Network"];
+  logger: BrowserLogger;
+  minTurnIndex?: number | null;
+  generateImagePath?: string;
+  outputPath?: string;
+  answerText: string;
+  answerMarkdown: string;
+}): Promise<{ answerText: string; answerMarkdown: string }> {
+  const targetPath = params.generateImagePath ?? params.outputPath;
+  if (!targetPath) {
+    return { answerText: params.answerText, answerMarkdown: params.answerMarkdown };
+  }
+  const images = await readAssistantGeneratedImages(
+    params.Runtime,
+    params.minTurnIndex ?? undefined,
+  ).catch(() => []);
+  if (!images.length) {
+    throw new Error(
+      `No images generated. Response text:\n${params.answerText || "(empty response)"}`,
+    );
+  }
+  const saved = await saveChatGptGeneratedImages({
+    Network: params.Network,
+    images,
+    outputPath: targetPath,
+    logger: params.logger,
+  });
+  if (!saved.saved) {
+    const detail = saved.errors.length > 0 ? `\n${saved.errors.join("\n")}` : "";
+    throw new Error(
+      `No images generated. Response text:\n${params.answerText || "(empty response)"}${detail}`,
+    );
+  }
+  const primaryPath = saved.savedImages[0]?.path ?? targetPath;
+  const suffix =
+    saved.savedImages.length > 1
+      ? `\n\n*Generated ${saved.imageCount} image(s). Saved ${saved.savedImages.length} file(s) starting at: ${primaryPath}*`
+      : `\n\n*Generated ${saved.imageCount} image(s). Saved to: ${primaryPath}*`;
+  return {
+    answerText: params.answerText,
+    answerMarkdown: `${params.answerMarkdown}${suffix}`,
+  };
 }
 
 export async function resumeBrowserSession(
@@ -81,9 +130,12 @@ export async function resumeBrowserSession(
       port: runtime.chromePort,
       target: target?.targetId,
     })) as unknown as ChromeClient;
-    const { Runtime, DOM } = client;
+    const { Runtime, DOM, Network } = client;
     if (Runtime?.enable) {
       await Runtime.enable();
+    }
+    if (Network?.enable) {
+      await Network.enable({});
     }
     if (DOM && typeof DOM.enable === "function") {
       await DOM.enable();
@@ -149,6 +201,16 @@ export async function resumeBrowserSession(
         "Reattach markdown capture timed out",
       )) ?? recovered.text;
     const aligned = alignPromptEchoMarkdown(recovered.text, markdown, promptEcho, logger);
+    const withImages = await maybeSaveReattachedImages({
+      Runtime,
+      Network,
+      logger,
+      minTurnIndex,
+      generateImagePath: deps.generateImagePath,
+      outputPath: deps.outputPath,
+      answerText: aligned.answerText,
+      answerMarkdown: aligned.answerMarkdown,
+    });
 
     if (client && typeof client.close === "function") {
       try {
@@ -158,7 +220,7 @@ export async function resumeBrowserSession(
       }
     }
 
-    return { answerText: aligned.answerText, answerMarkdown: aligned.answerMarkdown };
+    return { answerText: withImages.answerText, answerMarkdown: withImages.answerMarkdown };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     logger(
@@ -189,6 +251,9 @@ async function resumeBrowserSessionViaNewChrome(
 
   if (Runtime?.enable) {
     await Runtime.enable();
+  }
+  if (Network?.enable) {
+    await Network.enable({});
   }
   if (DOM && typeof DOM.enable === "function") {
     await DOM.enable();
@@ -260,6 +325,16 @@ async function resumeBrowserSessionViaNewChrome(
   );
   const markdown = (await captureMarkdown(Runtime, recovered.meta, logger)) ?? recovered.text;
   const aligned = alignPromptEchoMarkdown(recovered.text, markdown, promptEcho, logger);
+  const withImages = await maybeSaveReattachedImages({
+    Runtime,
+    Network,
+    logger,
+    minTurnIndex,
+    generateImagePath: deps.generateImagePath,
+    outputPath: deps.outputPath,
+    answerText: aligned.answerText,
+    answerMarkdown: aligned.answerMarkdown,
+  });
 
   if (client && typeof client.close === "function") {
     try {
@@ -283,7 +358,7 @@ async function resumeBrowserSessionViaNewChrome(
     }
   }
 
-  return { answerText: aligned.answerText, answerMarkdown: aligned.answerMarkdown };
+  return { answerText: withImages.answerText, answerMarkdown: withImages.answerMarkdown };
 }
 
 // biome-ignore lint/style/useNamingConvention: test-only export used in vitest suite

--- a/src/browser/sessionRunner.ts
+++ b/src/browser/sessionRunner.ts
@@ -108,6 +108,8 @@ export async function runBrowserSessionExecution(
       log: automationLogger,
       heartbeatIntervalMs: runOptions.heartbeatIntervalMs,
       verbose: runOptions.verbose,
+      generateImagePath: runOptions.generateImage,
+      outputPath: runOptions.outputPath,
       runtimeHintCb: async (runtime) => {
         await persistRuntimeHint({
           ...runtime,
@@ -167,6 +169,9 @@ export async function runBrowserSessionExecution(
       chromePort: browserResult.chromePort,
       chromeHost: browserResult.chromeHost,
       userDataDir: browserResult.userDataDir,
+      chromeTargetId: browserResult.chromeTargetId,
+      tabUrl: browserResult.tabUrl,
+      conversationId: browserResult.conversationId,
       controllerPid: browserResult.controllerPid ?? process.pid,
     },
     answerText,

--- a/src/browser/sessionRunner.ts
+++ b/src/browser/sessionRunner.ts
@@ -89,6 +89,9 @@ export async function runBrowserSessionExecution(
 
   log(headerLine);
   log(chalk.dim("This run can take up to an hour (usually ~10 minutes)."));
+  if (runOptions.generateImage) {
+    log(chalk.dim("Image generation may take longer than 2 minutes."));
+  }
   if (runOptions.verbose) {
     log(chalk.dim("Chrome automation does not stream output; this may take a minute..."));
   }

--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -61,6 +61,26 @@ export interface BrowserAutomationConfig {
   thinkingTime?: ThinkingTimeLevel;
 }
 
+export interface BrowserGeneratedImage {
+  url: string;
+  alt?: string;
+  width?: number;
+  height?: number;
+  fileId?: string;
+}
+
+export interface SavedBrowserImage {
+  path: string;
+  url: string;
+  finalUrl?: string;
+  alt?: string;
+  width?: number;
+  height?: number;
+  fileId?: string;
+  contentType?: string;
+  sizeBytes?: number;
+}
+
 export interface BrowserRunOptions {
   prompt: string;
   attachments?: BrowserAttachment[];
@@ -73,6 +93,8 @@ export interface BrowserRunOptions {
   log?: BrowserLogger;
   heartbeatIntervalMs?: number;
   verbose?: boolean;
+  generateImagePath?: string;
+  outputPath?: string;
   /** Optional hook to persist runtime info (port/url/target) as soon as Chrome is ready. */
   runtimeHintCb?: (hint: BrowserRuntimeMetadata) => void | Promise<void>;
 }
@@ -81,6 +103,8 @@ export interface BrowserRunResult {
   answerText: string;
   answerMarkdown: string;
   answerHtml?: string;
+  generatedImages?: BrowserGeneratedImage[];
+  savedImages?: SavedBrowserImage[];
   tookMs: number;
   answerTokens: number;
   answerChars: number;
@@ -90,6 +114,7 @@ export interface BrowserRunResult {
   userDataDir?: string;
   chromeTargetId?: string;
   tabUrl?: string;
+  conversationId?: string;
   controllerPid?: number;
 }
 

--- a/src/cli/sessionDisplay.ts
+++ b/src/cli/sessionDisplay.ts
@@ -190,7 +190,11 @@ export async function attachSession(
           }) as unknown as BrowserLogger,
           { verbose: true },
         ),
-        { promptPreview: metadata.promptPreview },
+        {
+          promptPreview: metadata.promptPreview,
+          generateImagePath: metadata.options?.generateImage,
+          outputPath: metadata.options?.outputPath,
+        },
       );
       const outputTokens = estimateTokenCount(result.answerMarkdown);
       const logWriter = sessionStore.createLogWriter(sessionId);

--- a/src/cli/sessionRunner.ts
+++ b/src/cli/sessionRunner.ts
@@ -679,6 +679,8 @@ async function autoReattachUntilComplete({
       };
       const result = await resumeBrowserSession(runtime, reattachConfig, logger, {
         promptPreview: sessionMeta.promptPreview,
+        generateImagePath: runOptions.generateImage,
+        outputPath: runOptions.outputPath,
       });
       const answerText = result.answerMarkdown || result.answerText || "";
       const outputTokens = estimateTokenCount(answerText);

--- a/src/oracle/types.ts
+++ b/src/oracle/types.ts
@@ -166,6 +166,10 @@ export interface RunOracleOptions {
   background?: boolean;
   /** Optional absolute path to save only the assistant's final text output. */
   writeOutputPath?: string;
+  /** Browser/Gemini image generation output path. For browser chat surfaces, extra images save alongside this file. */
+  generateImage?: string;
+  /** Optional output path used by edit/image workflows. */
+  outputPath?: string;
   /** Number of seconds to wait before timing out, or 'auto' to use model defaults. */
   timeoutSeconds?: number | "auto";
   /** Override HTTP client timeout (milliseconds). */

--- a/src/remote/server.ts
+++ b/src/remote/server.ts
@@ -373,12 +373,15 @@ function sanitizeResult(result: BrowserRunResult): BrowserRunResult {
     answerText: result.answerText,
     answerMarkdown: result.answerMarkdown,
     answerHtml: result.answerHtml,
+    generatedImages: result.generatedImages,
+    savedImages: result.savedImages,
     tookMs: result.tookMs,
     answerTokens: result.answerTokens,
     answerChars: result.answerChars,
     chromePid: undefined,
     chromePort: undefined,
     userDataDir: undefined,
+    conversationId: result.conversationId,
   };
 }
 

--- a/tests/browser/chatgptImages.test.ts
+++ b/tests/browser/chatgptImages.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  readAssistantGeneratedImages,
+  saveChatGptGeneratedImages,
+} from "../../src/browser/chatgptImages.js";
+import type { ChromeClient } from "../../src/browser/types.js";
+
+describe("readAssistantGeneratedImages", () => {
+  test("dedupes duplicate image urls by file id and keeps the largest candidate", async () => {
+    const runtime = {
+      evaluate: vi.fn().mockResolvedValue({
+        result: {
+          value: [
+            {
+              url: "https://chatgpt.com/backend-api/estuary/content?id=file_a",
+              alt: "one",
+              width: 512,
+              height: 512,
+            },
+            {
+              url: "https://chatgpt.com/backend-api/estuary/content?id=file_a",
+              alt: "one-large",
+              width: 1024,
+              height: 1024,
+            },
+            {
+              url: "https://chatgpt.com/backend-api/estuary/content?id=file_b",
+              alt: "two",
+              width: 640,
+              height: 480,
+            },
+          ],
+        },
+      }),
+    } as unknown as ChromeClient["Runtime"];
+
+    const images = await readAssistantGeneratedImages(runtime);
+    expect(images).toHaveLength(2);
+    expect(images[0]?.fileId).toBe("file_a");
+    expect(images[0]?.width).toBe(1024);
+    expect(images[1]?.fileId).toBe("file_b");
+  });
+});
+
+describe("saveChatGptGeneratedImages", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test("saves multiple generated images as real files", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-chatgpt-images-"));
+    const network = {
+      getCookies: vi.fn().mockResolvedValue({
+        cookies: [
+          { name: "__Secure-next-auth.session-token", value: "abc" },
+          { name: "oai-did", value: "def" },
+        ],
+      }),
+    } as unknown as ChromeClient["Network"];
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        url: "https://files.local/1",
+        headers: { get: (name: string) => (name === "content-type" ? "image/png" : null) },
+        arrayBuffer: async () => Uint8Array.from([1, 2, 3, 4]).buffer,
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        url: "https://files.local/2",
+        headers: { get: (name: string) => (name === "content-type" ? "image/png" : null) },
+        arrayBuffer: async () => Uint8Array.from([5, 6, 7, 8]).buffer,
+      } as Response);
+
+    const result = await saveChatGptGeneratedImages({
+      Network: network,
+      images: [
+        { url: "https://chatgpt.com/backend-api/estuary/content?id=file_1", fileId: "file_1" },
+        { url: "https://chatgpt.com/backend-api/estuary/content?id=file_2", fileId: "file_2" },
+      ],
+      outputPath: path.join(tmpDir, "generated.png"),
+    });
+
+    expect(result.saved).toBe(true);
+    expect(result.imageCount).toBe(2);
+    expect(result.savedImages).toHaveLength(2);
+    expect(result.savedImages[0]?.path).toBe(path.join(tmpDir, "generated.png"));
+    expect(result.savedImages[1]?.path).toBe(path.join(tmpDir, "generated.2.png"));
+    await expect(fs.readFile(path.join(tmpDir, "generated.png"))).resolves.toEqual(
+      Buffer.from([1, 2, 3, 4]),
+    );
+    await expect(fs.readFile(path.join(tmpDir, "generated.2.png"))).resolves.toEqual(
+      Buffer.from([5, 6, 7, 8]),
+    );
+  });
+});

--- a/tests/browser/chatgptImages.test.ts
+++ b/tests/browser/chatgptImages.test.ts
@@ -3,10 +3,13 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
+  collectGeneratedImageArtifacts,
   readAssistantGeneratedImages,
+  resolveGeneratedImageWaitTimeoutMsForTest,
   saveChatGptGeneratedImages,
 } from "../../src/browser/chatgptImages.js";
 import type { ChromeClient } from "../../src/browser/types.js";
+import { setOracleHomeDirOverrideForTest } from "../../src/oracleHome.js";
 
 describe("readAssistantGeneratedImages", () => {
   test("dedupes duplicate image urls by file id and keeps the largest candidate", async () => {
@@ -103,5 +106,215 @@ describe("saveChatGptGeneratedImages", () => {
     await expect(fs.readFile(path.join(tmpDir, "generated.2.png"))).resolves.toEqual(
       Buffer.from([5, 6, 7, 8]),
     );
+  });
+});
+
+describe("resolveGeneratedImageWaitTimeoutMsForTest", () => {
+  test("defaults to a 15 minute wait window when no timeout is provided", () => {
+    expect(resolveGeneratedImageWaitTimeoutMsForTest()).toBe(15 * 60_000);
+  });
+
+  test("caps image waits at 15 minutes even when a longer timeout is requested", () => {
+    expect(resolveGeneratedImageWaitTimeoutMsForTest(20 * 60_000)).toBe(15 * 60_000);
+  });
+});
+
+describe("collectGeneratedImageArtifacts", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    setOracleHomeDirOverrideForTest(null);
+  });
+
+  test("keeps waiting for generated images after the answer text stops changing", async () => {
+    vi.useFakeTimers();
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-chatgpt-artifacts-"));
+    let imagePolls = 0;
+    const runtime = {
+      evaluate: vi.fn(async ({ expression }: { expression: string }) => {
+        if (expression.includes("/backend-api/estuary/content?id=file_")) {
+          imagePolls += 1;
+          if (imagePolls < 6) {
+            return { result: { value: [] } };
+          }
+          return {
+            result: {
+              value: [
+                {
+                  url: "https://chatgpt.com/backend-api/estuary/content?id=file_waited",
+                  alt: "waited",
+                  width: 1024,
+                  height: 1024,
+                },
+              ],
+            },
+          };
+        }
+        if (expression.includes("extractAssistantTurn")) {
+          return {
+            result: {
+              value: {
+                text: "Still rendering image",
+                html: "<p>Still rendering image</p>",
+                messageId: "m1",
+                turnId: "t1",
+                turnIndex: 0,
+              },
+            },
+          };
+        }
+        return { result: { value: null } };
+      }),
+    } as unknown as ChromeClient["Runtime"];
+    const network = {
+      getCookies: vi.fn().mockResolvedValue({
+        cookies: [{ name: "__Secure-next-auth.session-token", value: "abc" }],
+      }),
+    } as unknown as ChromeClient["Network"];
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      url: "https://files.local/waited",
+      headers: { get: (name: string) => (name === "content-type" ? "image/png" : null) },
+      arrayBuffer: async () => Uint8Array.from([1, 2, 3]).buffer,
+    } as Response);
+
+    const resultPromise = collectGeneratedImageArtifacts({
+      Runtime: runtime,
+      Network: network,
+      outputPath: path.join(tmpDir, "waited.png"),
+      answerText: "Still rendering image",
+      waitTimeoutMs: 15_000,
+    });
+
+    await vi.advanceTimersByTimeAsync(7_600);
+    const result = await resultPromise;
+
+    expect(imagePolls).toBe(6);
+    expect(result.imageCount).toBe(1);
+    expect(result.savedImages[0]?.path).toBe(path.join(tmpDir, "waited.png"));
+  });
+
+  test("falls back to the last assistant image turn when minTurnIndex is one step ahead", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-chatgpt-fallback-"));
+    const runtime = {
+      evaluate: vi.fn(async ({ expression }: { expression: string }) => {
+        if (expression.includes("/backend-api/estuary/content?id=file_")) {
+          const withMinTurn = expression.includes("MIN_TURN_INDEX = 2");
+          if (withMinTurn) {
+            return { result: { value: [] } };
+          }
+          return {
+            result: {
+              value: [
+                {
+                  url: "https://chatgpt.com/backend-api/estuary/content?id=file_fallback",
+                  alt: "fallback",
+                  width: 1024,
+                  height: 1024,
+                },
+              ],
+            },
+          };
+        }
+        if (expression.includes("extractAssistantTurn")) {
+          const withMinTurn = expression.includes("const MIN_TURN_INDEX = 2");
+          if (withMinTurn) {
+            return { result: { value: null } };
+          }
+          return {
+            result: {
+              value: {
+                text: "Stopped thinking\nEdit",
+                html: "<div><img src=\"https://chatgpt.com/backend-api/estuary/content?id=file_fallback\"></div>",
+                messageId: "m1",
+                turnId: "t1",
+                turnIndex: 1,
+              },
+            },
+          };
+        }
+        return { result: { value: null } };
+      }),
+    } as unknown as ChromeClient["Runtime"];
+    const network = {
+      getCookies: vi.fn().mockResolvedValue({
+        cookies: [{ name: "__Secure-next-auth.session-token", value: "abc" }],
+      }),
+    } as unknown as ChromeClient["Network"];
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      url: "https://files.local/fallback",
+      headers: { get: (name: string) => (name === "content-type" ? "image/png" : null) },
+      arrayBuffer: async () => Uint8Array.from([9, 8, 7]).buffer,
+    } as Response);
+
+    const result = await collectGeneratedImageArtifacts({
+      Runtime: runtime,
+      Network: network,
+      outputPath: path.join(tmpDir, "fallback.png"),
+      answerText: "Stopped thinking\nEdit",
+      minTurnIndex: 2,
+      waitTimeoutMs: 15_000,
+    });
+
+    expect(result.imageCount).toBe(1);
+    expect(result.savedImages[0]?.path).toBe(path.join(tmpDir, "fallback.png"));
+  });
+
+  test("auto-saves generated images to the default oracle temp directory when no path is provided", async () => {
+    const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-home-"));
+    setOracleHomeDirOverrideForTest(tmpHome);
+    const runtime = {
+      evaluate: vi.fn(async ({ expression }: { expression: string }) => {
+        if (expression.includes("/backend-api/estuary/content?id=file_")) {
+          return {
+            result: {
+              value: [
+                {
+                  url: "https://chatgpt.com/backend-api/estuary/content?id=file_auto_saved",
+                  alt: "auto-saved",
+                  width: 1024,
+                  height: 1024,
+                },
+              ],
+            },
+          };
+        }
+        return { result: { value: null } };
+      }),
+    } as unknown as ChromeClient["Runtime"];
+    const network = {
+      getCookies: vi.fn().mockResolvedValue({
+        cookies: [{ name: "__Secure-next-auth.session-token", value: "abc" }],
+      }),
+    } as unknown as ChromeClient["Network"];
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      url: "https://files.local/auto-saved",
+      headers: { get: (name: string) => (name === "content-type" ? "image/png" : null) },
+      arrayBuffer: async () => Uint8Array.from([4, 3, 2, 1]).buffer,
+    } as Response);
+
+    const result = await collectGeneratedImageArtifacts({
+      Runtime: runtime,
+      Network: network,
+      answerText: "Stopped thinking\nEdit",
+      waitTimeoutMs: 15_000,
+    });
+
+    expect(result.imageCount).toBe(1);
+    expect(result.savedImages).toHaveLength(1);
+    expect(result.savedImages[0]?.path).toContain(path.join(tmpHome, ".temp"));
+    expect(result.markdownSuffix).toContain("Saved to:");
+    await expect(fs.readFile(result.savedImages[0]!.path)).resolves.toEqual(Buffer.from([4, 3, 2, 1]));
   });
 });

--- a/tests/browser/index.test.ts
+++ b/tests/browser/index.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, test } from "vitest";
-import { shouldPreserveBrowserOnErrorForTest } from "../../src/browser/index.js";
+import { describe, expect, test, vi } from "vitest";
+import {
+  shouldPreserveBrowserOnErrorForTest,
+  resolveBaselineTurnIndexForTest,
+  recoverGeneratedImageAnswerAfterReloadForTest,
+  resolveAssistantResponseTimeoutMsForTest,
+  shouldSkipMarkdownCaptureForGeneratedImageForTest,
+} from "../../src/browser/index.js";
 import { BrowserAutomationError } from "../../src/oracle/errors.js";
 
 describe("shouldPreserveBrowserOnErrorForTest", () => {
@@ -22,5 +28,142 @@ describe("shouldPreserveBrowserOnErrorForTest", () => {
       stage: "execute-browser",
     });
     expect(shouldPreserveBrowserOnErrorForTest(error, false)).toBe(false);
+  });
+});
+
+describe("resolveBaselineTurnIndexForTest", () => {
+  test("returns the last existing turn index instead of the raw turn count", () => {
+    expect(resolveBaselineTurnIndexForTest(0)).toBe(0);
+    expect(resolveBaselineTurnIndexForTest(1)).toBe(0);
+    expect(resolveBaselineTurnIndexForTest(2)).toBe(1);
+    expect(resolveBaselineTurnIndexForTest(5)).toBe(4);
+  });
+});
+
+describe("resolveAssistantResponseTimeoutMsForTest", () => {
+  test("keeps the configured timeout for non-image browser runs", () => {
+    expect(resolveAssistantResponseTimeoutMsForTest(1_200_000, false)).toBe(1_200_000);
+  });
+
+  test("caps image-mode assistant waits at 2 minutes by default", () => {
+    expect(resolveAssistantResponseTimeoutMsForTest(1_200_000, true)).toBe(120_000);
+    expect(resolveAssistantResponseTimeoutMsForTest(90_000, true)).toBe(90_000);
+  });
+});
+
+describe("shouldSkipMarkdownCaptureForGeneratedImageForTest", () => {
+  test("skips markdown capture when the assistant html already contains a downloadable generated image", () => {
+    expect(
+      shouldSkipMarkdownCaptureForGeneratedImageForTest({
+        text: "Stopped thinking\nEdit",
+        html: '<div><img src="https://chatgpt.com/backend-api/estuary/content?id=file_done"></div>',
+      }),
+    ).toBe(true);
+  });
+
+  test("does not skip markdown capture for normal text answers", () => {
+    expect(
+      shouldSkipMarkdownCaptureForGeneratedImageForTest({
+        text: "Here is the answer",
+        html: "<p>Here is the answer</p>",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("recoverGeneratedImageAnswerAfterReloadForTest", () => {
+  test("recovers a generated-image answer from the refreshed DOM", async () => {
+    const runtime = {
+      evaluate: vi.fn().mockImplementation(async ({ expression }: { expression: string }) => {
+        if (expression.includes('/backend-api/estuary/content?id=file_')) {
+          return {
+            result: {
+              value: [
+                {
+                  url: "https://chatgpt.com/backend-api/estuary/content?id=file_done",
+                  alt: "Generated image",
+                  width: 1024,
+                  height: 1024,
+                },
+              ],
+            },
+          };
+        }
+        if (expression.includes("extractAssistantTurn")) {
+          return {
+            result: {
+              value: {
+                text: "Stopped thinking\nEdit",
+                html: "<div><img src=\"https://chatgpt.com/backend-api/estuary/content?id=file_done\"></div>",
+                messageId: "mid-image",
+                turnId: "tid-image",
+                turnIndex: 1,
+              },
+            },
+          };
+        }
+        return { result: { value: null } };
+      }),
+    } as any;
+
+    const recovered = await recoverGeneratedImageAnswerAfterReloadForTest(runtime, 1);
+
+    expect(recovered).toEqual({
+      text: "Stopped thinking\nEdit",
+      html: "<div><img src=\"https://chatgpt.com/backend-api/estuary/content?id=file_done\"></div>",
+      meta: { messageId: "mid-image", turnId: "tid-image" },
+    });
+  });
+
+  test("keeps polling after reload until the generated image appears", async () => {
+    vi.useFakeTimers();
+    try {
+      let imagePolls = 0;
+      const runtime = {
+        evaluate: vi.fn().mockImplementation(async ({ expression }: { expression: string }) => {
+          if (expression.includes('/backend-api/estuary/content?id=file_')) {
+            imagePolls += 1;
+            if (imagePolls < 3) {
+              return { result: { value: [] } };
+            }
+            return {
+              result: {
+                value: [
+                  {
+                    url: "https://chatgpt.com/backend-api/estuary/content?id=file_done",
+                    alt: "Generated image",
+                    width: 1024,
+                    height: 1024,
+                  },
+                ],
+              },
+            };
+          }
+          if (expression.includes("extractAssistantTurn")) {
+            return {
+              result: {
+                value: {
+                  text: "Stopped thinking\nEdit",
+                  html: "<div><img src=\"https://chatgpt.com/backend-api/estuary/content?id=file_done\"></div>",
+                  messageId: "mid-image",
+                  turnId: "tid-image",
+                  turnIndex: 1,
+                },
+              },
+            };
+          }
+          return { result: { value: null } };
+        }),
+      } as any;
+
+      const recoveredPromise = recoverGeneratedImageAnswerAfterReloadForTest(runtime, 1);
+      await vi.advanceTimersByTimeAsync(1_200);
+      const recovered = await recoveredPromise;
+
+      expect(imagePolls).toBe(3);
+      expect(recovered?.meta).toEqual({ messageId: "mid-image", turnId: "tid-image" });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -9,6 +9,7 @@ import {
   ensurePromptReady,
   ensureNotBlocked,
   ensureLoggedIn,
+  isGeneratedImageControlsTextForTest,
 } from "../../src/browser/pageActions.js";
 import * as attachments from "../../src/browser/actions/attachments.js";
 import * as attachmentDataTransfer from "../../src/browser/actions/attachmentDataTransfer.js";
@@ -146,6 +147,35 @@ describe("ensurePromptReady", () => {
     } as unknown as ChromeClient["Runtime"];
     await expect(ensurePromptReady(runtime, 0, logger)).rejects.toThrow(/textarea did not appear/i);
   });
+
+  test("surfaces browser error pages instead of a generic textarea timeout", async () => {
+    const runtime = {
+      evaluate: vi.fn().mockImplementation(async (params: { expression?: string }) => {
+        const expression = String(params?.expression ?? "");
+        if (expression.includes("const selectors") && expression.includes("prompt-textarea")) {
+          return { result: { value: false } };
+        }
+        if (expression.includes("document.title") && expression.includes("document.body")) {
+          return {
+            result: {
+              value: {
+                unavailable: true,
+                title: "This site can't be reached",
+                pageUrl: "chrome-error://chromewebdata/",
+                errorCode: "ERR_NAME_NOT_RESOLVED",
+              },
+            },
+          };
+        }
+        if (expression.includes("location.href")) {
+          return { result: { value: "chrome-error://chromewebdata/" } };
+        }
+        return { result: { value: null } };
+      }),
+    } as unknown as ChromeClient["Runtime"];
+
+    await expect(ensurePromptReady(runtime, 0, logger)).rejects.toThrow(/page is unavailable/i);
+  });
 });
 
 describe("ensureNotBlocked", () => {
@@ -222,6 +252,31 @@ describe("ensureLoggedIn", () => {
     } as unknown as ChromeClient["Runtime"];
     await expect(ensureLoggedIn(runtime, logger, { remoteSession: true })).rejects.toThrow(
       /remote Chrome session/i,
+    );
+  });
+
+  test("does not treat browser network error pages as a successful login", async () => {
+    const runtime = {
+      evaluate: vi.fn().mockResolvedValue({
+        result: {
+          value: {
+            ok: true,
+            status: 0,
+            url: "chrome-error://chromewebdata/",
+            pageUrl: "chrome-error://chromewebdata/",
+            domLoginCta: false,
+            onAuthPage: false,
+            error: "TypeError: Failed to fetch",
+            pageUnavailable: true,
+            pageTitle: "This site can't be reached",
+            pageErrorCode: "ERR_NAME_NOT_RESOLVED",
+          },
+        },
+      }),
+    } as unknown as ChromeClient["Runtime"];
+
+    await expect(ensureLoggedIn(runtime, logger, { appliedCookies: 2 })).rejects.toThrow(
+      /page is unavailable/i,
     );
   });
 });
@@ -329,6 +384,170 @@ describe("waitForAssistantResponse", () => {
     const result = await waitForAssistantResponse(runtime, 200, logger);
     expect(result.text).toBe("Recovered");
     expect(evaluate).toHaveBeenCalled();
+  });
+
+  test("keeps polling while image generation is still pending", async () => {
+    vi.useFakeTimers();
+    try {
+      let snapshotPolls = 0;
+      let statusPolls = 0;
+      const runtime = {
+        evaluate: vi.fn().mockImplementation(
+          async (params: { expression?: string; awaitPromise?: boolean }) => {
+            const expression = String(params?.expression ?? "");
+            if (params?.awaitPromise) {
+              return new Promise(() => undefined);
+            }
+            if (expression.includes("extractAssistantTurn")) {
+              snapshotPolls += 1;
+              if (snapshotPolls < 4) {
+                return {
+                  result: {
+                    value: {
+                      text: "Generating a more detailed image — hang tight.",
+                      html: "<p>Generating a more detailed image — hang tight.</p>",
+                      messageId: "mid-pending",
+                      turnId: "tid-pending",
+                      turnIndex: 0,
+                    },
+                  },
+                };
+              }
+              return {
+                result: {
+                  value: {
+                    text: "Stopped thinking\nEdit",
+                    html: "<div>Stopped thinking<br>Edit</div>",
+                    messageId: "mid-ready",
+                    turnId: "tid-ready",
+                    turnIndex: 0,
+                  },
+                },
+              };
+            }
+            if (expression.includes('/backend-api/estuary/content?id=file_')) {
+              statusPolls += 1;
+              if (statusPolls < 4) {
+                return {
+                  result: {
+                    value: {
+                      text: "Generating a more detailed image — hang tight.",
+                      html: "<p>Generating a more detailed image — hang tight.</p>",
+                      turnId: "tid-pending",
+                      messageId: "mid-pending",
+                      turnIndex: 0,
+                      hasFinishedActions: false,
+                      hasDoneMarkdown: false,
+                      generatedImageCount: 0,
+                      imageGenerationPending: true,
+                    },
+                  },
+                };
+              }
+              return {
+                result: {
+                  value: {
+                    text: "Stopped thinking\nEdit",
+                    html: "<div><img src=\"https://chatgpt.com/backend-api/estuary/content?id=file_ready\"></div>",
+                    turnId: "tid-ready",
+                    messageId: "mid-ready",
+                    turnIndex: 0,
+                    hasFinishedActions: false,
+                    hasDoneMarkdown: false,
+                    generatedImageCount: 1,
+                    imageGenerationPending: false,
+                  },
+                },
+              };
+            }
+            if (expression.includes('data-testid="stop-button"')) {
+              return { result: { value: false } };
+            }
+            return { result: { value: null } };
+          },
+        ),
+        terminateExecution: vi.fn().mockResolvedValue(undefined),
+      } as unknown as ChromeClient["Runtime"];
+
+      const responsePromise = waitForAssistantResponse(runtime, 30_000, logger);
+      await vi.advanceTimersByTimeAsync(4_000);
+      const result = await responsePromise;
+
+      expect(result.text).toBe("Stopped thinking\nEdit");
+      expect(snapshotPolls).toBeGreaterThanOrEqual(4);
+      expect(statusPolls).toBeGreaterThanOrEqual(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("treats downloadable image turns as completed assistant responses", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtime = {
+        evaluate: vi.fn().mockImplementation(
+          async (params: { expression?: string; awaitPromise?: boolean }) => {
+            const expression = String(params?.expression ?? "");
+            if (params?.awaitPromise) {
+              return new Promise(() => undefined);
+            }
+            if (expression.includes("extractAssistantTurn")) {
+              return {
+                result: {
+                  value: {
+                    text: "Stopped thinking\nEdit",
+                    html: "<div><img src=\"https://chatgpt.com/backend-api/estuary/content?id=file_done\"></div>",
+                    messageId: "mid-image",
+                    turnId: "tid-image",
+                    turnIndex: 0,
+                  },
+                },
+              };
+            }
+            if (expression.includes("querySelectorAll('img[src*=")) {
+              return { result: { value: 1 } };
+            }
+            if (expression.includes('/backend-api/estuary/content?id=file_')) {
+              return {
+                result: {
+                  value: {
+                    text: "Stopped thinking\nEdit",
+                    html: "<div><img src=\"https://chatgpt.com/backend-api/estuary/content?id=file_done\"></div>",
+                    turnId: "tid-image",
+                    messageId: "mid-image",
+                    turnIndex: 0,
+                    hasFinishedActions: false,
+                    hasDoneMarkdown: false,
+                    generatedImageCount: 1,
+                    imageGenerationPending: false,
+                  },
+                },
+              };
+            }
+            if (expression.includes('data-testid="stop-button"')) {
+              return { result: { value: false } };
+            }
+            return { result: { value: null } };
+          },
+        ),
+        terminateExecution: vi.fn().mockResolvedValue(undefined),
+      } as unknown as ChromeClient["Runtime"];
+
+      const responsePromise = waitForAssistantResponse(runtime, 30_000, logger);
+      await vi.advanceTimersByTimeAsync(2_000);
+      const result = await responsePromise;
+
+      expect(result.text).toBe("Stopped thinking\nEdit");
+      expect(result.meta).toEqual({ messageId: "mid-image", turnId: "tid-image" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("recognizes compact generated-image control text", () => {
+    expect(isGeneratedImageControlsTextForTest("Stopped thinking\nEdit")).toBe(true);
+    expect(isGeneratedImageControlsTextForTest("Thinking\nPreview")).toBe(true);
+    expect(isGeneratedImageControlsTextForTest("Here is the answer")).toBe(false);
   });
 });
 

--- a/tests/browser/reattach.test.ts
+++ b/tests/browser/reattach.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { resumeBrowserSession, __test__ } from "../../src/browser/reattach.js";
 import type { BrowserLogger, ChromeClient } from "../../src/browser/types.js";
 
@@ -13,9 +16,22 @@ type FakeClient = {
     }) => Promise<{ result: { value: unknown } }>;
   };
   // biome-ignore lint/style/useNamingConvention: mirrors DevTools protocol domain names
+  Network?: {
+    enable?: () => void;
+    getCookies: () => Promise<{ cookies: Array<{ name: string; value: string }> }>;
+  };
+  // biome-ignore lint/style/useNamingConvention: mirrors DevTools protocol domain names
   DOM: { enable: () => void };
   close: () => Promise<void> | void;
 };
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
 
 describe("resumeBrowserSession", () => {
   test("selects target and captures markdown via stubs", async () => {
@@ -109,6 +125,181 @@ describe("resumeBrowserSession", () => {
 
     expect(result.answerText).toBe("fallback");
     expect(recoverSession).toHaveBeenCalled();
+  });
+
+  test("waits for generated images during reattach before saving them", async () => {
+    vi.useFakeTimers();
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-reattach-images-"));
+    const runtime = {
+      chromePort: 51559,
+      chromeHost: "127.0.0.1",
+      chromeTargetId: "target-1",
+      tabUrl: "https://chatgpt.com/c/abc",
+    };
+    let imagePolls = 0;
+    const listTargets = vi.fn(
+      async () =>
+        [
+          { targetId: "target-1", type: "page", url: runtime.tabUrl },
+          { targetId: "target-2", type: "page", url: "about:blank" },
+        ] satisfies FakeTarget[],
+    ) as unknown as () => Promise<FakeTarget[]>;
+    const evaluate = vi.fn(async ({ expression }: { expression: string }) => {
+      if (expression === "location.href") {
+        return { result: { value: runtime.tabUrl } };
+      }
+      if (expression === "1+1") {
+        return { result: { value: 2 } };
+      }
+      if (expression.includes("/backend-api/estuary/content?id=file_")) {
+        imagePolls += 1;
+        if (imagePolls < 6) {
+          return { result: { value: [] } };
+        }
+        return {
+          result: {
+            value: [
+              {
+                url: "https://chatgpt.com/backend-api/estuary/content?id=file_waited",
+                alt: "waited",
+                width: 1024,
+                height: 1024,
+              },
+            ],
+          },
+        };
+      }
+      if (expression.includes("extractAssistantTurn")) {
+        return {
+          result: {
+            value: {
+              text: "Still rendering image",
+              html: "<p>Still rendering image</p>",
+              messageId: "m1",
+              turnId: "t1",
+              turnIndex: 0,
+            },
+          },
+        };
+      }
+      if (expression.includes("document.querySelectorAll(") && expression.includes(".length")) {
+        return { result: { value: 1 } };
+      }
+      return { result: { value: null } };
+    });
+    const connect = vi.fn(
+      async () =>
+        ({
+          // biome-ignore lint/style/useNamingConvention: mirrors DevTools protocol domain names
+          Runtime: { enable: vi.fn(), evaluate },
+          // biome-ignore lint/style/useNamingConvention: mirrors DevTools protocol domain names
+          Network: {
+            enable: vi.fn(),
+            getCookies: vi.fn().mockResolvedValue({
+              cookies: [{ name: "__Secure-next-auth.session-token", value: "abc" }],
+            }),
+          },
+          // biome-ignore lint/style/useNamingConvention: mirrors DevTools protocol domain names
+          DOM: { enable: vi.fn() },
+          close: vi.fn(async () => {}),
+        }) satisfies FakeClient,
+    ) as unknown as (options?: unknown) => Promise<ChromeClient>;
+    const waitForAssistantResponse = vi.fn(async () => ({
+      text: "Still rendering image",
+      html: "",
+      meta: { messageId: "m1", turnId: "conversation-turn-1" },
+    }));
+    const captureAssistantMarkdown = vi.fn(async () => "markdown response");
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      url: "https://files.local/waited",
+      headers: { get: (name: string) => (name === "content-type" ? "image/png" : null) },
+      arrayBuffer: async () => Uint8Array.from([1, 2, 3]).buffer,
+    } as Response);
+    const logger = vi.fn() as BrowserLogger;
+    logger.verbose = true;
+
+    const resultPromise = resumeBrowserSession(runtime, {}, logger, {
+      listTargets,
+      connect,
+      waitForAssistantResponse,
+      captureAssistantMarkdown,
+      outputPath: path.join(tmpDir, "reattach.png"),
+    });
+
+    await vi.advanceTimersByTimeAsync(7_600);
+    const result = await resultPromise;
+
+    expect(imagePolls).toBe(6);
+    expect(result.answerMarkdown).toContain("Saved to:");
+  });
+
+  test("closes the existing chrome browser after successful reattach when keepBrowser is false", async () => {
+    const runtime = {
+      chromePort: 51559,
+      chromeHost: "127.0.0.1",
+      chromeTargetId: "target-1",
+      chromePid: 43210,
+      tabUrl: "https://chatgpt.com/c/abc",
+    };
+    const listTargets = vi.fn(
+      async () =>
+        [{ targetId: "target-1", type: "page", url: runtime.tabUrl }] satisfies FakeTarget[],
+    ) as unknown as () => Promise<FakeTarget[]>;
+    const browserClose = vi.fn(async () => {});
+    const clientClose = vi.fn(async () => {});
+    const evaluate = vi.fn(async ({ expression }: { expression: string }) => {
+      if (expression === "location.href") {
+        return { result: { value: runtime.tabUrl } };
+      }
+      if (expression === "1+1") {
+        return { result: { value: 2 } };
+      }
+      if (expression.includes("document.querySelectorAll(") && expression.includes(".length")) {
+        return { result: { value: 1 } };
+      }
+      return { result: { value: null } };
+    });
+    const connect = vi.fn(
+      async () =>
+        ({
+          // biome-ignore lint/style/useNamingConvention: mirrors DevTools protocol domain names
+          Runtime: { enable: vi.fn(), evaluate },
+          // biome-ignore lint/style/useNamingConvention: mirrors DevTools protocol domain names
+          Network: { enable: vi.fn(), getCookies: vi.fn().mockResolvedValue({ cookies: [] }) },
+          // biome-ignore lint/style/useNamingConvention: mirrors DevTools protocol domain names
+          DOM: { enable: vi.fn() },
+          // biome-ignore lint/style/useNamingConvention: mirrors DevTools protocol domain names
+          Browser: { close: browserClose },
+          close: clientClose,
+        }) satisfies FakeClient & { Browser: { close: () => Promise<void> } },
+    ) as unknown as (options?: unknown) => Promise<ChromeClient>;
+    const waitForAssistantResponse = vi.fn(async () => ({
+      text: "Stopped thinking\nEdit",
+      html: "<div><img src=\"https://chatgpt.com/backend-api/estuary/content?id=file_done\"></div>",
+      meta: { messageId: "m1", turnId: "conversation-turn-1" },
+    }));
+    const captureAssistantMarkdown = vi.fn(async () => "Stopped thinking\nEdit");
+    const logger = vi.fn() as BrowserLogger;
+    logger.verbose = true;
+
+    const result = await resumeBrowserSession(
+      runtime,
+      { timeoutMs: 2_000, keepBrowser: false },
+      logger,
+      {
+        listTargets,
+        connect,
+        waitForAssistantResponse,
+        captureAssistantMarkdown,
+      },
+    );
+
+    expect(result.answerMarkdown).toBe("Stopped thinking\nEdit");
+    expect(browserClose).toHaveBeenCalledTimes(1);
+    expect(clientClose).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/tests/browser/sessionRunner.test.ts
+++ b/tests/browser/sessionRunner.test.ts
@@ -29,11 +29,17 @@ describe("runBrowserSessionExecution", () => {
         tookMs: 1000,
         answerTokens: 12,
         answerChars: 20,
+        chromeTargetId: "t-1",
+        tabUrl: "https://chatgpt.com/c/foo",
       };
     });
     const result = await runBrowserSessionExecution(
       {
-        runOptions: baseRunOptions,
+        runOptions: {
+          ...baseRunOptions,
+          generateImage: "/tmp/generated.png",
+          outputPath: "/tmp/output.png",
+        },
         browserConfig: baseConfig,
         cwd: "/repo",
         log,
@@ -60,9 +66,19 @@ describe("runBrowserSessionExecution", () => {
       reasoningTokens: 0,
       totalTokens: 54,
     });
-    expect(result.runtime).toMatchObject({ chromePid: undefined });
+    expect(result.runtime).toMatchObject({
+      chromePid: undefined,
+      chromeTargetId: "t-1",
+      tabUrl: "https://chatgpt.com/c/foo",
+    });
     expect(persistRuntimeHint).toHaveBeenCalledWith(
       expect.objectContaining({ chromePort: 9999, chromeHost: "127.0.0.1", chromeTargetId: "t-1" }),
+    );
+    expect(executeBrowser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        generateImagePath: "/tmp/generated.png",
+        outputPath: "/tmp/output.png",
+      }),
     );
     expect(log).toHaveBeenCalled();
   });

--- a/tests/browser/sessionRunner.test.ts
+++ b/tests/browser/sessionRunner.test.ts
@@ -245,6 +245,44 @@ describe("runBrowserSessionExecution", () => {
     );
   });
 
+  test("prints a short image-generation timing hint when --generate-image is set", async () => {
+    const log = vi.fn();
+    await runBrowserSessionExecution(
+      {
+        runOptions: { ...baseRunOptions, verbose: false, generateImage: "/tmp/generated.png" },
+        browserConfig: baseConfig,
+        cwd: "/repo",
+        log,
+      },
+      {
+        assemblePrompt: async () => ({
+          markdown: "prompt",
+          composerText: "prompt",
+          estimatedInputTokens: 1,
+          attachments: [],
+          inlineFileCount: 0,
+          tokenEstimateIncludesInlineFiles: false,
+          attachmentsPolicy: "auto",
+          attachmentMode: "inline",
+          fallback: null,
+        }),
+        executeBrowser: async () => ({
+          answerText: "text",
+          answerMarkdown: "markdown",
+          tookMs: 10,
+          answerTokens: 1,
+          answerChars: 5,
+        }),
+      },
+    );
+
+    expect(
+      log.mock.calls.some((call) =>
+        String(call[0]).includes("Image generation may take longer than 2 minutes."),
+      ),
+    ).toBe(true);
+  });
+
   test("verbose output spells out token labels", async () => {
     const log = vi.fn();
     await runBrowserSessionExecution(


### PR DESCRIPTION
## Summary

Adds native image download support for ChatGPT browser mode, bringing it to feature parity with Gemini's `--generate-image <file>` workflow.

### Problem

When using Oracle's browser engine with ChatGPT, the assistant sometimes generates images (e.g., DALL-E / GPT image generation). Previously these images were only visible in the browser — Oracle had no way to save them to disk. Users had to manually right-click and save each image.

Gemini web mode already supports `--generate-image <file>` to automatically save generated images. ChatGPT browser mode had no equivalent.

### Solution

This PR introduces a new `chatgptImages` module that:

1. **Detects generated images** in ChatGPT responses by scanning `<img>` elements pointing to the `backend-api/estuary/content?id=file_...` endpoint
2. **Downloads original full-resolution images** using the live browser session cookies (not screenshots or DOM-captured thumbnails)
3. **Deduplicates images** by file ID, keeping the highest-resolution variant
4. **Saves to disk** with automatic file naming (`output.png`, `output.2.png`, etc.)
5. **Integrates with existing CLI flags** — `--generate-image <file>` now works for ChatGPT browser mode too

### How it works

- After the assistant response completes, the browser automation evaluates a DOM expression to find all estuary image URLs in the latest assistant turn
- Image URLs are extracted and deduplicated by `file_...` ID
- Each image is downloaded via `fetch()` with the browser's ChatGPT session cookies
- Files are saved to the path specified by `--generate-image <file>` (or `--output <file>`)

### Changes

| File | Description |
|------|-------------|
| `src/browser/chatgptImages.ts` | **New** — Core module: DOM extraction, image dedup, cookie-authenticated download, file save |
| `tests/browser/chatgptImages.test.ts` | **New** — Unit tests for extraction dedup and multi-image save |
| `src/browser/index.ts` | Integrated image detection + download into browser session flow |
| `src/browser/types.ts` | Added `BrowserGeneratedImage`, `SavedBrowserImage` types |
| `src/browser/reattach.ts` | Image download on session reattach |
| `src/browser/sessionRunner.ts` | Thread image results through session runner |
| `bin/oracle-cli.ts` | Updated help text for `--generate-image` and `--output` |
| `README.md` | Updated `--generate-image` docs to mention ChatGPT browser support |
| `src/cli/sessionDisplay.ts` | Display saved image paths in session output |
| `src/cli/sessionRunner.ts` | Pass-through for image metadata |
| `src/oracle/types.ts` | Session metadata types for images |
| `src/remote/server.ts` | Remote server image passthrough |
| `tests/browser/sessionRunner.test.ts` | Updated tests for image flow |

### Usage

```bash
# Generate an image with ChatGPT and save it
oracle --engine browser --generate-image output.png \
  --prompt "Generate a 1:1 4K white-background product photo of a coffee cup"

# Multi-image output automatically numbered
oracle --engine browser --generate-image product.png \
  --prompt "Generate 4 product photos of different angles"
# → product.png, product.2.png, product.3.png, product.4.png
```

### Testing

- All 106 existing test files pass (627 tests)
- 2 new unit tests for `chatgptImages` module
- `pnpm run check` (format + lint) clean
- `pnpm run build` clean
- Manual E2E tested: generated 4K product images and verified full-resolution PNG downloads

### Notes

- Requires an active ChatGPT browser session (cookies must be valid)
- Image detection scans the last assistant turn for estuary content URLs
- Gracefully handles missing cookies, download failures, and empty results
- Follows the same patterns as the existing Gemini image download flow