### PR TITLE
feat(browser): explain browser control before runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Browser: add repeatable `--browser-follow-up` prompts and MCP `browserFollowUps` for multi-turn ChatGPT browser consults in one conversation. (#170) — thanks @pdurlej.
 - Browser: add live ChatGPT tab inspection, `oracle status --browser-tabs`, browser session harvest/live-tail commands, and `--browser-tab <ref>` to reuse an existing ChatGPT tab by current tab, target id, URL, or title substring. (#126) — thanks @NathanSkene.
 - Browser: add `--browser-archive` / MCP `browserArchive` to archive successful one-shot ChatGPT browser runs after local artifacts are saved. (#178) — thanks @pdurlej.
+- Browser: print a browser control plan before ChatGPT runs and dry-runs, and clean up leftover blank tabs after completed manual-profile runs. (#179) — thanks @pdurlej.
 - MCP: add the `chatgpt-pro-heavy` consult preset, MCP dry-runs, browser model strategy passthrough, and `oracle bridge claude-config --local-browser` for Claude Code + local ChatGPT Pro browser consults. (#149) — thanks @pdurlej.
 
 ### Docs

--- a/README.md
+++ b/README.md
@@ -212,6 +212,15 @@ oracle --engine browser \
   -p "Run the long UI audit" --file "src/**/*.ts"
 ```
 
+## Calmer browser runs
+
+Browser automation can open or control Chrome, so dry-runs and live runs print a short browser control plan before touching ChatGPT. Use it to choose the least disruptive path for shared desktops and agent-driven consults.
+
+- `--dry-run summary --engine browser ...` previews whether Oracle will launch visible Chrome, hide a new window, attach to an existing browser, or use remote Chrome.
+- `--browser-attach-running` and `--remote-chrome <host:port>` are the calmest options when a signed-in Chrome is already running with DevTools enabled.
+- `--browser-hide-window` is best-effort: Chrome can briefly take focus before Oracle hides it.
+- Long GPT-5.5 Pro browser consults are normal. Use `--heartbeat`, `oracle status`, and `oracle session <id>` instead of starting a duplicate run if the host agent appears to be waiting.
+
 ## Flags you’ll actually use
 
 | Flag                                                            | Purpose                                                                                                                                                                                                                                                                                                                                   |

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Browser automation can open or control Chrome, so dry-runs and live runs print a
 - `--browser-attach-running` and `--remote-chrome <host:port>` are the calmest options when a signed-in Chrome is already running with DevTools enabled.
 - `--browser-hide-window` is best-effort: Chrome can briefly take focus before Oracle hides it.
 - Long GPT-5.5 Pro browser consults are normal. Use `--heartbeat`, `oracle status`, and `oracle session <id>` instead of starting a duplicate run if the host agent appears to be waiting.
+- Successful manual-profile runs close Oracle's own ChatGPT tab and clean up leftover blank startup tabs when no other Oracle browser slots are active. Incomplete runs leave the tab open so `oracle session <id>` can reattach.
 
 ## Flags you’ll actually use
 

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -1610,6 +1610,22 @@ async function runRootCommand(options: CliOptions): Promise<void> {
     return;
   }
 
+  const getSource = (key: keyof CliOptions) =>
+    program.getOptionValueSource?.(key as string) ?? undefined;
+  applyBrowserDefaultsFromConfig(options, userConfig, getSource);
+
+  const sessionMode: SessionMode = engine === "browser" ? "browser" : "api";
+  const browserModelLabelOverride =
+    sessionMode === "browser" ? resolveBrowserModelLabel(cliModelArg, resolvedModel) : undefined;
+  const browserConfig =
+    sessionMode === "browser"
+      ? await buildBrowserConfig({
+          ...options,
+          model: resolvedModel,
+          browserModelLabel: browserModelLabelOverride,
+        })
+      : undefined;
+
   if (previewMode) {
     if (!options.prompt) {
       throw new Error("Prompt is required when using --dry-run/preview.");
@@ -1646,6 +1662,7 @@ async function runRootCommand(options: CliOptions): Promise<void> {
           version: VERSION,
           previewMode,
           log: console.log,
+          browserConfig,
         },
         {},
       );
@@ -1727,28 +1744,12 @@ async function runRootCommand(options: CliOptions): Promise<void> {
     }
   }
 
-  const getSource = (key: keyof CliOptions) =>
-    program.getOptionValueSource?.(key as string) ?? undefined;
-  applyBrowserDefaultsFromConfig(options, userConfig, getSource);
-
   const notifications = resolveNotificationSettings({
     cliNotify: options.notify,
     cliNotifySound: options.notifySound,
     env: process.env,
     config: userConfig.notify,
   });
-
-  const sessionMode: SessionMode = engine === "browser" ? "browser" : "api";
-  const browserModelLabelOverride =
-    sessionMode === "browser" ? resolveBrowserModelLabel(cliModelArg, resolvedModel) : undefined;
-  const browserConfig =
-    sessionMode === "browser"
-      ? await buildBrowserConfig({
-          ...options,
-          model: resolvedModel,
-          browserModelLabel: browserModelLabelOverride,
-        })
-      : undefined;
 
   let browserDeps: BrowserSessionRunnerDeps | undefined;
   if (browserConfig && remoteHost) {

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -111,6 +111,8 @@ oracle bridge claude-config --local-browser > .mcp.json
 
 This points Claude Code at `oracle-mcp`, sets `ORACLE_ENGINE="browser"`, and reuses the shared manual-login profile at `~/.oracle/browser-profile`. From Claude Code, call `consult` with `preset:"chatgpt-pro-heavy"` for the “Let Them Fight” workflow: Claude asks Oracle, Oracle asks ChatGPT Pro Extended in browser mode, and the answer comes back through MCP. Use `dryRun:true` first when you only want to validate the resolved request.
 
+For long Pro runs, keep the Oracle session id visible in the agent transcript and inspect `oracle status` / `oracle session <id>` before retrying. Browser consults may wait on ChatGPT for several minutes; the dry-run/browser control plan is the operator-facing signal for whether Oracle will attach to an existing browser, use remote Chrome, or launch a visible window.
+
 Override local paths when needed:
 
 ```bash

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -20,6 +20,10 @@ Claude Code can call `oracle-mcp` and ask a subscription-backed ChatGPT browser 
 - Multi-turn consults: set `browserFollowUps:["Challenge your recommendation", "Give the final decision"]` to keep one ChatGPT browser conversation open and ask sequential follow-up prompts. This is useful when Claude Code or another agent needs a stronger review than a single one-shot prompt, while preserving one Oracle session/transcript.
 - Archiving: set `browserArchive:"auto"|"always"|"never"` to control ChatGPT conversation cleanup. `auto` archives only successful browser one-shots after local artifacts are saved, and skips project, Deep Research, multi-turn, failed, and incomplete sessions.
 
+#### Long browser consults from agents
+
+Browser-backed GPT-5.5 Pro consults can legitimately run for many minutes. Some MCP clients show little progress while a tool call is active, so agents should treat a long Oracle call as a running browser job, not as a failed step. Start with `dryRun:true` when configuring a new agent, prefer `preset:"chatgpt-pro-heavy"` or `engine:"browser"` explicitly, and use the shared session store (`sessions`, `oracle status`, or `oracle session <id>`) before retrying a prompt. If the browser control plan says Oracle will launch visible Chrome, use attach/remote Chrome when the operator is actively using the computer.
+
 ### `sessions`
 
 - Inputs: `{id?, hours?, limit?, includeAll?, detail?}` mirroring `oracle status` / `oracle session`.

--- a/src/browser/chromeLifecycle.ts
+++ b/src/browser/chromeLifecycle.ts
@@ -528,6 +528,59 @@ export async function closeTab(
   }
 }
 
+export async function closeBlankChromeTabs(
+  port: number,
+  logger: BrowserLogger,
+  host?: string,
+  options?: { excludeTargetIds?: Iterable<string | null | undefined> },
+): Promise<void> {
+  const effectiveHost = host ?? "127.0.0.1";
+  const excluded = new Set(
+    [...(options?.excludeTargetIds ?? [])].filter(
+      (targetId): targetId is string => typeof targetId === "string" && targetId.length > 0,
+    ),
+  );
+  let targets: Array<{ id?: string; targetId?: string; type?: string; url?: string }>;
+  try {
+    targets = (await CDP.List({ host: effectiveHost, port })) as Array<{
+      id?: string;
+      targetId?: string;
+      type?: string;
+      url?: string;
+    }>;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger(`Failed to inspect blank Chrome tabs: ${message}`);
+    return;
+  }
+
+  let closed = 0;
+  for (const target of targets) {
+    const targetId = target.targetId ?? target.id;
+    if (!targetId || excluded.has(targetId) || !isBlankPageTarget(target)) {
+      continue;
+    }
+    try {
+      await CDP.Close({ host: effectiveHost, port, id: targetId });
+      closed += 1;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger(`Failed to close blank Chrome tab ${targetId}: ${message}`);
+    }
+  }
+  if (closed > 0) {
+    logger(`Closed ${closed} blank Chrome tab${closed === 1 ? "" : "s"}.`);
+  }
+}
+
+function isBlankPageTarget(target: { type?: string; url?: string }): boolean {
+  if (target.type && target.type !== "page") {
+    return false;
+  }
+  const url = (target.url ?? "").trim().toLowerCase();
+  return url === "about:blank" || url === "chrome://newtab/" || url === "chrome://new-tab-page/";
+}
+
 function buildChromeFlags(headless: boolean, debugBindAddress?: string | null): string[] {
   const flags = [
     "--disable-background-networking",

--- a/src/browser/controlPlan.ts
+++ b/src/browser/controlPlan.ts
@@ -1,0 +1,101 @@
+import type { BrowserAutomationConfig } from "./types.js";
+
+type BrowserControlConfig = Pick<
+  BrowserAutomationConfig,
+  "attachRunning" | "remoteChrome" | "headless" | "hideWindow" | "keepBrowser" | "manualLogin"
+>;
+
+export interface BrowserControlPlan {
+  mode: "attach-running" | "remote-chrome" | "headless" | "hidden-window" | "visible-window";
+  launchesChrome: boolean;
+  mayFocusWindow: boolean;
+  summary: string;
+  guidance: string[];
+}
+
+export function describeBrowserControlPlan(config: BrowserControlConfig = {}): BrowserControlPlan {
+  const guidance: string[] = [];
+
+  if (config.attachRunning) {
+    guidance.push("Oracle opens a dedicated tab and leaves the existing browser process alone.");
+    if (config.keepBrowser) {
+      guidance.push("The browser stays open because Oracle did not launch it.");
+    }
+    return {
+      mode: "attach-running",
+      launchesChrome: false,
+      mayFocusWindow: true,
+      summary: "attach to an already-running local Chrome session",
+      guidance,
+    };
+  }
+
+  if (config.remoteChrome) {
+    guidance.push("Oracle opens a dedicated tab in the configured remote Chrome session.");
+    guidance.push("Local Chrome launch, cookie copy, and window hiding flags are skipped.");
+    return {
+      mode: "remote-chrome",
+      launchesChrome: false,
+      mayFocusWindow: false,
+      summary: "reuse an existing remote Chrome session",
+      guidance,
+    };
+  }
+
+  if (config.headless) {
+    guidance.push("Headless mode avoids visible UI but may be blocked by ChatGPT or Cloudflare.");
+    return {
+      mode: "headless",
+      launchesChrome: true,
+      mayFocusWindow: false,
+      summary: "launch headless Chrome",
+      guidance,
+    };
+  }
+
+  if (config.hideWindow) {
+    guidance.push("Chrome may briefly focus while launching before Oracle hides it.");
+    guidance.push(
+      "For the calmest shared-desktop flow, prefer --browser-attach-running or --remote-chrome.",
+    );
+    return {
+      mode: "hidden-window",
+      launchesChrome: true,
+      mayFocusWindow: true,
+      summary: "launch Chrome and hide the window after startup",
+      guidance,
+    };
+  }
+
+  guidance.push(
+    config.manualLogin
+      ? "Manual-login mode may show the persistent Oracle Chrome profile for sign-in or automation."
+      : "A visible automation Chrome window may take focus while Oracle controls ChatGPT.",
+  );
+  guidance.push(
+    "Use --browser-hide-window, --browser-attach-running, or --remote-chrome to reduce desktop disruption.",
+  );
+  if (config.keepBrowser) {
+    guidance.push(
+      "Chrome will remain open after the run because --browser-keep-browser is enabled.",
+    );
+  }
+
+  return {
+    mode: "visible-window",
+    launchesChrome: true,
+    mayFocusWindow: true,
+    summary: "launch visible Chrome",
+    guidance,
+  };
+}
+
+export function formatBrowserControlPlan(plan: BrowserControlPlan, label = "browser"): string[] {
+  const risk = plan.mayFocusWindow
+    ? "may focus/control the browser UI"
+    : "does not use a visible local browser window";
+  return [
+    `[${label}] Browser control: ${plan.summary}; ${risk}.`,
+    ...plan.guidance.map((entry) => `[${label}] Browser guidance: ${entry}`),
+  ];
+}

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -20,6 +20,7 @@ import {
   connectWithNewTab,
   closeTab,
   closeRemoteChromeTarget,
+  closeBlankChromeTabs,
 } from "./chromeLifecycle.js";
 import { syncCookies } from "./cookies.js";
 import {
@@ -1779,6 +1780,33 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
     let keepBrowserOpen = effectiveKeepBrowser || preserveBrowserOnError;
     let cleanupProfileLock: ProfileRunLock | null = null;
     let terminatedRecordedChrome = false;
+    let otherActiveBrowserTabLeases: boolean | null = null;
+    const hasOtherActiveLeases = async () => {
+      if (!manualLogin || !tabLease) {
+        return false;
+      }
+      if (otherActiveBrowserTabLeases === null) {
+        otherActiveBrowserTabLeases = await hasOtherActiveBrowserTabLeases(
+          userDataDir,
+          tabLease.id,
+        );
+      }
+      return otherActiveBrowserTabLeases;
+    };
+    if (
+      runStatus === "complete" &&
+      manualLogin &&
+      !connectionClosedUnexpectedly &&
+      chrome?.port &&
+      ownsTarget
+    ) {
+      const otherLeasesActive = await hasOtherActiveLeases().catch(() => true);
+      if (!otherLeasesActive) {
+        await closeBlankChromeTabs(chrome.port, logger, chromeHost, {
+          excludeTargetIds: [isolatedTargetId, lastTargetId],
+        }).catch(() => undefined);
+      }
+    }
     if (!keepBrowserOpen && manualLogin && tabLease) {
       const cleanupLockTimeoutMs = Math.max(0, config.profileLockTimeoutMs ?? 0);
       if (cleanupLockTimeoutMs > 0) {
@@ -1788,9 +1816,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
           sessionId: options.sessionId,
         }).catch(() => null);
       }
-      keepBrowserOpen = await hasOtherActiveBrowserTabLeases(userDataDir, tabLease.id).catch(
-        () => false,
-      );
+      keepBrowserOpen = await hasOtherActiveLeases().catch(() => false);
       if (keepBrowserOpen) {
         logger("[browser] Other ChatGPT tab leases still active; leaving shared Chrome running.");
       } else if (reusedChrome && !connectionClosedUnexpectedly) {

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -87,6 +87,7 @@ import {
   archiveChatGptConversation,
   resolveBrowserArchiveDecision,
 } from "./actions/archiveConversation.js";
+import { describeBrowserControlPlan, formatBrowserControlPlan } from "./controlPlan.js";
 
 export type { BrowserAutomationConfig, BrowserRunOptions, BrowserRunResult } from "./types.js";
 export { CHATGPT_URL, DEFAULT_MODEL_STRATEGY, DEFAULT_MODEL_TARGET } from "./constants.js";
@@ -586,6 +587,9 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
         promptLength: promptText.length,
       })}`,
     );
+  }
+  for (const line of formatBrowserControlPlan(describeBrowserControlPlan(config), "browser")) {
+    logger(line);
   }
 
   if (config.attachRunning) {

--- a/src/browser/sessionRunner.ts
+++ b/src/browser/sessionRunner.ts
@@ -93,7 +93,9 @@ export async function runBrowserSessionExecution(
     if (typeof message !== "string") return;
     const shouldAlwaysPrint =
       message.startsWith("[browser] ") &&
-      /archive|fallback|follow-up|retry|thinking|waiting for chatgpt|browser slot/i.test(message);
+      /archive|fallback|follow-up|retry|thinking|waiting for chatgpt|browser slot|browser control|browser guidance/i.test(
+        message,
+      );
     if (!runOptions.verbose && !shouldAlwaysPrint) return;
     log(message);
   }) as BrowserLogger;

--- a/src/cli/browserDefaults.ts
+++ b/src/cli/browserDefaults.ts
@@ -51,6 +51,9 @@ export function applyBrowserDefaultsFromConfig(
     const source = getSource(key);
     return source === undefined || source === "default";
   };
+  const attachRunningRequested =
+    options.browserAttachRunning === true ||
+    (isUnset("browserAttachRunning") && browser.attachRunning === true);
 
   const configuredChatgptUrl = browser.chatgptUrl ?? browser.url;
   const cliChatgptSet = options.chatgptUrl !== undefined || options.browserUrl !== undefined;
@@ -58,13 +61,21 @@ export function applyBrowserDefaultsFromConfig(
     options.chatgptUrl = normalizeChatgptUrl(configuredChatgptUrl ?? "", CHATGPT_URL);
   }
 
-  if (isUnset("browserChromeProfile") && browser.chromeProfile !== undefined) {
+  if (
+    !attachRunningRequested &&
+    isUnset("browserChromeProfile") &&
+    browser.chromeProfile !== undefined
+  ) {
     options.browserChromeProfile = browser.chromeProfile ?? undefined;
   }
   if (isUnset("browserChromePath") && browser.chromePath !== undefined) {
     options.browserChromePath = browser.chromePath ?? undefined;
   }
-  if (isUnset("browserCookiePath") && browser.chromeCookiePath !== undefined) {
+  if (
+    !attachRunningRequested &&
+    isUnset("browserCookiePath") &&
+    browser.chromeCookiePath !== undefined
+  ) {
     options.browserCookiePath = browser.chromeCookiePath ?? undefined;
   }
   if (isUnset("browserAttachRunning") && browser.attachRunning !== undefined) {
@@ -76,7 +87,7 @@ export function applyBrowserDefaultsFromConfig(
   if (isUnset("browserTimeout") && typeof browser.timeoutMs === "number") {
     options.browserTimeout = String(browser.timeoutMs);
   }
-  if (isUnset("browserPort") && typeof browser.debugPort === "number") {
+  if (!attachRunningRequested && isUnset("browserPort") && typeof browser.debugPort === "number") {
     options.browserPort = browser.debugPort;
   }
   if (isUnset("browserInputTimeout") && typeof browser.inputTimeoutMs === "number") {
@@ -115,10 +126,14 @@ export function applyBrowserDefaultsFromConfig(
   if (isUnset("browserHeadless") && browser.headless !== undefined) {
     options.browserHeadless = browser.headless;
   }
-  if (isUnset("browserHideWindow") && browser.hideWindow !== undefined) {
+  if (!attachRunningRequested && isUnset("browserHideWindow") && browser.hideWindow !== undefined) {
     options.browserHideWindow = browser.hideWindow;
   }
-  if (isUnset("browserKeepBrowser") && browser.keepBrowser !== undefined) {
+  if (
+    !attachRunningRequested &&
+    isUnset("browserKeepBrowser") &&
+    browser.keepBrowser !== undefined
+  ) {
     options.browserKeepBrowser = browser.keepBrowser;
   }
   if (isUnset("browserModelStrategy") && browser.modelStrategy !== undefined) {
@@ -133,10 +148,18 @@ export function applyBrowserDefaultsFromConfig(
   if (isUnset("browserArchive") && browser.archiveConversations !== undefined) {
     options.browserArchive = browser.archiveConversations;
   }
-  if (isUnset("browserManualLogin") && browser.manualLogin !== undefined) {
+  if (
+    !attachRunningRequested &&
+    isUnset("browserManualLogin") &&
+    browser.manualLogin !== undefined
+  ) {
     options.browserManualLogin = browser.manualLogin;
   }
-  if (isUnset("browserManualLoginProfileDir") && browser.manualLoginProfileDir !== undefined) {
+  if (
+    !attachRunningRequested &&
+    isUnset("browserManualLoginProfileDir") &&
+    browser.manualLoginProfileDir !== undefined
+  ) {
     options.browserManualLoginProfileDir = browser.manualLoginProfileDir;
   }
 }

--- a/src/cli/dryRun.ts
+++ b/src/cli/dryRun.ts
@@ -16,6 +16,7 @@ import type { BrowserAttachment } from "../browser/types.js";
 import type { BrowserSessionConfig } from "../sessionStore.js";
 import { buildTokenEstimateSuffix, formatAttachmentLabel } from "../browser/promptSummary.js";
 import { buildCookiePlan } from "../browser/policies.js";
+import { describeBrowserControlPlan, formatBrowserControlPlan } from "../browser/controlPlan.js";
 
 interface DryRunDeps {
   readFilesImpl?: typeof readFiles;
@@ -114,10 +115,22 @@ async function runBrowserDryRun(
   const suffix = buildTokenEstimateSuffix(artifacts);
   const headerLine = `[dry-run] Oracle (${version}) would launch browser mode (${runOptions.model}) with ~${artifacts.estimatedInputTokens.toLocaleString()} tokens${suffix}.`;
   log(chalk.cyan(headerLine));
+  logBrowserControlPlan(browserConfig, log, "dry-run");
   logBrowserFollowUpSummary(runOptions.browserFollowUps, log, "dry-run");
   logBrowserCookieStrategy(browserConfig, log, "dry-run");
   logBrowserArchivePolicy(browserConfig, log, "dry-run");
   logBrowserFileSummary(artifacts, log, "dry-run");
+}
+
+function logBrowserControlPlan(
+  browserConfig: BrowserSessionConfig | undefined,
+  log: (message: string) => void,
+  label: string,
+) {
+  const plan = describeBrowserControlPlan(browserConfig);
+  for (const line of formatBrowserControlPlan(plan, label)) {
+    log(chalk.dim(line));
+  }
 }
 
 function logBrowserCookieStrategy(
@@ -178,20 +191,24 @@ export async function runBrowserPreview(
     version,
     previewMode,
     log,
+    browserConfig,
   }: {
     runOptions: RunOracleOptions;
     cwd: string;
     version: string;
     previewMode: PreviewMode;
     log: (message: string) => void;
+    browserConfig?: BrowserSessionConfig;
   },
   deps: DryRunDeps = {},
 ): Promise<void> {
+  validateBrowserFollowUps(runOptions, browserConfig);
   const assemblePromptImpl = deps.assembleBrowserPromptImpl ?? assembleBrowserPrompt;
   const artifacts = await assemblePromptImpl(runOptions, { cwd });
   const suffix = buildTokenEstimateSuffix(artifacts);
   const headerLine = `[preview] Oracle (${version}) browser mode (${runOptions.model}) with ~${artifacts.estimatedInputTokens.toLocaleString()} tokens${suffix}.`;
   log(chalk.cyan(headerLine));
+  logBrowserControlPlan(browserConfig, log, "preview");
   logBrowserFollowUpSummary(runOptions.browserFollowUps, log, "preview");
   logBrowserFileSummary(artifacts, log, "preview");
   if (previewMode === "json" || previewMode === "full") {

--- a/src/mcp/tools/consult.ts
+++ b/src/mcp/tools/consult.ts
@@ -378,7 +378,7 @@ export function registerConsultTool(server: McpServer): void {
     {
       title: "Run an oracle session",
       description:
-        'Run an Oracle session (API or ChatGPT browser automation). Use `files` to attach project context. If `engine` is omitted, Oracle follows CLI defaults: config/ORACLE_ENGINE first, then API when OPENAI_API_KEY is set, otherwise browser. For browser-based image/file uploads, set `browserAttachments:"always"`. Browser consults can include `browserFollowUps` for a multi-turn ChatGPT review in one conversation. Sessions are stored under `ORACLE_HOME_DIR` (shared with the CLI).',
+        'Run an Oracle session (API or ChatGPT browser automation). Use `files` to attach project context. If `engine` is omitted, Oracle follows CLI defaults: config/ORACLE_ENGINE first, then API when OPENAI_API_KEY is set, otherwise browser. Browser GPT-5.5 Pro consults can take many minutes; use `dryRun:true` first when configuring an agent and inspect `sessions`/`oracle status` before retrying. For browser-based image/file uploads, set `browserAttachments:"always"`. Browser consults can include `browserFollowUps` for a multi-turn ChatGPT review in one conversation. Sessions are stored under `ORACLE_HOME_DIR` (shared with the CLI).',
       // Cast to any to satisfy SDK typings across differing Zod versions.
       inputSchema: consultInputShape,
       outputSchema: consultOutputShape,

--- a/tests/browser/chromeLifecycle.test.ts
+++ b/tests/browser/chromeLifecycle.test.ts
@@ -132,6 +132,51 @@ describe("connectWithNewTab", () => {
     expect(cdpNewMock).toHaveBeenCalledTimes(1);
     expect(cdpMock).toHaveBeenCalledWith({ host: "127.0.0.1", port: 9222, target: "target-2" });
   });
+});
+
+describe("closeBlankChromeTabs", () => {
+  beforeEach(() => {
+    cdpMock.mockReset();
+    cdpNewMock.mockReset();
+    cdpCloseMock.mockReset();
+    cdpListMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("closes blank tabs while preserving active and conversation targets", async () => {
+    cdpListMock.mockResolvedValue([
+      { id: "blank-1", type: "page", url: "about:blank" },
+      { id: "chat-1", type: "page", url: "https://chatgpt.com/c/abc" },
+      { id: "active-blank", type: "page", url: "about:blank" },
+      { id: "newtab-1", type: "page", url: "chrome://newtab/" },
+      { id: "worker-1", type: "service_worker", url: "about:blank" },
+    ]);
+    cdpCloseMock.mockResolvedValue(undefined);
+
+    const { closeBlankChromeTabs } = await import("../../src/browser/chromeLifecycle.js");
+    const logger = vi.fn();
+
+    await closeBlankChromeTabs(9222, logger, "127.0.0.1", {
+      excludeTargetIds: ["active-blank"],
+    });
+
+    expect(cdpListMock).toHaveBeenCalledWith({ host: "127.0.0.1", port: 9222 });
+    expect(cdpCloseMock).toHaveBeenCalledTimes(2);
+    expect(cdpCloseMock).toHaveBeenNthCalledWith(1, {
+      host: "127.0.0.1",
+      port: 9222,
+      id: "blank-1",
+    });
+    expect(cdpCloseMock).toHaveBeenNthCalledWith(2, {
+      host: "127.0.0.1",
+      port: 9222,
+      id: "newtab-1",
+    });
+    expect(logger).toHaveBeenCalledWith("Closed 2 blank Chrome tabs.");
+  });
 
   test("opens a dedicated tab through a browser websocket endpoint", async () => {
     const browserClient = {

--- a/tests/browser/controlPlan.test.ts
+++ b/tests/browser/controlPlan.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vitest";
+import {
+  describeBrowserControlPlan,
+  formatBrowserControlPlan,
+} from "../../src/browser/controlPlan.js";
+
+describe("browser control plan", () => {
+  test("describes visible Chrome as a focus-taking launch", () => {
+    const plan = describeBrowserControlPlan({});
+
+    expect(plan).toMatchObject({
+      mode: "visible-window",
+      launchesChrome: true,
+      mayFocusWindow: true,
+    });
+    expect(formatBrowserControlPlan(plan, "dry-run").join("\n")).toContain(
+      "Browser control: launch visible Chrome",
+    );
+    expect(formatBrowserControlPlan(plan, "dry-run").join("\n")).toContain("--browser-hide-window");
+  });
+
+  test("describes attach-running as a lower-disruption existing browser flow", () => {
+    const plan = describeBrowserControlPlan({ attachRunning: true });
+
+    expect(plan).toMatchObject({
+      mode: "attach-running",
+      launchesChrome: false,
+      mayFocusWindow: true,
+    });
+    expect(formatBrowserControlPlan(plan, "browser").join("\n")).toContain(
+      "leaves the existing browser process alone",
+    );
+  });
+
+  test("describes hidden and remote modes distinctly", () => {
+    expect(describeBrowserControlPlan({ hideWindow: true }).mode).toBe("hidden-window");
+    expect(
+      describeBrowserControlPlan({ remoteChrome: { host: "127.0.0.1", port: 9222 } }).mode,
+    ).toBe("remote-chrome");
+    expect(describeBrowserControlPlan({ headless: true }).mode).toBe("headless");
+  });
+});

--- a/tests/browser/sessionRunner.test.ts
+++ b/tests/browser/sessionRunner.test.ts
@@ -428,6 +428,53 @@ describe("runBrowserSessionExecution", () => {
     });
   });
 
+  test("prints browser control guidance even when not verbose", async () => {
+    const log = vi.fn();
+    await runBrowserSessionExecution(
+      {
+        runOptions: { ...baseRunOptions, verbose: false },
+        browserConfig: baseConfig,
+        cwd: "/repo",
+        log,
+      },
+      {
+        assemblePrompt: async () => ({
+          markdown: "prompt",
+          composerText: "prompt",
+          estimatedInputTokens: 5,
+          attachments: [],
+          inlineFileCount: 0,
+          tokenEstimateIncludesInlineFiles: false,
+          attachmentsPolicy: "auto",
+          attachmentMode: "inline",
+          fallback: null,
+        }),
+        executeBrowser: async ({ log: automationLog }) => {
+          automationLog?.(
+            "[browser] Browser control: launch visible Chrome; may focus/control the browser UI.",
+          );
+          automationLog?.(
+            "[browser] Browser guidance: Use --browser-attach-running to reduce desktop disruption.",
+          );
+          automationLog?.("[browser] Prompt textarea ready");
+          return {
+            answerText: "text",
+            answerMarkdown: "markdown",
+            tookMs: 1,
+            answerTokens: 1,
+            answerChars: 4,
+          };
+        },
+      },
+    );
+
+    expect(log.mock.calls.some((call) => String(call[0]).includes("Browser control"))).toBe(true);
+    expect(log.mock.calls.some((call) => String(call[0]).includes("Browser guidance"))).toBe(true);
+    expect(log.mock.calls.some((call) => String(call[0]).includes("Prompt textarea ready"))).toBe(
+      false,
+    );
+  });
+
   test("passes fallback submission through to browser runner", async () => {
     const log = vi.fn();
     const executeBrowser = vi.fn(async () => ({

--- a/tests/cli/browserDefaults.test.ts
+++ b/tests/cli/browserDefaults.test.ts
@@ -149,6 +149,39 @@ describe("applyBrowserDefaultsFromConfig", () => {
     expect(options.browserAttachRunning).toBe(true);
   });
 
+  test("attach-running skips conflicting launch-only defaults from config", () => {
+    const options: BrowserDefaultsOptions = { browserAttachRunning: true };
+    const config: UserConfig = {
+      browser: {
+        chromeProfile: "Default",
+        chromeCookiePath: "/tmp/cookies",
+        attachRunning: false,
+        debugPort: 9222,
+        timeoutMs: 120_000,
+        hideWindow: true,
+        keepBrowser: true,
+        manualLogin: true,
+        manualLoginProfileDir: "/tmp/oracle-profile",
+        thinkingTime: "extended",
+      },
+    };
+    const source = (key: keyof BrowserDefaultsOptions) =>
+      key === "browserAttachRunning" ? "cli" : "default";
+
+    applyBrowserDefaultsFromConfig(options, config, source);
+
+    expect(options.browserAttachRunning).toBe(true);
+    expect(options.browserChromeProfile).toBeUndefined();
+    expect(options.browserCookiePath).toBeUndefined();
+    expect(options.browserPort).toBeUndefined();
+    expect(options.browserHideWindow).toBeUndefined();
+    expect(options.browserKeepBrowser).toBeUndefined();
+    expect(options.browserManualLogin).toBeUndefined();
+    expect(options.browserManualLoginProfileDir).toBeUndefined();
+    expect(options.browserTimeout).toBe("120000");
+    expect(options.browserThinkingTime).toBe("extended");
+  });
+
   test("does not override manual-login when CLI enabled it", () => {
     const options: BrowserDefaultsOptions = { browserManualLogin: true };
     const config: UserConfig = {

--- a/tests/cli/dryRun.coverage.test.ts
+++ b/tests/cli/dryRun.coverage.test.ts
@@ -148,10 +148,12 @@ describe("runDryRunSummary", () => {
         version: "0.4.1",
         previewMode: "json",
         log,
+        browserConfig: { attachRunning: true },
       },
       { assembleBrowserPromptImpl },
     );
     let joined = log.mock.calls.flat().join("\n");
+    expect(joined).toContain("Browser control: attach to an already-running local Chrome session");
     expect(joined).toContain("Preview JSON");
     expect(joined).toContain('"composerText": "Preview text"');
 

--- a/tests/cli/dryRun.test.ts
+++ b/tests/cli/dryRun.test.ts
@@ -75,6 +75,11 @@ describe("runDryRunSummary", () => {
       String(entry).includes("would launch browser mode"),
     );
     expect(header?.[0]).toContain("browser mode");
+    expect(
+      log.mock.calls.some(([entry]) =>
+        String(entry).includes("Browser control: launch visible Chrome"),
+      ),
+    ).toBe(true);
     expect(log.mock.calls.some(([entry]) => String(entry).includes("Attachments to upload"))).toBe(
       true,
     );
@@ -184,6 +189,48 @@ describe("runDryRunSummary", () => {
     );
     expect(
       log.mock.calls.some(([entry]) => String(entry).includes("Cookies: inline payload")),
+    ).toBe(true);
+  });
+
+  test("prints calmer browser control guidance for attach-running dry-runs", async () => {
+    const log = vi.fn();
+    await runDryRunSummary(
+      {
+        engine: "browser",
+        runOptions: { ...baseRunOptions, model: "gpt-5.2" },
+        cwd: "/repo",
+        version: "3.0.0",
+        log,
+        browserConfig: {
+          attachRunning: true,
+        },
+      },
+      {
+        assembleBrowserPromptImpl: async () => ({
+          markdown: "bundle",
+          composerText: "prompt",
+          estimatedInputTokens: 10,
+          attachments: [],
+          inlineFileCount: 0,
+          tokenEstimateIncludesInlineFiles: false,
+          attachmentsPolicy: "auto",
+          attachmentMode: "inline",
+          fallback: null,
+        }),
+      },
+    );
+
+    expect(
+      log.mock.calls.some(([entry]) =>
+        String(entry).includes(
+          "Browser control: attach to an already-running local Chrome session",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      log.mock.calls.some(([entry]) =>
+        String(entry).includes("leaves the existing browser process alone"),
+      ),
     ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add a small browser control-plan helper so dry-runs and live browser sessions say whether Oracle will launch visible Chrome, hide a new window, attach to an existing browser, or use remote/headless Chrome
- surface those browser-control lines through non-verbose session logs so MCP/agent callers get a visible progress signal before long GPT-5.5 Pro waits
- document calmer shared-desktop/Claude Code usage and clarify that long browser consults should be inspected via sessions/status before retrying
- let `--browser-attach-running` ignore conflicting launch-only defaults from user config, while still allowing explicitly provided conflicts to fail validation

## Why
Agents such as Claude Code can look stuck during long browser-backed GPT-5.5 Pro consults, and visible Chrome automation can surprise the operator. This PR keeps behavior explicit before touching ChatGPT and makes the attach-running path usable even when a user config defaults to manual-login browser launches.

## Tests
- `pnpm install --frozen-lockfile`
- `pnpm vitest run tests/cli/browserDefaults.test.ts tests/cli/browserConfig.test.ts tests/cli/dryRun.test.ts tests/cli/dryRun.coverage.test.ts tests/browser/controlPlan.test.ts tests/browser/sessionRunner.test.ts`
- `pnpm run check`
- `pnpm run build`
- `pnpm test`
- `git diff --check`

## Smoke / Dogfood
- `node ./dist/bin/oracle-cli.js --dry-run summary --engine browser --model gpt-5.5-pro --browser-attach-running -p "CHECK_CONTROL_PLAN" --file README.md`
  - confirmed preview prints `Browser control: attach to an already-running local Chrome session` without inheriting manual-login config conflicts
- Oracle GPT-5.5 Pro browser review, slug `calmer-browser-ux-review`: `ACCEPTABLE`
- Oracle GPT-5.5 Pro browser follow-up, slug `calmer-browser-ux-review-2`: `ACCEPTABLE`; during the wait it emitted `[browser] Waiting for ChatGPT response ...`, matching the agent-facing progress case this PR documents
