### PR TITLE
fix: honor Gemini browser profile dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Browser: track ChatGPT's composer rewrite by matching the new `__composer-pill` model button and selecting thinking effort from the model menu's per-row effort control, with bilingual label matching and old-chip fallback. (#146) — thanks @SyntaxSmith.
 - Browser: open isolated local browser tabs directly on the configured ChatGPT URL instead of starting at `about:blank` and navigating later. (#139) — thanks @betamod.
 - MCP: prevent the stdio server from auto-starting a second time when imported by an `oracle-mcp` bin shim. (#137) — thanks @SyntaxSmith.
+- Gemini web: honor resolved manual-login browser profile directories when launching Gemini browser sessions. (#124) — thanks @blackopsrepl.
 
 ## 0.9.0 — 2026-03-08
 

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -73,10 +73,10 @@ export function resolveBrowserConfig(
   const manualLogin =
     config?.manualLogin ?? (isWindows ? true : DEFAULT_BROWSER_CONFIG.manualLogin);
   const cookieSyncDefault = isWindows ? false : DEFAULT_BROWSER_CONFIG.cookieSync;
-  const resolvedProfileDir =
-    config?.manualLoginProfileDir ??
-    process.env.ORACLE_BROWSER_PROFILE_DIR ??
-    path.join(os.homedir(), ".oracle", "browser-profile");
+  const resolvedProfileDir = resolveManualLoginProfileDir(
+    config?.manualLoginProfileDir,
+    process.env.ORACLE_BROWSER_PROFILE_DIR,
+  );
   return {
     ...DEFAULT_BROWSER_CONFIG,
     ...config,
@@ -128,4 +128,12 @@ function parseDebugPort(raw?: string | null): number | null {
     return null;
   }
   return value;
+}
+
+function resolveManualLoginProfileDir(...candidates: Array<string | null | undefined>): string {
+  for (const candidate of candidates) {
+    const profileDir = candidate?.trim();
+    if (profileDir) return profileDir;
+  }
+  return path.join(os.homedir(), ".oracle", "browser-profile");
 }

--- a/src/gemini-web/browserSessionManager.ts
+++ b/src/gemini-web/browserSessionManager.ts
@@ -31,16 +31,14 @@ export async function openGeminiBrowserSession(
   input: OpenGeminiBrowserSessionInput,
 ): Promise<GeminiBrowserSession> {
   const { browserConfig, keepBrowserDefault, purpose, log } = input;
-  const profileDir =
-    browserConfig?.manualLoginProfileDir ?? path.join(os.homedir(), ".oracle", "browser-profile");
-  await mkdir(profileDir, { recursive: true });
-
   const resolvedConfig = resolveBrowserConfig({
     ...browserConfig,
     manualLogin: true,
-    manualLoginProfileDir: profileDir,
     keepBrowser: browserConfig?.keepBrowser ?? keepBrowserDefault,
   });
+  const profileDir =
+    resolvedConfig.manualLoginProfileDir ?? path.join(os.homedir(), ".oracle", "browser-profile");
+  await mkdir(profileDir, { recursive: true });
   const keepBrowser = Boolean(resolvedConfig.keepBrowser);
 
   let port = await readDevToolsPort(profileDir);

--- a/tests/browser/config.test.ts
+++ b/tests/browser/config.test.ts
@@ -1,8 +1,20 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
+import os from "node:os";
+import path from "node:path";
 import { resolveBrowserConfig } from "../../src/browser/config.js";
 import { CHATGPT_URL } from "../../src/browser/constants.js";
 
 describe("resolveBrowserConfig", () => {
+  const originalProfileDir = process.env.ORACLE_BROWSER_PROFILE_DIR;
+
+  afterEach(() => {
+    if (originalProfileDir === undefined) {
+      delete process.env.ORACLE_BROWSER_PROFILE_DIR;
+    } else {
+      process.env.ORACLE_BROWSER_PROFILE_DIR = originalProfileDir;
+    }
+  });
+
   test("returns defaults when config missing", () => {
     const resolved = resolveBrowserConfig(undefined);
     expect(resolved.url).toBe(CHATGPT_URL);
@@ -43,5 +55,27 @@ describe("resolveBrowserConfig", () => {
         desiredModel: "GPT-5.2 Pro",
       }),
     ).toThrow(/Temporary Chat/i);
+  });
+
+  test("resolves manual-login profile dirs from config, env, and default", () => {
+    process.env.ORACLE_BROWSER_PROFILE_DIR = "/tmp/env-profile";
+
+    expect(
+      resolveBrowserConfig({
+        manualLogin: true,
+        manualLoginProfileDir: " /tmp/config-profile ",
+      }).manualLoginProfileDir,
+    ).toBe("/tmp/config-profile");
+
+    expect(resolveBrowserConfig({ manualLogin: true }).manualLoginProfileDir).toBe(
+      "/tmp/env-profile",
+    );
+
+    process.env.ORACLE_BROWSER_PROFILE_DIR = "   ";
+    expect(resolveBrowserConfig({ manualLogin: true }).manualLoginProfileDir).toBe(
+      path.join(os.homedir(), ".oracle", "browser-profile"),
+    );
+
+    expect(resolveBrowserConfig({ manualLogin: false }).manualLoginProfileDir).toBeNull();
   });
 });

--- a/tests/gemini-web/browserSessionManager.test.ts
+++ b/tests/gemini-web/browserSessionManager.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+
+const {
+  launchChrome,
+  connectWithNewTab,
+  closeTab,
+  readDevToolsPort,
+  writeDevToolsActivePort,
+  writeChromePid,
+  cleanupStaleProfileState,
+  verifyDevToolsReachable,
+} = vi.hoisted(() => ({
+  launchChrome: vi.fn(),
+  connectWithNewTab: vi.fn(),
+  closeTab: vi.fn(async () => undefined),
+  readDevToolsPort: vi.fn(async () => null),
+  writeDevToolsActivePort: vi.fn(async () => undefined),
+  writeChromePid: vi.fn(async () => undefined),
+  cleanupStaleProfileState: vi.fn(async () => undefined),
+  verifyDevToolsReachable: vi.fn(async () => ({ ok: false, error: "unreachable" })),
+}));
+
+vi.mock("../../src/browser/chromeLifecycle.js", () => ({
+  launchChrome,
+  connectWithNewTab,
+  closeTab,
+}));
+
+vi.mock("../../src/browser/profileState.js", () => ({
+  readDevToolsPort,
+  writeDevToolsActivePort,
+  writeChromePid,
+  cleanupStaleProfileState,
+  verifyDevToolsReachable,
+}));
+
+describe("openGeminiBrowserSession", () => {
+  const originalProfileDir = process.env.ORACLE_BROWSER_PROFILE_DIR;
+  let tempRoot: string;
+
+  beforeEach(async () => {
+    tempRoot = await mkdtemp(path.join(os.tmpdir(), "oracle-gemini-profile-"));
+    delete process.env.ORACLE_BROWSER_PROFILE_DIR;
+
+    launchChrome.mockReset();
+    connectWithNewTab.mockReset();
+    closeTab.mockClear();
+    readDevToolsPort.mockReset();
+    writeDevToolsActivePort.mockClear();
+    writeChromePid.mockClear();
+    cleanupStaleProfileState.mockClear();
+    verifyDevToolsReachable.mockReset();
+
+    launchChrome.mockResolvedValue({
+      port: 9222,
+      pid: 12345,
+      kill: vi.fn(),
+    });
+    connectWithNewTab.mockResolvedValue({
+      targetId: "target-1",
+      client: {
+        close: vi.fn(async () => undefined),
+      },
+    });
+    readDevToolsPort.mockResolvedValue(null);
+    verifyDevToolsReachable.mockResolvedValue({ ok: false, error: "unreachable" });
+  });
+
+  afterEach(async () => {
+    if (originalProfileDir === undefined) {
+      delete process.env.ORACLE_BROWSER_PROFILE_DIR;
+    } else {
+      process.env.ORACLE_BROWSER_PROFILE_DIR = originalProfileDir;
+    }
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it("prefers an explicit manual-login profile dir over the environment", async () => {
+    const explicitDir = path.join(tempRoot, "explicit-profile");
+    process.env.ORACLE_BROWSER_PROFILE_DIR = path.join(tempRoot, "env-profile");
+
+    const { openGeminiBrowserSession } =
+      await import("../../src/gemini-web/browserSessionManager.js");
+    const session = await openGeminiBrowserSession({
+      browserConfig: { manualLoginProfileDir: explicitDir },
+      keepBrowserDefault: false,
+      purpose: "test",
+    });
+
+    expect(session.profileDir).toBe(explicitDir);
+    expect(launchChrome).toHaveBeenCalledWith(
+      expect.objectContaining({
+        manualLogin: true,
+        manualLoginProfileDir: explicitDir,
+      }),
+      explicitDir,
+      expect.any(Function),
+    );
+  });
+
+  it("uses ORACLE_BROWSER_PROFILE_DIR when no explicit profile dir is set", async () => {
+    const envDir = path.join(tempRoot, "env-profile");
+    process.env.ORACLE_BROWSER_PROFILE_DIR = envDir;
+
+    const { openGeminiBrowserSession } =
+      await import("../../src/gemini-web/browserSessionManager.js");
+    const session = await openGeminiBrowserSession({
+      browserConfig: {},
+      keepBrowserDefault: true,
+      purpose: "test",
+    });
+
+    expect(session.profileDir).toBe(envDir);
+    expect(launchChrome).toHaveBeenCalledWith(
+      expect.objectContaining({
+        keepBrowser: true,
+        manualLogin: true,
+        manualLoginProfileDir: envDir,
+      }),
+      envDir,
+      expect.any(Function),
+    );
+  });
+
+  it("ignores blank environment profile dirs and falls back to the default", async () => {
+    process.env.ORACLE_BROWSER_PROFILE_DIR = "   ";
+    const homedir = path.join(tempRoot, "home");
+    const homedirSpy = vi.spyOn(os, "homedir").mockReturnValue(homedir);
+    const defaultDir = path.join(homedir, ".oracle", "browser-profile");
+
+    const { openGeminiBrowserSession } =
+      await import("../../src/gemini-web/browserSessionManager.js");
+    const session = await openGeminiBrowserSession({
+      browserConfig: {},
+      keepBrowserDefault: false,
+      purpose: "test",
+    });
+
+    expect(session.profileDir).toBe(defaultDir);
+    expect(launchChrome).toHaveBeenCalledWith(
+      expect.objectContaining({
+        manualLogin: true,
+        manualLoginProfileDir: defaultDir,
+      }),
+      defaultDir,
+      expect.any(Function),
+    );
+    homedirSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Extracts and tightens the focused fix from #124.\n\n- resolves manual-login profile dirs through the shared browser config resolver\n- keeps Gemini session profile bookkeeping and launchChrome config aligned\n- ignores blank profile-dir values and falls back to the default profile\n- adds resolver/session regression tests\n\nVerification:\n- pnpm vitest run tests/gemini-web/browserSessionManager.test.ts tests/browser/config.test.ts\n- pnpm run check\n- pnpm test\n- pnpm run build