### PR TITLE
fix: open browser tab on requested URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Gemini web: prefer the latest non-empty streaming response chunk so `gemini-3-pro` and `gemini-3.1-pro` browser runs do not report `(no text output)` when the first chunk is an empty placeholder. (#153, #154) — thanks @manhtruong03.
 - CLI: avoid loading `clipboardy` during startup and add `/usr/sbin` before lazy clipboard loading on Intel macOS, preventing `spawnSync sysctl ENOENT` crashes from transitive architecture detection. (#129)
 - Browser: track ChatGPT's composer rewrite by matching the new `__composer-pill` model button and selecting thinking effort from the model menu's per-row effort control, with bilingual label matching and old-chip fallback. (#146) — thanks @SyntaxSmith.
+- Browser: open isolated local browser tabs directly on the configured ChatGPT URL instead of starting at `about:blank` and navigating later. (#139) — thanks @betamod.
 
 ## 0.9.0 — 2026-03-08
 

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -224,7 +224,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
   try {
     try {
       const strictTabIsolation = Boolean(manualLogin && reusedChrome);
-      const connection = await connectWithNewTab(chrome.port, logger, undefined, chromeHost, {
+      const connection = await connectWithNewTab(chrome.port, logger, config.url, chromeHost, {
         fallbackToDefault: !strictTabIsolation,
         retries: strictTabIsolation ? 3 : 0,
         retryDelayMs: 500,


### PR DESCRIPTION
## Summary
- Pass the resolved ChatGPT URL into local isolated browser tab creation so the tab opens directly on the requested workspace/folder instead of about:blank.
- Credit @betamod in CHANGELOG.md.

## Verification
- pnpm run check
- pnpm vitest run tests/browser/chromeLifecycle.test.ts tests/cli/browserConfig.test.ts
- pnpm run build

Supersedes #139.