### PR TITLE
fix(mcp): clarify API key fallback guidance

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -10,11 +10,11 @@ Claude Code can call `oracle-mcp` and ask a subscription-backed ChatGPT browser 
 
 ### `consult`
 
-- Inputs: `prompt` (required), `files?: string[]` (globs), `model?: string` (defaults to CLI), `engine?: "api" | "browser"` (CLI auto-defaults), `slug?: string`.
+- Inputs: `prompt` (required), `files?: string[]` (globs), `model?: string` (defaults to CLI), `engine?: "api" | "browser"` (optional; Oracle follows CLI defaults: config/`ORACLE_ENGINE` first, then API when `OPENAI_API_KEY` is set, otherwise browser), `slug?: string`.
 - Presets: `preset?: "chatgpt-pro-heavy"` applies browser mode + current Pro model alias + heavy thinking, unless the request overrides those fields.
 - Browser-only extras: `browserAttachments?: "auto"|"never"|"always"`, `browserBundleFiles?: boolean`, `browserThinkingTime?: "light"|"standard"|"extended"|"heavy"`, `browserKeepBrowser?: boolean`, `browserModelLabel?: string`, `browserModelStrategy?: "select"|"current"|"ignore"`.
 - Dry runs: set `dryRun: true` to preview the resolved request without creating a session or touching the browser.
-- Behavior: starts a session, runs it with the chosen engine, returns final output + metadata. Background/foreground follows the CLI (e.g., GPT‑5 Pro detaches by default).
+- Behavior: starts a session, runs it with the chosen engine, returns final output + metadata. Background/foreground follows the CLI (e.g., GPT‑5 Pro detaches by default). If API mode fails because `OPENAI_API_KEY` is missing and you have ChatGPT Pro, retry with `engine: "browser"` or `preset: "chatgpt-pro-heavy"` to use your signed-in ChatGPT session instead of an API key.
 - Logging: emits MCP logs (`info` per line, `debug` for streamed chunks with byte sizes). If browser prerequisites are missing, returns an error payload instead of running.
 
 ### `sessions`

--- a/src/mcp/tools/consult.ts
+++ b/src/mcp/tools/consult.ts
@@ -49,7 +49,7 @@ const consultInputShape = {
     .string()
     .optional()
     .describe(
-      "Single model name/label. Prefer setting `engine` explicitly to avoid default surprises.",
+      "Single model name/label. If `engine` is omitted, Oracle follows CLI defaults: config/ORACLE_ENGINE first, then `api` when OPENAI_API_KEY is set, otherwise `browser`. Prefer setting `engine` explicitly to avoid default surprises.",
     ),
   models: z
     .array(z.string())
@@ -59,7 +59,7 @@ const consultInputShape = {
     .enum(["api", "browser"])
     .optional()
     .describe(
-      "Execution engine. `api` uses OpenAI/other providers. `browser` automates the ChatGPT web UI (supports attachments and ChatGPT-only model labels).",
+      "Execution engine. `api` uses OpenAI/other providers. `browser` automates the ChatGPT web UI (supports attachments and ChatGPT-only model labels). When omitted, Oracle follows CLI defaults: config/ORACLE_ENGINE first, then `api` when OPENAI_API_KEY is set, otherwise `browser`.",
     ),
   browserModelLabel: z
     .string()
@@ -234,7 +234,7 @@ export function registerConsultTool(server: McpServer): void {
     {
       title: "Run an oracle session",
       description:
-        'Run a one-shot Oracle session (API or ChatGPT browser automation). Use `files` to attach project context. For browser-based image/file uploads, set `browserAttachments:"always"`. Sessions are stored under `ORACLE_HOME_DIR` (shared with the CLI).',
+        'Run a one-shot Oracle session (API or ChatGPT browser automation). Use `files` to attach project context. If `engine` is omitted, Oracle follows CLI defaults: config/ORACLE_ENGINE first, then API when OPENAI_API_KEY is set, otherwise browser. For browser-based image/file uploads, set `browserAttachments:"always"`. Sessions are stored under `ORACLE_HOME_DIR` (shared with the CLI).',
       // Cast to any to satisfy SDK typings across differing Zod versions.
       inputSchema: consultInputShape,
       outputSchema: consultOutputShape,

--- a/src/oracle/run.ts
+++ b/src/oracle/run.ts
@@ -178,8 +178,11 @@ export async function runOracle(
               : options.model.startsWith("grok")
                 ? "XAI_API_KEY"
                 : "OPENROUTER_API_KEY";
+    const browserModeHint = options.model.startsWith("gpt")
+      ? ' If you have a ChatGPT Pro subscription, retry with --engine browser (or MCP engine:"browser" / preset:"chatgpt-pro-heavy"); browser mode uses your signed-in ChatGPT session instead of an API key.'
+      : "";
     throw new PromptValidationError(
-      `Missing ${envVar}. Set it via the environment or a .env file.`,
+      `Missing ${envVar}. Set it via the environment or a .env file.${browserModeHint}`,
       {
         env: envVar,
       },

--- a/tests/cli/runOracle/runOracle.logging.test.ts
+++ b/tests/cli/runOracle/runOracle.logging.test.ts
@@ -195,7 +195,9 @@ describe("api key logging", () => {
             write: () => true,
           },
         ),
-      ).rejects.toThrow(/Missing OPENAI_API_KEY|Missing OPENROUTER_API_KEY|valid model ID/);
+      ).rejects.toThrow(
+        /Missing OPENAI_API_KEY.*retry with --engine browser.*preset:"chatgpt-pro-heavy"|Missing OPENROUTER_API_KEY|valid model ID/s,
+      );
     } finally {
       if (originalOpenai !== undefined) {
         process.env.OPENAI_API_KEY = originalOpenai;


### PR DESCRIPTION
## Summary
- document the actual MCP consult engine default path when `engine` is omitted
- add a ChatGPT browser-mode recovery hint to missing OpenAI API key errors for GPT models
- keep behavior unchanged: this does not add an `engine:auto` mode or silently switch engines

Fixes #171.

## Tests
- `pnpm vitest run tests/cli/runOracle/runOracle.logging.test.ts tests/mcp/consult.test.ts tests/mcp/utils.test.ts`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm test -- --no-file-parallelism --maxWorkers=1`

## Smoke
- Verified the missing-key session render now says to retry with `--engine browser` or MCP `engine:"browser"` / `preset:"chatgpt-pro-heavy"` for ChatGPT Pro subscription-backed browser mode.