### PR TITLE
fix: harden browser temp dirs and debug logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Browser: open isolated local browser tabs directly on the configured ChatGPT URL instead of starting at `about:blank` and navigating later. (#139) — thanks @betamod.
 - MCP: prevent the stdio server from auto-starting a second time when imported by an `oracle-mcp` bin shim. (#137) — thanks @SyntaxSmith.
 - Gemini web: honor resolved manual-login browser profile directories when launching Gemini browser sessions. (#124) — thanks @blackopsrepl.
+- Browser: avoid Linux hidden-home temp dirs for ephemeral Chrome profiles and redact inline cookie values in low-level debug config logs. (#136) — thanks @lodekeeper.
 
 ## 0.9.0 — 2026-03-08
 

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -64,6 +64,21 @@ export type { BrowserAutomationConfig, BrowserRunOptions, BrowserRunResult } fro
 export { CHATGPT_URL, DEFAULT_MODEL_STRATEGY, DEFAULT_MODEL_TARGET } from "./constants.js";
 export { parseDuration, delay, normalizeChatgptUrl, isTemporaryChatUrl } from "./utils.js";
 
+function redactBrowserConfigForDebugLog(config: Record<string, unknown>): Record<string, unknown> {
+  const redacted = { ...config };
+  if (Array.isArray(config.inlineCookies)) {
+    redacted.inlineCookies = `[redacted:${config.inlineCookies.length} cookies]`;
+    redacted.inlineCookieCount = config.inlineCookies.length;
+  }
+  return redacted;
+}
+
+export function redactBrowserConfigForDebugLogForTest(
+  config: Record<string, unknown>,
+): Record<string, unknown> {
+  return redactBrowserConfigForDebugLog(config);
+}
+
 function isCloudflareChallengeError(error: unknown): error is BrowserAutomationError {
   if (!(error instanceof BrowserAutomationError)) return false;
   return (error.details as { stage?: string } | undefined)?.stage === "cloudflare-challenge";
@@ -122,7 +137,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
   if (config.debug || process.env.CHATGPT_DEVTOOLS_TRACE === "1") {
     logger(
       `[browser-mode] config: ${JSON.stringify({
-        ...config,
+        ...redactBrowserConfigForDebugLog(config),
         promptLength: promptText.length,
       })}`,
     );
@@ -2145,7 +2160,38 @@ async function resolveUserDataBaseDir(): Promise<string> {
       }
     }
   }
-  return os.tmpdir();
+  const tmpDir = os.tmpdir();
+  if (shouldPreferSystemTmpDir(process.platform, tmpDir, os.homedir())) {
+    try {
+      await mkdir("/tmp", { recursive: true });
+      return "/tmp";
+    } catch {
+      // Fall back to the inherited tmpdir if /tmp is unavailable.
+    }
+  }
+  return tmpDir;
+}
+
+function shouldPreferSystemTmpDir(
+  platform: NodeJS.Platform,
+  tmpDir: string,
+  homeDir: string,
+): boolean {
+  if (platform !== "linux" || !tmpDir || !homeDir) return false;
+  const relativeToHome = path.relative(homeDir, tmpDir);
+  if (!relativeToHome || relativeToHome.startsWith("..") || path.isAbsolute(relativeToHome)) {
+    return false;
+  }
+  const firstSegment = relativeToHome.split(path.sep, 1)[0];
+  return Boolean(firstSegment?.startsWith("."));
+}
+
+export function shouldPreferSystemTmpDirForTest(
+  platform: NodeJS.Platform,
+  tmpDir: string,
+  homeDir: string,
+): boolean {
+  return shouldPreferSystemTmpDir(platform, tmpDir, homeDir);
 }
 
 function buildThinkingStatusExpression(): string {

--- a/tests/browser/index.test.ts
+++ b/tests/browser/index.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vitest";
-import { shouldPreserveBrowserOnErrorForTest } from "../../src/browser/index.js";
+import {
+  redactBrowserConfigForDebugLogForTest,
+  shouldPreferSystemTmpDirForTest,
+  shouldPreserveBrowserOnErrorForTest,
+} from "../../src/browser/index.js";
 import { BrowserAutomationError } from "../../src/oracle/errors.js";
 
 describe("shouldPreserveBrowserOnErrorForTest", () => {
@@ -22,5 +26,56 @@ describe("shouldPreserveBrowserOnErrorForTest", () => {
       stage: "execute-browser",
     });
     expect(shouldPreserveBrowserOnErrorForTest(error, false)).toBe(false);
+  });
+});
+
+describe("redactBrowserConfigForDebugLogForTest", () => {
+  test("redacts inline cookie values while preserving count context", () => {
+    const redacted = redactBrowserConfigForDebugLogForTest({
+      inlineCookies: [
+        { name: "__Secure-next-auth.session-token", value: "secret-token" },
+        { name: "_account", value: "secret-account" },
+      ],
+      inlineCookiesSource: "inline-file",
+      debug: true,
+    });
+
+    expect(redacted).toMatchObject({
+      inlineCookies: "[redacted:2 cookies]",
+      inlineCookieCount: 2,
+      inlineCookiesSource: "inline-file",
+      debug: true,
+    });
+    expect(JSON.stringify(redacted)).not.toContain("secret-token");
+    expect(JSON.stringify(redacted)).not.toContain("secret-account");
+  });
+
+  test("leaves missing inline cookies unchanged", () => {
+    expect(redactBrowserConfigForDebugLogForTest({ debug: true })).toEqual({ debug: true });
+  });
+});
+
+describe("shouldPreferSystemTmpDirForTest", () => {
+  test("prefers /tmp for Linux tmpdirs under a hidden home segment", () => {
+    expect(shouldPreferSystemTmpDirForTest("linux", "/home/openclaw/.tmp", "/home/openclaw")).toBe(
+      true,
+    );
+    expect(
+      shouldPreferSystemTmpDirForTest("linux", "/home/openclaw/.cache/tmp", "/home/openclaw"),
+    ).toBe(true);
+  });
+
+  test("keeps normal Linux tmpdirs and non-Linux platforms unchanged", () => {
+    expect(shouldPreferSystemTmpDirForTest("linux", "/tmp", "/home/openclaw")).toBe(false);
+    expect(shouldPreferSystemTmpDirForTest("linux", "/home/openclaw/tmp", "/home/openclaw")).toBe(
+      false,
+    );
+    expect(shouldPreferSystemTmpDirForTest("darwin", "/Users/me/.tmp", "/Users/me")).toBe(false);
+  });
+
+  test("does not treat sibling home paths as inside the home directory", () => {
+    expect(shouldPreferSystemTmpDirForTest("linux", "/home/openclaw2/.tmp", "/home/openclaw")).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
Extracts and tightens the focused fix from #136.\n\n- redacts inline cookie values from the low-level browser debug config log\n- preserves cookie count/source context for diagnostics\n- avoids Linux hidden-home temp dirs for ephemeral Chrome profiles when /tmp is available\n- uses a path.relative-based predicate so sibling home paths are not misclassified\n\nVerification:\n- pnpm vitest run tests/browser/index.test.ts\n- pnpm run check\n- pnpm test\n- pnpm run build