### PR TITLE
fix: prevent oracle-mcp double start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - CLI: avoid loading `clipboardy` during startup and add `/usr/sbin` before lazy clipboard loading on Intel macOS, preventing `spawnSync sysctl ENOENT` crashes from transitive architecture detection. (#129)
 - Browser: track ChatGPT's composer rewrite by matching the new `__composer-pill` model button and selecting thinking effort from the model menu's per-row effort control, with bilingual label matching and old-chip fallback. (#146) — thanks @SyntaxSmith.
 - Browser: open isolated local browser tabs directly on the configured ChatGPT URL instead of starting at `about:blank` and navigating later. (#139) — thanks @betamod.
+- MCP: prevent the stdio server from auto-starting a second time when imported by an `oracle-mcp` bin shim. (#137) — thanks @SyntaxSmith.
 
 ## 0.9.0 — 2026-03-08
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import "dotenv/config";
 import process from "node:process";
+import { pathToFileURL } from "node:url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { getCliVersion } from "../version.js";
@@ -40,7 +41,14 @@ export async function startMcpServer(): Promise<void> {
   await closed;
 }
 
-if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith("oracle-mcp")) {
+export function shouldStartMcpServerFromModule(
+  moduleUrl: string = import.meta.url,
+  argv1: string | undefined = process.argv[1],
+): boolean {
+  return argv1 ? moduleUrl === pathToFileURL(argv1).href : false;
+}
+
+if (shouldStartMcpServerFromModule()) {
   startMcpServer().catch((error) => {
     console.error("Failed to start oracle-mcp:", error);
     process.exitCode = 1;

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { pathToFileURL } from "node:url";
+import { shouldStartMcpServerFromModule } from "../../src/mcp/server.js";
+
+describe("oracle-mcp module startup guard", () => {
+  it("starts only when the server module is the executed entrypoint", () => {
+    const serverPath = "/repo/src/mcp/server.ts";
+    expect(shouldStartMcpServerFromModule(pathToFileURL(serverPath).href, serverPath)).toBe(true);
+  });
+
+  it("does not start when imported by an oracle-mcp bin shim", () => {
+    expect(
+      shouldStartMcpServerFromModule(
+        pathToFileURL("/repo/src/mcp/server.ts").href,
+        "/Users/me/.nvm/versions/node/bin/oracle-mcp",
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract the focused MCP double-start fix from #137 without the unrelated remote queue / MCP policy changes.
- Replace the broad process.argv[1].endsWith("oracle-mcp") auto-start guard with an exact entrypoint URL check.
- Add regression coverage for importing the MCP server from an oracle-mcp bin shim.
- Credit @SyntaxSmith in CHANGELOG.md.

## Verification
- pnpm vitest run tests/mcp/server.test.ts tests/mcp.integration.test.ts tests/mcp.stdout.test.ts tests/mcp.schema.test.ts
- pnpm run check
- pnpm test
- pnpm run build

Supersedes #137 for the double-start bug.