### PR TITLE
fix(mcp): reject unknown consult fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Fixed
 
+- MCP: reject unknown `consult` fields instead of silently ignoring misspelled tool-call arguments. (#184) — thanks @pdurlej.
 - Browser/MCP: harden ChatGPT Pro browser consults with louder GPT-5.5 Pro selection validation, resolved MCP dry-run details, assistant-timeout diagnostics, incomplete-capture reattach metadata, and clean Pro Extended live-run metadata. (#177) — thanks @pdurlej.
 - Browser: clear stale ChatGPT composer drafts before initial browser submissions and ignore model-picker thinking-effort controls while scanning model rows. (#176) — thanks @oirehT.
 - Browser: keep the completed conversation tab open when `--browser-keep-browser` is set so `oracle status --browser-tabs`, harvest, and `--browser-tab current` can inspect/reuse it.

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -2,26 +2,28 @@ import { z } from "zod";
 
 export const CONSULT_PRESETS = ["chatgpt-pro-heavy"] as const;
 
-export const consultInputSchema = z.object({
-  preset: z.enum(CONSULT_PRESETS).optional(),
-  prompt: z.string().min(1, "Prompt is required."),
-  files: z.array(z.string()).default([]),
-  model: z.string().optional(),
-  models: z.array(z.string()).optional(),
-  engine: z.enum(["api", "browser"]).optional(),
-  browserModelLabel: z.string().optional(),
-  browserAttachments: z.enum(["auto", "never", "always"]).optional(),
-  browserBundleFiles: z.boolean().optional(),
-  browserThinkingTime: z.enum(["light", "standard", "extended", "heavy"]).optional(),
-  browserModelStrategy: z.enum(["select", "current", "ignore"]).optional(),
-  browserResearchMode: z.enum(["deep"]).optional(),
-  browserArchive: z.enum(["auto", "always", "never"]).optional(),
-  browserFollowUps: z.array(z.string()).optional(),
-  browserKeepBrowser: z.boolean().optional(),
-  dryRun: z.boolean().optional(),
-  search: z.boolean().optional(),
-  slug: z.string().optional(),
-});
+export const consultInputSchema = z
+  .object({
+    preset: z.enum(CONSULT_PRESETS).optional(),
+    prompt: z.string().min(1, "Prompt is required."),
+    files: z.array(z.string()).default([]),
+    model: z.string().optional(),
+    models: z.array(z.string()).optional(),
+    engine: z.enum(["api", "browser"]).optional(),
+    browserModelLabel: z.string().optional(),
+    browserAttachments: z.enum(["auto", "never", "always"]).optional(),
+    browserBundleFiles: z.boolean().optional(),
+    browserThinkingTime: z.enum(["light", "standard", "extended", "heavy"]).optional(),
+    browserModelStrategy: z.enum(["select", "current", "ignore"]).optional(),
+    browserResearchMode: z.enum(["deep"]).optional(),
+    browserArchive: z.enum(["auto", "always", "never"]).optional(),
+    browserFollowUps: z.array(z.string()).optional(),
+    browserKeepBrowser: z.boolean().optional(),
+    dryRun: z.boolean().optional(),
+    search: z.boolean().optional(),
+    slug: z.string().optional(),
+  })
+  .strict();
 
 export type ConsultInput = z.infer<typeof consultInputSchema>;
 

--- a/tests/mcp/consult.test.ts
+++ b/tests/mcp/consult.test.ts
@@ -235,4 +235,33 @@ describe("summarizeModelRunsForConsult", () => {
     });
     expect(result.content[0]?.text).toContain("[dry-run] MCP resolved request:");
   });
+
+  test("rejects unsupported consult fields instead of silently ignoring them", async () => {
+    const handlers: Array<(input: unknown) => Promise<unknown>> = [];
+    registerConsultTool({
+      registerTool: (_name: string, _def: unknown, fn: (input: unknown) => Promise<unknown>) => {
+        handlers.push(fn);
+      },
+      server: {
+        sendLoggingMessage: async () => undefined,
+      },
+    } as unknown as Parameters<typeof registerConsultTool>[0]);
+    const handler = handlers[0];
+    if (!handler) throw new Error("handler not registered");
+
+    const result = (await handler({
+      dryRun: true,
+      engine: "browser",
+      model: "gpt-5.5-pro",
+      prompt: "review this",
+      files: [],
+      run_in_background: true,
+    })) as {
+      isError?: boolean;
+      content: Array<{ type: "text"; text: string }>;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("run_in_background");
+  });
 });


### PR DESCRIPTION
## Summary
- Make the MCP `consult` input schema strict so unsupported keys return a validation error instead of being silently ignored.
- Add coverage for the agent footgun where `run_in_background: true` looked accepted but had no effect.

## Why
During a browser-mode MCP consult, a caller passed `run_in_background: true`. Because the Zod object was not strict, the key was stripped and the request continued, making it look like Oracle supported detached MCP runs.

Failing loudly is safer for agent callers: they can correct the request instead of assuming a no-op option changed runtime behavior.

This PR does not change browser attachment policy. Separately, local smoke confirmed that real ChatGPT file chips should use `browserAttachments: "always"` when files must be uploaded rather than inlined.

## Tests
- `pnpm vitest run tests/mcp/consult.test.ts tests/mcp.schema.test.ts`
- `pnpm run format:check`
- `pnpm run build`
- `pnpm run check`
- `git diff --check`

## Local Smoke Note
- Local Oracle `0.11.0` browser run with `browserAttachments: "always"` and four small test files completed successfully and returned all expected attachment markers.
