### PR TITLE
feat(browser): manage ChatGPT Project Sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Browser: add `--browser-archive` / MCP `browserArchive` to archive successful one-shot ChatGPT browser runs after local artifacts are saved. (#178) — thanks @pdurlej.
 - Browser: print a browser control plan before ChatGPT runs and dry-runs, and clean up leftover blank tabs after completed manual-profile runs. (#179) — thanks @pdurlej.
 - Browser: document multi-turn consult guardrails and make browser dry-runs explicit that Oracle only sends caller-provided follow-up prompts. (#180) — thanks @pdurlej.
+- Browser/MCP: add non-destructive ChatGPT Project Sources management (`oracle project-sources list|add`, MCP `project_sources`) so Developer Mode workflows can share explicit project context through Sources. Addresses #131 and builds on #132 by @vgorlovi.
 - MCP: add the `chatgpt-pro-heavy` consult preset, MCP dry-runs, browser model strategy passthrough, and `oracle bridge claude-config --local-browser` for Claude Code + local ChatGPT Pro browser consults. (#149) — thanks @pdurlej.
 
 ### Docs

--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ npx -y @steipete/oracle --dry-run summary -p "Check release notes" --file docs/r
 # Browser run (no API key, will open ChatGPT)
 npx -y @steipete/oracle --engine browser -p "Walk through the UI smoke test" --file "src/**/*.ts"
 
+# Add explicit shared context to a ChatGPT Project without deleting anything
+npx -y @steipete/oracle project-sources add \
+  --chatgpt-url "https://chatgpt.com/g/g-p-example/project" \
+  --browser-manual-login \
+  --file docs/architecture.md \
+  --dry-run
+
 # Browser multi-turn consult in one ChatGPT conversation
 npx -y @steipete/oracle --engine browser --model gpt-5.5-pro \
   -p "Review this migration plan" --file docs/migration.md \
@@ -108,6 +115,7 @@ Engine auto-picks API when `OPENAI_API_KEY` is set, otherwise browser; browser i
 - Browser artifacts: browser sessions save `transcript.md` and generated artifacts under `~/.oracle/sessions/<id>/artifacts/`. Deep Research saves `deep-research-report.md` when the report surface is captured; ChatGPT-generated images are downloaded with the active browser cookies when image URLs are present.
 - Browser archiving: by default, successful non-project, non-Deep-Research, non-multi-turn ChatGPT one-shots are archived after local artifacts are saved. Use `--browser-archive never` to disable or `--browser-archive always` to force archiving after a successful browser run. Archived chats remain manageable in ChatGPT.
 - Conversation mode guidance: use one-shot browser runs for narrow bug reports or quick file-set reviews; use explicit browser follow-ups for ambiguous architecture/product tradeoffs where a challenge pass and final decision are valuable; use Deep Research for broad public-web questions that need citations. Oracle never invents follow-ups automatically.
+- Project Sources: `oracle project-sources list|add --chatgpt-url <project-url>` manages the Project Sources tab in ChatGPT browser mode. v1 is append-only (`list`, `add`, `--dry-run`) so agents can share explicit project context without deleting or replacing user sources.
 - AGENTS.md/CLAUDE.md:
   ```
   - Oracle bundles a prompt plus the right files so another AI (GPT 5 Pro + more) can answer. Use when stuck/bugs/reviewing.

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -780,6 +780,75 @@ program
     });
   });
 
+const projectSourcesCommand = program
+  .command("project-sources")
+  .description("Manage ChatGPT Project Sources as explicit shared project context.");
+
+function addProjectSourcesCommonOptions(command: Command): Command {
+  return command
+    .option(
+      "--chatgpt-url <url>",
+      "ChatGPT project URL ending in /project (or browser.chatgptUrl config).",
+    )
+    .addOption(
+      new Option("--browser-manual-login", "Reuse a persistent signed-in Chrome profile.").default(
+        undefined,
+      ),
+    )
+    .option("--browser-manual-login-profile-dir <path>", "Persistent Chrome profile directory.")
+    .option("--browser-timeout <duration>", "Overall browser timeout (e.g. 10m, 1h).")
+    .option("--browser-input-timeout <duration>", "Timeout waiting for the Project Sources UI.")
+    .option("--browser-profile-lock-timeout <duration>", "Timeout waiting for profile launch lock.")
+    .option("--browser-reuse-wait <duration>", "Wait for an existing shared Chrome to appear.")
+    .option("--browser-max-concurrent-tabs <n>", "Concurrent tabs allowed for the shared profile.")
+    .option("--browser-cookie-wait <duration>", "Wait before retrying cookie sync.")
+    .option("--browser-chrome-profile <profile>", "Chrome profile name for cookie sync.")
+    .option("--browser-chrome-path <path>", "Chrome/Chromium executable path.")
+    .option("--browser-cookie-path <path>", "Explicit Chrome cookie DB path.")
+    .option("--browser-inline-cookies <json>", "Inline ChatGPT cookies JSON.")
+    .option("--browser-inline-cookies-file <path>", "File containing ChatGPT cookies JSON.")
+    .option("--browser-no-cookie-sync", "Skip copying cookies from Chrome.")
+    .option("--browser-keep-browser", "Keep Chrome running after completion.", false)
+    .option("--browser-hide-window", "Hide Chrome window after launch on macOS.", false)
+    .option("--browser-allow-cookie-errors", "Continue when cookie sync fails.", false)
+    .option(
+      "--max-file-size-bytes <bytes>",
+      "Reject uploads larger than this many bytes.",
+      parseIntOption,
+    )
+    .option("--json", "Print structured JSON.", false)
+    .option("-v, --verbose", "Enable verbose browser logging.", false);
+}
+
+addProjectSourcesCommonOptions(
+  projectSourcesCommand
+    .command("list")
+    .description("List sources already attached to a ChatGPT Project."),
+).action(async function (this: Command) {
+  const { runProjectSourcesCliCommand } = await import("../src/cli/projectSources.js");
+  await runProjectSourcesCliCommand("list", this.optsWithGlobals());
+});
+
+addProjectSourcesCommonOptions(
+  projectSourcesCommand
+    .command("add")
+    .description("Upload files into a ChatGPT Project's persistent Sources tab.")
+    .option(
+      "-f, --file <paths...>",
+      "Files/directories or globs to add as project sources.",
+      collectPaths,
+      [],
+    )
+    .option(
+      "--dry-run",
+      "Validate files and show the upload plan without touching the browser.",
+      false,
+    ),
+).action(async function (this: Command) {
+  const { runProjectSourcesCliCommand } = await import("../src/cli/projectSources.js");
+  await runProjectSourcesCliCommand("add", this.optsWithGlobals());
+});
+
 const bridgeCommand = program
   .command("bridge")
   .description("Bridge a Windows-hosted ChatGPT session to Linux clients.");

--- a/docs/browser-mode.md
+++ b/docs/browser-mode.md
@@ -171,6 +171,34 @@ Browser mode keeps the local session as the source of truth, so Oracle can optio
 
 Oracle does not auto-archive failed, incomplete, running, project, Deep Research, or multi-turn sessions. Use `--browser-archive never` to disable archiving, or `--browser-archive always` when you explicitly want a successful browser conversation archived even outside the default one-shot policy. Archived chats are still visible and manageable from ChatGPT's own archive UI.
 
+### ChatGPT Project Sources
+
+ChatGPT Project Sources can act as explicit shared context for project workflows where chats should not implicitly share memory. This is especially useful with Developer Mode / Memory Off: separate chats do not see each other's conversation history, but they can read files attached to the Project Sources tab.
+
+Oracle exposes a narrow, non-destructive v1:
+
+```bash
+# Preview the upload plan without touching ChatGPT
+oracle project-sources add \
+  --chatgpt-url "https://chatgpt.com/g/g-p-example/project" \
+  --browser-manual-login \
+  --file docs/architecture.md \
+  --dry-run
+
+# List current sources
+oracle project-sources list \
+  --chatgpt-url "https://chatgpt.com/g/g-p-example/project" \
+  --browser-manual-login
+
+# Append files to the Sources tab
+oracle project-sources add \
+  --chatgpt-url "https://chatgpt.com/g/g-p-example/project" \
+  --browser-manual-login \
+  --file docs/architecture.md docs/decisions.md
+```
+
+This command uses browser automation but does not select a model, start a consult, or send a prompt. It only opens the Project Sources surface, lists existing files, or appends new files. Destructive operations such as delete, replace, and sync are intentionally left out until the UI path is safer and better covered by live tests.
+
 ### Multi-turn browser consults
 
 Use browser follow-ups when a one-shot review would be too easy for the model to answer shallowly. Oracle keeps the same ChatGPT conversation open, waits for each answer, then submits the next follow-up:

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -29,6 +29,13 @@ Browser-backed GPT-5.5 Pro consults can legitimately run for many minutes. Some 
 - Inputs: `{id?, hours?, limit?, includeAll?, detail?}` mirroring `oracle status` / `oracle session`.
 - Behavior: without `id`, returns a bounded list of recent sessions. With `id`/slug, returns a summary row; set `detail: true` to fetch full metadata, log, and stored request body.
 
+### `project_sources`
+
+- Inputs: `operation: "list"|"add"`, `chatgptUrl?: string`, `files?: string[]`, `dryRun?: boolean`, `confirmMutation?: boolean`, `browserKeepBrowser?: boolean`.
+- Behavior: manages the ChatGPT Project Sources tab through local browser automation. v1 is intentionally append-only: it can list existing sources and add files, but it cannot delete, replace, or sync.
+- Safety: `add` requires `confirmMutation: true` unless `dryRun: true`. This keeps agent callers from mutating a persistent ChatGPT Project by accident.
+- Workflow: use this when Claude Code, Codex, or another MCP host needs a durable shared context file in a ChatGPT Project. Use `consult` when you want an actual model answer.
+
 ## Resources
 
 - `oracle-session://{id}/{metadata|log|request}` — read-only resources that surface stored session artifacts via MCP resource reads.

--- a/src/browser/actions/projectSources.ts
+++ b/src/browser/actions/projectSources.ts
@@ -1,0 +1,585 @@
+import path from "node:path";
+import type { BrowserAttachment, BrowserLogger, ChromeClient } from "../types.js";
+import type { ProjectSourceEntry } from "../../projectSources/types.js";
+import {
+  PROJECT_SOURCES_MAX_UPLOAD_BATCH,
+  buildProjectSourcesUploadPlan,
+} from "../../projectSources/plan.js";
+import { delay } from "../utils.js";
+
+const PROJECT_SOURCES_INPUT_MARKER = "data-oracle-project-sources-input";
+
+type Runtime = ChromeClient["Runtime"];
+type Dom = ChromeClient["DOM"];
+type Input = ChromeClient["Input"];
+
+export async function waitForProjectSourcesReady(
+  runtime: Runtime,
+  timeoutMs: number,
+  logger: BrowserLogger,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastStatus = "unknown";
+  while (Date.now() < deadline) {
+    const status = await readProjectSourcesSurfaceStatus(runtime).catch((error) => ({
+      ready: false,
+      reason: error instanceof Error ? error.message : String(error),
+    }));
+    lastStatus = status.reason ?? "unknown";
+    if (status.ready) {
+      return;
+    }
+    await delay(250);
+  }
+  logger(`Project Sources tab did not become ready before timeout (${lastStatus})`);
+  throw new Error("Project Sources tab did not become ready before timeout.");
+}
+
+export async function openProjectSourcesTab(
+  runtime: Runtime,
+  input: Input | undefined,
+  timeoutMs: number,
+  logger: BrowserLogger,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastReason = "sources tab not found";
+  while (Date.now() < deadline) {
+    const locate = await runtime.evaluate({
+      expression: buildOpenProjectSourcesTabExpression(),
+      returnByValue: true,
+    });
+    const point = locate.result?.value as
+      | { ok?: boolean; alreadyOpen?: boolean; x?: number; y?: number; reason?: string }
+      | undefined;
+    if (point?.alreadyOpen) {
+      return;
+    }
+    if (point?.ok && typeof point.x === "number" && typeof point.y === "number") {
+      await clickPoint(runtime, input, point.x, point.y);
+      await delay(500);
+      return;
+    }
+    lastReason = point?.reason ?? lastReason;
+    await delay(250);
+  }
+  logger(`Project Sources tab did not become selectable before timeout (${lastReason})`);
+  throw new Error("Project Sources tab did not become selectable before timeout.");
+}
+
+async function readProjectSourcesSurfaceStatus(
+  runtime: Runtime,
+): Promise<{ ready: boolean; reason?: string }> {
+  const outcome = await runtime.evaluate({
+    expression: buildProjectSourcesReadyExpression(),
+    returnByValue: true,
+  });
+  const value = outcome.result?.value as { ready?: boolean; reason?: string } | undefined;
+  return {
+    ready: value?.ready === true,
+    reason: typeof value?.reason === "string" ? value.reason : undefined,
+  };
+}
+
+export async function listProjectSources(runtime: Runtime): Promise<ProjectSourceEntry[]> {
+  const outcome = await runtime.evaluate({
+    expression: buildProjectSourcesListExpression(),
+    returnByValue: true,
+  });
+  const value = outcome.result?.value as
+    | { ok?: boolean; sources?: ProjectSourceEntry[]; error?: string }
+    | undefined;
+  if (!value?.ok) {
+    throw new Error(value?.error ?? "Unable to read ChatGPT project sources.");
+  }
+  return Array.isArray(value.sources) ? value.sources.filter(isProjectSourceEntry) : [];
+}
+
+export async function waitForProjectSourcesListSettled(
+  runtime: Runtime,
+  timeoutMs: number,
+  logger: BrowserLogger,
+): Promise<ProjectSourceEntry[]> {
+  const deadline = Date.now() + Math.min(timeoutMs, 30_000);
+  const startedAt = Date.now();
+  let previousKey: string | null = null;
+  let stableSince = Date.now();
+  let latest: ProjectSourceEntry[] = [];
+  while (Date.now() < deadline) {
+    latest = await listProjectSources(runtime);
+    const key = latest.map((source) => source.name).join("\n");
+    if (key !== previousKey) {
+      previousKey = key;
+      stableSince = Date.now();
+    }
+    const stableForMs = Date.now() - stableSince;
+    const observedForMs = Date.now() - startedAt;
+    if (observedForMs >= 2500 && stableForMs >= 700) {
+      return latest;
+    }
+    await delay(300);
+  }
+  logger("Project Sources list did not settle before timeout; returning latest observed list.");
+  return latest;
+}
+
+export async function uploadProjectSources(
+  deps: {
+    runtime: Runtime;
+    dom?: Dom;
+    input?: Input;
+  },
+  attachments: BrowserAttachment[],
+  logger: BrowserLogger,
+  timeoutMs: number,
+): Promise<ProjectSourceEntry[]> {
+  const { runtime, dom, input } = deps;
+  if (!dom) {
+    throw new Error("Chrome DOM domain unavailable while uploading project sources.");
+  }
+  if (attachments.length === 0) {
+    return await listProjectSources(runtime);
+  }
+
+  const plan = buildProjectSourcesUploadPlan(attachments);
+  let latestSources = await listProjectSources(runtime);
+  for (let offset = 0; offset < attachments.length; offset += PROJECT_SOURCES_MAX_UPLOAD_BATCH) {
+    const batch = attachments.slice(offset, offset + PROJECT_SOURCES_MAX_UPLOAD_BATCH);
+    const batchIndex = Math.floor(offset / PROJECT_SOURCES_MAX_UPLOAD_BATCH) + 1;
+    const batchNames = batch.map((file) => path.basename(file.path));
+    logger(
+      `Uploading project source batch ${batchIndex} (${batch.length} file${batch.length === 1 ? "" : "s"})`,
+    );
+
+    await openProjectSourcesAddDialog(runtime, input);
+    await waitForUploadInput(runtime, Math.min(timeoutMs, 30_000));
+    await markProjectSourcesUploadInput(runtime);
+
+    const documentNode = await dom.getDocument({ depth: 5 });
+    const query = await dom.querySelector({
+      nodeId: documentNode.root.nodeId,
+      selector: `input[${PROJECT_SOURCES_INPUT_MARKER}="1"]`,
+    });
+    if (!query.nodeId) {
+      throw new Error("Unable to locate the Project Sources upload input.");
+    }
+    await dom.setFileInputFiles({ nodeId: query.nodeId, files: batch.map((file) => file.path) });
+    await runtime.evaluate({
+      expression: `(() => {
+        const input = document.querySelector('input[${PROJECT_SOURCES_INPUT_MARKER}="1"]');
+        if (!(input instanceof HTMLInputElement)) return false;
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        return true;
+      })()`,
+      returnByValue: true,
+    });
+    await clickProjectSourcesUploadConfirmation(runtime, input).catch(() => false);
+
+    latestSources = await waitForUploadedProjectSources(
+      runtime,
+      latestSources,
+      batchNames,
+      timeoutMs,
+    );
+  }
+
+  logger(
+    `Project source upload complete (${plan.length} planned file${plan.length === 1 ? "" : "s"}).`,
+  );
+  return latestSources;
+}
+
+export async function openProjectSourcesAddDialog(runtime: Runtime, input?: Input): Promise<void> {
+  const locate = await runtime.evaluate({
+    expression: buildOpenProjectSourcesAddDialogExpression(),
+    returnByValue: true,
+  });
+  const point = locate.result?.value as
+    | { ok?: boolean; alreadyOpen?: boolean; x?: number; y?: number; reason?: string }
+    | undefined;
+  if (!point?.ok) {
+    throw new Error(point?.reason ?? "Unable to open the Project Sources Add dialog.");
+  }
+  if (point.alreadyOpen) {
+    return;
+  }
+  if (typeof point.x !== "number" || typeof point.y !== "number") {
+    throw new Error("Unable to locate the Project Sources Add control.");
+  }
+  await clickPoint(runtime, input, point.x, point.y);
+
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const ready = await runtime.evaluate({
+      expression: buildProjectSourcesDialogReadyExpression(),
+      returnByValue: true,
+    });
+    if (ready.result?.value === true) {
+      return;
+    }
+    await delay(200);
+  }
+  throw new Error("Project Sources Add dialog did not open.");
+}
+
+export async function markProjectSourcesUploadInput(runtime: Runtime): Promise<void> {
+  const outcome = await runtime.evaluate({
+    expression: buildMarkProjectSourcesUploadInputExpression(PROJECT_SOURCES_INPUT_MARKER),
+    returnByValue: true,
+  });
+  const value = outcome.result?.value as { ok?: boolean; reason?: string } | undefined;
+  if (!value?.ok) {
+    throw new Error(value?.reason ?? "Project Sources upload input did not appear.");
+  }
+}
+
+async function waitForUploadInput(runtime: Runtime, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const found = await runtime.evaluate({
+      expression: buildMarkProjectSourcesUploadInputExpression(PROJECT_SOURCES_INPUT_MARKER),
+      returnByValue: true,
+    });
+    if ((found.result?.value as { ok?: boolean } | undefined)?.ok === true) {
+      return;
+    }
+    await delay(200);
+  }
+  throw new Error("Project Sources upload input did not appear.");
+}
+
+async function waitForUploadedProjectSources(
+  runtime: Runtime,
+  beforeBatch: ProjectSourceEntry[],
+  expectedNames: string[],
+  timeoutMs: number,
+): Promise<ProjectSourceEntry[]> {
+  const deadline = Date.now() + Math.max(timeoutMs, 30_000);
+  const beforeCounts = countSourceNames(beforeBatch);
+  let latestSources = beforeBatch;
+  while (Date.now() < deadline) {
+    latestSources = await listProjectSources(runtime);
+    const currentCounts = countSourceNames(latestSources);
+    const ready = hasUploadedProjectSourceBatch(beforeCounts, currentCounts, expectedNames);
+    if (ready) {
+      return latestSources;
+    }
+    await delay(500);
+  }
+  throw new Error(`Timed out waiting for uploaded project sources: ${expectedNames.join(", ")}`);
+}
+
+async function clickProjectSourcesUploadConfirmation(
+  runtime: Runtime,
+  input?: Input,
+): Promise<boolean> {
+  const locate = await runtime.evaluate({
+    expression: buildProjectSourcesConfirmationButtonExpression(),
+    returnByValue: true,
+  });
+  const point = locate.result?.value as { ok?: boolean; x?: number; y?: number } | undefined;
+  if (!point?.ok || typeof point.x !== "number" || typeof point.y !== "number") {
+    return false;
+  }
+  await clickPoint(runtime, input, point.x, point.y);
+  return true;
+}
+
+async function clickPoint(
+  runtime: Runtime,
+  input: Input | undefined,
+  x: number,
+  y: number,
+): Promise<void> {
+  if (input && typeof input.dispatchMouseEvent === "function") {
+    await input.dispatchMouseEvent({ type: "mouseMoved", x, y });
+    await input.dispatchMouseEvent({ type: "mousePressed", x, y, button: "left", clickCount: 1 });
+    await input.dispatchMouseEvent({ type: "mouseReleased", x, y, button: "left", clickCount: 1 });
+    return;
+  }
+  await runtime.evaluate({
+    expression: `(() => {
+      const el = document.elementFromPoint(${JSON.stringify(x)}, ${JSON.stringify(y)});
+      if (!(el instanceof HTMLElement)) return false;
+      el.click();
+      return true;
+    })()`,
+    returnByValue: true,
+  });
+}
+
+function countSourceNames(sources: ProjectSourceEntry[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const source of sources) {
+    counts.set(source.name, (counts.get(source.name) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function hasUploadedProjectSourceBatch(
+  beforeCounts: Map<string, number>,
+  currentCounts: Map<string, number>,
+  expectedNames: string[],
+): boolean {
+  const expectedCounts = new Map<string, number>();
+  for (const name of expectedNames) {
+    expectedCounts.set(name, (expectedCounts.get(name) ?? 0) + 1);
+  }
+  for (const [name, expectedCount] of expectedCounts) {
+    const before = beforeCounts.get(name) ?? 0;
+    const current = currentCounts.get(name) ?? 0;
+    if (current < before + expectedCount) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function hasUploadedProjectSourceBatchForTest(
+  before: ProjectSourceEntry[],
+  current: ProjectSourceEntry[],
+  expectedNames: string[],
+): boolean {
+  return hasUploadedProjectSourceBatch(
+    countSourceNames(before),
+    countSourceNames(current),
+    expectedNames,
+  );
+}
+
+function isProjectSourceEntry(value: unknown): value is ProjectSourceEntry {
+  const entry = value as ProjectSourceEntry;
+  return Boolean(entry) && typeof entry.name === "string" && typeof entry.index === "number";
+}
+
+export function buildProjectSourcesReadyExpression(): string {
+  return `(() => {
+    const normalize = (value) => String(value || '').toLowerCase().replace(/\\s+/g, ' ').trim();
+    const visible = (node) => {
+      if (!(node instanceof HTMLElement)) return false;
+      const rect = node.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) return false;
+      const style = window.getComputedStyle(node);
+      return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
+    };
+    const bodyText = normalize(document.body?.innerText || document.body?.textContent || '');
+    const selectedSourceTab = Array.from(document.querySelectorAll('[role="tab"],button,[aria-selected]')).some((node) => {
+      const label = normalize(node.textContent || node.getAttribute?.('aria-label') || '');
+      const selected =
+        node.getAttribute?.('aria-selected') === 'true' ||
+        node.getAttribute?.('data-state') === 'active' ||
+        /\\bactive\\b/i.test(node.getAttribute?.('class') || '');
+      return visible(node) && selected && (label === 'sources' || label === 'źródła' || label === 'zrodla');
+    });
+    const addSurface = Array.from(document.querySelectorAll('button,[role="button"]')).some((node) => {
+      const label = normalize(node.textContent || node.getAttribute?.('aria-label') || node.getAttribute?.('title') || '');
+      return visible(node) && /^(add source|add sources|dodaj źródła|dodaj zrodla)$/u.test(label);
+    });
+    if (selectedSourceTab || addSurface) return { ready: true };
+    if (bodyText.includes('new chat') || bodyText.includes('nowy czat')) return { ready: false, reason: 'project page loaded but sources tab not visible' };
+    return { ready: false, reason: 'sources surface not detected' };
+  })()`;
+}
+
+export function buildProjectSourcesDialogReadyExpression(): string {
+  return `(() => {
+    const normalize = (value) => String(value || '').toLowerCase().replace(/\\s+/g, ' ').trim();
+    return Array.from(document.querySelectorAll('[role="dialog"],dialog')).some((dialog) => {
+      if (!(dialog instanceof HTMLElement)) return false;
+      const text = normalize(dialog.innerText || dialog.textContent || '');
+      return text.includes('add source') || text.includes('add sources') || text.includes('dodaj źródła') || text.includes('dodaj zrodla') || text.includes('przeciągnij źródła') || text.includes('przeciagnij zrodla');
+    });
+  })()`;
+}
+
+export function buildProjectSourcesListExpression(): string {
+  return `(() => {
+    const normalize = (value) => String(value || '').replace(/\\s+/g, ' ').trim();
+    const lower = (value) => normalize(value).toLowerCase();
+    const visible = (node) => {
+      if (!(node instanceof HTMLElement)) return false;
+      const rect = node.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) return false;
+      const style = window.getComputedStyle(node);
+      return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
+    };
+    const isChromeLabel = (label) => {
+      const text = lower(label);
+      return (
+        !text ||
+        text === 'sources' ||
+        text === 'źródła' ||
+        text === 'zrodla' ||
+        text === 'chats' ||
+        text === 'czaty' ||
+        text === 'all' ||
+        text === 'wszystkie' ||
+        text === 'add' ||
+        text === 'add sources' ||
+        text === 'dodaj' ||
+        text === 'dodaj źródła' ||
+        text === 'dodaj zrodla' ||
+        text === 'source actions' ||
+        text === 'actions' ||
+        text === 'share' ||
+        text === 'udostępnij' ||
+        text === 'udostepnij'
+      );
+    };
+    const cleanSourceName = (label) => {
+      const text = normalize(label);
+      return text
+        .replace(/(?:file|document|spreadsheet|presentation|pdf|plik|dokument)\\s*·.*$/iu, '')
+        .trim();
+    };
+    const panel =
+      document.querySelector('[role="tabpanel"][id*="source" i]') ||
+      document.querySelector('[data-testid*="source" i]') ||
+      document.querySelector('main') ||
+      document.body;
+    if (!(panel instanceof HTMLElement)) {
+      return { ok: false, error: 'Project Sources panel not found.' };
+    }
+    const candidates = Array.from(panel.querySelectorAll('[aria-label], [title], a, button, [role="listitem"], [data-testid*="source" i], [class*="file" i], [class*="source" i]'))
+      .filter((node) => node instanceof HTMLElement && visible(node))
+      .map((node) => {
+        const raw = normalize(node.getAttribute('aria-label') || node.getAttribute('title') || node.textContent || '');
+        const rect = node.getBoundingClientRect();
+        return {
+          node,
+          raw,
+          name: cleanSourceName(raw),
+          hasMetadata: raw !== cleanSourceName(raw),
+          top: Math.round(rect.top),
+          left: Math.round(rect.left),
+        };
+      });
+    const plainNames = new Set(candidates.filter((candidate) => !candidate.hasMetadata).map((candidate) => candidate.name));
+    const rows = [];
+    for (const node of candidates) {
+      const raw = node.raw;
+      const name = node.name;
+      if (node.hasMetadata && plainNames.has(name)) continue;
+      if (isChromeLabel(name)) continue;
+      if (name.length < 2 || name.length > 200) continue;
+      if (/^(pdf|docx?|txt|md|csv|xlsx?|json)$/iu.test(name)) continue;
+      if (/^(copy|edit|remove|delete|pobierz|usuń|usun)$/iu.test(name)) continue;
+      if (/^(file|document|spreadsheet|presentation|plik|dokument)$/iu.test(name)) continue;
+      rows.push(node);
+    }
+    const sources = [];
+    const seen = new Set();
+    for (const row of rows) {
+      const key = row.name + '|' + row.top + '|' + row.left;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      sources.push({ name: row.name, index: sources.length, status: 'unknown' });
+    }
+    return { ok: true, sources };
+  })()`;
+}
+
+export function buildOpenProjectSourcesTabExpression(): string {
+  return `(() => {
+    const normalize = (value) => String(value || '').toLowerCase().replace(/\\s+/g, ' ').trim();
+    const visible = (node) => {
+      if (!(node instanceof HTMLElement)) return false;
+      const rect = node.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) return false;
+      const style = window.getComputedStyle(node);
+      return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
+    };
+    const controls = Array.from(document.querySelectorAll('[role="tab"],button,a,[aria-selected]'));
+    const sourceTab = controls.find((node) => {
+      if (!visible(node)) return false;
+      const label = normalize(node.textContent || node.getAttribute('aria-label') || node.getAttribute('title'));
+      return label === 'sources' || label === 'źródła' || label === 'zrodla';
+    });
+    if (!(sourceTab instanceof HTMLElement)) {
+      return { ok: false, reason: 'Project Sources tab control not found.' };
+    }
+    const selected =
+      sourceTab.getAttribute('aria-selected') === 'true' ||
+      sourceTab.getAttribute('data-state') === 'active' ||
+      /\\bactive\\b/i.test(sourceTab.getAttribute('class') || '');
+    if (selected) return { ok: true, alreadyOpen: true };
+    sourceTab.scrollIntoView({ block: 'center', inline: 'center' });
+    const rect = sourceTab.getBoundingClientRect();
+    return { ok: true, x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  })()`;
+}
+
+export function buildOpenProjectSourcesAddDialogExpression(): string {
+  return `(() => {
+    const normalize = (value) => String(value || '').toLowerCase().replace(/\\s+/g, ' ').trim();
+    const visible = (node) => {
+      if (!(node instanceof HTMLElement)) return false;
+      const rect = node.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) return false;
+      const style = window.getComputedStyle(node);
+      return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
+    };
+    if (${buildProjectSourcesDialogReadyExpression().replace(/\n/g, " ")}) return { ok: true, alreadyOpen: true };
+    const roots = [
+      document.querySelector('[role="tabpanel"][id*="source" i]'),
+      document.querySelector('[data-testid*="source" i]'),
+      document.querySelector('main'),
+      document.body,
+    ].filter(Boolean);
+    const controls = roots.flatMap((root) => Array.from(root.querySelectorAll('button,[role="button"],a,label')));
+    const add = controls.find((node) => {
+      if (!visible(node)) return false;
+      const label = normalize(node.innerText || node.textContent || node.getAttribute('aria-label') || node.getAttribute('title'));
+      return label === 'add source' || label === 'add sources' || label === 'dodaj źródła' || label === 'dodaj zrodla';
+    });
+    if (!(add instanceof HTMLElement)) return { ok: false, reason: 'Project Sources add control not found.' };
+    add.scrollIntoView({ block: 'center', inline: 'center' });
+    const rect = add.getBoundingClientRect();
+    return { ok: true, x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  })()`;
+}
+
+export function buildMarkProjectSourcesUploadInputExpression(marker: string): string {
+  return `(() => {
+    const normalize = (value) => String(value || '').toLowerCase().replace(/\\s+/g, ' ').trim();
+    const dialog = Array.from(document.querySelectorAll('[role="dialog"],dialog')).find((node) => {
+      if (!(node instanceof HTMLElement)) return false;
+      const text = normalize(node.innerText || node.textContent || '');
+      return text.includes('add source') || text.includes('add sources') || text.includes('dodaj źródła') || text.includes('dodaj zrodla') || text.includes('przeciągnij źródła') || text.includes('przeciagnij zrodla');
+    });
+    if (!dialog) return { ok: false, reason: 'Project Sources Add dialog missing' };
+    const roots = [dialog];
+    const input = roots
+      .flatMap((root) => Array.from(root.querySelectorAll('input[type="file"]')))
+      .find((node) => node instanceof HTMLInputElement);
+    if (!(input instanceof HTMLInputElement)) return { ok: false, reason: 'file input missing' };
+    Array.from(document.querySelectorAll('input[${marker}]')).forEach((node) => node.removeAttribute('${marker}'));
+    input.setAttribute('${marker}', '1');
+    return { ok: true };
+  })()`;
+}
+
+export function buildProjectSourcesConfirmationButtonExpression(): string {
+  return `(() => {
+    const normalize = (value) => String(value || '').toLowerCase().replace(/\\s+/g, ' ').trim();
+    const visible = (node) => {
+      if (!(node instanceof HTMLElement)) return false;
+      const rect = node.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) return false;
+      const style = window.getComputedStyle(node);
+      return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
+    };
+    const labels = new Set(['upload anyway', 'upload', 'add', 'continue', 'prześlij', 'przeslij', 'dodaj', 'kontynuuj']);
+    const roots = Array.from(document.querySelectorAll('[role="dialog"],dialog')).filter((node) => node instanceof HTMLElement);
+    const buttons = (roots.length > 0 ? roots : [document.body]).flatMap((root) => Array.from(root.querySelectorAll('button,[role="button"]')));
+    const button = buttons.find((node) => {
+      if (!visible(node)) return false;
+      const label = normalize(node.innerText || node.textContent || node.getAttribute('aria-label') || node.getAttribute('title'));
+      return labels.has(label);
+    });
+    if (!(button instanceof HTMLElement)) return { ok: false };
+    button.scrollIntoView({ block: 'center', inline: 'center' });
+    const rect = button.getBoundingClientRect();
+    return { ok: true, x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  })()`;
+}

--- a/src/browser/actions/projectSources.ts
+++ b/src/browser/actions/projectSources.ts
@@ -423,9 +423,17 @@ export function buildProjectSourcesListExpression(): string {
         text === 'actions' ||
         text === 'share' ||
         text === 'udostępnij' ||
-        text === 'udostepnij'
+        text === 'udostepnij' ||
+        text === 'add files and more' ||
+        text === 'chat with chatgpt' ||
+        text === 'ask anything' ||
+        text === 'pro' ||
+        text === 'voice' ||
+        text === 'start voice' ||
+        text === 'start dictation'
       );
     };
+    const hasLikelyFileName = (label) => /\\.[a-z0-9]{1,12}(?:\\s|$)/iu.test(label);
     const cleanSourceName = (label) => {
       const text = normalize(label);
       return text
@@ -461,6 +469,7 @@ export function buildProjectSourcesListExpression(): string {
       const name = node.name;
       if (node.hasMetadata && plainNames.has(name)) continue;
       if (isChromeLabel(name)) continue;
+      if (!node.hasMetadata && !hasLikelyFileName(name)) continue;
       if (name.length < 2 || name.length > 200) continue;
       if (/^(pdf|docx?|txt|md|csv|xlsx?|json)$/iu.test(name)) continue;
       if (/^(copy|edit|remove|delete|pobierz|usuń|usun)$/iu.test(name)) continue;

--- a/src/browser/projectSourcesRunner.ts
+++ b/src/browser/projectSourcesRunner.ts
@@ -1,0 +1,489 @@
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { LaunchedChrome } from "chrome-launcher";
+import {
+  closeTab,
+  connectWithNewTab,
+  hideChromeWindow,
+  launchChrome,
+  registerTerminationHooks,
+} from "./chromeLifecycle.js";
+import { resolveBrowserConfig } from "./config.js";
+import { syncCookies } from "./cookies.js";
+import {
+  installJavaScriptDialogAutoDismissal,
+  navigateToChatGPT,
+  ensureLoggedIn,
+} from "./pageActions.js";
+import type { BrowserLogger, ChromeClient, ResolvedBrowserConfig } from "./types.js";
+import {
+  acquireBrowserTabLease,
+  hasOtherActiveBrowserTabLeases,
+  type BrowserTabLease,
+} from "./tabLeaseRegistry.js";
+import {
+  acquireProfileRunLock,
+  cleanupStaleProfileState,
+  findRunningChromeDebugTargetForProfile,
+  readChromePid,
+  readDevToolsPort,
+  shouldCleanupManualLoginProfileState,
+  verifyDevToolsReachable,
+  writeChromePid,
+  writeDevToolsActivePort,
+  type ProfileRunLock,
+} from "./profileState.js";
+import { CHATGPT_URL } from "./constants.js";
+import { delay } from "./utils.js";
+import {
+  openProjectSourcesTab,
+  uploadProjectSources,
+  waitForProjectSourcesReady,
+  waitForProjectSourcesListSettled,
+} from "./actions/projectSources.js";
+import { normalizeProjectSourcesUrl } from "../projectSources/url.js";
+import { buildProjectSourcesUploadPlan, diffAddedProjectSources } from "../projectSources/plan.js";
+import type { ProjectSourcesRequest, ProjectSourcesResult } from "../projectSources/types.js";
+
+type BrowserChrome = LaunchedChrome & { host?: string };
+
+export async function runBrowserProjectSources(
+  request: ProjectSourcesRequest,
+): Promise<ProjectSourcesResult> {
+  const startedAt = Date.now();
+  const logger: BrowserLogger = ((message: string) => request.log?.(message)) as BrowserLogger;
+  const projectUrl = normalizeProjectSourcesUrl(request.chatgptUrl);
+  const operation = request.operation;
+  const files = request.files ?? [];
+  const plannedUploads = buildProjectSourcesUploadPlan(files);
+  const warnings: string[] = [];
+  if (operation === "add" && files.length === 0) {
+    throw new Error("Project Sources add requires at least one file.");
+  }
+  if (request.dryRun) {
+    return {
+      status: "dry-run",
+      operation,
+      projectUrl,
+      dryRun: true,
+      plannedUploads,
+      warnings,
+      tookMs: Date.now() - startedAt,
+    };
+  }
+
+  let config = resolveBrowserConfig({
+    ...request.config,
+    url: projectUrl,
+    chatgptUrl: projectUrl,
+  });
+  if (config.remoteChrome) {
+    throw new Error(
+      "Project Sources v1 uses local browser automation only. Run it on the signed-in browser host.",
+    );
+  }
+
+  const manualLogin = Boolean(config.manualLogin);
+  const manualProfileDir = config.manualLoginProfileDir
+    ? path.resolve(config.manualLoginProfileDir)
+    : path.join(os.homedir(), ".oracle", "browser-profile");
+  const userDataDir = manualLogin
+    ? manualProfileDir
+    : await mkdtemp(path.join(os.tmpdir(), "oracle-project-sources-"));
+  if (manualLogin) {
+    await mkdir(userDataDir, { recursive: true });
+    logger(`Manual login mode enabled; reusing persistent profile at ${userDataDir}`);
+  } else {
+    logger(`Created temporary Chrome profile at ${userDataDir}`);
+  }
+
+  let tabLease: BrowserTabLease | null = null;
+  if (manualLogin) {
+    tabLease = await acquireBrowserTabLease(userDataDir, {
+      maxConcurrentTabs: config.maxConcurrentTabs,
+      timeoutMs: config.timeoutMs,
+      logger,
+      sessionId: "project-sources",
+    });
+  }
+
+  let chrome: BrowserChrome | null = null;
+  let reusedChrome: LaunchedChrome | null = null;
+  let client: ChromeClient | null = null;
+  let isolatedTargetId: string | null = null;
+  let removeTerminationHooks: (() => void) | null = null;
+  let removeDialogHandler: (() => void) | null = null;
+  let connectionClosedUnexpectedly = false;
+  let completed = false;
+  const effectiveKeepBrowser = Boolean(config.keepBrowser);
+
+  try {
+    const acquired = manualLogin
+      ? await acquireManualLoginChromeForProjectSources(userDataDir, config, logger)
+      : {
+          chrome: await launchChrome({ ...config, remoteChrome: null }, userDataDir, logger),
+          reusedChrome: null,
+        };
+    chrome = acquired.chrome;
+    reusedChrome = acquired.reusedChrome;
+    const chromeHost = chrome.host ?? "127.0.0.1";
+    if (tabLease) {
+      await tabLease.update({ chromeHost, chromePort: chrome.port });
+    }
+
+    removeTerminationHooks = registerTerminationHooks(
+      chrome,
+      userDataDir,
+      effectiveKeepBrowser,
+      logger,
+      {
+        isInFlight: () => !completed,
+        preserveUserDataDir: manualLogin,
+      },
+    );
+
+    const strictTabIsolation = Boolean(manualLogin && reusedChrome);
+    const connection = await connectWithNewTab(chrome.port, logger, "about:blank", chromeHost, {
+      fallbackToDefault: !strictTabIsolation,
+      retries: strictTabIsolation ? 3 : 0,
+      retryDelayMs: 500,
+    });
+    client = connection.client;
+    isolatedTargetId = connection.targetId ?? null;
+    if (tabLease && isolatedTargetId) {
+      await tabLease.update({
+        chromeHost,
+        chromePort: chrome.port,
+        chromeTargetId: isolatedTargetId,
+        tabUrl: projectUrl,
+      });
+    }
+
+    const disconnectPromise = new Promise<never>((_, reject) => {
+      client?.on("disconnect", () => {
+        connectionClosedUnexpectedly = true;
+        reject(new Error("Chrome window closed before Project Sources finished."));
+      });
+    });
+    const raceWithDisconnect = <T>(promise: Promise<T>): Promise<T> =>
+      Promise.race([promise, disconnectPromise]);
+
+    const { Network, Page, Runtime, Input, DOM } = client;
+    if (!config.headless && config.hideWindow) {
+      await hideChromeWindow(chrome, logger);
+    }
+    const domainEnablers = [Network.enable({}), Page.enable(), Runtime.enable()];
+    if (DOM && typeof DOM.enable === "function") {
+      domainEnablers.push(DOM.enable());
+    }
+    await Promise.all(domainEnablers);
+    removeDialogHandler = installJavaScriptDialogAutoDismissal(Page, logger);
+    if (!manualLogin) {
+      await Network.clearBrowserCookies();
+    }
+
+    const appliedCookies = await applyProjectSourcesCookies({
+      config,
+      network: Network,
+      manualLogin,
+      logger,
+    });
+
+    await raceWithDisconnect(navigateToChatGPT(Page, Runtime, CHATGPT_URL, logger));
+    await raceWithDisconnect(
+      waitForProjectSourcesLogin({
+        runtime: Runtime,
+        logger,
+        appliedCookies,
+        manualLogin,
+        timeoutMs: config.timeoutMs,
+      }),
+    );
+    await raceWithDisconnect(navigateToChatGPT(Page, Runtime, projectUrl, logger));
+    await raceWithDisconnect(openProjectSourcesTab(Runtime, Input, config.inputTimeoutMs, logger));
+    await raceWithDisconnect(waitForProjectSourcesReady(Runtime, config.inputTimeoutMs, logger));
+
+    const sourcesBefore = await raceWithDisconnect(
+      waitForProjectSourcesListSettled(Runtime, config.inputTimeoutMs, logger),
+    );
+    let sourcesAfter = sourcesBefore;
+    if (operation === "add") {
+      sourcesAfter = await raceWithDisconnect(
+        uploadProjectSources(
+          { runtime: Runtime, dom: DOM, input: Input },
+          files,
+          logger,
+          config.timeoutMs,
+        ),
+      );
+    }
+    const added = operation === "add" ? diffAddedProjectSources(sourcesBefore, sourcesAfter) : [];
+    completed = true;
+    return {
+      status: "ok",
+      operation,
+      projectUrl,
+      dryRun: false,
+      sourcesBefore,
+      sourcesAfter,
+      plannedUploads,
+      added,
+      warnings,
+      tookMs: Date.now() - startedAt,
+    };
+  } finally {
+    removeDialogHandler?.();
+    removeTerminationHooks?.();
+    const chromeHost = chrome?.host ?? "127.0.0.1";
+    try {
+      await client?.close();
+    } catch {
+      // ignore close failures
+    }
+    if (completed && isolatedTargetId && chrome?.port) {
+      await closeTab(chrome.port, isolatedTargetId, logger, chromeHost).catch(() => undefined);
+    }
+
+    let keepBrowserOpen = effectiveKeepBrowser;
+    let cleanupProfileLock: ProfileRunLock | null = null;
+    let terminatedRecordedChrome = false;
+    if (!keepBrowserOpen && manualLogin && tabLease) {
+      const cleanupLockTimeoutMs = Math.max(0, config.profileLockTimeoutMs ?? 0);
+      if (cleanupLockTimeoutMs > 0) {
+        cleanupProfileLock = await acquireProfileRunLock(userDataDir, {
+          timeoutMs: cleanupLockTimeoutMs,
+          logger,
+          sessionId: "project-sources",
+        }).catch(() => null);
+      }
+      keepBrowserOpen = await hasOtherActiveBrowserTabLeases(userDataDir, tabLease.id).catch(
+        () => false,
+      );
+      if (keepBrowserOpen) {
+        logger("[browser] Other ChatGPT tab leases still active; leaving shared Chrome running.");
+      } else if (reusedChrome && !connectionClosedUnexpectedly) {
+        keepBrowserOpen = true;
+        logger("[browser] Reused shared Chrome; leaving browser process running.");
+      }
+    }
+    if (tabLease) {
+      const handle = tabLease;
+      tabLease = null;
+      await handle.release().catch(() => undefined);
+    }
+    if (!keepBrowserOpen && chrome) {
+      if (!connectionClosedUnexpectedly) {
+        try {
+          if (!terminatedRecordedChrome) {
+            await chrome.kill();
+          }
+        } catch {
+          // ignore kill failures
+        }
+      }
+      if (manualLogin) {
+        const shouldCleanup = await shouldCleanupManualLoginProfileState(
+          userDataDir,
+          logger.verbose ? logger : undefined,
+          { connectionClosedUnexpectedly, host: chrome.host ?? "127.0.0.1" },
+        );
+        if (shouldCleanup) {
+          await cleanupStaleProfileState(userDataDir, logger, { lockRemovalMode: "never" }).catch(
+            () => undefined,
+          );
+        }
+      } else {
+        await rm(userDataDir, { recursive: true, force: true }).catch(() => undefined);
+      }
+    } else if (chrome) {
+      try {
+        chrome.process?.unref();
+      } catch {
+        // best effort
+      }
+      logger(`Chrome left running on port ${chrome.port} with profile ${userDataDir}`);
+    }
+    if (cleanupProfileLock) {
+      await cleanupProfileLock.release().catch(() => undefined);
+    }
+  }
+}
+
+async function applyProjectSourcesCookies({
+  config,
+  network,
+  manualLogin,
+  logger,
+}: {
+  config: ResolvedBrowserConfig;
+  network: ChromeClient["Network"];
+  manualLogin: boolean;
+  logger: BrowserLogger;
+}): Promise<number> {
+  const manualLoginCookieSync = manualLogin && Boolean(config.manualLoginCookieSync);
+  const cookieSyncEnabled = config.cookieSync && (!manualLogin || manualLoginCookieSync);
+  if (!cookieSyncEnabled) {
+    logger(
+      manualLogin
+        ? "Skipping Chrome cookie sync (--browser-manual-login enabled); reuse the opened profile after signing in."
+        : "Skipping Chrome cookie sync (--browser-no-cookie-sync)",
+    );
+    return 0;
+  }
+  const cookieCount = await syncCookies(network, config.url, config.chromeProfile, logger, {
+    allowErrors: config.allowCookieErrors ?? false,
+    filterNames: config.cookieNames ?? undefined,
+    inlineCookies: config.inlineCookies ?? undefined,
+    cookiePath: config.chromeCookiePath ?? undefined,
+    waitMs: config.cookieSyncWaitMs ?? 0,
+  });
+  logger(
+    cookieCount > 0
+      ? config.inlineCookies
+        ? `Applied ${cookieCount} inline cookies`
+        : `Copied ${cookieCount} cookies from Chrome profile ${config.chromeProfile ?? "Default"}`
+      : "No Chrome cookies found; continuing without session reuse",
+  );
+  return cookieCount;
+}
+
+async function waitForProjectSourcesLogin({
+  runtime,
+  logger,
+  appliedCookies,
+  manualLogin,
+  timeoutMs,
+}: {
+  runtime: ChromeClient["Runtime"];
+  logger: BrowserLogger;
+  appliedCookies: number;
+  manualLogin: boolean;
+  timeoutMs: number;
+}): Promise<void> {
+  if (!manualLogin) {
+    await ensureLoggedIn(runtime, logger, { appliedCookies });
+    return;
+  }
+  const deadline = Date.now() + Math.min(timeoutMs ?? 1_200_000, 20 * 60_000);
+  let lastNotice = 0;
+  while (Date.now() < deadline) {
+    try {
+      await ensureLoggedIn(runtime, logger, { appliedCookies });
+      return;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const retryable =
+        message.toLowerCase().includes("login button") ||
+        message.toLowerCase().includes("session not detected");
+      if (!retryable) {
+        throw error;
+      }
+      const now = Date.now();
+      if (now - lastNotice > 5000) {
+        logger(
+          "Manual login mode: please sign into chatgpt.com in the opened Chrome window; waiting for session to appear...",
+        );
+        lastNotice = now;
+      }
+      await delay(1000);
+    }
+  }
+  throw new Error(
+    "Manual login mode timed out waiting for ChatGPT session; please sign in and retry.",
+  );
+}
+
+async function acquireManualLoginChromeForProjectSources(
+  userDataDir: string,
+  config: ResolvedBrowserConfig,
+  logger: BrowserLogger,
+): Promise<{ chrome: BrowserChrome; reusedChrome: LaunchedChrome | null }> {
+  const lockTimeoutMs = Math.max(0, config.profileLockTimeoutMs ?? 0);
+  let launchLock: ProfileRunLock | null = null;
+  if (lockTimeoutMs > 0) {
+    launchLock = await acquireProfileRunLock(userDataDir, {
+      timeoutMs: lockTimeoutMs,
+      logger,
+      sessionId: "project-sources",
+    });
+  }
+  try {
+    const reusedChrome = await maybeReuseProjectSourcesChrome(userDataDir, logger, {
+      waitForPortMs: config.reuseChromeWaitMs,
+    });
+    const chrome =
+      reusedChrome ??
+      (await launchChrome(
+        {
+          ...config,
+          remoteChrome: null,
+        },
+        userDataDir,
+        logger,
+      ));
+    if (chrome.port) {
+      await writeDevToolsActivePort(userDataDir, chrome.port);
+      if (!reusedChrome && chrome.pid) {
+        await writeChromePid(userDataDir, chrome.pid);
+      }
+    }
+    return { chrome, reusedChrome };
+  } finally {
+    await launchLock?.release().catch(() => undefined);
+  }
+}
+
+async function maybeReuseProjectSourcesChrome(
+  userDataDir: string,
+  logger: BrowserLogger,
+  options: { waitForPortMs?: number } = {},
+): Promise<LaunchedChrome | null> {
+  const waitForPortMs = Math.max(0, options.waitForPortMs ?? 0);
+  let port = await readDevToolsPort(userDataDir);
+  if (!port && waitForPortMs > 0) {
+    const deadline = Date.now() + waitForPortMs;
+    logger(`Waiting up to ${Math.round(waitForPortMs / 1000)}s for shared Chrome to appear...`);
+    while (!port && Date.now() < deadline) {
+      await delay(250);
+      port = await readDevToolsPort(userDataDir);
+    }
+  }
+  let pid = await readChromePid(userDataDir);
+  if (!port) {
+    const discovered = await findRunningChromeDebugTargetForProfile(userDataDir);
+    if (!discovered) {
+      return null;
+    }
+    const probe = await verifyDevToolsReachable({ port: discovered.port });
+    if (!probe.ok) {
+      logger(
+        `Discovered Chrome for ${userDataDir} on port ${discovered.port} but it was unreachable (${probe.error}); launching new Chrome.`,
+      );
+      return null;
+    }
+    await writeDevToolsActivePort(userDataDir, discovered.port);
+    await writeChromePid(userDataDir, discovered.pid);
+    port = discovered.port;
+    pid = discovered.pid;
+    logger(
+      `Discovered running Chrome for ${userDataDir}; reusing (DevTools port ${port}, pid ${pid})`,
+    );
+    return { port, pid, kill: async () => {}, process: undefined } as unknown as LaunchedChrome;
+  }
+  const probe = await verifyDevToolsReachable({ port });
+  if (!probe.ok) {
+    logger(
+      `Recorded Chrome DevTools port ${port} is stale (${probe.error}); launching new Chrome.`,
+    );
+    await cleanupStaleProfileState(userDataDir, logger, { lockRemovalMode: "if_oracle_pid_dead" });
+    return null;
+  }
+  logger(`Reusing running Chrome on port ${port} with profile ${userDataDir}`);
+  return {
+    port,
+    pid: pid ?? undefined,
+    kill: async () => {},
+    process: undefined,
+  } as unknown as LaunchedChrome;
+}

--- a/src/cli/projectSources.ts
+++ b/src/cli/projectSources.ts
@@ -1,0 +1,157 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import chalk from "chalk";
+import type { BrowserSessionConfig } from "../sessionStore.js";
+import type { BrowserAttachment } from "../browser/types.js";
+import type { BrowserFlagOptions } from "./browserConfig.js";
+import { buildBrowserConfig } from "./browserConfig.js";
+import { readFiles } from "../oracle/files.js";
+import { loadUserConfig } from "../config.js";
+import { resolveConfiguredMaxFileSizeBytes } from "./fileSize.js";
+import { runBrowserProjectSources } from "../browser/projectSourcesRunner.js";
+import type { ProjectSourcesOperation, ProjectSourcesResult } from "../projectSources/types.js";
+import { normalizeProjectSourcesUrl } from "../projectSources/url.js";
+
+export interface ProjectSourcesCliOptions extends Partial<BrowserFlagOptions> {
+  file?: string[];
+  dryRun?: boolean;
+  json?: boolean;
+  verbose?: boolean;
+  chatgptUrl?: string;
+  maxFileSizeBytes?: number;
+}
+
+export async function runProjectSourcesCliCommand(
+  operation: ProjectSourcesOperation,
+  options: ProjectSourcesCliOptions,
+): Promise<void> {
+  const { config: userConfig } = await loadUserConfig();
+  const configuredUrl = userConfig.browser?.chatgptUrl ?? userConfig.browser?.url;
+  const projectUrl = normalizeProjectSourcesUrl(options.chatgptUrl ?? configuredUrl ?? "");
+  const maxFileSizeBytes =
+    options.maxFileSizeBytes ?? resolveConfiguredMaxFileSizeBytes(userConfig, process.env);
+  const files =
+    operation === "add"
+      ? await resolveProjectSourceFiles(options.file ?? [], {
+          cwd: process.cwd(),
+          maxFileSizeBytes,
+        })
+      : [];
+  if (operation === "add" && files.length === 0) {
+    throw new Error("project-sources add requires at least one --file.");
+  }
+
+  const browserConfig = await buildProjectSourcesBrowserConfig({
+    options,
+    projectUrl,
+    configuredBrowser: userConfig.browser ?? {},
+  });
+  const result = await runBrowserProjectSources({
+    operation,
+    chatgptUrl: projectUrl,
+    files,
+    dryRun: options.dryRun,
+    config: browserConfig,
+    log: (message) => {
+      if (options.verbose || !message.startsWith("[debug]")) {
+        console.log(chalk.dim(message));
+      }
+    },
+  });
+  printProjectSourcesResult(result, Boolean(options.json));
+}
+
+export async function resolveProjectSourceFiles(
+  fileInputs: string[],
+  options: { cwd: string; maxFileSizeBytes?: number },
+): Promise<BrowserAttachment[]> {
+  const files = await readFiles(fileInputs, {
+    cwd: options.cwd,
+    maxFileSizeBytes: options.maxFileSizeBytes,
+    readContents: false,
+  });
+  const attachments: BrowserAttachment[] = [];
+  for (const file of files) {
+    const stats = await fs.stat(file.path);
+    attachments.push({
+      path: file.path,
+      displayPath: path.relative(options.cwd, file.path) || path.basename(file.path),
+      sizeBytes: stats.size,
+    });
+  }
+  return attachments;
+}
+
+export async function buildProjectSourcesBrowserConfig({
+  options,
+  projectUrl,
+  configuredBrowser,
+}: {
+  options: ProjectSourcesCliOptions;
+  projectUrl: string;
+  configuredBrowser: BrowserSessionConfig;
+}): Promise<BrowserSessionConfig> {
+  const flagConfig = removeUndefined(
+    await buildBrowserConfig({
+      ...options,
+      model: "gpt-5.5-pro",
+      chatgptUrl: projectUrl,
+    }),
+  );
+  const envProfileDir = process.env.ORACLE_BROWSER_PROFILE_DIR?.trim();
+  const manualLogin =
+    flagConfig.manualLogin ?? configuredBrowser.manualLogin ?? (envProfileDir ? true : undefined);
+  const manualLoginProfileDir =
+    manualLogin === true
+      ? (flagConfig.manualLoginProfileDir ??
+        configuredBrowser.manualLoginProfileDir ??
+        envProfileDir ??
+        null)
+      : null;
+  return {
+    ...configuredBrowser,
+    ...flagConfig,
+    url: projectUrl,
+    chatgptUrl: projectUrl,
+    cookieSync: manualLogin ? false : (flagConfig.cookieSync ?? configuredBrowser.cookieSync),
+    manualLogin,
+    manualLoginProfileDir,
+    desiredModel: null,
+    modelStrategy: "ignore",
+    researchMode: "off",
+  };
+}
+
+function removeUndefined<T extends object>(value: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).filter(([, entry]) => entry !== undefined),
+  ) as Partial<T>;
+}
+
+function printProjectSourcesResult(result: ProjectSourcesResult, json: boolean): void {
+  if (json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  if (result.status === "dry-run") {
+    console.log(chalk.bold(`Project Sources ${result.operation} dry run`));
+    console.log(`Project: ${result.projectUrl}`);
+    const plan = result.plannedUploads ?? [];
+    if (plan.length > 0) {
+      console.log(`Planned uploads: ${plan.length}`);
+      for (const upload of plan) {
+        console.log(`  batch ${upload.batch}: ${upload.displayPath}`);
+      }
+    }
+    return;
+  }
+  console.log(chalk.bold(`Project Sources ${result.operation} completed`));
+  console.log(`Project: ${result.projectUrl}`);
+  const before = result.sourcesBefore?.length ?? 0;
+  const after = result.sourcesAfter?.length ?? 0;
+  console.log(`Before: ${before}`);
+  console.log(`After: ${after}`);
+  if (result.added && result.added.length > 0) {
+    console.log(`Added: ${result.added.map((source) => source.name).join(", ")}`);
+  }
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -6,6 +6,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { getCliVersion } from "../version.js";
 import { registerConsultTool } from "./tools/consult.js";
+import { registerProjectSourcesTool } from "./tools/projectSources.js";
 import { registerSessionsTool } from "./tools/sessions.js";
 import { registerSessionResources } from "./tools/sessionResources.js";
 
@@ -23,6 +24,7 @@ export async function startMcpServer(): Promise<void> {
   );
 
   registerConsultTool(server);
+  registerProjectSourcesTool(server);
   registerSessionsTool(server);
   registerSessionResources(server);
 

--- a/src/mcp/tools/projectSources.ts
+++ b/src/mcp/tools/projectSources.ts
@@ -1,0 +1,149 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { loadUserConfig } from "../../config.js";
+import { resolveRemoteServiceConfig } from "../../remote/remoteServiceConfig.js";
+import { runBrowserProjectSources } from "../../browser/projectSourcesRunner.js";
+import { normalizeProjectSourcesUrl } from "../../projectSources/url.js";
+import {
+  buildProjectSourcesBrowserConfig,
+  resolveProjectSourceFiles,
+} from "../../cli/projectSources.js";
+import { resolveConfiguredMaxFileSizeBytes } from "../../cli/fileSize.js";
+
+const projectSourceEntryShape = z.object({
+  name: z.string(),
+  index: z.number(),
+  status: z.enum(["ready", "processing", "unknown"]).optional(),
+});
+
+const projectSourceUploadPlanShape = z.object({
+  path: z.string(),
+  displayPath: z.string(),
+  name: z.string(),
+  sizeBytes: z.number().optional(),
+  batch: z.number(),
+});
+
+const projectSourcesInputShape = {
+  operation: z
+    .enum(["list", "add"])
+    .describe(
+      "Project Sources operation. v1 intentionally supports only non-destructive list/add.",
+    ),
+  chatgptUrl: z
+    .string()
+    .optional()
+    .describe("ChatGPT project URL ending in /project. Falls back to browser.chatgptUrl config."),
+  files: z
+    .array(z.string())
+    .default([])
+    .describe("Local file paths or globs to add as persistent ChatGPT Project Sources."),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe("Validate files and return an upload plan without touching the browser."),
+  confirmMutation: z
+    .boolean()
+    .optional()
+    .describe(
+      "Required for mutating add operations so agents do not modify project state accidentally.",
+    ),
+  browserKeepBrowser: z.boolean().optional().describe("Keep Chrome running after completion."),
+} satisfies z.ZodRawShape;
+
+const projectSourcesOutputShape = {
+  status: z.enum(["ok", "dry-run"]),
+  operation: z.enum(["list", "add"]),
+  projectUrl: z.string(),
+  dryRun: z.boolean(),
+  sourcesBefore: z.array(projectSourceEntryShape).optional(),
+  sourcesAfter: z.array(projectSourceEntryShape).optional(),
+  plannedUploads: z.array(projectSourceUploadPlanShape).optional(),
+  added: z.array(projectSourceEntryShape).optional(),
+  warnings: z.array(z.string()),
+  tookMs: z.number(),
+} satisfies z.ZodRawShape;
+
+const projectSourcesInputSchema = z.object(projectSourcesInputShape);
+
+export function registerProjectSourcesTool(server: McpServer): void {
+  server.registerTool(
+    "project_sources",
+    {
+      title: "Manage ChatGPT Project Sources",
+      description:
+        "List or append files to a ChatGPT Project's persistent Sources tab. This is useful for Developer Mode workflows where chats do not share memory, but explicit project sources provide shared context. Destructive delete/replace/sync operations are intentionally not included in v1.",
+      inputSchema: projectSourcesInputShape,
+      outputSchema: projectSourcesOutputShape,
+    },
+    async (input: unknown) => {
+      const textContent = (text: string) => [{ type: "text" as const, text }];
+      let parsed;
+      try {
+        parsed = projectSourcesInputSchema.parse(input);
+      } catch (error) {
+        return {
+          isError: true,
+          content: textContent(error instanceof Error ? error.message : String(error)),
+        };
+      }
+      const { config: userConfig } = await loadUserConfig();
+      const resolvedRemote = resolveRemoteServiceConfig({ userConfig, env: process.env });
+      if (resolvedRemote.host) {
+        return {
+          isError: true,
+          content: textContent(
+            "project_sources v1 must run on the signed-in browser host; remote oracle serve support is not enabled yet.",
+          ),
+        };
+      }
+      const projectUrl = normalizeProjectSourcesUrl(
+        parsed.chatgptUrl ?? userConfig.browser?.chatgptUrl ?? userConfig.browser?.url ?? "",
+      );
+      if (parsed.operation === "add" && !parsed.dryRun && parsed.confirmMutation !== true) {
+        return {
+          isError: true,
+          content: textContent(
+            "project_sources add modifies persistent ChatGPT Project Sources. Retry with `confirmMutation: true` or use `dryRun: true` first.",
+          ),
+        };
+      }
+      const maxFileSizeBytes = resolveConfiguredMaxFileSizeBytes(userConfig, process.env);
+      const files =
+        parsed.operation === "add"
+          ? await resolveProjectSourceFiles(parsed.files ?? [], {
+              cwd: process.cwd(),
+              maxFileSizeBytes,
+            })
+          : [];
+      const browserConfig = await buildProjectSourcesBrowserConfig({
+        options: {
+          chatgptUrl: projectUrl,
+          browserKeepBrowser: parsed.browserKeepBrowser,
+        },
+        projectUrl,
+        configuredBrowser: userConfig.browser ?? {},
+      });
+      const result = await runBrowserProjectSources({
+        operation: parsed.operation,
+        chatgptUrl: projectUrl,
+        files,
+        dryRun: parsed.dryRun,
+        config: browserConfig,
+        log: (message) => {
+          server.server
+            .sendLoggingMessage({ level: "info", data: { text: message } })
+            .catch(() => undefined);
+        },
+      });
+      const output =
+        result.status === "dry-run"
+          ? `Project Sources ${result.operation} dry run: ${result.plannedUploads?.length ?? 0} planned upload(s).`
+          : `Project Sources ${result.operation} completed: ${result.sourcesAfter?.length ?? 0} source(s).`;
+      return {
+        content: textContent(output),
+        structuredContent: result as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/src/projectSources/plan.ts
+++ b/src/projectSources/plan.ts
@@ -1,0 +1,37 @@
+import path from "node:path";
+import type { BrowserAttachment } from "../browser/types.js";
+import type { ProjectSourceEntry, ProjectSourceUploadPlan } from "./types.js";
+
+export const PROJECT_SOURCES_MAX_UPLOAD_BATCH = 10;
+
+export function buildProjectSourcesUploadPlan(
+  files: BrowserAttachment[],
+): ProjectSourceUploadPlan[] {
+  return files.map((file, index) => ({
+    path: file.path,
+    displayPath: file.displayPath,
+    name: path.basename(file.path),
+    sizeBytes: file.sizeBytes,
+    batch: Math.floor(index / PROJECT_SOURCES_MAX_UPLOAD_BATCH) + 1,
+  }));
+}
+
+export function diffAddedProjectSources(
+  before: ProjectSourceEntry[],
+  after: ProjectSourceEntry[],
+): ProjectSourceEntry[] {
+  const remainingBefore = new Map<string, number>();
+  for (const source of before) {
+    remainingBefore.set(source.name, (remainingBefore.get(source.name) ?? 0) + 1);
+  }
+  const added: ProjectSourceEntry[] = [];
+  for (const source of after) {
+    const count = remainingBefore.get(source.name) ?? 0;
+    if (count > 0) {
+      remainingBefore.set(source.name, count - 1);
+      continue;
+    }
+    added.push(source);
+  }
+  return added;
+}

--- a/src/projectSources/types.ts
+++ b/src/projectSources/types.ts
@@ -1,0 +1,39 @@
+import type { BrowserAutomationConfig, BrowserAttachment } from "../browser/types.js";
+
+export type ProjectSourcesOperation = "list" | "add";
+
+export interface ProjectSourceEntry {
+  name: string;
+  index: number;
+  status?: "ready" | "processing" | "unknown";
+}
+
+export interface ProjectSourceUploadPlan {
+  path: string;
+  displayPath: string;
+  name: string;
+  sizeBytes?: number;
+  batch: number;
+}
+
+export interface ProjectSourcesRequest {
+  operation: ProjectSourcesOperation;
+  chatgptUrl: string;
+  files?: BrowserAttachment[];
+  dryRun?: boolean;
+  config?: BrowserAutomationConfig;
+  log?: (message: string) => void;
+}
+
+export interface ProjectSourcesResult {
+  status: "ok" | "dry-run";
+  operation: ProjectSourcesOperation;
+  projectUrl: string;
+  dryRun: boolean;
+  sourcesBefore?: ProjectSourceEntry[];
+  sourcesAfter?: ProjectSourceEntry[];
+  plannedUploads?: ProjectSourceUploadPlan[];
+  added?: ProjectSourceEntry[];
+  warnings: string[];
+  tookMs: number;
+}

--- a/src/projectSources/url.ts
+++ b/src/projectSources/url.ts
@@ -1,0 +1,26 @@
+export function normalizeProjectSourcesUrl(rawUrl: string): string {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch (error) {
+    throw new Error(
+      `Invalid ChatGPT project URL: ${rawUrl} (${error instanceof Error ? error.message : String(error)})`,
+    );
+  }
+  const hostname = url.hostname.toLowerCase();
+  if (hostname !== "chatgpt.com" && hostname !== "chat.openai.com") {
+    throw new Error(`Project Sources require a ChatGPT URL, received: ${rawUrl}`);
+  }
+  if (!/\/project\/?$/u.test(url.pathname)) {
+    throw new Error(
+      `Project Sources require a ChatGPT project URL ending in /project, received: ${rawUrl}`,
+    );
+  }
+  const existingParams = Array.from(url.searchParams.entries()).filter(([key]) => key !== "tab");
+  url.search = "";
+  url.searchParams.set("tab", "sources");
+  for (const [key, value] of existingParams) {
+    url.searchParams.append(key, value);
+  }
+  return url.toString();
+}

--- a/tests/browser/projectSources.test.ts
+++ b/tests/browser/projectSources.test.ts
@@ -42,6 +42,9 @@ describe("Project Sources browser expressions", () => {
     const expression = buildProjectSourcesListExpression();
     expect(expression).toContain("sources.push");
     expect(expression).toContain("hasMetadata");
+    expect(expression).toContain("hasLikelyFileName");
+    expect(expression).toContain("add files and more");
+    expect(expression).toContain("start voice");
     expect(expression).toContain("row.top");
   });
 

--- a/tests/browser/projectSources.test.ts
+++ b/tests/browser/projectSources.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildMarkProjectSourcesUploadInputExpression,
+  buildOpenProjectSourcesTabExpression,
+  buildOpenProjectSourcesAddDialogExpression,
+  buildProjectSourcesConfirmationButtonExpression,
+  buildProjectSourcesListExpression,
+  buildProjectSourcesReadyExpression,
+  hasUploadedProjectSourceBatchForTest,
+} from "../../src/browser/actions/projectSources.js";
+
+describe("Project Sources browser expressions", () => {
+  test("recognizes English and Polish Project Sources UI labels", () => {
+    const ready = buildProjectSourcesReadyExpression();
+    expect(ready).toContain("sources");
+    expect(ready).toContain("źródła");
+    expect(ready).toContain("dodaj źródła");
+  });
+
+  test("targets Sources controls without relying only on one English label", () => {
+    const openTab = buildOpenProjectSourcesTabExpression();
+    expect(openTab).toContain("sources");
+    expect(openTab).toContain("źródła");
+
+    const openDialog = buildOpenProjectSourcesAddDialogExpression();
+    expect(openDialog).toContain("add sources");
+    expect(openDialog).toContain("dodaj źródła");
+    expect(openDialog).toContain('[role="tabpanel"][id*="source" i]');
+  });
+
+  test("marks only file inputs scoped through the Sources dialog/panel search", () => {
+    const expression = buildMarkProjectSourcesUploadInputExpression(
+      "data-oracle-project-sources-input",
+    );
+    expect(expression).toContain('input[type="file"]');
+    expect(expression).toContain("data-oracle-project-sources-input");
+    expect(expression).toContain("dialog");
+    expect(expression).not.toContain("document.body");
+  });
+
+  test("keeps source rows distinct while filtering duplicated metadata labels", () => {
+    const expression = buildProjectSourcesListExpression();
+    expect(expression).toContain("sources.push");
+    expect(expression).toContain("hasMetadata");
+    expect(expression).toContain("row.top");
+  });
+
+  test("supports localized upload confirmation labels", () => {
+    const expression = buildProjectSourcesConfirmationButtonExpression();
+    expect(expression).toContain("upload anyway");
+    expect(expression).toContain("prześlij");
+  });
+
+  test("requires all duplicate basenames in an upload batch to appear", () => {
+    const before = [{ name: "context.md", index: 0 }];
+    expect(
+      hasUploadedProjectSourceBatchForTest(
+        before,
+        [
+          { name: "context.md", index: 0 },
+          { name: "context.md", index: 1 },
+        ],
+        ["context.md", "context.md"],
+      ),
+    ).toBe(false);
+    expect(
+      hasUploadedProjectSourceBatchForTest(
+        before,
+        [
+          { name: "context.md", index: 0 },
+          { name: "context.md", index: 1 },
+          { name: "context.md", index: 2 },
+        ],
+        ["context.md", "context.md"],
+      ),
+    ).toBe(true);
+  });
+});

--- a/tests/cli/projectSources.test.ts
+++ b/tests/cli/projectSources.test.ts
@@ -1,0 +1,81 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  buildProjectSourcesBrowserConfig,
+  resolveProjectSourceFiles,
+} from "../../src/cli/projectSources.js";
+
+describe("project sources CLI helpers", () => {
+  const originalProfileDir = process.env.ORACLE_BROWSER_PROFILE_DIR;
+
+  afterEach(() => {
+    if (originalProfileDir === undefined) {
+      delete process.env.ORACLE_BROWSER_PROFILE_DIR;
+    } else {
+      process.env.ORACLE_BROWSER_PROFILE_DIR = originalProfileDir;
+    }
+  });
+
+  test("resolves files without reading their contents into memory", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "oracle-project-sources-test-"));
+    try {
+      await writeFile(path.join(dir, "context.md"), "PROJECT_SOURCE_OK\n", "utf8");
+      const files = await resolveProjectSourceFiles(["context.md"], {
+        cwd: dir,
+        maxFileSizeBytes: 1_000_000,
+      });
+      expect(files).toEqual([
+        expect.objectContaining({
+          path: path.join(dir, "context.md"),
+          displayPath: "context.md",
+          sizeBytes: 18,
+        }),
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("builds browser config without a model picker target", async () => {
+    const config = await buildProjectSourcesBrowserConfig({
+      options: {
+        browserKeepBrowser: true,
+        browserManualLogin: true,
+        browserManualLoginProfileDir: "/tmp/oracle-profile",
+      },
+      projectUrl: "https://chatgpt.com/g/g-p-123/project?tab=sources",
+      configuredBrowser: {
+        desiredModel: "GPT-5.5 Pro",
+        modelStrategy: "select",
+      },
+    });
+    expect(config).toMatchObject({
+      url: "https://chatgpt.com/g/g-p-123/project?tab=sources",
+      chatgptUrl: "https://chatgpt.com/g/g-p-123/project?tab=sources",
+      keepBrowser: true,
+      manualLogin: true,
+      manualLoginProfileDir: "/tmp/oracle-profile",
+      desiredModel: null,
+      modelStrategy: "ignore",
+      researchMode: "off",
+    });
+  });
+
+  test("uses ORACLE_BROWSER_PROFILE_DIR as the local signed-in profile for MCP-style calls", async () => {
+    process.env.ORACLE_BROWSER_PROFILE_DIR = "/tmp/env-oracle-profile";
+    const config = await buildProjectSourcesBrowserConfig({
+      options: {},
+      projectUrl: "https://chatgpt.com/g/g-p-123/project?tab=sources",
+      configuredBrowser: {},
+    });
+    expect(config).toMatchObject({
+      manualLogin: true,
+      manualLoginProfileDir: "/tmp/env-oracle-profile",
+      cookieSync: false,
+      desiredModel: null,
+      modelStrategy: "ignore",
+    });
+  });
+});

--- a/tests/mcp/projectSources.test.ts
+++ b/tests/mcp/projectSources.test.ts
@@ -1,0 +1,86 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const loadUserConfig = vi.fn(async () => ({
+  config: {
+    browser: {
+      chatgptUrl: "https://chatgpt.com/g/g-p-test/project",
+    },
+  },
+  path: "/tmp/oracle-config.json",
+  loaded: true,
+}));
+const resolveRemoteServiceConfig = vi.fn(() => ({}));
+const runBrowserProjectSources = vi.fn(async () => ({
+  status: "dry-run",
+  operation: "add",
+  projectUrl: "https://chatgpt.com/g/g-p-test/project?tab=sources",
+  dryRun: true,
+  plannedUploads: [],
+  warnings: [],
+  tookMs: 1,
+}));
+
+vi.mock("../../src/config.js", () => ({ loadUserConfig }));
+vi.mock("../../src/remote/remoteServiceConfig.js", () => ({ resolveRemoteServiceConfig }));
+vi.mock("../../src/browser/projectSourcesRunner.js", () => ({ runBrowserProjectSources }));
+
+const { registerProjectSourcesTool } = await import("../../src/mcp/tools/projectSources.ts");
+
+describe("project_sources MCP tool", () => {
+  let handler: ((input: unknown) => Promise<unknown>) | null = null;
+  const sendLoggingMessage = vi.fn(async () => undefined);
+
+  beforeEach(() => {
+    handler = null;
+    loadUserConfig.mockClear();
+    resolveRemoteServiceConfig.mockClear();
+    runBrowserProjectSources.mockClear();
+    sendLoggingMessage.mockClear();
+    registerProjectSourcesTool({
+      registerTool: (_name: string, _def: unknown, fn: (input: unknown) => Promise<unknown>) => {
+        handler = fn;
+      },
+      server: { sendLoggingMessage },
+    } as unknown as Parameters<typeof registerProjectSourcesTool>[0]);
+    if (!handler) throw new Error("handler not registered");
+  });
+
+  test("requires explicit confirmation for persistent source mutations", async () => {
+    const result = (await handler?.({
+      operation: "add",
+      files: ["/tmp/context.md"],
+    })) as { isError?: boolean; content: Array<{ text: string }> };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/confirmMutation/i);
+    expect(runBrowserProjectSources).not.toHaveBeenCalled();
+  });
+
+  test("allows dry-run add without confirmation", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "oracle-project-sources-mcp-"));
+    try {
+      const filePath = path.join(dir, "architecture.md");
+      await writeFile(filePath, "shared project context\n", "utf8");
+
+      const result = (await handler?.({
+        operation: "add",
+        files: [filePath],
+        dryRun: true,
+      })) as { structuredContent: { status: string; dryRun: boolean } };
+
+      expect(runBrowserProjectSources).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: "add",
+          dryRun: true,
+          files: [expect.objectContaining({ path: filePath })],
+        }),
+      );
+      expect(result.structuredContent).toMatchObject({ status: "dry-run", dryRun: true });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/projectSources/plan.test.ts
+++ b/tests/projectSources/plan.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest";
+import {
+  PROJECT_SOURCES_MAX_UPLOAD_BATCH,
+  buildProjectSourcesUploadPlan,
+  diffAddedProjectSources,
+} from "../../src/projectSources/plan.js";
+
+describe("project sources plan helpers", () => {
+  test("plans uploads in batches of ten", () => {
+    const files = Array.from({ length: 11 }, (_, index) => ({
+      path: `/tmp/source-${index + 1}.md`,
+      displayPath: `source-${index + 1}.md`,
+      sizeBytes: 10,
+    }));
+    expect(PROJECT_SOURCES_MAX_UPLOAD_BATCH).toBe(10);
+    expect(buildProjectSourcesUploadPlan(files).map((entry) => entry.batch)).toEqual([
+      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2,
+    ]);
+  });
+
+  test("diffs duplicate source names by count instead of set membership", () => {
+    expect(
+      diffAddedProjectSources(
+        [
+          { name: "architecture.md", index: 0 },
+          { name: "notes.md", index: 1 },
+        ],
+        [
+          { name: "architecture.md", index: 0 },
+          { name: "notes.md", index: 1 },
+          { name: "architecture.md", index: 2 },
+        ],
+      ),
+    ).toEqual([{ name: "architecture.md", index: 2 }]);
+  });
+});

--- a/tests/projectSources/url.test.ts
+++ b/tests/projectSources/url.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest";
+import { normalizeProjectSourcesUrl } from "../../src/projectSources/url.js";
+
+describe("normalizeProjectSourcesUrl", () => {
+  test("forces ChatGPT project URLs to the Sources tab", () => {
+    expect(normalizeProjectSourcesUrl("https://chatgpt.com/g/g-p-123/project")).toBe(
+      "https://chatgpt.com/g/g-p-123/project?tab=sources",
+    );
+    expect(
+      normalizeProjectSourcesUrl("https://chatgpt.com/g/g-p-123/project?tab=chats&foo=bar"),
+    ).toBe("https://chatgpt.com/g/g-p-123/project?tab=sources&foo=bar");
+  });
+
+  test("rejects non-project URLs", () => {
+    expect(() => normalizeProjectSourcesUrl("https://chatgpt.com/c/abc")).toThrow(/project URL/i);
+    expect(() => normalizeProjectSourcesUrl("https://chatgpt.com/g/g-p-123/project/foo")).toThrow(
+      /ending in \/project/i,
+    );
+    expect(() => normalizeProjectSourcesUrl("https://example.com/g/g-p-123/project")).toThrow(
+      /ChatGPT URL/i,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds a focused, non-destructive ChatGPT Project Sources v1 for browser-mode workflows:

- `oracle project-sources list|add` for the ChatGPT Project Sources tab.
- MCP `project_sources` tool with `operation:"list"|"add"`.
- `add` supports `--dry-run` / `dryRun:true` and MCP requires `confirmMutation:true` for persistent mutations.
- Project Sources browser automation does not select a model, start a consult, or send a prompt.

This addresses #131 and is a narrower successor/alternative to #132. Credit to @vgorlovi for identifying the Project Sources workflow and proving the first spike. This PR keeps only the safe v1 surface: list, append, and dry-run. Delete/replace/sync are intentionally left for a follow-up after more UI coverage.

## Why

With ChatGPT Developer Mode / Memory Off, separate chats in a Project do not implicitly share chat history. Project Sources still provide explicit shared project context through uploaded files. That makes Sources useful for agent workflows where context should be deliberate and inspectable rather than hidden memory.

## Safety / scope

- Browser only; no API model ids or model picker changes.
- Local signed-in browser host only for v1; remote `oracle serve` support is rejected for `project_sources` for now.
- No destructive source operations.
- Mutating MCP calls require `confirmMutation:true` unless `dryRun:true`.
- Upload input selection is scoped to the recognized Add Sources dialog to avoid normal composer upload controls.

## Tests

Local:

```text
pnpm run check
# All matched files use the correct format.
# tsgo --noEmit
# Found 0 warnings and 0 errors.

pnpm run build
# tsgo -p tsconfig.build.json && pnpm run build:vendor

pnpm vitest run tests/projectSources/url.test.ts tests/browser/projectSources.test.ts tests/cli/projectSources.test.ts tests/mcp/projectSources.test.ts
# Test Files 4 passed (4)
# Tests 13 passed (13)

pnpm test
# Test Files 118 passed | 18 skipped (136)
# Tests 790 passed | 41 skipped (831)

git diff --check
# no output
```

CLI dry-run:

```text
node ./dist/bin/oracle-cli.js project-sources add \
  --chatgpt-url https://chatgpt.com/g/g-p-123/project \
  --file /tmp/oracle-project-sources-dry-run.md \
  --dry-run --json

status: dry-run
projectUrl: https://chatgpt.com/g/g-p-123/project?tab=sources
plannedUploads: 1
```

Live browser smoke on a dedicated test ChatGPT Project using `/Users/pd/.oracle/browser-profile`:

```text
project-sources list
# status: ok
# sourcesBefore/sourcesAfter included existing test sources
# lease registry released cleanly

project-sources add --file /tmp/oracle-project-source-safe-selector-smoke-20260505.md
# status: ok
# uploaded one markdown file
# added[] contained only oracle-project-source-safe-selector-smoke-20260505.md
# lease registry released cleanly
```

Dogfood review:

- Asked local Oracle browser GPT-5.5 Pro to review the patch.
- Accepted and fixed its findings: avoid terminating reused shared Chrome, require all duplicate basenames in an upload batch, strictly require `/project` URLs, and scope upload input detection to the Add Sources dialog.
