### PR TITLE
feat(mcp): improve Claude Code ChatGPT browser consults

### DIFF
--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -806,6 +806,16 @@ bridgeCommand
   .command("claude-config")
   .description("Print a Claude Code MCP config snippet (.mcp.json) for oracle-mcp.")
   .option("--print-token", "Include ORACLE_REMOTE_TOKEN in the snippet.", false)
+  .option(
+    "--local-browser",
+    "Use a local signed-in Chrome profile instead of a remote bridge.",
+    false,
+  )
+  .option("--oracle-home-dir <path>", "Override ORACLE_HOME_DIR in the generated snippet.")
+  .option(
+    "--browser-profile-dir <path>",
+    "Override ORACLE_BROWSER_PROFILE_DIR in the generated snippet.",
+  )
   .action(async (commandOptions) => {
     const { runBridgeClaudeConfig } = await import("../src/cli/bridge/claudeConfig.js");
     await runBridgeClaudeConfig(commandOptions);

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -101,6 +101,25 @@ Notes:
 - The snippet includes `ORACLE_ENGINE="browser"` so MCP consult calls use browser mode even if `OPENAI_API_KEY` is set.
 - By default the snippets leave `ORACLE_REMOTE_TOKEN` as `<YOUR_TOKEN>` to avoid printing secrets; rerun with `--print-token` if you explicitly want it included.
 
+### macOS local browser: Let Them Fight
+
+If Claude Code and the signed-in Chrome profile are on the same Mac, skip the remote bridge and generate a local config:
+
+```bash
+oracle bridge claude-config --local-browser > .mcp.json
+```
+
+This points Claude Code at `oracle-mcp`, sets `ORACLE_ENGINE="browser"`, and reuses the shared manual-login profile at `~/.oracle/browser-profile`. From Claude Code, call `consult` with `preset:"chatgpt-pro-heavy"` for the “Let Them Fight” workflow: Claude asks Oracle, Oracle asks ChatGPT Pro in browser mode, and the answer comes back through MCP. Use `dryRun:true` first when you only want to validate the resolved request.
+
+Override local paths when needed:
+
+```bash
+oracle bridge claude-config \
+  --local-browser \
+  --oracle-home-dir ~/.oracle \
+  --browser-profile-dir ~/.oracle/browser-profile > .mcp.json
+```
+
 ## 4) Troubleshooting
 
 Run:

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -2,12 +2,18 @@
 
 `oracle-mcp` is a minimal MCP stdio server that mirrors the Oracle CLI. It shares session storage with the CLI (`~/.oracle/sessions` or `ORACLE_HOME_DIR`) so you can mix and match: run with the CLI, inspect or re-run via MCP, or vice versa.
 
+## Let Them Fight
+
+Claude Code can call `oracle-mcp` and ask a subscription-backed ChatGPT browser session for a second opinion. Use the `chatgpt-pro-heavy` preset when you want a compact MCP request that targets ChatGPT browser mode, the current Pro picker alias, and heavy thinking time. The preset is intentionally boring at the API layer: it is a shortcut for existing browser-mode fields, not a new model id.
+
 ## Tools
 
 ### `consult`
 
 - Inputs: `prompt` (required), `files?: string[]` (globs), `model?: string` (defaults to CLI), `engine?: "api" | "browser"` (CLI auto-defaults), `slug?: string`.
-- Browser-only extras: `browserAttachments?: "auto"|"never"|"always"`, `browserBundleFiles?: boolean`, `browserThinkingTime?: "light"|"standard"|"extended"|"heavy"`, `browserKeepBrowser?: boolean`, `browserModelLabel?: string`.
+- Presets: `preset?: "chatgpt-pro-heavy"` applies browser mode + current Pro model alias + heavy thinking, unless the request overrides those fields.
+- Browser-only extras: `browserAttachments?: "auto"|"never"|"always"`, `browserBundleFiles?: boolean`, `browserThinkingTime?: "light"|"standard"|"extended"|"heavy"`, `browserKeepBrowser?: boolean`, `browserModelLabel?: string`, `browserModelStrategy?: "select"|"current"|"ignore"`.
+- Dry runs: set `dryRun: true` to preview the resolved request without creating a session or touching the browser.
 - Behavior: starts a session, runs it with the chosen engine, returns final output + metadata. Background/foreground follows the CLI (e.g., GPT‑5 Pro detaches by default).
 - Logging: emits MCP logs (`info` per line, `debug` for streamed chunks with byte sizes). If browser prerequisites are missing, returns an error payload instead of running.
 
@@ -52,5 +58,6 @@
 - Bridge helper snippets:
   - Codex CLI: `oracle bridge codex-config`
   - Claude Code: `oracle bridge claude-config`
+  - Claude Code with local macOS Chrome: `oracle bridge claude-config --local-browser > .mcp.json`
 - Tools and resources operate on the same session store as `oracle status|session`.
 - Defaults (model/engine/etc.) come from your Oracle CLI config; see `docs/configuration.md` or `~/.oracle/config.json`.

--- a/src/cli/bridge/claudeConfig.ts
+++ b/src/cli/bridge/claudeConfig.ts
@@ -6,6 +6,9 @@ import { resolveRemoteServiceConfig } from "../../remote/remoteServiceConfig.js"
 
 export interface BridgeClaudeConfigCliOptions {
   printToken?: boolean;
+  localBrowser?: boolean;
+  oracleHomeDir?: string;
+  browserProfileDir?: string;
 }
 
 export async function runBridgeClaudeConfig(options: BridgeClaudeConfigCliOptions): Promise<void> {
@@ -18,13 +21,22 @@ export async function runBridgeClaudeConfig(options: BridgeClaudeConfigCliOption
   });
 
   const snippet = formatClaudeMcpConfig({
-    oracleHomeDir: process.env.ORACLE_HOME_DIR ?? path.join(os.homedir(), ".oracle-local"),
+    oracleHomeDir:
+      options.oracleHomeDir ??
+      process.env.ORACLE_HOME_DIR ??
+      path.join(os.homedir(), options.localBrowser ? ".oracle" : ".oracle-local"),
     browserProfileDir:
+      options.browserProfileDir ??
       process.env.ORACLE_BROWSER_PROFILE_DIR ??
-      path.join(os.homedir(), ".oracle-local", "browser-profile"),
+      path.join(
+        os.homedir(),
+        options.localBrowser ? ".oracle" : ".oracle-local",
+        "browser-profile",
+      ),
     remoteHost: resolved.host,
     remoteToken: resolved.token,
     includeToken: Boolean(options.printToken),
+    localBrowser: Boolean(options.localBrowser),
   });
 
   console.log(snippet);
@@ -42,12 +54,14 @@ export function formatClaudeMcpConfig({
   remoteHost,
   remoteToken,
   includeToken,
+  localBrowser = false,
 }: {
   oracleHomeDir: string;
   browserProfileDir: string;
   remoteHost?: string;
   remoteToken?: string;
   includeToken: boolean;
+  localBrowser?: boolean;
 }): string {
   const env: Record<string, string> = {};
   // biome-ignore lint/complexity/useLiteralKeys: env vars are uppercase and include underscores.
@@ -57,7 +71,7 @@ export function formatClaudeMcpConfig({
   // biome-ignore lint/complexity/useLiteralKeys: env vars are uppercase and include underscores.
   env["ORACLE_BROWSER_PROFILE_DIR"] = browserProfileDir;
 
-  if (remoteHost) {
+  if (remoteHost && !localBrowser) {
     // biome-ignore lint/complexity/useLiteralKeys: env vars are uppercase and include underscores.
     env["ORACLE_REMOTE_HOST"] = remoteHost;
     // biome-ignore lint/complexity/useLiteralKeys: env vars are uppercase and include underscores.

--- a/src/mcp/consultPresets.ts
+++ b/src/mcp/consultPresets.ts
@@ -1,0 +1,21 @@
+import type { ConsultInput } from "./types.js";
+
+const CHATGPT_PRO_HEAVY_MODEL = "gpt-5.4-pro";
+
+export function applyConsultPreset(input: ConsultInput): ConsultInput {
+  if (!input.preset) {
+    return input;
+  }
+  if (input.preset === "chatgpt-pro-heavy") {
+    if (input.models && input.models.length > 0) {
+      throw new Error('MCP consult preset "chatgpt-pro-heavy" cannot be combined with models.');
+    }
+    return {
+      ...input,
+      engine: input.engine ?? "browser",
+      model: input.model ?? CHATGPT_PRO_HEAVY_MODEL,
+      browserThinkingTime: input.browserThinkingTime ?? "heavy",
+    };
+  }
+  return input;
+}

--- a/src/mcp/consultPresets.ts
+++ b/src/mcp/consultPresets.ts
@@ -1,6 +1,6 @@
 import type { ConsultInput } from "./types.js";
 
-const CHATGPT_PRO_HEAVY_MODEL = "gpt-5.4-pro";
+const CHATGPT_PRO_HEAVY_MODEL = "gpt-5-pro";
 
 export function applyConsultPreset(input: ConsultInput): ConsultInput {
   if (!input.preset) {

--- a/src/mcp/consultPresets.ts
+++ b/src/mcp/consultPresets.ts
@@ -1,6 +1,6 @@
 import type { ConsultInput } from "./types.js";
 
-const CHATGPT_PRO_HEAVY_MODEL = "gpt-5-pro";
+const CHATGPT_PRO_HEAVY_MODEL = "gpt-5.5-pro";
 
 export function applyConsultPreset(input: ConsultInput): ConsultInput {
   if (!input.preset) {

--- a/src/mcp/tools/consult.ts
+++ b/src/mcp/tools/consult.ts
@@ -21,14 +21,23 @@ async function readSessionLogTail(sessionId: string, maxBytes: number): Promise<
   }
 }
 import { performSessionRun } from "../../cli/sessionRunner.js";
+import { runDryRunSummary } from "../../cli/dryRun.js";
 import { CHATGPT_URL } from "../../browser/constants.js";
-import { consultInputSchema } from "../types.js";
+import { CONSULT_PRESETS, consultInputSchema } from "../types.js";
+import { applyConsultPreset } from "../consultPresets.js";
 import { loadUserConfig, type UserConfig } from "../../config.js";
 import { resolveNotificationSettings } from "../../cli/notifier.js";
 import { mapModelToBrowserLabel, resolveBrowserModelLabel } from "../../cli/browserConfig.js";
+import type { BrowserModelStrategy } from "../../browser/types.js";
 
 // Use raw shapes so the MCP SDK (with its bundled Zod) wraps them and emits valid JSON Schema.
 const consultInputShape = {
+  preset: z
+    .enum(CONSULT_PRESETS)
+    .optional()
+    .describe(
+      'Optional MCP convenience preset. "chatgpt-pro-heavy" selects ChatGPT browser mode, the current Pro model alias, and heavy thinking unless overridden.',
+    ),
   prompt: z.string().min(1, "Prompt is required.").describe("User prompt to run."),
   files: z
     .array(z.string())
@@ -72,10 +81,22 @@ const consultInputShape = {
     .enum(["light", "standard", "extended", "heavy"])
     .optional()
     .describe("Browser-only: set ChatGPT thinking time when supported by the chosen model."),
+  browserModelStrategy: z
+    .enum(["select", "current", "ignore"])
+    .optional()
+    .describe(
+      "Browser-only: model picker strategy. Mirrors the CLI --browser-model-strategy flag.",
+    ),
   browserKeepBrowser: z
     .boolean()
     .optional()
     .describe("Browser-only: keep Chrome running after completion (useful for debugging)."),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe(
+      "Preview the resolved Oracle run without creating a session or touching the browser.",
+    ),
   search: z
     .boolean()
     .optional()
@@ -117,9 +138,10 @@ const consultModelSummaryShape = z.object({
 });
 
 const consultOutputShape = {
-  sessionId: z.string(),
+  sessionId: z.string().optional(),
   status: z.string(),
   output: z.string(),
+  dryRun: z.boolean().optional(),
   models: z.array(consultModelSummaryShape).optional(),
 } satisfies z.ZodRawShape;
 
@@ -165,6 +187,7 @@ export function buildConsultBrowserConfig({
   inputModel,
   browserModelLabel,
   browserThinkingTime,
+  browserModelStrategy,
   browserKeepBrowser,
 }: {
   userConfig: UserConfig;
@@ -173,6 +196,7 @@ export function buildConsultBrowserConfig({
   inputModel?: string;
   browserModelLabel?: string;
   browserThinkingTime?: "light" | "standard" | "extended" | "heavy";
+  browserModelStrategy?: BrowserModelStrategy;
   browserKeepBrowser?: boolean;
 }): BrowserSessionConfig {
   const configuredBrowser = userConfig.browser ?? {};
@@ -199,6 +223,7 @@ export function buildConsultBrowserConfig({
       ? ((envProfileDir || configuredBrowser.manualLoginProfileDir) ?? null)
       : null,
     thinkingTime: browserThinkingTime ?? configuredBrowser.thinkingTime,
+    modelStrategy: browserModelStrategy ?? configuredBrowser.modelStrategy,
     desiredModel: desiredModelLabel || mapModelToBrowserLabel(runModel),
   };
 }
@@ -216,6 +241,15 @@ export function registerConsultTool(server: McpServer): void {
     },
     async (input: unknown) => {
       const textContent = (text: string) => [{ type: "text" as const, text }];
+      let parsedInput;
+      try {
+        parsedInput = applyConsultPreset(consultInputSchema.parse(input));
+      } catch (error) {
+        return {
+          isError: true,
+          content: textContent(error instanceof Error ? error.message : String(error)),
+        };
+      }
       const {
         prompt,
         files,
@@ -227,9 +261,11 @@ export function registerConsultTool(server: McpServer): void {
         browserAttachments,
         browserBundleFiles,
         browserThinkingTime,
+        browserModelStrategy,
         browserKeepBrowser,
+        dryRun,
         slug,
-      } = consultInputSchema.parse(input);
+      } = parsedInput;
       const { config: userConfig } = await loadUserConfig();
       const { runOptions, resolvedEngine } = mapConsultToRunOptions({
         prompt,
@@ -244,8 +280,57 @@ export function registerConsultTool(server: McpServer): void {
         env: process.env,
       });
       const cwd = process.cwd();
+      const sendLog = (text: string, level: "info" | "debug" = "info") =>
+        server.server
+          .sendLoggingMessage(
+            LoggingMessageNotificationParamsSchema.parse({
+              level,
+              data: { text, bytes: Buffer.byteLength(text, "utf8") },
+            }),
+          )
+          .catch(() => {});
 
       const resolvedRemote = resolveRemoteServiceConfig({ userConfig, env: process.env });
+
+      let browserConfig: BrowserSessionConfig | undefined;
+      if (resolvedEngine === "browser") {
+        browserConfig = buildConsultBrowserConfig({
+          userConfig,
+          env: process.env,
+          runModel: runOptions.model,
+          inputModel: model,
+          browserModelLabel,
+          browserThinkingTime,
+          browserModelStrategy,
+          browserKeepBrowser,
+        });
+      }
+
+      if (dryRun) {
+        const lines: string[] = [];
+        const log = (line: string): void => {
+          lines.push(line);
+          sendLog(line);
+        };
+        await runDryRunSummary({
+          engine: resolvedEngine,
+          runOptions,
+          cwd,
+          version: getCliVersion(),
+          log,
+          browserConfig,
+        });
+        const output = lines.join("\n").trim();
+        return {
+          content: textContent(output),
+          structuredContent: {
+            status: "dry-run",
+            output,
+            dryRun: true,
+          },
+        };
+      }
+
       const browserGuard = ensureBrowserAvailable(resolvedEngine, {
         remoteHost: resolvedRemote.host,
       });
@@ -274,19 +359,6 @@ export function registerConsultTool(server: McpServer): void {
         };
       }
 
-      let browserConfig: BrowserSessionConfig | undefined;
-      if (resolvedEngine === "browser") {
-        browserConfig = buildConsultBrowserConfig({
-          userConfig,
-          env: process.env,
-          runModel: runOptions.model,
-          inputModel: model,
-          browserModelLabel,
-          browserThinkingTime,
-          browserKeepBrowser,
-        });
-      }
-
       const notifications = resolveNotificationSettings({
         cliNotify: undefined,
         cliNotifySound: undefined,
@@ -307,17 +379,6 @@ export function registerConsultTool(server: McpServer): void {
       );
 
       const logWriter = sessionStore.createLogWriter(sessionMeta.id);
-      // Best-effort: emit MCP logging notifications for live chunks but never block the run.
-      const sendLog = (text: string, level: "info" | "debug" = "info") =>
-        server.server
-          .sendLoggingMessage(
-            LoggingMessageNotificationParamsSchema.parse({
-              level,
-              data: { text, bytes: Buffer.byteLength(text, "utf8") },
-            }),
-          )
-          .catch(() => {});
-
       // Stream logs to both the session log and MCP logging notifications, but avoid buffering in memory
       const log = (line?: string): void => {
         logWriter.logLine(line);

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 
+export const CONSULT_PRESETS = ["chatgpt-pro-heavy"] as const;
+
 export const consultInputSchema = z.object({
+  preset: z.enum(CONSULT_PRESETS).optional(),
   prompt: z.string().min(1, "Prompt is required."),
   files: z.array(z.string()).default([]),
   model: z.string().optional(),
@@ -10,7 +13,9 @@ export const consultInputSchema = z.object({
   browserAttachments: z.enum(["auto", "never", "always"]).optional(),
   browserBundleFiles: z.boolean().optional(),
   browserThinkingTime: z.enum(["light", "standard", "extended", "heavy"]).optional(),
+  browserModelStrategy: z.enum(["select", "current", "ignore"]).optional(),
   browserKeepBrowser: z.boolean().optional(),
+  dryRun: z.boolean().optional(),
   search: z.boolean().optional(),
   slug: z.string().optional(),
 });

--- a/tests/cli/bridgeClaudeConfig.test.ts
+++ b/tests/cli/bridgeClaudeConfig.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "vitest";
+import { formatClaudeMcpConfig } from "../../src/cli/bridge/claudeConfig.ts";
+
+describe("formatClaudeMcpConfig", () => {
+  test("prints a remote Claude Code MCP config without exposing tokens by default", () => {
+    const parsed = JSON.parse(
+      formatClaudeMcpConfig({
+        oracleHomeDir: "/Users/test/.oracle-local",
+        browserProfileDir: "/Users/test/.oracle-local/browser-profile",
+        remoteHost: "127.0.0.1:9473",
+        remoteToken: "secret-token",
+        includeToken: false,
+      }),
+    );
+
+    expect(parsed.mcpServers.oracle).toMatchObject({
+      type: "stdio",
+      command: "oracle-mcp",
+      args: [],
+    });
+    expect(parsed.mcpServers.oracle.env).toMatchObject({
+      ORACLE_ENGINE: "browser",
+      ORACLE_HOME_DIR: "/Users/test/.oracle-local",
+      ORACLE_BROWSER_PROFILE_DIR: "/Users/test/.oracle-local/browser-profile",
+      ORACLE_REMOTE_HOST: "127.0.0.1:9473",
+      ORACLE_REMOTE_TOKEN: "<YOUR_TOKEN>",
+    });
+  });
+
+  test("prints a local-browser Claude Code MCP config without remote bridge env", () => {
+    const parsed = JSON.parse(
+      formatClaudeMcpConfig({
+        oracleHomeDir: "/Users/test/.oracle",
+        browserProfileDir: "/Users/test/.oracle/browser-profile",
+        remoteHost: "127.0.0.1:9473",
+        remoteToken: "secret-token",
+        includeToken: true,
+        localBrowser: true,
+      }),
+    );
+
+    expect(parsed.mcpServers.oracle.env).toEqual({
+      ORACLE_ENGINE: "browser",
+      ORACLE_HOME_DIR: "/Users/test/.oracle",
+      ORACLE_BROWSER_PROFILE_DIR: "/Users/test/.oracle/browser-profile",
+    });
+  });
+});

--- a/tests/mcp/consult.test.ts
+++ b/tests/mcp/consult.test.ts
@@ -16,7 +16,7 @@ describe("summarizeModelRunsForConsult", () => {
       }),
     ).toMatchObject({
       engine: "browser",
-      model: "gpt-5-pro",
+      model: "gpt-5.5-pro",
       browserThinkingTime: "heavy",
     });
 

--- a/tests/mcp/consult.test.ts
+++ b/tests/mcp/consult.test.ts
@@ -16,7 +16,7 @@ describe("summarizeModelRunsForConsult", () => {
       }),
     ).toMatchObject({
       engine: "browser",
-      model: "gpt-5.4-pro",
+      model: "gpt-5-pro",
       browserThinkingTime: "heavy",
     });
 

--- a/tests/mcp/consult.test.ts
+++ b/tests/mcp/consult.test.ts
@@ -1,11 +1,51 @@
 import { describe, expect, test } from "vitest";
 import type { SessionModelRun } from "../../src/sessionStore.js";
+import { applyConsultPreset } from "../../src/mcp/consultPresets.ts";
 import {
   buildConsultBrowserConfig,
   summarizeModelRunsForConsult,
 } from "../../src/mcp/tools/consult.ts";
 
 describe("summarizeModelRunsForConsult", () => {
+  test("applies the ChatGPT Pro Heavy consult preset as overridable defaults", () => {
+    expect(
+      applyConsultPreset({
+        preset: "chatgpt-pro-heavy",
+        prompt: "review this plan",
+        files: [],
+      }),
+    ).toMatchObject({
+      engine: "browser",
+      model: "gpt-5.4-pro",
+      browserThinkingTime: "heavy",
+    });
+
+    expect(
+      applyConsultPreset({
+        preset: "chatgpt-pro-heavy",
+        prompt: "use current picker",
+        files: [],
+        model: "gpt-5.2",
+        browserThinkingTime: "extended",
+      }),
+    ).toMatchObject({
+      engine: "browser",
+      model: "gpt-5.2",
+      browserThinkingTime: "extended",
+    });
+  });
+
+  test("rejects the ChatGPT Pro Heavy preset with multi-model fan-out", () => {
+    expect(() =>
+      applyConsultPreset({
+        preset: "chatgpt-pro-heavy",
+        prompt: "review this plan",
+        files: [],
+        models: ["gpt-5.1", "gpt-5.2"],
+      }),
+    ).toThrow(/cannot be combined with models/i);
+  });
+
   test("maps per-model metadata into consult summaries", () => {
     const runs: SessionModelRun[] = [
       {
@@ -83,6 +123,7 @@ describe("summarizeModelRunsForConsult", () => {
       browserModelLabel: "Claude Sonnet",
       browserKeepBrowser: true,
       browserThinkingTime: "heavy",
+      browserModelStrategy: "current",
     });
 
     expect(config).toMatchObject({
@@ -90,6 +131,7 @@ describe("summarizeModelRunsForConsult", () => {
       manualLogin: true,
       manualLoginProfileDir: "/tmp/env-profile",
       thinkingTime: "heavy",
+      modelStrategy: "current",
       desiredModel: "Claude Sonnet",
       cookieSync: false,
     });


### PR DESCRIPTION
## Summary

Adds a focused Claude Code / MCP browser-consult path without adding new MCP tools or changing unrelated API defaults.

- Adds MCP `consult` preset `chatgpt-pro-heavy`.
- Adds MCP `dryRun:true` so Claude/Codex can inspect the resolved Oracle run without opening Chrome or creating a session.
- Adds MCP `browserModelStrategy` passthrough for parity with the CLI.
- Adds `oracle bridge claude-config --local-browser` plus explicit `--oracle-home-dir` and `--browser-profile-dir` overrides for macOS/local Claude Code setups.
- Documents the "Let Them Fight" workflow: Claude Code asks Oracle, Oracle asks ChatGPT browser mode, and the answer returns through MCP.

The preset targets `gpt-5.5-pro` directly, matching the current upstream model support from #156.

## Public API

- MCP `consult`:
  - `preset?: "chatgpt-pro-heavy"`
  - `dryRun?: boolean`
  - `browserModelStrategy?: "select" | "current" | "ignore"`
- Bridge CLI:
  - `oracle bridge claude-config --local-browser`
  - `--oracle-home-dir <path>`
  - `--browser-profile-dir <path>`

## PR / Issue Map

- Builds on #156 for official GPT-5.5 / GPT-5.5 Pro model support.
- Complements #148 by giving Claude/Codex a better long-run browser consult path with heartbeat support when both land.
- Complements #150 because multiple MCP/CLI callers may share one browser profile.
- Complements #151 by exposing Deep Research/research-mode fields through the same MCP consult surface when that PR lands.
- Does not implement ChatGPT Project Sources management from #131 / #132.

## Validation

Latest branch head: `ab735615`; no code changes were needed in the final May 4 PR-body cleanup.

- `pnpm install --frozen-lockfile` -> passed, including prepare/build
- `pnpm vitest run tests/mcp/consult.test.ts tests/cli/bridgeClaudeConfig.test.ts` -> 2 files passed, 8 tests passed
- `pnpm run check` -> passed
- `pnpm run build` -> passed
- `pnpm test` -> 107 files passed / 18 skipped, 656 tests passed / 41 skipped
- `pnpm run test:mcp:unit` -> 5 files passed, 7 tests passed
- `pnpm run test:mcp:mcporter` -> passed
- MCP dry-run smoke: `preset:chatgpt-pro-heavy`, `dryRun:true` returned browser mode with `gpt-5.5-pro` and did not create a session or touch Chrome.
- `git diff --check` -> passed
- GitHub: mergeable, GitGuardian green
