### PR TITLE
fix: address small issue cleanup bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 - Browser: target ChatGPT `GPT-5.5 Pro` by default for Pro browser runs and recognize current GPT-5.5 picker labels such as `Pro Extended` and `Thinking Heavy`.
 - Dependencies: update the npm dependency set.
 
+### Fixed
+
+- Gemini web: prefer the latest non-empty streaming response chunk so `gemini-3-pro` and `gemini-3.1-pro` browser runs do not report `(no text output)` when the first chunk is an empty placeholder. (#153, #154) — thanks @manhtruong03.
+- CLI: avoid loading `clipboardy` during startup and add `/usr/sbin` before lazy clipboard loading on Intel macOS, preventing `spawnSync sysctl ENOENT` crashes from transitive architecture detection. (#129)
+
 ## 0.9.0 — 2026-03-08
 
 ### Changed

--- a/src/cli/clipboard.ts
+++ b/src/cli/clipboard.ts
@@ -1,13 +1,23 @@
-import clipboard from "clipboardy";
-
 export interface CopyResult {
   success: boolean;
   command?: string;
   error?: unknown;
 }
 
+async function loadClipboard() {
+  if (process.platform === "darwin" && process.arch === "x64") {
+    const paths = (process.env.PATH ?? "").split(":").filter(Boolean);
+    if (!paths.includes("/usr/sbin")) {
+      process.env.PATH = ["/usr/sbin", ...paths].join(":");
+    }
+  }
+
+  return (await import("clipboardy")).default;
+}
+
 export async function copyToClipboard(text: string): Promise<CopyResult> {
   try {
+    const clipboard = await loadClipboard();
     await clipboard.write(text);
     return { success: true, command: "clipboardy" };
   } catch (error) {

--- a/src/gemini-web/client.ts
+++ b/src/gemini-web/client.ts
@@ -255,9 +255,14 @@ export function parseGeminiStreamGenerateResponse(rawText: string): {
       const parsed = JSON.parse(partBody) as unknown;
       const candidateList = getNestedValue<unknown[]>(parsed, [4], []);
       if (Array.isArray(candidateList) && candidateList.length > 0) {
-        bodyIndex = i;
-        body = parsed;
-        break;
+        const candidateText = getNestedValue<unknown>(candidateList[0], [1, 0], "");
+        const hasText = typeof candidateText === "string" && candidateText.length > 0;
+        if (body === null) {
+          bodyIndex = i;
+          body = parsed;
+        } else if (hasText) {
+          body = parsed;
+        }
       }
     } catch {
       // ignore

--- a/tests/cli/clipboard.test.ts
+++ b/tests/cli/clipboard.test.ts
@@ -1,24 +1,42 @@
-import { describe, expect, test, vi } from "vitest";
-import clipboard from "clipboardy";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { copyToClipboard } from "../../src/cli/clipboard.ts";
+
+const clipboardWrite = vi.hoisted(() => vi.fn());
 
 vi.mock("clipboardy", () => ({
   default: {
-    write: vi.fn(),
+    write: clipboardWrite,
   },
 }));
 
+function overrideProcessValue(name: "arch" | "platform", value: string): () => void {
+  const descriptor = Object.getOwnPropertyDescriptor(process, name);
+  Object.defineProperty(process, name, {
+    configurable: true,
+    value,
+  });
+  return () => {
+    if (descriptor) {
+      Object.defineProperty(process, name, descriptor);
+    }
+  };
+}
+
 describe("copyToClipboard", () => {
+  beforeEach(() => {
+    clipboardWrite.mockReset();
+  });
+
   test("returns success when clipboardy.write resolves", async () => {
-    (clipboard.write as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    clipboardWrite.mockResolvedValue(undefined);
     const result = await copyToClipboard("hello");
     expect(result).toEqual({ success: true, command: "clipboardy" });
-    expect(clipboard.write).toHaveBeenCalledWith("hello");
+    expect(clipboardWrite).toHaveBeenCalledWith("hello");
   });
 
   test("returns failure when clipboardy.write throws", async () => {
     const error = new Error("boom");
-    (clipboard.write as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(error);
+    clipboardWrite.mockRejectedValue(error);
     const result = await copyToClipboard("hi");
     expect(result.success).toBe(false);
     expect(result.error).toBe(error);
@@ -26,9 +44,27 @@ describe("copyToClipboard", () => {
 
   test("coerces non-string input rejection from clipboardy", async () => {
     const typeError = new TypeError("Expected a string");
-    (clipboard.write as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(typeError);
+    clipboardWrite.mockRejectedValue(typeError);
     const result = await copyToClipboard(123 as unknown as string);
     expect(result.success).toBe(false);
     expect(result.error).toBe(typeError);
+  });
+
+  test("adds /usr/sbin before loading clipboardy on Intel macOS", async () => {
+    const restorePlatform = overrideProcessValue("platform", "darwin");
+    const restoreArch = overrideProcessValue("arch", "x64");
+    vi.stubEnv("PATH", "/usr/bin:/bin");
+    clipboardWrite.mockResolvedValue(undefined);
+
+    try {
+      const result = await copyToClipboard("hello");
+
+      expect(result.success).toBe(true);
+      expect(process.env.PATH?.split(":")[0]).toBe("/usr/sbin");
+    } finally {
+      restoreArch();
+      restorePlatform();
+      vi.unstubAllEnvs();
+    }
   });
 });

--- a/tests/gemini-web/parse.test.ts
+++ b/tests/gemini-web/parse.test.ts
@@ -5,8 +5,23 @@ import {
 } from "../../src/gemini-web/client.js";
 
 function makeRawResponseWithBody(body: unknown): string {
-  const responseJson = [[null, null, JSON.stringify(body)]];
+  return makeRawResponseWithBodies([body]);
+}
+
+function makeRawResponseWithBodies(bodies: unknown[]): string {
+  const responseJson = bodies.map((body) => [null, null, JSON.stringify(body)]);
   return `)]}'\n\n${JSON.stringify(responseJson)}`;
+}
+
+function makeBodyWithText(rcid: string, text: string): unknown[] {
+  const candidate: unknown[] = [];
+  candidate[0] = rcid;
+  candidate[1] = [text];
+
+  const body: unknown[] = [];
+  body[1] = ["cid", "rid", rcid];
+  body[4] = [candidate];
+  return body;
 }
 
 describe("gemini-web parseGeminiStreamGenerateResponse", () => {
@@ -66,6 +81,35 @@ describe("gemini-web parseGeminiStreamGenerateResponse", () => {
 
     const parsed = parseGeminiStreamGenerateResponse(makeRawResponseWithBody(body));
     expect(parsed.text).toBe("Expanded card content");
+  });
+
+  it("picks the latest non-empty text across streaming chunks", () => {
+    const raw = makeRawResponseWithBodies([
+      makeBodyWithText("rcid-1", ""),
+      makeBodyWithText("rcid-1", "partial"),
+      makeBodyWithText("rcid-1", "partial answer with more"),
+      makeBodyWithText("rcid-1", "partial answer with more final"),
+    ]);
+
+    const parsed = parseGeminiStreamGenerateResponse(raw);
+    expect(parsed.text).toBe("partial answer with more final");
+  });
+
+  it("still parses a single coalesced chunk", () => {
+    const raw = makeRawResponseWithBody(makeBodyWithText("rcid-1", "single-chunk reply"));
+
+    const parsed = parseGeminiStreamGenerateResponse(raw);
+    expect(parsed.text).toBe("single-chunk reply");
+  });
+
+  it("preserves the previous non-empty chunk when a later chunk has empty text", () => {
+    const raw = makeRawResponseWithBodies([
+      makeBodyWithText("rcid-1", "first answer"),
+      makeBodyWithText("rcid-1", ""),
+    ]);
+
+    const parsed = parseGeminiStreamGenerateResponse(raw);
+    expect(parsed.text).toBe("first answer");
   });
 
   it("extracts model-unavailable error code 1052 from response json", () => {


### PR DESCRIPTION
## Summary
- Fix Gemini web stream parsing to prefer the latest non-empty candidate text chunk, covering #153 / #154 without shifting the generated-image scan anchor.
- Avoid eager clipboardy loading at startup and add /usr/sbin before lazy clipboard loading on Intel macOS, addressing #129.
- Update the changelog with contributor credit.

## Verification
- pnpm vitest run tests/gemini-web/parse.test.ts tests/cli/clipboard.test.ts
- pnpm run check
- pnpm test
- pnpm run build
- PATH=/usr/bin:/bin /opt/homebrew/bin/node -e "Object.defineProperty(process, 'platform', {value: 'darwin'}); Object.defineProperty(process, 'arch', {value: 'x64'}); await import('./dist/src/cli/clipboard.js'); console.log('clipboard import ok')"
- PATH=/usr/bin:/bin /opt/homebrew/bin/node -e "Object.defineProperty(process, 'platform', {value: 'darwin'}); Object.defineProperty(process, 'arch', {value: 'x64'}); const mod = await import('./dist/src/cli/clipboard.js'); const result = await mod.copyToClipboard('oracle clipboard smoke'); console.log(JSON.stringify({ success: result.success, command: result.command, pathHead: process.env.PATH.split(':')[0] }));"
- PATH=/usr/bin:/bin /opt/homebrew/bin/node -e "Object.defineProperty(process, 'platform', {value: 'darwin'}); Object.defineProperty(process, 'arch', {value: 'x64'}); process.argv = ['node', 'oracle', '--version']; await import('./dist/bin/oracle-cli.js');"