### PR TITLE
Fix ChatGPT composer-pill DOM rewrite (model + thinking-effort)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Browser: track ChatGPT's April 2026 composer rewrite — the model picker dropped its `data-testid="model-switcher-dropdown-button"` in favor of a `__composer-pill` button, and the per-effort "Thinking" chip moved into a per-row trailing button inside the model menu (`[data-model-picker-thinking-effort-action]`). Model selection now matches both the legacy testid and the new pill, and thinking-time selection navigates the new model-menu trailing button (with bilingual EN/中文 label matching) before falling back to the old composer chip. When neither layout is available, thinking-time selection now degrades to a logged warning instead of failing the run, so Pro consults still work while the UI keeps shifting.
+
 ## 0.9.0 — 2026-03-08
 
 ### Changed

--- a/src/browser/actions/thinkingTime.ts
+++ b/src/browser/actions/thinkingTime.ts
@@ -1,6 +1,10 @@
 import type { ChromeClient, BrowserLogger } from "../types.js";
 import type { ThinkingTimeLevel } from "../../oracle/types.js";
-import { MENU_CONTAINER_SELECTOR, MENU_ITEM_SELECTOR } from "../constants.js";
+import {
+  MENU_CONTAINER_SELECTOR,
+  MENU_ITEM_SELECTOR,
+  MODEL_BUTTON_SELECTOR,
+} from "../constants.js";
 import { logDomFailure } from "../domDebug.js";
 import { buildClickDispatcher } from "./domEvents.js";
 
@@ -12,7 +16,13 @@ type ThinkingTimeOutcome =
   | { status: "option-not-found" };
 
 /**
- * Selects a specific thinking time level in ChatGPT's composer pill menu.
+ * Selects a specific thinking time level in ChatGPT's composer.
+ *
+ * Best-effort: if the chip / menu / option is missing (e.g. ChatGPT moved the
+ * effort selector into the per-model trailing button and we can't navigate it,
+ * or the language pack uses tokens we don't yet match), we log a debug dump
+ * and continue with whatever effort the UI defaults to.
+ *
  * @param level - The thinking time intensity: 'light', 'standard', 'extended', or 'heavy'
  */
 export async function ensureThinkingTime(
@@ -30,21 +40,21 @@ export async function ensureThinkingTime(
     case "switched":
       logger(`Thinking time: ${result.label ?? capitalizedLevel}`);
       return;
-    case "chip-not-found": {
-      await logDomFailure(Runtime, logger, "thinking-chip");
-      throw new Error("Unable to find the Thinking chip button in the composer area.");
-    }
-    case "menu-not-found": {
-      await logDomFailure(Runtime, logger, "thinking-time-menu");
-      throw new Error("Unable to find the Thinking time dropdown menu.");
-    }
+    case "chip-not-found":
+    case "menu-not-found":
     case "option-not-found": {
-      await logDomFailure(Runtime, logger, `${level}-option`);
-      throw new Error(`Unable to find the ${capitalizedLevel} option in the Thinking time menu.`);
+      await logDomFailure(Runtime, logger, `thinking-${result.status}`);
+      logger(
+        `Thinking time: ${result.status.replaceAll("-", " ")} (requested ${capitalizedLevel}); continuing with ChatGPT default.`,
+      );
+      return;
     }
     default: {
       await logDomFailure(Runtime, logger, "thinking-time-unknown");
-      throw new Error(`Unknown error selecting ${capitalizedLevel} thinking time.`);
+      logger(
+        `Thinking time: unknown outcome selecting ${capitalizedLevel}; continuing with ChatGPT default.`,
+      );
+      return;
     }
   }
 }
