### PR TITLE
feat: read dash prompt from stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Browser: avoid Linux hidden-home temp dirs for ephemeral Chrome profiles and redact inline cookie values in low-level debug config logs. (#136) — thanks @lodekeeper.
 - Browser: fail attachment submissions before send instead of falling back to Enter after upload/send-readiness timeouts. (#115, #116) — thanks @HeMuling.
 - Browser: stabilize localized ChatGPT model selection when the header stays generic by waiting on composer-footer model state changes. (#118) — thanks @dedene.
+- CLI: accept `-p -` / `--prompt -` to read the prompt from stdin. (#117) — thanks @frankekn.
 
 ## 0.9.0 — 2026-03-08
 

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -13,6 +13,7 @@ if (process.argv[2] === "oracle-mcp") {
 }
 import { resolveEngine, type EngineMode, defaultWaitPreference } from "../src/cli/engine.js";
 import { shouldRequirePrompt } from "../src/cli/promptRequirement.js";
+import { resolveDashPrompt } from "../src/cli/stdin.js";
 import chalk from "chalk";
 import type { SessionMetadata, SessionMode, BrowserSessionConfig } from "../src/sessionStore.js";
 import { sessionStore, pruneOldSessions } from "../src/sessionStore.js";
@@ -216,7 +217,7 @@ program.hook("preAction", () => {
   introPrinted = true;
 });
 applyHelpStyling(program, VERSION, isTty);
-program.hook("preAction", (thisCommand) => {
+program.hook("preAction", async (thisCommand) => {
   if (thisCommand !== program) {
     return;
   }
@@ -233,6 +234,11 @@ program.hook("preAction", (thisCommand) => {
   if (!opts.prompt && positional) {
     opts.prompt = positional;
     thisCommand.setOptionValue("prompt", positional);
+  }
+  const resolvedPrompt = await resolveDashPrompt(opts.prompt);
+  if (resolvedPrompt !== opts.prompt) {
+    opts.prompt = resolvedPrompt;
+    thisCommand.setOptionValue("prompt", resolvedPrompt);
   }
   if (shouldRequirePrompt(userCliArgs, opts)) {
     console.log(

--- a/src/cli/stdin.ts
+++ b/src/cli/stdin.ts
@@ -1,0 +1,26 @@
+export async function readStdin(stream: NodeJS.ReadableStream = process.stdin): Promise<string> {
+  const chunks: string[] = [];
+  const maybeTextStream = stream as { setEncoding?: (encoding: BufferEncoding) => void };
+  maybeTextStream.setEncoding?.("utf8");
+  for await (const chunk of stream) {
+    chunks.push(typeof chunk === "string" ? chunk : String(chunk));
+  }
+  return chunks.join("");
+}
+
+export async function resolveDashPrompt(
+  prompt: string | undefined,
+  stream: NodeJS.ReadableStream = process.stdin,
+): Promise<string | undefined> {
+  if (prompt !== "-") {
+    return prompt;
+  }
+  if ((stream as NodeJS.ReadStream).isTTY) {
+    throw new Error(`"-p -" requires piped input, for example: echo "prompt" | oracle -p -.`);
+  }
+  const stdinPrompt = (await readStdin(stream)).trim();
+  if (!stdinPrompt) {
+    throw new Error(`"-p -" received empty stdin.`);
+  }
+  return stdinPrompt;
+}

--- a/tests/cli/stdin.test.ts
+++ b/tests/cli/stdin.test.ts
@@ -1,0 +1,34 @@
+import { Readable } from "node:stream";
+import { describe, expect, test } from "vitest";
+import { readStdin, resolveDashPrompt } from "../../src/cli/stdin.js";
+
+describe("stdin helpers", () => {
+  test("readStdin reads the full stream payload", async () => {
+    const stream = Readable.from(["Hello", " ", "world"]);
+    await expect(readStdin(stream)).resolves.toBe("Hello world");
+  });
+
+  test("resolveDashPrompt keeps normal prompts unchanged", async () => {
+    await expect(resolveDashPrompt("normal prompt", Readable.from([]))).resolves.toBe(
+      "normal prompt",
+    );
+  });
+
+  test("resolveDashPrompt reads piped stdin", async () => {
+    const stream = Readable.from(["Hello world\n"]);
+    Object.assign(stream, { isTTY: false });
+    await expect(resolveDashPrompt("-", stream)).resolves.toBe("Hello world");
+  });
+
+  test("resolveDashPrompt rejects tty stdin", async () => {
+    const stream = Readable.from([]);
+    Object.assign(stream, { isTTY: true });
+    await expect(resolveDashPrompt("-", stream)).rejects.toThrow(/requires piped input/i);
+  });
+
+  test("resolveDashPrompt rejects empty stdin", async () => {
+    const stream = Readable.from([" \n "]);
+    Object.assign(stream, { isTTY: false });
+    await expect(resolveDashPrompt("-", stream)).rejects.toThrow(/received empty stdin/i);
+  });
+});


### PR DESCRIPTION
## Summary
- support `-p -` / `--prompt -` by reading the prompt from stdin
- reject TTY stdin and empty stdin with explicit errors
- add focused stdin helper tests

Extracts the scoped stdin prompt support from contributor PR #117. Thanks @frankekn.

## Verification
- pnpm vitest run tests/cli/stdin.test.ts
- pnpm run check
- pnpm test
- pnpm run build
- printf 'stdin prompt ok\n' | node dist/bin/oracle-cli.js --render-plain --render -p -