### PR TITLE
fix: fail attachment sends before Enter fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - MCP: prevent the stdio server from auto-starting a second time when imported by an `oracle-mcp` bin shim. (#137) — thanks @SyntaxSmith.
 - Gemini web: honor resolved manual-login browser profile directories when launching Gemini browser sessions. (#124) — thanks @blackopsrepl.
 - Browser: avoid Linux hidden-home temp dirs for ephemeral Chrome profiles and redact inline cookie values in low-level debug config logs. (#136) — thanks @lodekeeper.
+- Browser: fail attachment submissions before send instead of falling back to Enter after upload/send-readiness timeouts. (#115, #116) — thanks @HeMuling.
 
 ## 0.9.0 — 2026-03-08
 

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -397,6 +397,16 @@ async function attemptSendButton(
     }
     await delay(100);
   }
+  if (Array.isArray(attachmentNames) && attachmentNames.length > 0) {
+    throw new BrowserAutomationError(
+      "Attachments never reached a clickable send button before timeout.",
+      {
+        stage: "submit-prompt",
+        code: "attachment-send-not-ready",
+        attachmentNames,
+      },
+    );
+  }
   return false;
 }
 
@@ -567,5 +577,6 @@ async function verifyPromptCommitted(
 
 // biome-ignore lint/style/useNamingConvention: test-only export used in vitest suite
 export const __test__ = {
+  attemptSendButton,
   verifyPromptCommitted,
 };

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -519,7 +519,6 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
       const baselineAssistantText =
         typeof baselineSnapshot?.text === "string" ? baselineSnapshot.text.trim() : "";
       const attachmentNames = submissionAttachments.map((a) => path.basename(a.path));
-      let attachmentWaitTimedOut = false;
       let inputOnlyAttachments = false;
       if (submissionAttachments.length > 0) {
         if (!DOM) {
@@ -549,24 +548,11 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
         const perFileTimeout = 20_000;
         const waitBudget =
           Math.max(baseTimeout, 45_000) + (submissionAttachments.length - 1) * perFileTimeout;
-        try {
-          await waitForAttachmentCompletion(Runtime, waitBudget, attachmentNames, logger);
-          logger("All attachments uploaded");
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          if (/Attachments did not finish uploading before timeout/i.test(message)) {
-            attachmentWaitTimedOut = true;
-            logger(
-              `[browser] Attachment upload timed out after ${Math.round(waitBudget / 1000)}s; continuing without confirmation.`,
-            );
-          } else {
-            throw error;
-          }
-        }
+        await waitForAttachmentCompletion(Runtime, waitBudget, attachmentNames, logger);
+        logger("All attachments uploaded");
       }
       let baselineTurns = await readConversationTurnCount(Runtime, logger);
       // Learned: return baselineTurns so assistant polling can ignore earlier content.
-      const sendAttachmentNames = attachmentWaitTimedOut ? [] : attachmentNames;
       const providerState: Record<string, unknown> = {
         runtime: Runtime,
         input: Input,
@@ -574,7 +560,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
         timeoutMs: config.timeoutMs,
         inputTimeoutMs: config.inputTimeoutMs ?? undefined,
         baselineTurns: baselineTurns ?? undefined,
-        attachmentNames: sendAttachmentNames,
+        attachmentNames,
       };
       await runProviderSubmissionFlow(chatgptDomProvider, {
         prompt,
@@ -588,9 +574,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
         baselineTurns = providerBaselineTurns;
       }
       if (attachmentNames.length > 0) {
-        if (attachmentWaitTimedOut) {
-          logger("Attachment confirmation timed out; skipping user-turn attachment verification.");
-        } else if (inputOnlyAttachments) {
+        if (inputOnlyAttachments) {
           logger(
             "Attachment UI did not render before send; skipping user-turn attachment verification.",
           );

--- a/tests/browser/promptComposer.test.ts
+++ b/tests/browser/promptComposer.test.ts
@@ -72,4 +72,31 @@ describe("promptComposer", () => {
       promptComposer.verifyPromptCommitted(runtime as never, "hello", 150),
     ).resolves.toBe(1);
   });
+
+  test("attachment sends time out instead of allowing Enter fallback", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtime = {
+        evaluate: vi.fn(async ({ expression }: { expression: string }) => {
+          if (expression.includes("dispatchClickSequence")) {
+            return { result: { value: "disabled" } };
+          }
+          return { result: { value: true } };
+        }),
+      } as unknown as {
+        evaluate: (args: { expression: string; returnByValue?: boolean }) => Promise<unknown>;
+      };
+
+      const promise = promptComposer.attemptSendButton(
+        runtime as never,
+        (() => undefined) as never,
+        ["oracle-attach-verify.txt"],
+      );
+      const assertion = expect(promise).rejects.toThrow(/clickable send button/i);
+      await vi.advanceTimersByTimeAsync(9_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
Extracts the narrow, verifiable safety fix from #116 for #115.\n\n- local browser attachment upload timeouts now fail before submission instead of clearing attachment names and continuing\n- attachment submissions that never reach a clickable send button throw an explicit browser automation error\n- plain Enter fallback remains available for non-attachment submissions\n- adds regression coverage for the attachment send timeout path\n\nVerification:\n- pnpm vitest run tests/browser/promptComposer.test.ts tests/browser/attachmentsCompletion.test.ts tests/browser/pageActions.test.ts\n- pnpm run check\n- pnpm test\n- pnpm run build