### PR TITLE
fix: guard browser response capture by conversation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Browser: stabilize localized ChatGPT model selection when the header stays generic by waiting on composer-footer model state changes. (#118) — thanks @dedene.
 - CLI: accept `-p -` / `--prompt -` to read the prompt from stdin. (#117) — thanks @frankekn.
 - Browser: preserve prompt-too-large fallback recovery after a dead-composer retry. (#117) — thanks @frankekn.
+- Browser: guard assistant response capture against stale turns from a different ChatGPT conversation. (#117) — thanks @frankekn.
 
 ## 0.9.0 — 2026-03-08
 

--- a/src/browser/actions/assistantResponse.ts
+++ b/src/browser/actions/assistantResponse.ts
@@ -39,6 +39,7 @@ export async function waitForAssistantResponse(
   timeoutMs: number,
   logger: BrowserLogger,
   minTurnIndex?: number,
+  expectedConversationId?: string,
 ): Promise<{
   text: string;
   html?: string;
@@ -49,7 +50,11 @@ export async function waitForAssistantResponse(
   // Learned: two paths are needed:
   // 1) DOM observer (fast when mutations fire),
   // 2) snapshot poller (fallback when observers miss or JS stalls).
-  const expression = buildResponseObserverExpression(timeoutMs, minTurnIndex);
+  const expression = buildResponseObserverExpression(
+    timeoutMs,
+    minTurnIndex,
+    expectedConversationId,
+  );
   const evaluationPromise = Runtime.evaluate({
     expression,
     awaitPromise: true,
@@ -68,6 +73,7 @@ export async function waitForAssistantResponse(
     Runtime,
     timeoutMs,
     minTurnIndex,
+    expectedConversationId,
     pollerAbort.signal,
   ).then(
     (value) => ({ kind: "poll" as const, value }),
@@ -108,7 +114,13 @@ export async function waitForAssistantResponse(
       } else if (source === "poll") {
         throw error;
       } else if (source === "evaluation") {
-        const recovered = await recoverAssistantResponse(Runtime, timeoutMs, logger, minTurnIndex);
+        const recovered = await recoverAssistantResponse(
+          Runtime,
+          timeoutMs,
+          logger,
+          minTurnIndex,
+          expectedConversationId,
+        );
         if (recovered) {
           return recovered;
         }
@@ -129,7 +141,13 @@ export async function waitForAssistantResponse(
   if (!parsed) {
     let remainingMs = Math.max(0, timeoutMs - (Date.now() - start));
     if (remainingMs > 0) {
-      const recovered = await recoverAssistantResponse(Runtime, remainingMs, logger, minTurnIndex);
+      const recovered = await recoverAssistantResponse(
+        Runtime,
+        remainingMs,
+        logger,
+        minTurnIndex,
+        expectedConversationId,
+      );
       if (recovered) {
         return recovered;
       }
@@ -148,7 +166,13 @@ export async function waitForAssistantResponse(
     throw new Error("Unable to capture assistant response");
   }
 
-  const refreshed = await refreshAssistantSnapshot(Runtime, parsed, logger, minTurnIndex);
+  const refreshed = await refreshAssistantSnapshot(
+    Runtime,
+    parsed,
+    logger,
+    minTurnIndex,
+    expectedConversationId,
+  );
   const candidate = refreshed ?? parsed;
   // The evaluation path can race ahead of completion. If ChatGPT is still streaming, wait for the watchdog poller.
   const elapsedMs = Date.now() - start;
@@ -160,7 +184,12 @@ export async function waitForAssistantResponse(
     ]);
     if (stopVisible) {
       logger("Assistant still generating; waiting for completion");
-      const completed = await pollAssistantCompletion(Runtime, remainingMs, minTurnIndex);
+      const completed = await pollAssistantCompletion(
+        Runtime,
+        remainingMs,
+        minTurnIndex,
+        expectedConversationId,
+      );
       if (completed) {
         return completed;
       }
@@ -175,9 +204,10 @@ export async function waitForAssistantResponse(
 export async function readAssistantSnapshot(
   Runtime: ChromeClient["Runtime"],
   minTurnIndex?: number,
+  expectedConversationId?: string,
 ): Promise<AssistantSnapshot | null> {
   const { result } = await Runtime.evaluate({
-    expression: buildAssistantSnapshotExpression(minTurnIndex),
+    expression: buildAssistantSnapshotExpression(minTurnIndex, expectedConversationId),
     returnByValue: true,
   });
   const value = result?.value;
@@ -225,6 +255,13 @@ export function buildAssistantExtractorForTest(name: string): string {
   return buildAssistantExtractor(name);
 }
 
+export function buildAssistantSnapshotExpressionForTest(
+  minTurnIndex?: number,
+  expectedConversationId?: string,
+): string {
+  return buildAssistantSnapshotExpression(minTurnIndex, expectedConversationId);
+}
+
 export function buildConversationDebugExpressionForTest(): string {
   return buildConversationDebugExpression();
 }
@@ -244,6 +281,7 @@ async function recoverAssistantResponse(
   timeoutMs: number,
   logger: BrowserLogger,
   minTurnIndex?: number,
+  expectedConversationId?: string,
 ): Promise<{
   text: string;
   html?: string;
@@ -255,7 +293,7 @@ async function recoverAssistantResponse(
   }
   const recovered = await waitForCondition(
     async () => {
-      const snapshot = await readAssistantSnapshot(Runtime, minTurnIndex);
+      const snapshot = await readAssistantSnapshot(Runtime, minTurnIndex, expectedConversationId);
       return normalizeAssistantSnapshot(snapshot);
     },
     recoveryTimeoutMs,
@@ -324,6 +362,7 @@ async function refreshAssistantSnapshot(
   },
   logger: BrowserLogger,
   minTurnIndex?: number,
+  expectedConversationId?: string,
 ): Promise<{
   text: string;
   html?: string;
@@ -339,7 +378,11 @@ async function refreshAssistantSnapshot(
   const stableTarget = 3;
   while (Date.now() < deadline) {
     // Learned: short/fast answers can race; poll a few extra cycles to pick up messageId + full text.
-    const latestSnapshot = await readAssistantSnapshot(Runtime, minTurnIndex).catch(() => null);
+    const latestSnapshot = await readAssistantSnapshot(
+      Runtime,
+      minTurnIndex,
+      expectedConversationId,
+    ).catch(() => null);
     const latest = normalizeAssistantSnapshot(latestSnapshot);
     if (latest) {
       if (
@@ -388,6 +431,7 @@ async function pollAssistantCompletion(
   Runtime: ChromeClient["Runtime"],
   timeoutMs: number,
   minTurnIndex?: number,
+  expectedConversationId?: string,
   abortSignal?: AbortSignal,
 ): Promise<{
   text: string;
@@ -403,7 +447,7 @@ async function pollAssistantCompletion(
     if (abortSignal?.aborted) {
       return null;
     }
-    const snapshot = await readAssistantSnapshot(Runtime, minTurnIndex);
+    const snapshot = await readAssistantSnapshot(Runtime, minTurnIndex, expectedConversationId);
     const normalized = normalizeAssistantSnapshot(snapshot);
     if (normalized) {
       const currentLength = normalized.text.length;
@@ -545,13 +589,30 @@ async function waitForCondition<T>(
   return null;
 }
 
-function buildAssistantSnapshotExpression(minTurnIndex?: number): string {
+function buildAssistantSnapshotExpression(
+  minTurnIndex?: number,
+  expectedConversationId?: string,
+): string {
   const minTurnLiteral =
     typeof minTurnIndex === "number" && Number.isFinite(minTurnIndex) && minTurnIndex >= 0
       ? Math.floor(minTurnIndex)
       : -1;
+  const expectedConversationLiteral =
+    typeof expectedConversationId === "string" && expectedConversationId.trim().length > 0
+      ? JSON.stringify(expectedConversationId.trim())
+      : "null";
   return `(() => {
     const MIN_TURN_INDEX = ${minTurnLiteral};
+    const EXPECTED_CONVERSATION_ID = ${expectedConversationLiteral};
+    const currentHref = typeof location === 'object' && location.href ? location.href : '';
+    const currentConversationId = currentHref.match(/\\/c\\/([a-zA-Z0-9-]+)/)?.[1] ?? null;
+    if (
+      EXPECTED_CONVERSATION_ID &&
+      currentConversationId &&
+      currentConversationId !== EXPECTED_CONVERSATION_ID
+    ) {
+      return null;
+    }
     // Learned: the default turn DOM misses project view; keep a fallback extractor.
     ${buildAssistantExtractor("extractAssistantTurn")}
     const extracted = extractAssistantTurn();
@@ -572,7 +633,11 @@ function buildAssistantSnapshotExpression(minTurnIndex?: number): string {
   })()`;
 }
 
-function buildResponseObserverExpression(timeoutMs: number, minTurnIndex?: number): string {
+function buildResponseObserverExpression(
+  timeoutMs: number,
+  minTurnIndex?: number,
+  expectedConversationId?: string,
+): string {
   const selectorsLiteral = JSON.stringify(ANSWER_SELECTORS);
   const conversationLiteral = JSON.stringify(CONVERSATION_TURN_SELECTOR);
   const assistantLiteral = JSON.stringify(ASSISTANT_ROLE_SELECTOR);
@@ -580,6 +645,10 @@ function buildResponseObserverExpression(timeoutMs: number, minTurnIndex?: numbe
     typeof minTurnIndex === "number" && Number.isFinite(minTurnIndex) && minTurnIndex >= 0
       ? Math.floor(minTurnIndex)
       : -1;
+  const expectedConversationLiteral =
+    typeof expectedConversationId === "string" && expectedConversationId.trim().length > 0
+      ? JSON.stringify(expectedConversationId.trim())
+      : "null";
   return `(() => {
     ${buildClickDispatcher()}
     const SELECTORS = ${selectorsLiteral};
@@ -587,8 +656,18 @@ function buildResponseObserverExpression(timeoutMs: number, minTurnIndex?: numbe
     const FINISHED_SELECTOR = '${FINISHED_ACTIONS_SELECTOR}';
     const CONVERSATION_SELECTOR = ${conversationLiteral};
     const ASSISTANT_SELECTOR = ${assistantLiteral};
+    const EXPECTED_CONVERSATION_ID = ${expectedConversationLiteral};
     // Learned: settling avoids capturing mid-stream HTML; keep short.
     const settleDelayMs = 800;
+    const currentConversationId = () => {
+      const href = typeof location === 'object' && location.href ? location.href : '';
+      return href.match(/\\/c\\/([a-zA-Z0-9-]+)/)?.[1] ?? null;
+    };
+    const matchesExpectedConversation = () => {
+      if (!EXPECTED_CONVERSATION_ID) return true;
+      const currentId = currentConversationId();
+      return !currentId || currentId === EXPECTED_CONVERSATION_ID;
+    };
     const isAnswerNowPlaceholder = (snapshot) => {
       const normalized = String(snapshot?.text ?? '').toLowerCase().trim();
       if (normalized === 'chatgpt said:' || normalized === 'chatgpt said') return true;
@@ -617,6 +696,7 @@ function buildResponseObserverExpression(timeoutMs: number, minTurnIndex?: numbe
 
     const acceptSnapshot = (snapshot) => {
       if (!snapshot) return null;
+      if (!matchesExpectedConversation()) return null;
       const index = typeof snapshot.turnIndex === 'number' ? snapshot.turnIndex : -1;
       if (MIN_TURN_INDEX >= 0) {
         if (index < 0 || index < MIN_TURN_INDEX) {

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -704,6 +704,8 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
     // Helper to normalize text for echo detection (collapse whitespace, lowercase)
     const normalizeForComparison = (text: string): string =>
       text.toLowerCase().replace(/\s+/g, " ").trim();
+    const expectedConversationId = () =>
+      lastUrl ? extractConversationIdFromUrl(lastUrl) : undefined;
     const waitForFreshAssistantResponse = async (baselineNormalized: string, timeoutMs: number) => {
       const baselinePrefix =
         baselineNormalized.length >= 80
@@ -711,9 +713,11 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
           : "";
       const deadline = Date.now() + timeoutMs;
       while (Date.now() < deadline) {
-        const snapshot = await readAssistantSnapshot(Runtime, baselineTurns ?? undefined).catch(
-          () => null,
-        );
+        const snapshot = await readAssistantSnapshot(
+          Runtime,
+          baselineTurns ?? undefined,
+          expectedConversationId(),
+        ).catch(() => null);
         const text = typeof snapshot?.text === "string" ? snapshot.text.trim() : "";
         if (text) {
           const normalized = normalizeForComparison(text);
@@ -794,12 +798,14 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
           timeoutMs,
           logger,
           baselineTurns ?? undefined,
+          expectedConversationId(),
         ),
       );
       logger("Recovered assistant response after delayed recheck");
       return rechecked;
     };
     try {
+      await updateConversationHint("assistant-wait", 15_000).catch(() => false);
       answer = await raceWithDisconnect(
         waitForAssistantResponseWithReload(
           Runtime,
@@ -807,6 +813,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
           config.timeoutMs,
           logger,
           baselineTurns ?? undefined,
+          expectedConversationId(),
         ),
       );
     } catch (error) {
@@ -896,9 +903,11 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
     }));
 
     // Final sanity check: ensure we didn't accidentally capture the user prompt instead of the assistant turn.
-    const finalSnapshot = await readAssistantSnapshot(Runtime, baselineTurns ?? undefined).catch(
-      () => null,
-    );
+    const finalSnapshot = await readAssistantSnapshot(
+      Runtime,
+      baselineTurns ?? undefined,
+      expectedConversationId(),
+    ).catch(() => null);
     const finalText = typeof finalSnapshot?.text === "string" ? finalSnapshot.text.trim() : "";
     if (finalText && finalText !== promptText.trim()) {
       const trimmedMarkdown = answerMarkdown.trim();
@@ -936,9 +945,11 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
       let bestText: string | null = null;
       let stableCount = 0;
       while (Date.now() < deadline) {
-        const snapshot = await readAssistantSnapshot(Runtime, baselineTurns ?? undefined).catch(
-          () => null,
-        );
+        const snapshot = await readAssistantSnapshot(
+          Runtime,
+          baselineTurns ?? undefined,
+          expectedConversationId(),
+        ).catch(() => null);
         const text = typeof snapshot?.text === "string" ? snapshot.text.trim() : "";
         const isStillEcho = !text || Boolean(promptEchoMatcher?.isEcho(text));
         if (!isStillEcho) {
@@ -966,9 +977,11 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
       let bestText = answerText.trim();
       let stableCycles = 0;
       while (Date.now() < deadline) {
-        const snapshot = await readAssistantSnapshot(Runtime, baselineTurns ?? undefined).catch(
-          () => null,
-        );
+        const snapshot = await readAssistantSnapshot(
+          Runtime,
+          baselineTurns ?? undefined,
+          expectedConversationId(),
+        ).catch(() => null);
         const text = typeof snapshot?.text === "string" ? snapshot.text.trim() : "";
         if (text && text.length > bestText.length) {
           bestText = text;
@@ -1526,6 +1539,8 @@ async function runRemoteBrowserMode(
     // Helper to normalize text for echo detection (collapse whitespace, lowercase)
     const normalizeForComparison = (text: string): string =>
       text.toLowerCase().replace(/\s+/g, " ").trim();
+    const expectedConversationId = () =>
+      lastUrl ? extractConversationIdFromUrl(lastUrl) : undefined;
     const waitForFreshAssistantResponse = async (baselineNormalized: string, timeoutMs: number) => {
       const baselinePrefix =
         baselineNormalized.length >= 80
@@ -1533,9 +1548,11 @@ async function runRemoteBrowserMode(
           : "";
       const deadline = Date.now() + timeoutMs;
       while (Date.now() < deadline) {
-        const snapshot = await readAssistantSnapshot(Runtime, baselineTurns ?? undefined).catch(
-          () => null,
-        );
+        const snapshot = await readAssistantSnapshot(
+          Runtime,
+          baselineTurns ?? undefined,
+          expectedConversationId(),
+        ).catch(() => null);
         const text = typeof snapshot?.text === "string" ? snapshot.text.trim() : "";
         if (text) {
           const normalized = normalizeForComparison(text);
@@ -1613,17 +1630,24 @@ async function runRemoteBrowserMode(
         timeoutMs,
         logger,
         baselineTurns ?? undefined,
+        expectedConversationId(),
       );
       logger("Recovered assistant response after delayed recheck");
       return rechecked;
     };
     try {
+      const conversationUrl = await readConversationUrl(Runtime).catch(() => null);
+      if (conversationUrl && isConversationUrl(conversationUrl)) {
+        lastUrl = conversationUrl;
+        await emitRuntimeHint();
+      }
       answer = await waitForAssistantResponseWithReload(
         Runtime,
         Page,
         config.timeoutMs,
         logger,
         baselineTurns ?? undefined,
+        expectedConversationId(),
       );
     } catch (error) {
       if (isAssistantResponseTimeoutError(error)) {
@@ -1713,9 +1737,11 @@ async function runRemoteBrowserMode(
     }));
 
     // Final sanity check: ensure we didn't accidentally capture the user prompt instead of the assistant turn.
-    const finalSnapshot = await readAssistantSnapshot(Runtime, baselineTurns ?? undefined).catch(
-      () => null,
-    );
+    const finalSnapshot = await readAssistantSnapshot(
+      Runtime,
+      baselineTurns ?? undefined,
+      expectedConversationId(),
+    ).catch(() => null);
     const finalText = typeof finalSnapshot?.text === "string" ? finalSnapshot.text.trim() : "";
     if (
       finalText &&
@@ -1749,9 +1775,11 @@ async function runRemoteBrowserMode(
       let bestText: string | null = null;
       let stableCount = 0;
       while (Date.now() < deadline) {
-        const snapshot = await readAssistantSnapshot(Runtime, baselineTurns ?? undefined).catch(
-          () => null,
-        );
+        const snapshot = await readAssistantSnapshot(
+          Runtime,
+          baselineTurns ?? undefined,
+          expectedConversationId(),
+        ).catch(() => null);
         const text = typeof snapshot?.text === "string" ? snapshot.text.trim() : "";
         const isStillEcho = !text || Boolean(promptEchoMatcher?.isEcho(text));
         if (!isStillEcho) {
@@ -1890,9 +1918,16 @@ async function waitForAssistantResponseWithReload(
   timeoutMs: number,
   logger: BrowserLogger,
   minTurnIndex?: number,
+  expectedConversationId?: string,
 ) {
   try {
-    return await waitForAssistantResponse(Runtime, timeoutMs, logger, minTurnIndex);
+    return await waitForAssistantResponse(
+      Runtime,
+      timeoutMs,
+      logger,
+      minTurnIndex,
+      expectedConversationId,
+    );
   } catch (error) {
     if (!shouldReloadAfterAssistantError(error)) {
       throw error;
@@ -1904,7 +1939,13 @@ async function waitForAssistantResponseWithReload(
     logger("Assistant response stalled; reloading conversation and retrying once");
     await Page.navigate({ url: conversationUrl });
     await delay(1000);
-    return await waitForAssistantResponse(Runtime, timeoutMs, logger, minTurnIndex);
+    return await waitForAssistantResponse(
+      Runtime,
+      timeoutMs,
+      logger,
+      minTurnIndex,
+      expectedConversationId,
+    );
   }
 }
 

--- a/src/browser/pageActions.ts
+++ b/src/browser/pageActions.ts
@@ -19,6 +19,7 @@ export {
   readAssistantSnapshot,
   captureAssistantMarkdown,
   buildAssistantExtractorForTest,
+  buildAssistantSnapshotExpressionForTest,
   buildConversationDebugExpressionForTest,
   buildMarkdownFallbackExtractorForTest,
   buildCopyExpressionForTest,

--- a/tests/browser/pageActionsExpressions.test.ts
+++ b/tests/browser/pageActionsExpressions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
   buildAssistantExtractorForTest,
+  buildAssistantSnapshotExpressionForTest,
   buildConversationDebugExpressionForTest,
   buildMarkdownFallbackExtractorForTest,
   buildCopyExpressionForTest,
@@ -20,6 +21,13 @@ describe("browser automation expressions", () => {
   test("conversation debug expression references conversation selector", () => {
     const expression = buildConversationDebugExpressionForTest();
     expect(expression).toContain(JSON.stringify(CONVERSATION_TURN_SELECTOR));
+  });
+
+  test("assistant snapshot expression guards against conversation drift", () => {
+    const expression = buildAssistantSnapshotExpressionForTest(4, "conv-123");
+    expect(expression).toContain('const EXPECTED_CONVERSATION_ID = "conv-123"');
+    expect(expression).toContain("currentConversationId !== EXPECTED_CONVERSATION_ID");
+    expect(expression).toContain("return null;");
   });
 
   test("markdown fallback filters user turns and respects assistant indicators", () => {


### PR DESCRIPTION
## Summary
- pass the expected ChatGPT conversation id into assistant response capture
- make observer, snapshot, recovery, refresh, and completion polling ignore mismatched /c/ conversations
- carry the same guard through final snapshot refreshes and stale/echo recovery paths

Extracts the stale-conversation response-capture fix from contributor PR #117. Thanks @frankekn.

## Verification
- pnpm vitest run tests/browser/pageActionsExpressions.test.ts tests/browser/pageActions.test.ts
- pnpm run check
- pnpm test
- pnpm run build