### PR TITLE
fix: guard browser attachment verification by turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - CLI: accept `-p -` / `--prompt -` to read the prompt from stdin. (#117) — thanks @frankekn.
 - Browser: preserve prompt-too-large fallback recovery after a dead-composer retry. (#117) — thanks @frankekn.
 - Browser: guard assistant response capture against stale turns from a different ChatGPT conversation. (#117) — thanks @frankekn.
+- Browser: verify sent attachments against the expected user turn instead of stale earlier turns. (#117) — thanks @frankekn.
 
 ## 0.9.0 — 2026-03-08
 

--- a/src/browser/actions/attachments.ts
+++ b/src/browser/actions/attachments.ts
@@ -1688,25 +1688,138 @@ export async function waitForUserTurnAttachments(
   expectedNames: string[],
   timeoutMs: number,
   logger?: BrowserLogger,
+  options?: {
+    minTurnIndex?: number;
+    expectedPrompt?: string;
+    expectedConversationId?: string;
+  },
 ): Promise<boolean> {
   if (!expectedNames || expectedNames.length === 0) {
     return true;
   }
 
   const expectedNormalized = expectedNames.map((name) => name.toLowerCase());
+  const minTurnIndex =
+    typeof options?.minTurnIndex === "number" && Number.isFinite(options.minTurnIndex)
+      ? Math.max(0, Math.floor(options.minTurnIndex))
+      : null;
+  const expectedPromptPrefix = options?.expectedPrompt
+    ? options.expectedPrompt.toLowerCase().replace(/\s+/g, " ").trim().slice(0, 80)
+    : "";
+  const expectedConversationId =
+    typeof options?.expectedConversationId === "string" &&
+    options.expectedConversationId.trim().length > 0
+      ? options.expectedConversationId.trim()
+      : null;
+  const expression = buildUserTurnAttachmentExpression({
+    minTurnIndex,
+    expectedPromptPrefix,
+    expectedConversationId,
+  });
+
+  const deadline = Date.now() + timeoutMs;
+  let sawAttachmentUi = false;
+  while (Date.now() < deadline) {
+    const { result } = await Runtime.evaluate({ expression, returnByValue: true });
+    const value = result?.value as
+      | {
+          ok?: boolean;
+          text?: string;
+          attrs?: string[];
+          fileCount?: number;
+          hasAttachmentUi?: boolean;
+          attachmentUiCount?: number;
+          promptMatches?: boolean;
+          turnIndex?: number;
+          conversationMismatch?: boolean;
+        }
+      | undefined;
+    if (!value?.ok) {
+      if (value?.conversationMismatch && logger?.verbose) {
+        logger("User-turn attachment verification ignored mismatched conversation.");
+      }
+      await delay(200);
+      continue;
+    }
+    if (value.hasAttachmentUi) {
+      sawAttachmentUi = true;
+    }
+    const haystack = [value.text ?? "", ...(value.attrs ?? [])].join("\n");
+    const fileCount = typeof value.fileCount === "number" ? value.fileCount : 0;
+    const attachmentUiCount =
+      typeof value.attachmentUiCount === "number" ? value.attachmentUiCount : 0;
+    const promptMatches = expectedPromptPrefix ? value.promptMatches !== false : true;
+    const fileCountSatisfied =
+      fileCount >= expectedNormalized.length && expectedNormalized.length > 0;
+    const attachmentUiSatisfied =
+      attachmentUiCount >= expectedNormalized.length && expectedNormalized.length > 0;
+    const missing = expectedNormalized.filter((expected) => {
+      const baseName = expected.split("/").pop()?.split("\\").pop() ?? expected;
+      const normalizedExpected = baseName.toLowerCase().replace(/\s+/g, " ").trim();
+      const expectedNoExt = normalizedExpected.replace(/\.[a-z0-9]{1,10}$/i, "");
+      if (haystack.includes(normalizedExpected)) return false;
+      if (expectedNoExt.length >= 6 && haystack.includes(expectedNoExt)) return false;
+      return true;
+    });
+    if (promptMatches && (missing.length === 0 || fileCountSatisfied || attachmentUiSatisfied)) {
+      return true;
+    }
+    await delay(250);
+  }
+
+  if (!sawAttachmentUi) {
+    logger?.("Sent user message did not expose attachment UI; skipping attachment verification.");
+    return false;
+  }
+
+  logger?.("Sent user message did not show expected attachment names in time.");
+  await logDomFailure(Runtime, logger ?? (() => {}), "attachment-missing-user-turn");
+  throw new Error("Attachment was not present on the sent user message.");
+}
+
+function buildUserTurnAttachmentExpression(options: {
+  minTurnIndex: number | null;
+  expectedPromptPrefix: string;
+  expectedConversationId: string | null;
+}): string {
   const conversationSelectorLiteral = JSON.stringify(CONVERSATION_TURN_SELECTOR);
-  const expression = `(() => {
+  const minTurnLiteral = options.minTurnIndex === null ? "null" : String(options.minTurnIndex);
+  const expectedPromptLiteral = JSON.stringify(options.expectedPromptPrefix);
+  const expectedConversationLiteral = options.expectedConversationId
+    ? JSON.stringify(options.expectedConversationId)
+    : "null";
+  return `(() => {
     const CONVERSATION_SELECTOR = ${conversationSelectorLiteral};
+    const MIN_TURN_INDEX = ${minTurnLiteral};
+    const EXPECTED_PROMPT_PREFIX = ${expectedPromptLiteral};
+    const EXPECTED_CONVERSATION_ID = ${expectedConversationLiteral};
+    const currentHref = typeof location === 'object' && location.href ? location.href : '';
+    const currentConversationId = currentHref.match(/\\/c\\/([a-zA-Z0-9-]+)/)?.[1] ?? null;
+    if (
+      EXPECTED_CONVERSATION_ID &&
+      currentConversationId &&
+      currentConversationId !== EXPECTED_CONVERSATION_ID
+    ) {
+      return { ok: false, conversationMismatch: true };
+    }
     const turns = Array.from(document.querySelectorAll(CONVERSATION_SELECTOR));
-    const userTurns = turns.filter((node) => {
+    const userTurns = turns.map((node, index) => ({ node, index })).filter(({ node }) => {
       const attr = (node.getAttribute('data-message-author-role') || node.getAttribute('data-turn') || node.dataset?.turn || '').toLowerCase();
       if (attr === 'user') return true;
       return Boolean(node.querySelector('[data-message-author-role="user"]'));
     });
-    const lastUser = userTurns[userTurns.length - 1];
+    const eligibleTurns =
+      MIN_TURN_INDEX === null ? userTurns : userTurns.filter(({ index }) => index >= MIN_TURN_INDEX);
+    const lastUser = eligibleTurns[eligibleTurns.length - 1];
     if (!lastUser) return { ok: false };
-    const text = (lastUser.innerText || '').toLowerCase();
-    const attrs = Array.from(lastUser.querySelectorAll('[aria-label],[title]')).map((el) => {
+    const text = (lastUser.node.innerText || '').toLowerCase().replace(/\\s+/g, ' ').trim();
+    const textPrefix = text.slice(0, Math.min(text.length, EXPECTED_PROMPT_PREFIX.length));
+    const promptMatches =
+      !EXPECTED_PROMPT_PREFIX ||
+      (text.length > 0 &&
+        (text.includes(EXPECTED_PROMPT_PREFIX) ||
+          (textPrefix.length > 0 && EXPECTED_PROMPT_PREFIX.includes(textPrefix))));
+    const attrs = Array.from(lastUser.node.querySelectorAll('[aria-label],[title]')).map((el) => {
       const aria = el.getAttribute('aria-label') || '';
       const title = el.getAttribute('title') || '';
       return (aria + ' ' + title).trim().toLowerCase();
@@ -1720,11 +1833,11 @@ export async function waitForUserTurnAttachments(
       '[title*="file"]',
       '[title*="attachment"]',
     ];
-    const attachmentUiCount = lastUser.querySelectorAll(attachmentSelectors.join(',')).length;
+    const attachmentUiCount = lastUser.node.querySelectorAll(attachmentSelectors.join(',')).length;
     const hasAttachmentUi =
       attachmentUiCount > 0 || attrs.some((attr) => attr.includes('file') || attr.includes('attachment'));
     const countRegex = /(?:^|\\b)(\\d+)\\s+(?:files?|attachments?)\\b/;
-    const fileCountNodes = Array.from(lastUser.querySelectorAll('button,span,div,[aria-label],[title]'));
+    const fileCountNodes = Array.from(lastUser.node.querySelectorAll('button,span,div,[aria-label],[title]'));
     let fileCount = 0;
     for (const node of fileCountNodes) {
       if (!(node instanceof HTMLElement)) continue;
@@ -1757,60 +1870,36 @@ export async function waitForUserTurnAttachments(
         }
       }
     }
-    return { ok: true, text, attrs, fileCount, hasAttachmentUi, attachmentUiCount };
+    return {
+      ok: true,
+      text,
+      attrs,
+      fileCount,
+      hasAttachmentUi,
+      attachmentUiCount,
+      promptMatches,
+      turnIndex: lastUser.index,
+    };
   })()`;
+}
 
-  const deadline = Date.now() + timeoutMs;
-  let sawAttachmentUi = false;
-  while (Date.now() < deadline) {
-    const { result } = await Runtime.evaluate({ expression, returnByValue: true });
-    const value = result?.value as
-      | {
-          ok?: boolean;
-          text?: string;
-          attrs?: string[];
-          fileCount?: number;
-          hasAttachmentUi?: boolean;
-          attachmentUiCount?: number;
-        }
-      | undefined;
-    if (!value?.ok) {
-      await delay(200);
-      continue;
-    }
-    if (value.hasAttachmentUi) {
-      sawAttachmentUi = true;
-    }
-    const haystack = [value.text ?? "", ...(value.attrs ?? [])].join("\n");
-    const fileCount = typeof value.fileCount === "number" ? value.fileCount : 0;
-    const attachmentUiCount =
-      typeof value.attachmentUiCount === "number" ? value.attachmentUiCount : 0;
-    const fileCountSatisfied =
-      fileCount >= expectedNormalized.length && expectedNormalized.length > 0;
-    const attachmentUiSatisfied =
-      attachmentUiCount >= expectedNormalized.length && expectedNormalized.length > 0;
-    const missing = expectedNormalized.filter((expected) => {
-      const baseName = expected.split("/").pop()?.split("\\").pop() ?? expected;
-      const normalizedExpected = baseName.toLowerCase().replace(/\s+/g, " ").trim();
-      const expectedNoExt = normalizedExpected.replace(/\.[a-z0-9]{1,10}$/i, "");
-      if (haystack.includes(normalizedExpected)) return false;
-      if (expectedNoExt.length >= 6 && haystack.includes(expectedNoExt)) return false;
-      return true;
-    });
-    if (missing.length === 0 || fileCountSatisfied || attachmentUiSatisfied) {
-      return true;
-    }
-    await delay(250);
-  }
-
-  if (!sawAttachmentUi) {
-    logger?.("Sent user message did not expose attachment UI; skipping attachment verification.");
-    return false;
-  }
-
-  logger?.("Sent user message did not show expected attachment names in time.");
-  await logDomFailure(Runtime, logger ?? (() => {}), "attachment-missing-user-turn");
-  throw new Error("Attachment was not present on the sent user message.");
+export function buildUserTurnAttachmentExpressionForTest(options?: {
+  minTurnIndex?: number | null;
+  expectedPromptPrefix?: string;
+  expectedConversationId?: string | null;
+}): string {
+  return buildUserTurnAttachmentExpression({
+    minTurnIndex:
+      typeof options?.minTurnIndex === "number" && Number.isFinite(options.minTurnIndex)
+        ? Math.max(0, Math.floor(options.minTurnIndex))
+        : null,
+    expectedPromptPrefix: options?.expectedPromptPrefix ?? "",
+    expectedConversationId:
+      typeof options?.expectedConversationId === "string" &&
+      options.expectedConversationId.trim().length > 0
+        ? options.expectedConversationId.trim()
+        : null,
+  });
 }
 
 export async function waitForAttachmentVisible(

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -661,6 +661,11 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
             attachmentNames,
             20_000,
             logger,
+            {
+              minTurnIndex: baselineTurns ?? undefined,
+              expectedPrompt: prompt,
+              expectedConversationId: lastUrl ? extractConversationIdFromUrl(lastUrl) : undefined,
+            },
           );
           if (!verified) {
             throw new Error("Sent user message did not expose attachment UI after upload.");

--- a/src/browser/pageActions.ts
+++ b/src/browser/pageActions.ts
@@ -13,6 +13,7 @@ export {
   uploadAttachmentFile,
   waitForAttachmentCompletion,
   waitForUserTurnAttachments,
+  buildUserTurnAttachmentExpressionForTest,
 } from "./actions/attachments.js";
 export {
   waitForAssistantResponse,

--- a/tests/browser/attachmentsCompletion.test.ts
+++ b/tests/browser/attachmentsCompletion.test.ts
@@ -222,4 +222,91 @@ describe("sent turn attachment verification", () => {
       ),
     ).resolves.toBe(true);
   });
+
+  test("waitForUserTurnAttachments ignores turns before the expected baseline", async () => {
+    useFakeTime();
+
+    const runtime = {
+      evaluate: vi.fn().mockResolvedValue({
+        result: {
+          value: {
+            ok: false,
+          },
+        },
+      }),
+    } as unknown as ChromeClient["Runtime"];
+
+    const promise = waitForUserTurnAttachments(
+      runtime,
+      ["oracle-attach-verify.txt"],
+      600,
+      undefined,
+      {
+        minTurnIndex: 4,
+      },
+    );
+    await vi.advanceTimersByTimeAsync(2_000);
+    await expect(promise).resolves.toBe(false);
+    useRealTime();
+  });
+
+  test("waitForUserTurnAttachments requires prompt evidence when provided", async () => {
+    useFakeTime();
+
+    const runtime = {
+      evaluate: vi.fn().mockResolvedValue({
+        result: {
+          value: {
+            ok: true,
+            text: "You said: unrelated prompt oracle-attach-verify.txt",
+            attrs: [],
+            hasAttachmentUi: true,
+            promptMatches: false,
+          },
+        },
+      }),
+    } as unknown as ChromeClient["Runtime"];
+
+    const promise = waitForUserTurnAttachments(
+      runtime,
+      ["oracle-attach-verify.txt"],
+      600,
+      undefined,
+      {
+        expectedPrompt: "expected prompt text",
+      },
+    );
+    const assertion = expect(promise).rejects.toThrow(/Attachment was not present/i);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await assertion;
+    useRealTime();
+  });
+
+  test("waitForUserTurnAttachments ignores mismatched conversations", async () => {
+    useFakeTime();
+
+    const runtime = {
+      evaluate: vi.fn().mockResolvedValue({
+        result: {
+          value: {
+            ok: false,
+            conversationMismatch: true,
+          },
+        },
+      }),
+    } as unknown as ChromeClient["Runtime"];
+
+    const promise = waitForUserTurnAttachments(
+      runtime,
+      ["oracle-attach-verify.txt"],
+      600,
+      undefined,
+      {
+        expectedConversationId: "conv-123",
+      },
+    );
+    await vi.advanceTimersByTimeAsync(2_000);
+    await expect(promise).resolves.toBe(false);
+    useRealTime();
+  });
 });

--- a/tests/browser/pageActionsExpressions.test.ts
+++ b/tests/browser/pageActionsExpressions.test.ts
@@ -5,6 +5,7 @@ import {
   buildConversationDebugExpressionForTest,
   buildMarkdownFallbackExtractorForTest,
   buildCopyExpressionForTest,
+  buildUserTurnAttachmentExpressionForTest,
 } from "../../src/browser/pageActions.ts";
 import {
   CONVERSATION_TURN_SELECTOR,
@@ -52,5 +53,14 @@ describe("browser automation expressions", () => {
     expect(expression).toContain(ASSISTANT_ROLE_SELECTOR);
     expect(expression).toContain("isAssistantTurn");
     expect(expression).toContain("copy-turn-action-button");
+  });
+
+  test("user-turn attachment expression requires non-empty prompt text for prefix fallback", () => {
+    const expression = buildUserTurnAttachmentExpressionForTest({
+      expectedPromptPrefix: "expected prompt text",
+    });
+    expect(expression).toContain("const textPrefix = text.slice");
+    expect(expression).toContain("text.length > 0");
+    expect(expression).toContain("textPrefix.length > 0");
   });
 });


### PR DESCRIPTION
## Summary
- verify sent attachment UI against the expected user turn instead of any previous matching turn
- allow attachment verification to constrain by baseline turn index, prompt prefix, and conversation id
- add regression coverage for stale-turn, prompt-mismatch, and conversation-mismatch cases

Extracts the sent-turn attachment verification fix from contributor PR #117. Thanks @frankekn.

## Verification
- pnpm vitest run tests/browser/attachmentsCompletion.test.ts tests/browser/pageActionsExpressions.test.ts
- pnpm run check
- pnpm test
- pnpm run build