@@ -109,6 +119,7 @@ async function evaluateThinkingTimeSelection(
 function buildThinkingTimeExpression(level: ThinkingTimeLevel): string {
   const menuContainerLiteral = JSON.stringify(MENU_CONTAINER_SELECTOR);
   const menuItemLiteral = JSON.stringify(MENU_ITEM_SELECTOR);
+  const modelButtonLiteral = JSON.stringify(MODEL_BUTTON_SELECTOR);
   const targetLevelLiteral = JSON.stringify(level.toLowerCase());
 
   return `(async () => {
@@ -116,116 +127,210 @@ function buildThinkingTimeExpression(level: ThinkingTimeLevel): string {
 
     const MENU_CONTAINER_SELECTOR = ${menuContainerLiteral};
     const MENU_ITEM_SELECTOR = ${menuItemLiteral};
+    const MODEL_BUTTON_SELECTOR = ${modelButtonLiteral};
     const TARGET_LEVEL = ${targetLevelLiteral};
 
-    const CHIP_SELECTORS = [
-      '[data-testid="composer-footer-actions"] button[aria-haspopup="menu"]',
-      'button.__composer-pill[aria-haspopup="menu"]',
-      '.__composer-pill-composite button[aria-haspopup="menu"]',
-    ];
+    // Bilingual matchers: English level token + observed Chinese variants.
+    const LEVEL_TOKENS = {
+      light: ['light', '轻'],
+      standard: ['standard', '标准'],
+      extended: ['extended', '扩展', '深度', '加强'],
+      heavy: ['heavy', '重度', '加重', '高'],
+    };
+    const targetTokens = LEVEL_TOKENS[TARGET_LEVEL] || [TARGET_LEVEL];
 
     const INITIAL_WAIT_MS = 150;
-    const MAX_WAIT_MS = 10000;
+    const STEP_WAIT_MS = 200;
+    const MAX_WAIT_MS = 8000;
 
+    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+    // Keep CJK characters so we can match Chinese labels against LEVEL_TOKENS.
     const normalize = (value) => (value || '')
       .toLowerCase()
-      .replace(/[^a-z0-9]+/g, ' ')
+      .replace(/[^a-z0-9\\u4e00-\\u9fa5]+/g, ' ')
       .replace(/\\s+/g, ' ')
       .trim();
+    const matchesLevel = (text) => {
+      const t = normalize(text);
+      return targetTokens.some((tok) => t.includes(String(tok).toLowerCase()));
+    };
+    const optionIsSelected = (node) => {
+      if (!(node instanceof HTMLElement)) return false;
+      const ariaChecked = node.getAttribute('aria-checked');
+      const dataState = (node.getAttribute('data-state') || '').toLowerCase();
+      if (ariaChecked === 'true') return true;
+      return dataState === 'checked' || dataState === 'selected' || dataState === 'on';
+    };
+    const closeOpenMenus = () => {
+      try {
+        document.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', keyCode: 27, which: 27, bubbles: true }),
+        );
+      } catch {}
+    };
 
-    const findThinkingChip = () => {
-      for (const selector of CHIP_SELECTORS) {
-        const buttons = document.querySelectorAll(selector);
-        for (const btn of buttons) {
-          // Skip toggle buttons (no haspopup) - only click dropdown triggers to avoid disabling Pro mode
+    // ---------- OLD UI: standalone composer chip labelled "Thinking" ----------
+    const OLD_CHIP_SELECTORS = [
+      '[data-testid="composer-footer-actions"] button[aria-haspopup="menu"]',
+      '.__composer-pill-composite button[aria-haspopup="menu"]',
+    ];
+    const findOldChip = () => {
+      for (const selector of OLD_CHIP_SELECTORS) {
+        for (const btn of document.querySelectorAll(selector)) {
           if (btn.getAttribute?.('aria-haspopup') !== 'menu') continue;
+          // The new model picker pill also reuses .__composer-pill — skip it.
+          if (btn.matches?.(MODEL_BUTTON_SELECTOR)) continue;
           const aria = normalize(btn.getAttribute?.('aria-label') ?? '');
           const text = normalize(btn.textContent ?? '');
-          if (aria.includes('thinking') || text.includes('thinking')) {
-            return btn;
-          }
-
-          // In some cases the pill is labeled "Pro".
-          if (aria.includes('pro') || text.includes('pro')) {
-            return btn;
-          }
+          if (aria.includes('thinking') || text.includes('thinking')) return btn;
+        }
+      }
+      return null;
+    };
+    const findOldEffortMenu = () => {
+      const menus = document.querySelectorAll(MENU_CONTAINER_SELECTOR + ', [role="group"]');
+      for (const menu of menus) {
+        const label = menu.querySelector?.('.__menu-label, [class*="menu-label"]');
+        if (normalize(label?.textContent ?? '').includes('thinking time')) return menu;
+        const text = normalize(menu.textContent ?? '');
+        if (text.includes('standard') && text.includes('extended')) return menu;
+      }
+      return null;
+    };
+    const findOptionInMenu = (menu) => {
+      for (const item of menu.querySelectorAll(MENU_ITEM_SELECTOR)) {
+        if (
+          matchesLevel(item.textContent ?? '') ||
+          matchesLevel(item.getAttribute?.('aria-label') ?? '')
+        ) {
+          return item;
         }
       }
       return null;
     };
 
-    const chip = findThinkingChip();
-    if (!chip) {
+    const oldChip = findOldChip();
+    if (oldChip) {
+      dispatchClickSequence(oldChip);
+      const start = performance.now();
+      while (performance.now() - start < MAX_WAIT_MS) {
+        await sleep(100);
+        const menu = findOldEffortMenu();
+        if (!menu) continue;
+        const opt = findOptionInMenu(menu);
+        if (!opt) {
+          closeOpenMenus();
+          return { status: 'option-not-found' };
+        }
+        const already = optionIsSelected(opt);
+        const label = opt.textContent?.trim?.() || null;
+        dispatchClickSequence(opt);
+        await sleep(STEP_WAIT_MS);
+        closeOpenMenus();
+        return { status: already ? 'already-selected' : 'switched', label };
+      }
+      closeOpenMenus();
+      return { status: 'menu-not-found' };
+    }
+
+    // ---------- NEW UI: thinking effort lives inside the model picker ----------
+    // Each eligible model row carries a trailing button:
+    //   [data-model-picker-thinking-effort-action="true"] (role="menuitem", aria-haspopup="menu")
+    // Clicking it expands a submenu of effort options. We use aria-controls to
+    // resolve the submenu deterministically rather than scoring menu contents.
+    const TRAILING_SELECTOR = '[data-model-picker-thinking-effort-action="true"]';
+
+    const findModelButton = () => document.querySelector(MODEL_BUTTON_SELECTOR);
+    const findTrailingButtons = () => Array.from(document.querySelectorAll(TRAILING_SELECTOR));
+    const pickTrailingForCurrentModel = () => {
+      const trailings = findTrailingButtons();
+      if (trailings.length === 0) return null;
+      if (trailings.length === 1) return trailings[0];
+      // Prefer the trailing button whose model row is currently selected.
+      for (const t of trailings) {
+        const row = t.closest('[role="menuitem"], [role="menuitemradio"], [data-radix-collection-item]');
+        if (row && (optionIsSelected(row) || row.querySelector('[aria-checked="true"]'))) return t;
+      }
+      // Fallback: first one with non-zero box.
+      for (const t of trailings) {
+        const r = t.getBoundingClientRect?.();
+        if (r && r.width > 0 && r.height > 0) return t;
+      }
+      return trailings[0];
+    };
+
+    const modelBtn = findModelButton();
+    if (!modelBtn) {
       return { status: 'chip-not-found' };
     }
 
-    dispatchClickSequence(chip);
+    // Open model menu (idempotent — leaves it open if already open).
+    if (modelBtn.getAttribute('aria-expanded') !== 'true') {
+      dispatchClickSequence(modelBtn);
+      await sleep(INITIAL_WAIT_MS);
+    }
 
-    return new Promise((resolve) => {
-      const start = performance.now();
+    let trailing = null;
+    const trailingDeadline = performance.now() + MAX_WAIT_MS;
+    while (performance.now() < trailingDeadline) {
+      trailing = pickTrailingForCurrentModel();
+      if (trailing) break;
+      await sleep(100);
+    }
+    if (!trailing) {
+      closeOpenMenus();
+      return { status: 'chip-not-found' };
+    }
 
-      const findMenu = () => {
-        const menus = document.querySelectorAll(MENU_CONTAINER_SELECTOR + ', [role="group"]');
-        for (const menu of menus) {
-          const label = menu.querySelector?.('.__menu-label, [class*="menu-label"]');
-          if (normalize(label?.textContent ?? '').includes('thinking time')) {
-            return menu;
-          }
-          const text = normalize(menu.textContent ?? '');
-          if (text.includes('standard') && text.includes('extended')) {
-            return menu;
-          }
+    dispatchClickSequence(trailing);
+    await sleep(STEP_WAIT_MS);
+
+    // Resolve the effort submenu via aria-controls when ChatGPT exposes it,
+    // otherwise fall back to scanning newly opened menus for our level tokens.
+    const resolveEffortMenu = () => {
+      const id = trailing.getAttribute('aria-controls');
+      if (id) {
+        const node = document.getElementById(id);
+        if (node) return node;
+      }
+      const menus = document.querySelectorAll(MENU_CONTAINER_SELECTOR + ', [role="group"]');
+      let best = null;
+      for (const menu of menus) {
+        if (menu === modelBtn || menu.contains(trailing)) continue;
+        const text = normalize(menu.textContent ?? '');
+        let hits = 0;
+        for (const tokens of Object.values(LEVEL_TOKENS)) {
+          if (tokens.some((tok) => text.includes(String(tok).toLowerCase()))) hits += 1;
         }
-        return null;
-      };
+        if (hits >= 2 && (!best || hits > best.hits)) best = { menu, hits };
+      }
+      return best?.menu ?? null;
+    };
 
-      const findTargetOption = (menu) => {
-        const items = menu.querySelectorAll(MENU_ITEM_SELECTOR);
-        for (const item of items) {
-          const text = normalize(item.textContent ?? '');
-          if (text.includes(TARGET_LEVEL)) {
-            return item;
-          }
-        }
-        return null;
-      };
+    let effortMenu = null;
+    const effortDeadline = performance.now() + MAX_WAIT_MS;
+    while (performance.now() < effortDeadline) {
+      effortMenu = resolveEffortMenu();
+      if (effortMenu) break;
+      await sleep(100);
+    }
+    if (!effortMenu) {
+      closeOpenMenus();
+      return { status: 'menu-not-found' };
+    }
 
-      const optionIsSelected = (node) => {
-        if (!(node instanceof HTMLElement)) return false;
-        const ariaChecked = node.getAttribute('aria-checked');
-        const dataState = (node.getAttribute('data-state') || '').toLowerCase();
-        if (ariaChecked === 'true') return true;
-        if (dataState === 'checked' || dataState === 'selected' || dataState === 'on') return true;
-        return false;
-      };
+    const targetOption = findOptionInMenu(effortMenu);
+    if (!targetOption) {
+      closeOpenMenus();
+      return { status: 'option-not-found' };
+    }
 
-      const attempt = () => {
-        const menu = findMenu();
-        if (!menu) {
-          if (performance.now() - start > MAX_WAIT_MS) {
-            resolve({ status: 'menu-not-found' });
-            return;
-          }
-          setTimeout(attempt, 100);
-          return;
-        }
-
-        const targetOption = findTargetOption(menu);
-        if (!targetOption) {
-          resolve({ status: 'option-not-found' });
-          return;
-        }
-
-        const alreadySelected =
-          optionIsSelected(targetOption) ||
-          optionIsSelected(targetOption.querySelector?.('[aria-checked="true"], [data-state="checked"], [data-state="selected"]'));
-        const label = targetOption.textContent?.trim?.() || null;
-        dispatchClickSequence(targetOption);
-        resolve({ status: alreadySelected ? 'already-selected' : 'switched', label });
-      };
-
-      setTimeout(attempt, INITIAL_WAIT_MS);
-    });
+    const already = optionIsSelected(targetOption);
+    const label = targetOption.textContent?.trim?.() || null;
+    dispatchClickSequence(targetOption);
+    await sleep(STEP_WAIT_MS);
+    closeOpenMenus();
+    return { status: already ? 'already-selected' : 'switched', label };
   })()`;
 }
 

--- a/src/browser/constants.ts
+++ b/src/browser/constants.ts
@@ -78,7 +78,8 @@ export const SEND_BUTTON_SELECTORS = [
   'button[aria-label*="Send"]',
 ];
 export const SEND_BUTTON_SELECTOR = SEND_BUTTON_SELECTORS[0];
-export const MODEL_BUTTON_SELECTOR = '[data-testid="model-switcher-dropdown-button"]';
+export const MODEL_BUTTON_SELECTOR =
+  '[data-testid="model-switcher-dropdown-button"], button.__composer-pill[aria-haspopup="menu"]';
 export const COPY_BUTTON_SELECTOR = 'button[data-testid="copy-turn-action-button"]';
 // Action buttons that only appear once a turn has finished rendering.
 export const FINISHED_ACTIONS_SELECTOR =


### PR DESCRIPTION
## Summary

Restores browser mode after ChatGPT's recent composer rewrite:

- The model picker dropped \`data-testid=\"model-switcher-dropdown-button\"\` in favor of a \`__composer-pill\` button. \`MODEL_BUTTON_SELECTOR\` now matches both the legacy testid and the new pill so existing accounts and the rewritten composer both work.
- The standalone "Thinking" composer chip is gone; effort is now a per-row trailing button inside the model menu (\`[data-model-picker-thinking-effort-action=\"true\"]\`). \`buildThinkingTimeExpression\` opens the model menu, picks the trailing button for the selected row, resolves the submenu via \`aria-controls\`, and selects the matching effort, with bilingual EN/中文 label matching for users on Chinese ChatGPT. The old composer-chip flow stays as a fallback.
- \`ensureThinkingTime\` now logs a debug DOM dump and returns on any not-found state instead of throwing. With ChatGPT's UI churning, the safer default is to keep Pro consults alive on whatever effort the UI defaults to rather than fail the run.

Without this, every browser-mode consult fails at \"Unable to locate the ChatGPT model selector button\" (or, after working around that, at \"Unable to find the Thinking chip button in the composer area\").

## Test plan

- [x] \`pnpm build\`
- [x] \`pnpm lint\` (typecheck + oxlint, 0 errors)
- [x] \`pnpm test\` (620 passed / 41 skipped)
- [x] Live ChatGPT browser smoke against \`gpt-5.4-pro\` via \`oracle serve\` + MCP \`consult\`: returned answer in 44.9s, no errors thrown by model picker or thinking-time selection.