### PR TITLE
fix: preserve browser submission fallback recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Browser: fail attachment submissions before send instead of falling back to Enter after upload/send-readiness timeouts. (#115, #116) — thanks @HeMuling.
 - Browser: stabilize localized ChatGPT model selection when the header stays generic by waiting on composer-footer model state changes. (#118) — thanks @dedene.
 - CLI: accept `-p -` / `--prompt -` to read the prompt from stdin. (#117) — thanks @frankekn.
+- Browser: preserve prompt-too-large fallback recovery after a dead-composer retry. (#117) — thanks @frankekn.
 
 ## 0.9.0 — 2026-03-08
 

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -92,6 +92,83 @@ export function shouldPreserveBrowserOnErrorForTest(error: unknown, headless: bo
   return shouldPreserveBrowserOnError(error, headless);
 }
 
+function hasBrowserErrorCode(error: unknown, code: string): boolean {
+  return (
+    error instanceof BrowserAutomationError &&
+    (error.details as { code?: string } | undefined)?.code === code
+  );
+}
+
+type BrowserSubmissionResult = {
+  baselineTurns: number | null;
+  baselineAssistantText: string | null;
+};
+
+type BrowserSubmissionFallback = {
+  prompt: string;
+  attachments: BrowserAttachment[];
+};
+
+async function runSubmissionWithRecovery({
+  prompt,
+  attachments,
+  fallbackSubmission,
+  submit,
+  reloadPromptComposer,
+  prepareFallbackSubmission,
+  logger,
+}: {
+  prompt: string;
+  attachments: BrowserAttachment[];
+  fallbackSubmission?: BrowserSubmissionFallback;
+  submit: (prompt: string, attachments: BrowserAttachment[]) => Promise<BrowserSubmissionResult>;
+  reloadPromptComposer: () => Promise<void>;
+  prepareFallbackSubmission: () => Promise<void>;
+  logger: BrowserLogger;
+}): Promise<BrowserSubmissionResult> {
+  let currentPrompt = prompt;
+  let currentAttachments = attachments;
+  let retriedDeadComposer = false;
+  let usedFallbackSubmission = false;
+
+  while (true) {
+    try {
+      return await submit(currentPrompt, currentAttachments);
+    } catch (error) {
+      const isDeadComposer = hasBrowserErrorCode(error, "dead-composer");
+      if (isDeadComposer && !retriedDeadComposer) {
+        retriedDeadComposer = true;
+        await reloadPromptComposer();
+        continue;
+      }
+
+      const isPromptTooLarge = hasBrowserErrorCode(error, "prompt-too-large");
+      if (fallbackSubmission && isPromptTooLarge && !usedFallbackSubmission) {
+        usedFallbackSubmission = true;
+        logger("[browser] Inline prompt too large; retrying with file uploads.");
+        await prepareFallbackSubmission();
+        currentPrompt = fallbackSubmission.prompt;
+        currentAttachments = fallbackSubmission.attachments;
+        continue;
+      }
+
+      throw error;
+    }
+  }
+}
+
+export async function runSubmissionWithRecoveryForTest(args: {
+  prompt: string;
+  attachments: BrowserAttachment[];
+  fallbackSubmission?: BrowserSubmissionFallback;
+  submit: (prompt: string, attachments: BrowserAttachment[]) => Promise<BrowserSubmissionResult>;
+  reloadPromptComposer: () => Promise<void>;
+  prepareFallbackSubmission: () => Promise<void>;
+  logger: BrowserLogger;
+}): Promise<BrowserSubmissionResult> {
+  return runSubmissionWithRecovery(args);
+}
+
 export async function runBrowserMode(options: BrowserRunOptions): Promise<BrowserRunResult> {
   const promptText = options.prompt?.trim();
   if (!promptText) {
@@ -595,33 +672,31 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
       scheduleConversationHint("post-submit", config.timeoutMs ?? 120_000);
       return { baselineTurns, baselineAssistantText };
     };
+    const reloadPromptComposer = async () => {
+      logger("[browser] Composer became unresponsive; reloading page and retrying once.");
+      await raceWithDisconnect(Page.reload({ ignoreCache: true }));
+      await raceWithDisconnect(ensurePromptReady(Runtime, config.inputTimeoutMs, logger));
+    };
 
     let baselineTurns: number | null = null;
     let baselineAssistantText: string | null = null;
     await acquireProfileLockIfNeeded();
     try {
-      try {
-        const submission = await raceWithDisconnect(submitOnce(promptText, attachments));
-        baselineTurns = submission.baselineTurns;
-        baselineAssistantText = submission.baselineAssistantText;
-      } catch (error) {
-        const isPromptTooLarge =
-          error instanceof BrowserAutomationError &&
-          (error.details as { code?: string } | undefined)?.code === "prompt-too-large";
-        if (fallbackSubmission && isPromptTooLarge) {
-          // Learned: when prompts truncate, retry with file uploads so the UI receives the full content.
-          logger("[browser] Inline prompt too large; retrying with file uploads.");
+      const submission = await runSubmissionWithRecovery({
+        prompt: promptText,
+        attachments,
+        fallbackSubmission,
+        submit: (submissionPrompt, submissionAttachments) =>
+          raceWithDisconnect(submitOnce(submissionPrompt, submissionAttachments)),
+        reloadPromptComposer,
+        prepareFallbackSubmission: async () => {
           await raceWithDisconnect(clearPromptComposer(Runtime, logger));
           await raceWithDisconnect(ensurePromptReady(Runtime, config.inputTimeoutMs, logger));
-          const submission = await raceWithDisconnect(
-            submitOnce(fallbackSubmission.prompt, fallbackSubmission.attachments),
-          );
-          baselineTurns = submission.baselineTurns;
-          baselineAssistantText = submission.baselineAssistantText;
-        } else {
-          throw error;
-        }
-      }
+        },
+        logger,
+      });
+      baselineTurns = submission.baselineTurns;
+      baselineAssistantText = submission.baselineAssistantText;
     } finally {
       await releaseProfileLockIfHeld();
     }
@@ -1425,31 +1500,28 @@ async function runRemoteBrowserMode(
       }
       return { baselineTurns, baselineAssistantText };
     };
+    const reloadPromptComposer = async () => {
+      logger("[browser] Composer became unresponsive; reloading page and retrying once.");
+      await Page.reload({ ignoreCache: true });
+      await ensurePromptReady(Runtime, config.inputTimeoutMs, logger);
+    };
 
     let baselineTurns: number | null = null;
     let baselineAssistantText: string | null = null;
-    try {
-      const submission = await submitOnce(promptText, attachments);
-      baselineTurns = submission.baselineTurns;
-      baselineAssistantText = submission.baselineAssistantText;
-    } catch (error) {
-      const isPromptTooLarge =
-        error instanceof BrowserAutomationError &&
-        (error.details as { code?: string } | undefined)?.code === "prompt-too-large";
-      if (options.fallbackSubmission && isPromptTooLarge) {
-        logger("[browser] Inline prompt too large; retrying with file uploads.");
+    const submission = await runSubmissionWithRecovery({
+      prompt: promptText,
+      attachments,
+      fallbackSubmission: options.fallbackSubmission,
+      submit: submitOnce,
+      reloadPromptComposer,
+      prepareFallbackSubmission: async () => {
         await clearPromptComposer(Runtime, logger);
         await ensurePromptReady(Runtime, config.inputTimeoutMs, logger);
-        const submission = await submitOnce(
-          options.fallbackSubmission.prompt,
-          options.fallbackSubmission.attachments,
-        );
-        baselineTurns = submission.baselineTurns;
-        baselineAssistantText = submission.baselineAssistantText;
-      } else {
-        throw error;
-      }
-    }
+      },
+      logger,
+    });
+    baselineTurns = submission.baselineTurns;
+    baselineAssistantText = submission.baselineAssistantText;
     stopThinkingMonitor = startThinkingStatusMonitor(Runtime, logger, options.verbose ?? false);
     // Helper to normalize text for echo detection (collapse whitespace, lowercase)
     const normalizeForComparison = (text: string): string =>

--- a/tests/browser/index.test.ts
+++ b/tests/browser/index.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import {
   redactBrowserConfigForDebugLogForTest,
+  runSubmissionWithRecoveryForTest,
   shouldPreferSystemTmpDirForTest,
   shouldPreserveBrowserOnErrorForTest,
 } from "../../src/browser/index.js";
@@ -77,5 +78,78 @@ describe("shouldPreferSystemTmpDirForTest", () => {
     expect(shouldPreferSystemTmpDirForTest("linux", "/home/openclaw2/.tmp", "/home/openclaw")).toBe(
       false,
     );
+  });
+});
+
+describe("runSubmissionWithRecoveryForTest", () => {
+  test("preserves prompt-too-large fallback after a dead-composer retry", async () => {
+    const submit = vi
+      .fn()
+      .mockRejectedValueOnce(new BrowserAutomationError("dead composer", { code: "dead-composer" }))
+      .mockRejectedValueOnce(
+        new BrowserAutomationError("prompt too large", { code: "prompt-too-large" }),
+      )
+      .mockResolvedValueOnce({
+        baselineTurns: 7,
+        baselineAssistantText: "done",
+      });
+    const reloadPromptComposer = vi.fn().mockResolvedValue(undefined);
+    const prepareFallbackSubmission = vi.fn().mockResolvedValue(undefined);
+    const logger = vi.fn<(message: string) => void>();
+
+    await expect(
+      runSubmissionWithRecoveryForTest({
+        prompt: "inline prompt",
+        attachments: [],
+        fallbackSubmission: {
+          prompt: "fallback prompt",
+          attachments: [{ path: "/tmp/fallback.txt", displayPath: "fallback.txt", sizeBytes: 12 }],
+        },
+        submit,
+        reloadPromptComposer,
+        prepareFallbackSubmission,
+        logger,
+      }),
+    ).resolves.toEqual({
+      baselineTurns: 7,
+      baselineAssistantText: "done",
+    });
+
+    expect(reloadPromptComposer).toHaveBeenCalledTimes(1);
+    expect(prepareFallbackSubmission).toHaveBeenCalledTimes(1);
+    expect(logger).toHaveBeenCalledWith(
+      "[browser] Inline prompt too large; retrying with file uploads.",
+    );
+    expect(submit).toHaveBeenNthCalledWith(1, "inline prompt", []);
+    expect(submit).toHaveBeenNthCalledWith(2, "inline prompt", []);
+    expect(submit).toHaveBeenNthCalledWith(3, "fallback prompt", [
+      expect.objectContaining({ displayPath: "fallback.txt" }),
+    ]);
+  });
+
+  test("throws when prompt-too-large happens again after fallback", async () => {
+    const submit = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new BrowserAutomationError("prompt too large", { code: "prompt-too-large" }),
+      )
+      .mockRejectedValueOnce(
+        new BrowserAutomationError("prompt too large again", { code: "prompt-too-large" }),
+      );
+
+    await expect(
+      runSubmissionWithRecoveryForTest({
+        prompt: "inline prompt",
+        attachments: [],
+        fallbackSubmission: {
+          prompt: "fallback prompt",
+          attachments: [],
+        },
+        submit,
+        reloadPromptComposer: vi.fn().mockResolvedValue(undefined),
+        prepareFallbackSubmission: vi.fn().mockResolvedValue(undefined),
+        logger: vi.fn<(message: string) => void>(),
+      }),
+    ).rejects.toThrow(/prompt too large again/i);
   });
 });


### PR DESCRIPTION
## Summary
- route local and remote browser submissions through a shared recovery helper
- retry a dead composer once by reloading before resubmitting
- preserve prompt-too-large fallback upload recovery even after a dead-composer retry

Extracts a scoped recovery fix from contributor PR #117. Thanks @frankekn.

## Verification
- pnpm vitest run tests/browser/index.test.ts
- pnpm run check
- pnpm test
- pnpm run build