### PR TITLE
Fix browser Pro Extended selection and stale composer prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
 ### Fixed
 
 - Bridge: keep generated Codex/Claude MCP config snippets clean on stdout so redirecting `oracle bridge claude-config --local-browser > .mcp.json` produces valid JSON.
+- Browser: keep `--browser-thinking-time extended` on the selected GPT-5.5 Pro row instead of applying Extended to regular GPT-5.5.
+- Browser: clear stale manual-login composer text before every initial submission so new prompts do not append to leftover drafts.
+- Browser: ignore per-row thinking-effort controls while selecting a model so GPT-5.5 Pro selection cannot stop at regular GPT-5.5 Thinking's Extended control.
 - MCP: clarify `consult` engine defaults and add ChatGPT browser-mode recovery guidance to missing GPT API-key errors. (#172) — thanks @pdurlej.
 
 ## 0.10.0 — 2026-05-04

--- a/skills/oracle/SKILL.md
+++ b/skills/oracle/SKILL.md
@@ -7,21 +7,21 @@ description: Use the @steipete/oracle CLI to bundle a prompt plus the right file
 
 Oracle bundles your prompt + selected files into one “one-shot” request so another model can answer with real repo context (API or browser automation). Treat outputs as advisory: verify against the codebase + tests.
 
-## Main use case (browser, GPT‑5.4 Pro)
+## Main use case (browser, GPT‑5.5 Pro)
 
-Default workflow here: `--engine browser` with GPT‑5.4 Pro in ChatGPT. This is the “human in the loop” path: it can take ~10 minutes to ~1 hour; expect a stored session you can reattach to.
+Default workflow here: `--engine browser` with GPT‑5.5 Pro in ChatGPT. This is the “human in the loop” path: it can take ~10 minutes to ~1 hour; expect a stored session you can reattach to.
 
 Recommended defaults:
 
 - Engine: browser (`--engine browser`)
-- Model: GPT‑5.4 Pro (either `--model gpt-5.4-pro` or a ChatGPT picker label like `--model "5.4 Pro"`)
+- Model: GPT‑5.5 Pro (either `--model gpt-5.5-pro` or a ChatGPT picker label like `--model "5.5 Pro"`)
 - Attachments: directories/globs + excludes; avoid secrets.
 
 ## Golden path (fast + reliable)
 
 1. Pick a tight file set (fewest files that still contain the truth).
 2. Preview what you’re about to send (`--dry-run` + `--files-report` when needed).
-3. Run in browser mode for the usual GPT‑5.4 Pro ChatGPT workflow; use API only when you explicitly want it.
+3. Run in browser mode for the usual GPT‑5.5 Pro ChatGPT workflow; use API only when you explicitly want it.
 4. If the run detaches/timeouts: reattach to the stored session (don’t re-run).
 
 ## Commands (preferred)
@@ -37,7 +37,7 @@ Recommended defaults:
   - `npx -y @steipete/oracle --dry-run summary --files-report -p "<task>" --file "src/**"`
 
 - Browser run (main path; long-running is normal):
-  - `npx -y @steipete/oracle --engine browser --model gpt-5.4-pro -p "<task>" --file "src/**"`
+  - `npx -y @steipete/oracle --engine browser --model gpt-5.5-pro -p "<task>" --file "src/**"`
 
 - Manual paste fallback (assemble bundle, copy to clipboard):
   - `npx -y @steipete/oracle --render --copy -p "<task>" --file "src/**"`
@@ -83,7 +83,7 @@ Recommended defaults:
 
 - Stored under `~/.oracle/sessions` (override with `ORACLE_HOME_DIR`).
 - Browser runs save durable files under `~/.oracle/sessions/<id>/artifacts/`, including `transcript.md`, Deep Research reports, and downloaded ChatGPT-generated images when available.
-- Runs may detach or take a long time (browser + GPT‑5.4 Pro often does). If the CLI times out: don’t re-run; reattach.
+- Runs may detach or take a long time (browser + GPT‑5.5 Pro often does). If the CLI times out: don’t re-run; reattach.
   - List: `oracle status --hours 72`
   - Attach: `oracle session <id> --render`
 - Use `--slug "<3-5 words>"` to keep session IDs readable.

--- a/src/browser/actions/modelSelection.ts
+++ b/src/browser/actions/modelSelection.ts
@@ -144,12 +144,6 @@ function buildModelSelectionExpression(
 
     const closeMenu = () => {
       try {
-        if (dispatchClickSequence(button)) {
-          lastPointerClick = performance.now();
-          return;
-        }
-      } catch {}
-      try {
         document.dispatchEvent(
           new KeyboardEvent('keydown', {
             key: 'Escape',
@@ -159,6 +153,11 @@ function buildModelSelectionExpression(
             bubbles: true,
           }),
         );
+      } catch {}
+      try {
+        if (button.getAttribute?.('aria-expanded') === 'true' && dispatchClickSequence(button)) {
+          lastPointerClick = performance.now();
+        }
       } catch {}
     };
 
@@ -241,6 +240,10 @@ function buildModelSelectionExpression(
     };
 
     const getOptionLabel = (node) => node?.textContent?.trim() ?? '';
+    const isThinkingEffortControl = (node) =>
+      node instanceof HTMLElement &&
+      (node.getAttribute('data-model-picker-thinking-effort-action') === 'true' ||
+        Boolean(node.closest('[data-model-picker-thinking-effort-action="true"]')));
     const optionIsSelected = (node) => {
       if (!(node instanceof HTMLElement)) {
         return false;
@@ -403,6 +406,9 @@ function buildModelSelectionExpression(
       for (const menu of menus) {
         const buttons = Array.from(menu.querySelectorAll(${menuItemLiteral}));
         for (const option of buttons) {
+          if (isThinkingEffortControl(option)) {
+            continue;
+          }
           const text = option.textContent ?? '';
           const normalizedText = normalizeText(text);
           const testid = option.getAttribute('data-testid') ?? '';

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -235,44 +235,69 @@ export async function clearPromptComposer(Runtime: ChromeClient["Runtime"], logg
   const inputSelectorsLiteral = JSON.stringify(INPUT_SELECTORS);
   const result = await Runtime.evaluate({
     expression: `(() => {
+      const SELECTORS = ${inputSelectorsLiteral};
       const fallback = document.querySelector(${fallbackSelectorLiteral});
       const editor = document.querySelector(${primarySelectorLiteral});
-      const inputSelectors = ${inputSelectorsLiteral};
-      let cleared = false;
-      if (fallback) {
-        fallback.value = '';
-        fallback.dispatchEvent(new InputEvent('input', { bubbles: true, data: '', inputType: 'deleteByCut' }));
-        fallback.dispatchEvent(new Event('change', { bubbles: true }));
-        cleared = true;
-      }
-      if (editor) {
-        editor.textContent = '';
-        editor.dispatchEvent(new InputEvent('input', { bubbles: true, data: '', inputType: 'deleteByCut' }));
-        cleared = true;
-      }
-      const nodes = inputSelectors
-        .map((selector) => document.querySelector(selector))
-        .filter((node) => Boolean(node));
-      for (const node of nodes) {
-        if (!node) continue;
-        if (node instanceof HTMLTextAreaElement) {
-          node.value = '';
+      const readValue = (node) => {
+        if (!node) return '';
+        if (node instanceof HTMLTextAreaElement || node instanceof HTMLInputElement) return node.value ?? '';
+        return node.innerText ?? node.textContent ?? '';
+      };
+      const dispatchClearEvents = (node) => {
+        try {
+          node.dispatchEvent(new InputEvent('beforeinput', { bubbles: true, cancelable: true, data: null, inputType: 'deleteContentBackward' }));
+        } catch {}
+        try {
           node.dispatchEvent(new InputEvent('input', { bubbles: true, data: '', inputType: 'deleteByCut' }));
-          node.dispatchEvent(new Event('change', { bubbles: true }));
-          cleared = true;
-          continue;
+        } catch {
+          node.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+        node.dispatchEvent(new Event('change', { bubbles: true }));
+      };
+      const clearEditable = (node) => {
+        if (!node) return false;
+        try {
+          node.focus?.();
+        } catch {}
+        if (node instanceof HTMLTextAreaElement || node instanceof HTMLInputElement) {
+          node.value = '';
+          dispatchClearEvents(node);
+          return true;
         }
         if (node.isContentEditable || node.getAttribute('contenteditable') === 'true') {
+          try {
+            const selection = node.ownerDocument?.getSelection?.();
+            const range = node.ownerDocument?.createRange?.();
+            if (selection && range) {
+              range.selectNodeContents(node);
+              selection.removeAllRanges();
+              selection.addRange(range);
+              node.ownerDocument?.execCommand?.('delete', false);
+            }
+          } catch {}
           node.textContent = '';
-          node.dispatchEvent(new InputEvent('input', { bubbles: true, data: '', inputType: 'deleteByCut' }));
-          cleared = true;
+          dispatchClearEvents(node);
+          return true;
         }
+        return false;
+      };
+      let cleared = false;
+      const nodes = SELECTORS
+        .map((selector) => document.querySelector(selector))
+        .filter((node) => Boolean(node));
+      for (const node of Array.from(new Set([fallback, editor, ...nodes])).filter(Boolean)) {
+        cleared = clearEditable(node) || cleared;
       }
-      return { cleared };
+      const remaining = Array.from(new Set([fallback, editor, ...nodes]))
+        .filter(Boolean)
+        .map((node) => readValue(node).trim())
+        .filter(Boolean);
+      return { cleared, remaining };
     })()`,
     returnByValue: true,
   });
-  if (!result.result?.value?.cleared) {
+  const value = result.result?.value as { cleared?: boolean; remaining?: string[] } | undefined;
+  if (!value?.cleared || (value.remaining?.length ?? 0) > 0) {
     await logDomFailure(Runtime, logger, "clear-composer");
     throw new Error("Failed to clear prompt composer");
   }

--- a/src/browser/actions/thinkingTime.ts
+++ b/src/browser/actions/thinkingTime.ts
@@ -29,8 +29,9 @@ export async function ensureThinkingTime(
   Runtime: ChromeClient["Runtime"],
   level: ThinkingTimeLevel,
   logger: BrowserLogger,
+  targetModel?: string | null,
 ) {
-  const result = await evaluateThinkingTimeSelection(Runtime, level);
+  const result = await evaluateThinkingTimeSelection(Runtime, level, targetModel);
   const capitalizedLevel = level.charAt(0).toUpperCase() + level.slice(1);
 
   switch (result?.status) {
@@ -106,9 +107,10 @@ export async function ensureThinkingTimeIfAvailable(
 async function evaluateThinkingTimeSelection(
   Runtime: ChromeClient["Runtime"],
   level: ThinkingTimeLevel,
+  targetModel?: string | null,
 ): Promise<ThinkingTimeOutcome | undefined> {
   const outcome = await Runtime.evaluate({
-    expression: buildThinkingTimeExpression(level),
+    expression: buildThinkingTimeExpression(level, targetModel),
     awaitPromise: true,
     returnByValue: true,
   });
@@ -116,11 +118,15 @@ async function evaluateThinkingTimeSelection(
   return outcome.result?.value as ThinkingTimeOutcome | undefined;
 }
 
-function buildThinkingTimeExpression(level: ThinkingTimeLevel): string {
+function buildThinkingTimeExpression(
+  level: ThinkingTimeLevel,
+  targetModel?: string | null,
+): string {
   const menuContainerLiteral = JSON.stringify(MENU_CONTAINER_SELECTOR);
   const menuItemLiteral = JSON.stringify(MENU_ITEM_SELECTOR);
   const modelButtonLiteral = JSON.stringify(MODEL_BUTTON_SELECTOR);
   const targetLevelLiteral = JSON.stringify(level.toLowerCase());
+  const targetModelLiteral = JSON.stringify(targetModel?.trim() || null);
 
   return `(async () => {
     ${buildClickDispatcher()}
@@ -129,6 +135,7 @@ function buildThinkingTimeExpression(level: ThinkingTimeLevel): string {
     const MENU_ITEM_SELECTOR = ${menuItemLiteral};
     const MODEL_BUTTON_SELECTOR = ${modelButtonLiteral};
     const TARGET_LEVEL = ${targetLevelLiteral};
+    const TARGET_MODEL = ${targetModelLiteral};
 
     // Bilingual matchers: English level token + observed Chinese variants.
     const LEVEL_TOKENS = {
@@ -150,6 +157,21 @@ function buildThinkingTimeExpression(level: ThinkingTimeLevel): string {
       .replace(/[^a-z0-9\\u4e00-\\u9fa5]+/g, ' ')
       .replace(/\\s+/g, ' ')
       .trim();
+    const normalizedTargetModel = normalize(TARGET_MODEL);
+    const targetModelVersion = normalizedTargetModel.includes('5 5')
+      ? '5-5'
+      : normalizedTargetModel.includes('5 4')
+        ? '5-4'
+        : normalizedTargetModel.includes('5 2')
+          ? '5-2'
+          : normalizedTargetModel.includes('5 1')
+            ? '5-1'
+            : normalizedTargetModel.includes('5 0')
+              ? '5-0'
+              : null;
+    const targetWantsPro = normalizedTargetModel.includes('pro');
+    const targetWantsThinking = normalizedTargetModel.includes('thinking');
+    const targetWantsInstant = normalizedTargetModel.includes('instant');
     const matchesLevel = (text) => {
       const t = normalize(text);
       return targetTokens.some((tok) => t.includes(String(tok).toLowerCase()));
@@ -242,13 +264,60 @@ function buildThinkingTimeExpression(level: ThinkingTimeLevel): string {
 
     const findModelButton = () => document.querySelector(MODEL_BUTTON_SELECTOR);
     const findTrailingButtons = () => Array.from(document.querySelectorAll(TRAILING_SELECTOR));
+    const normalizeModelRowText = (node) => {
+      if (!(node instanceof HTMLElement)) return '';
+      const parts = [
+        node.textContent ?? '',
+        node.getAttribute('aria-label') ?? '',
+        node.getAttribute('data-testid') ?? '',
+      ];
+      return normalize(parts.join(' '));
+    };
+    const modelRowMatchesTarget = (row) => {
+      if (!normalizedTargetModel || !(row instanceof HTMLElement)) return false;
+      const text = normalizeModelRowText(row);
+      if (!text) return false;
+      if (targetModelVersion === '5-5') {
+        const has55 = text.includes('5 5') || text.includes('gpt55') || text.includes('gpt 5 5');
+        const isCurrentProAlias = targetWantsPro && text.includes('pro') && !text.includes('thinking');
+        if (!has55 && !isCurrentProAlias) return false;
+      } else if (targetModelVersion === '5-4' && !text.includes('5 4')) {
+        return false;
+      } else if (targetModelVersion === '5-2' && !text.includes('5 2')) {
+        return false;
+      } else if (targetModelVersion === '5-1' && !text.includes('5 1')) {
+        return false;
+      } else if (targetModelVersion === '5-0' && !text.includes('5 0')) {
+        return false;
+      }
+      if (targetWantsPro && !text.includes('pro')) return false;
+      if (!targetWantsPro && text.includes('pro')) return false;
+      if (targetWantsThinking && !text.includes('thinking')) return false;
+      if (!targetWantsThinking && text.includes('thinking')) return false;
+      if (targetWantsInstant && !text.includes('instant')) return false;
+      if (!targetWantsInstant && text.includes('instant')) return false;
+      return true;
+    };
+    const getModelRowForTrailing = (trailing) => {
+      const rowContainer = trailing?.closest?.('[class*="model-picker-thinking-effort-row"]');
+      const row = rowContainer?.querySelector?.(
+        '[data-model-picker-thinking-effort-menu-item="true"], [role="menuitemradio"][data-testid*="model-switcher-"]',
+      );
+      if (row) return row;
+      return trailing?.closest?.('[role="menuitemradio"], [data-radix-collection-item]');
+    };
     const pickTrailingForCurrentModel = () => {
       const trailings = findTrailingButtons();
       if (trailings.length === 0) return null;
       if (trailings.length === 1) return trailings[0];
+      // Prefer the trailing effort button on the model row Oracle just selected.
+      for (const t of trailings) {
+        const row = getModelRowForTrailing(t);
+        if (modelRowMatchesTarget(row)) return t;
+      }
       // Prefer the trailing button whose model row is currently selected.
       for (const t of trailings) {
-        const row = t.closest('[role="menuitem"], [role="menuitemradio"], [data-radix-collection-item]');
+        const row = getModelRowForTrailing(t);
         if (row && (optionIsSelected(row) || row.querySelector('[aria-checked="true"]'))) return t;
       }
       // Fallback: first one with non-zero box.
@@ -281,6 +350,9 @@ function buildThinkingTimeExpression(level: ThinkingTimeLevel): string {
       closeOpenMenus();
       return { status: 'chip-not-found' };
     }
+
+    const targetModelRow = getModelRowForTrailing(trailing);
+    const targetModelAlreadySelected = !TARGET_MODEL || optionIsSelected(targetModelRow);
 
     dispatchClickSequence(trailing);
     await sleep(STEP_WAIT_MS);
@@ -325,15 +397,29 @@ function buildThinkingTimeExpression(level: ThinkingTimeLevel): string {
       return { status: 'option-not-found' };
     }
 
-    const already = optionIsSelected(targetOption);
+    const effortAlreadySelected = optionIsSelected(targetOption);
     const label = targetOption.textContent?.trim?.() || null;
-    dispatchClickSequence(targetOption);
-    await sleep(STEP_WAIT_MS);
+    if (!effortAlreadySelected) {
+      dispatchClickSequence(targetOption);
+      await sleep(STEP_WAIT_MS);
+    }
+    if (
+      TARGET_MODEL &&
+      targetModelRow instanceof HTMLElement &&
+      targetModelRow.isConnected &&
+      !optionIsSelected(targetModelRow)
+    ) {
+      dispatchClickSequence(targetModelRow);
+      await sleep(STEP_WAIT_MS);
+    }
     closeOpenMenus();
-    return { status: already ? 'already-selected' : 'switched', label };
+    return { status: effortAlreadySelected && targetModelAlreadySelected ? 'already-selected' : 'switched', label };
   })()`;
 }
 
-export function buildThinkingTimeExpressionForTest(level: ThinkingTimeLevel = "extended"): string {
-  return buildThinkingTimeExpression(level);
+export function buildThinkingTimeExpressionForTest(
+  level: ThinkingTimeLevel = "extended",
+  targetModel?: string | null,
+): string {
+  return buildThinkingTimeExpression(level, targetModel);
 }

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -825,8 +825,9 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
     // Handle thinking time selection if specified. Deep Research owns its own effort flow.
     const thinkingTime = config.thinkingTime;
     if (thinkingTime && !deepResearch) {
+      const thinkingTargetModel = modelStrategy === "select" ? config.desiredModel : null;
       await raceWithDisconnect(
-        withRetries(() => ensureThinkingTime(Runtime, thinkingTime, logger), {
+        withRetries(() => ensureThinkingTime(Runtime, thinkingTime, logger, thinkingTargetModel), {
           retries: 2,
           delayMs: 300,
           onRetry: (attempt, error) => {
@@ -879,6 +880,8 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
         typeof baselineSnapshot?.text === "string" ? baselineSnapshot.text.trim() : "";
       const attachmentNames = submissionAttachments.map((a) => path.basename(a.path));
       let inputOnlyAttachments = false;
+      await clearPromptComposer(Runtime, logger);
+      await ensurePromptReady(Runtime, config.inputTimeoutMs, logger);
       if (submissionAttachments.length > 0) {
         if (!DOM) {
           throw new Error("Chrome DOM domain unavailable while uploading attachments.");
@@ -2080,17 +2083,21 @@ async function runRemoteBrowserMode(
     // Handle thinking time selection if specified. Deep Research owns its own effort flow.
     const thinkingTime = config.thinkingTime;
     if (thinkingTime && !deepResearch) {
-      await withRetries(() => ensureThinkingTime(Runtime, thinkingTime, logger), {
-        retries: 2,
-        delayMs: 300,
-        onRetry: (attempt, error) => {
-          if (options.verbose) {
-            logger(
-              `[retry] Thinking time (${thinkingTime}) attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
-            );
-          }
+      const thinkingTargetModel = modelStrategy === "select" ? config.desiredModel : null;
+      await withRetries(
+        () => ensureThinkingTime(Runtime, thinkingTime, logger, thinkingTargetModel),
+        {
+          retries: 2,
+          delayMs: 300,
+          onRetry: (attempt, error) => {
+            if (options.verbose) {
+              logger(
+                `[retry] Thinking time (${thinkingTime}) attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
+              );
+            }
+          },
         },
-      });
+      );
     }
     if (deepResearch) {
       await withRetries(() => activateDeepResearch(Runtime, Input, logger), {
@@ -2115,6 +2122,8 @@ async function runRemoteBrowserMode(
       const baselineAssistantText =
         typeof baselineSnapshot?.text === "string" ? baselineSnapshot.text.trim() : "";
       const attachmentNames = submissionAttachments.map((a) => path.basename(a.path));
+      await clearPromptComposer(Runtime, logger);
+      await ensurePromptReady(Runtime, config.inputTimeoutMs, logger);
       if (submissionAttachments.length > 0) {
         if (!DOM) {
           throw new Error("Chrome DOM domain unavailable while uploading attachments.");

--- a/tests/browser/modelSelection.test.ts
+++ b/tests/browser/modelSelection.test.ts
@@ -78,6 +78,7 @@ describe("browser model selection matchers", () => {
     const expression = buildModelSelectionExpressionForTest("gpt-5.4");
     expect(expression).toContain("const closeMenu = () =>");
     expect(expression).toContain("key: 'Escape'");
+    expect(expression).toContain("button.getAttribute?.('aria-expanded') === 'true'");
     expect(expression).toContain("closeMenu();");
   });
 
@@ -129,5 +130,12 @@ describe("browser model selection matchers", () => {
     const expression = buildModelSelectionExpressionForTest("gpt-5.5-pro");
     expect(expression).toContain('data-testid="model-switcher-dropdown-button"');
     expect(expression).toContain("button.__composer-pill[aria-haspopup=");
+  });
+
+  it("does not treat per-row thinking effort controls as model options", () => {
+    const expression = buildModelSelectionExpressionForTest("gpt-5.5-pro");
+    expect(expression).toContain("const isThinkingEffortControl = (node) =>");
+    expect(expression).toContain("data-model-picker-thinking-effort-action");
+    expect(expression).toContain("if (isThinkingEffortControl(option))");
   });
 });

--- a/tests/browser/thinkingTime.test.ts
+++ b/tests/browser/thinkingTime.test.ts
@@ -32,6 +32,39 @@ describe("browser thinking-time selection expression", () => {
     expect(expression).toContain("LEVEL_TOKENS");
   });
 
+  it("prefers the effort control attached to the requested model row", () => {
+    const expression = buildThinkingTimeExpressionForTest("extended", "gpt-5.5-pro");
+    expect(expression).toContain('const TARGET_MODEL = "gpt-5.5-pro"');
+    expect(expression).toContain("const modelRowMatchesTarget = (row) =>");
+    expect(expression).toContain("if (targetWantsPro && !text.includes('pro')) return false;");
+    expect(expression).toContain("if (!targetWantsPro && text.includes('pro')) return false;");
+    expect(expression).toContain("if (modelRowMatchesTarget(row)) return t;");
+  });
+
+  it("keeps regular GPT-5.5 thinking-time requests on the non-Pro row", () => {
+    const expression = buildThinkingTimeExpressionForTest("heavy", "Thinking 5.5");
+    expect(expression).toContain('const TARGET_MODEL = "Thinking 5.5"');
+    expect(expression).toContain("const targetWantsPro = normalizedTargetModel.includes('pro');");
+    expect(expression).toContain(
+      "const targetWantsThinking = normalizedTargetModel.includes('thinking');",
+    );
+    expect(expression).toContain("if (!targetWantsPro && text.includes('pro')) return false;");
+    expect(expression).toContain(
+      "if (targetWantsThinking && !text.includes('thinking')) return false;",
+    );
+    expect(expression).toContain("if (modelRowMatchesTarget(row)) return t;");
+  });
+
+  it("activates the requested model row after changing its effort", () => {
+    const expression = buildThinkingTimeExpressionForTest("extended", "gpt-5.5-pro");
+    expect(expression).toContain('[class*="model-picker-thinking-effort-row"]');
+    expect(expression).toContain('data-model-picker-thinking-effort-menu-item="true"');
+    expect(expression).toContain("const targetModelRow = getModelRowForTrailing(trailing);");
+    expect(expression).toContain("if (!effortAlreadySelected)");
+    expect(expression).toContain("!optionIsSelected(targetModelRow)");
+    expect(expression).toContain("dispatchClickSequence(targetModelRow);");
+  });
+
   it("preserves Chinese thinking-effort labels while normalizing", () => {
     const expression = buildThinkingTimeExpressionForTest("heavy");
     expect(expression).toContain("\\u4e00-\\u9fa5");


### PR DESCRIPTION
Hi, I had some time on my hands and wanted to contribute by fixing the issues I found. I hope that’s okay. If there’s anything else I can or have to do, please reach out to me.

## Summary

Fixes two browser-mode issues:

- Fixes #174 by keeping `--browser-thinking-time extended` scoped to the selected GPT-5.5 Pro row instead of letting the thinking-time flow land on regular GPT-5.5 Thinking.
- Fixes #175 by clearing the ChatGPT composer before normal initial submissions so stale draft text is not prepended/appended to the next prompt.
- Updates the shipped Oracle skill docs from GPT-5.4 Pro to GPT-5.5 Pro.

## Changes

- Ignore per-row thinking-effort controls while scanning model picker options.
- Pass the desired model into thinking-time selection so the correct model row is targeted.
- Resolve the owning model row for trailing effort buttons and keep that row selected after effort selection.
- Avoid clicking an already-selected effort option, which could cause ChatGPT to return to the wrong row.
- Clear and re-check the composer before initial browser submissions in local and remote browser paths.
- Strengthen composer clearing for textarea/input/contenteditable composer implementations.
- Add focused regression coverage for model selection and thinking-time behavior, including the regular GPT-5.5 non-Pro row.

## Verification

- `pnpm vitest run tests/browser/thinkingTime.test.ts tests/browser/modelSelection.test.ts` (21 tests)
- `pnpm run typecheck`
- `pnpm run format:check`
- `pnpm run build`
- `pnpm test`

Live browser verification from repo build:

```bash
pnpm run oracle -- \
  --engine browser \
  --browser-manual-login \
  --browser-keep-browser \
  --model gpt-5.5-pro \
  --browser-thinking-time extended \
  --slug pro-extended-selector-fix-live-3 \
  --prompt "Reply exactly: PRO_EXTENDED_SELECTOR_FIX_3_OK" \
  --wait \
  --verbose \
  --force
```

Post-run DOM inspection confirmed:

- composer/model pill: `Extended Pro`
- `model-switcher-gpt-5-5-pro`: `aria-checked="true"`
- `model-switcher-gpt-5-5-thinking`: `aria-checked="false"`
- stale prompt text absent

Regular GPT-5.5 Extended verification:

```bash
pnpm run oracle -- \
  --engine browser \
  --browser-manual-login \
  --browser-keep-browser \
  --model gpt-5.5 \
  --browser-thinking-time extended \
  --slug regular-55-extended-live \
  --prompt "Reply exactly: REGULAR_55_EXTENDED_OK" \
  --wait \
  --verbose \
  --force
```

Post-run DOM inspection confirmed:

- composer/model pill: `Extended`
- `model-switcher-gpt-5-5-thinking`: `aria-checked="true"`
- `model-switcher-gpt-5-5-pro`: `aria-checked="false"`
