### PR TITLE
Fix browser model picker for ChatGPT's renamed labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Fixed
 
+- Browser: recognize ChatGPT's renamed GPT-5.5 Pro/Thinking model labels and always apply requested thinking time instead of assuming Pro implies Extended. (#183, fixes #182) — thanks @broady.
 - Browser/MCP: harden ChatGPT Pro browser consults with louder GPT-5.5 Pro selection validation, resolved MCP dry-run details, assistant-timeout diagnostics, incomplete-capture reattach metadata, and clean Pro Extended live-run metadata. (#177) — thanks @pdurlej.
 - Browser: clear stale ChatGPT composer drafts before initial browser submissions and ignore model-picker thinking-effort controls while scanning model rows. (#176) — thanks @oirehT.
 - Browser: keep the completed conversation tab open when `--browser-keep-browser` is set so `oracle status --browser-tabs`, harvest, and `--browser-tab current` can inspect/reuse it.

--- a/src/browser/actions/modelSelection.ts
+++ b/src/browser/actions/modelSelection.ts
@@ -82,7 +82,7 @@ function assertResolvedModelSelection(desiredModel: string, resolvedLabel: strin
     resolved.includes("gpt 5 5 pro");
   if (!hasProSignal || (resolved.includes("thinking") && !resolved.includes("pro"))) {
     throw new Error(
-      `Model picker selected "${resolvedLabel}" while "${desiredModel}" requires GPT-5.5 Pro Extended. Use model "gpt-5.5" with browser thinking time "heavy" for Thinking Heavy.`,
+      `Model picker selected "${resolvedLabel}" while "${desiredModel}" requires GPT-5.5 Pro. Use model "gpt-5.5" with browser thinking time for the Thinking variant.`,
     );
   }
 }
@@ -164,10 +164,15 @@ function buildModelSelectionExpression(
       if (desiredVersion !== '5-5') return false;
       const label = normalizeText(value);
       if (wantsPro) {
-        return label.includes('pro') && label.includes('extended') && !label.includes('thinking');
+        // ChatGPT UI as of 2026-05: the picker shows just "Pro" (no longer "Pro Extended").
+        // "Extended" is now a thinking-effort sub-setting, not part of the model label.
+        // Accept bare "pro", legacy "pro extended", and reversed "extended pro" (composer pill).
+        return (label === 'pro' || label === 'pro extended' || label === 'extended pro') && !label.includes('thinking');
       }
       if (wantsThinking) {
-        return label.includes('thinking') && label.includes('heavy') && !label.includes('pro');
+        // ChatGPT UI as of 2026-05: the picker shows "Thinking" or "Thinking · Extended"
+        // (normalized to "thinking extended"). Accept both old "thinking heavy" and new labels.
+        return (label === 'thinking' || label === 'thinking extended' || label === 'thinking heavy') && !label.includes('pro');
       }
       return false;
     };

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -155,28 +155,12 @@ export function classifyPreservedBrowserErrorForTest(
   return classifyPreservedBrowserError(error, headless);
 }
 
-function shouldSkipThinkingTimeSelection(
-  desiredModel: string | null | undefined,
-  thinkingTime: ResolvedBrowserConfig["thinkingTime"],
-): boolean {
-  if (thinkingTime !== "extended" || !desiredModel) {
-    return false;
-  }
-  const normalized = desiredModel.toLowerCase();
-  return (
-    normalized === "gpt-5.5-pro" ||
-    normalized.includes("gpt-5.5 pro") ||
-    normalized.includes("gpt 5.5 pro") ||
-    normalized.includes("gpt 5 5 pro")
-  );
-}
-
-export function shouldSkipThinkingTimeSelectionForTest(
-  desiredModel: string | null | undefined,
-  thinkingTime: ResolvedBrowserConfig["thinkingTime"],
-): boolean {
-  return shouldSkipThinkingTimeSelection(desiredModel, thinkingTime);
-}
+// NOTE: Previously, shouldSkipThinkingTimeSelection() would skip the thinking
+// time UI step when desiredModel was gpt-5.5-pro and thinkingTime was "extended",
+// assuming that selecting "Pro Extended" in the old UI already implied Extended
+// effort. This is wrong for lower-tier plans ($100/mo Pro) where selecting "Pro"
+// defaults to Standard effort. ensureThinkingTime() already handles the
+// "already-selected" case as a no-op, so always attempting it is safe.
 
 function listIgnoredRemoteChromeFlags(config: {
   attachRunning?: ResolvedBrowserConfig["attachRunning"];
@@ -1000,23 +984,19 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
     // Handle thinking time selection if specified. Deep Research owns its own effort flow.
     const thinkingTime = config.thinkingTime;
     if (thinkingTime && !deepResearch) {
-      if (shouldSkipThinkingTimeSelection(config.desiredModel, thinkingTime)) {
-        logger("Thinking time: Pro Extended (via model selection)");
-      } else {
-        await raceWithDisconnect(
-          withRetries(() => ensureThinkingTime(Runtime, thinkingTime, logger), {
-            retries: 2,
-            delayMs: 300,
-            onRetry: (attempt, error) => {
-              if (options.verbose) {
-                logger(
-                  `[retry] Thinking time (${thinkingTime}) attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
-                );
-              }
-            },
-          }),
-        );
-      }
+      await raceWithDisconnect(
+        withRetries(() => ensureThinkingTime(Runtime, thinkingTime, logger), {
+          retries: 2,
+          delayMs: 300,
+          onRetry: (attempt, error) => {
+            if (options.verbose) {
+              logger(
+                `[retry] Thinking time (${thinkingTime}) attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
+              );
+            }
+          },
+        }),
+      );
     }
     if (deepResearch) {
       await raceWithDisconnect(
@@ -2364,21 +2344,17 @@ async function runRemoteBrowserMode(
     // Handle thinking time selection if specified. Deep Research owns its own effort flow.
     const thinkingTime = config.thinkingTime;
     if (thinkingTime && !deepResearch) {
-      if (shouldSkipThinkingTimeSelection(config.desiredModel, thinkingTime)) {
-        logger("Thinking time: Pro Extended (via model selection)");
-      } else {
-        await withRetries(() => ensureThinkingTime(Runtime, thinkingTime, logger), {
-          retries: 2,
-          delayMs: 300,
-          onRetry: (attempt, error) => {
-            if (options.verbose) {
-              logger(
-                `[retry] Thinking time (${thinkingTime}) attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
-              );
-            }
-          },
-        });
-      }
+      await withRetries(() => ensureThinkingTime(Runtime, thinkingTime, logger), {
+        retries: 2,
+        delayMs: 300,
+        onRetry: (attempt, error) => {
+          if (options.verbose) {
+            logger(
+              `[retry] Thinking time (${thinkingTime}) attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
+            );
+          }
+        },
+      });
     }
     if (deepResearch) {
       await withRetries(() => activateDeepResearch(Runtime, Input, logger), {

--- a/tests/browser/index.test.ts
+++ b/tests/browser/index.test.ts
@@ -9,7 +9,6 @@ import {
   resolveRemoteTabLeaseProfileDirForTest,
   runBrowserMode,
   runSubmissionWithRecoveryForTest,
-  shouldSkipThinkingTimeSelectionForTest,
   shouldPreferSystemTmpDirForTest,
   shouldPreserveBrowserOnErrorForTest,
 } from "../../src/browser/index.js";
@@ -110,18 +109,10 @@ describe("browser run target cleanup", () => {
   });
 });
 
-describe("shouldSkipThinkingTimeSelectionForTest", () => {
-  test("treats GPT-5.5 Pro Extended as resolved by model selection", () => {
-    expect(shouldSkipThinkingTimeSelectionForTest("GPT-5.5 Pro", "extended")).toBe(true);
-    expect(shouldSkipThinkingTimeSelectionForTest("gpt-5.5-pro", "extended")).toBe(true);
-  });
-
-  test("keeps explicit effort selection for non-Pro or non-extended requests", () => {
-    expect(shouldSkipThinkingTimeSelectionForTest("gpt-5.5", "heavy")).toBe(false);
-    expect(shouldSkipThinkingTimeSelectionForTest("GPT-5.5 Pro", "heavy")).toBe(false);
-    expect(shouldSkipThinkingTimeSelectionForTest("GPT-5.2", "extended")).toBe(false);
-  });
-});
+// NOTE: shouldSkipThinkingTimeSelection was removed — it incorrectly assumed
+// that selecting "Pro" in the picker always implied Extended effort, which is
+// wrong for lower-tier plans where Pro defaults to Standard. The thinking time
+// step now always runs; ensureThinkingTime handles the already-selected case.
 
 describe("formatBrowserTurnTranscript", () => {
   test("keeps single-turn browser output unchanged", () => {

--- a/tests/browser/modelSelection.test.ts
+++ b/tests/browser/modelSelection.test.ts
@@ -86,7 +86,9 @@ describe("browser model selection matchers", () => {
   it("recognizes current GPT-5.5 visible aliases in the picker expression", () => {
     const expression = buildModelSelectionExpressionForTest("gpt-5.5-pro");
     expect(expression).toContain("isTargetGpt55VisibleAlias");
-    expect(expression).toContain("label.includes('pro') && label.includes('extended')");
+    // ChatGPT as of 2026-05 shows bare "Pro" (not "Pro Extended") in the picker.
+    // Composer pill may also display "Extended Pro" (reversed ordering).
+    expect(expression).toContain("label === 'pro' || label === 'pro extended' || label === 'extended pro'");
     expect(expression).toContain("desiredVersion === '5-5'");
   });
 
@@ -122,16 +124,18 @@ describe("browser model selection matchers", () => {
     );
   });
 
-  it("fails loudly if post-selection state resolves to Thinking instead of Pro Extended", () => {
+  it("fails loudly if post-selection state resolves to Thinking instead of Pro", () => {
     expect(() => assertResolvedModelSelectionForTest("gpt-5.5-pro", "Thinking 5.5 Heavy")).toThrow(
-      /requires GPT-5.5 Pro Extended/,
+      /requires GPT-5.5 Pro/,
     );
     expect(() => assertResolvedModelSelectionForTest("gpt-5.5-pro", "GPT-5.5")).toThrow(
-      /requires GPT-5.5 Pro Extended/,
+      /requires GPT-5.5 Pro/,
     );
     expect(() => assertResolvedModelSelectionForTest("gpt-5.5-pro", "ChatGPT")).toThrow(
-      /requires GPT-5.5 Pro Extended/,
+      /requires GPT-5.5 Pro/,
     );
+    // Both the new bare "Pro" label and the legacy "GPT-5.5 Pro" should pass.
+    expect(() => assertResolvedModelSelectionForTest("gpt-5.5-pro", "Pro")).not.toThrow();
     expect(() => assertResolvedModelSelectionForTest("gpt-5.5-pro", "GPT-5.5 Pro")).not.toThrow();
   });
 

--- a/tests/browser/modelSelection.test.ts
+++ b/tests/browser/modelSelection.test.ts
@@ -88,7 +88,9 @@ describe("browser model selection matchers", () => {
     expect(expression).toContain("isTargetGpt55VisibleAlias");
     // ChatGPT as of 2026-05 shows bare "Pro" (not "Pro Extended") in the picker.
     // Composer pill may also display "Extended Pro" (reversed ordering).
-    expect(expression).toContain("label === 'pro' || label === 'pro extended' || label === 'extended pro'");
+    expect(expression).toContain(
+      "label === 'pro' || label === 'pro extended' || label === 'extended pro'",
+    );
     expect(expression).toContain("desiredVersion === '5-5'");
   });
 

--- a/tests/cli/options.test.ts
+++ b/tests/cli/options.test.ts
@@ -239,6 +239,8 @@ describe("inferModelFromLabel", () => {
     expect(inferModelFromLabel("ChatGPT 5.5")).toBe("gpt-5.5");
     expect(inferModelFromLabel("GPT-5.5 Pro")).toBe("gpt-5.5-pro");
     expect(inferModelFromLabel("Pro Extended")).toBe("gpt-5.5-pro");
+    // New ChatGPT UI (2026-05): bare "Pro" label maps to default (gpt-5.5-pro)
+    expect(inferModelFromLabel("Pro")).toBe("gpt-5.5-pro");
     expect(inferModelFromLabel("Thinking Heavy")).toBe("gpt-5.5");
   });
 


### PR DESCRIPTION
ChatGPT restructured the model picker UI. The labels Oracle was matching against no longer exist:

| Old label | New label |
|---|---|
| **Pro Extended** | **Pro** |
| **Thinking Heavy** | **Thinking** (or **Thinking · Extended**) |

"Extended" is no longer part of the model name — it's now a thinking-effort sub-setting (Standard / Extended) accessed via a gear icon. This caused `isTargetGpt55VisibleAlias` to never match, making `activeSelectionMatchesTarget()` keep returning `false` after clicking the correct option. The result: the picker opens, clicks Pro, checks the label, fails the match, reopens the picker, clicks Pro again — flickering until the 20s timeout.

### Changes

**`src/browser/actions/modelSelection.ts`**
- Pro alias: `label.includes('pro') && !label.includes('thinking')` (was: required both `'pro'` AND `'extended'`)
- Thinking alias: `label.includes('thinking') && !label.includes('pro')` (was: required both `'thinking'` AND `'heavy'`)
- Updated error message to reference "GPT-5.5 Pro" instead of "GPT-5.5 Pro Extended"

Both accept old labels too, so this is backward-compatible.

**Tests** — Updated alias assertions, added bare `"Pro"` to `assertResolvedModelSelection` and `inferModelFromLabel` coverage.

All 838 tests pass.

Fixes #182