### PR TITLE
Fix ChatGPT browser model selection for compact labels

### DIFF
--- a/src/browser/actions/modelSelection.ts
+++ b/src/browser/actions/modelSelection.ts
@@ -576,6 +576,11 @@ function buildModelSelectionExpression(
               resolve({ status: 'switched', label: getResolvedLabel(match.label) });
               return;
             }
+            if (selectionSettled === 'changed' || selectionSettled === 'timeout') {
+              closeMenu();
+              resolve({ status: 'switched-best-effort', label: getResolvedLabel(match.label) });
+              return;
+            }
             attempt();
           });
           return;

--- a/src/cli/browserConfig.ts
+++ b/src/cli/browserConfig.ts
@@ -126,9 +126,7 @@ export async function buildBrowserConfig(
   const desiredModelOverride = options.browserModelLabel?.trim();
   const normalizedOverride = desiredModelOverride?.toLowerCase() ?? "";
   const baseModel = options.model.toLowerCase();
-  const isChatGptModel = baseModel.startsWith("gpt-") && !baseModel.includes("codex");
-  const shouldUseOverride =
-    !isChatGptModel && normalizedOverride.length > 0 && normalizedOverride !== baseModel;
+  const shouldUseOverride = normalizedOverride.length > 0 && normalizedOverride !== baseModel;
   const modelStrategy =
     normalizeBrowserModelStrategy(options.browserModelStrategy) ?? DEFAULT_MODEL_STRATEGY;
   const cookieNames = parseCookieNames(
@@ -157,11 +155,9 @@ export async function buildBrowserConfig(
   const rawUrl = options.chatgptUrl ?? options.browserUrl;
   const url = rawUrl ? normalizeChatgptUrl(rawUrl, CHATGPT_URL) : undefined;
 
-  const desiredModel = isChatGptModel
-    ? mapModelToBrowserLabel(options.model)
-    : shouldUseOverride
-      ? desiredModelOverride
-      : mapModelToBrowserLabel(options.model);
+  const desiredModel = shouldUseOverride
+    ? desiredModelOverride
+    : mapModelToBrowserLabel(options.model);
 
   if (
     modelStrategy === "select" &&

--- a/tests/browser/modelSelection.test.ts
+++ b/tests/browser/modelSelection.test.ts
@@ -112,10 +112,14 @@ describe("browser model selection matchers", () => {
     expect(expression).toContain("if (isThinkingEffortControl(option))");
   });
 
-  it("does not accept a changed but wrong model selection as success", () => {
+  it("accepts post-click state changes as a best-effort switch", () => {
     const expression = buildModelSelectionExpressionForTest("gpt-5.5-pro");
     expect(expression).toContain("resolve('target')");
     expect(expression).toContain("resolve('changed')");
+    expect(expression).toContain("resolve({ status: 'switched-best-effort'");
+    expect(expression).toContain(
+      "selectionSettled === 'changed' || selectionSettled === 'timeout'",
+    );
     expect(expression).toContain("if (selectionSettled === 'target')");
     expect(expression).not.toContain(
       "optionIsSelected(match.node) || activeSelectionMatchesTarget()",

--- a/tests/cli/browserConfig.test.ts
+++ b/tests/cli/browserConfig.test.ts
@@ -96,7 +96,7 @@ describe("buildBrowserConfig", () => {
       model: "gpt-5.2-pro",
       browserModelLabel: "Instant",
     });
-    expect(config.desiredModel).toBe("GPT-5.5 Pro");
+    expect(config.desiredModel).toBe("Instant");
   });
 
   test("rejects invalid browser max concurrent tabs", async () => {
@@ -135,7 +135,7 @@ describe("buildBrowserConfig", () => {
       model: "gpt-5.1",
       browserModelLabel: "  ChatGPT 5.1 Instant  ",
     });
-    expect(config.desiredModel).toBe("GPT-5.2");
+    expect(config.desiredModel).toBe("ChatGPT 5.1 Instant");
   });
 
   test("parses remoteChrome host targets", async () => {


### PR DESCRIPTION
## Summary
- Preserve explicit ChatGPT browser model labels such as `Instant` instead of remapping them back to canonical labels like `GPT-5.2 Instant`.
- Treat post-click model picker state changes or delayed UI settlement as a best-effort successful switch, preventing repeated picker reopen/click loops after selecting options such as `Thinking Heavy`.
- Update browser config and model selection tests for the current ChatGPT compact model picker labels.

## Why
The current ChatGPT picker can show compact options like `Instant`, `Thinking • Heavy`, and `Pro • Extended`. In local browser runs, Oracle could fail to match these compact labels or continue reopening the picker after the selection already changed, which caused visible flashing and prevented prompt submission.

## Validation
- `pnpm exec vitest run tests/browser/modelSelection.test.ts tests/cli/browserConfig.test.ts`
- `pnpm run build`
- `pnpm run check`
- Live browser smoke tests:
  - `--model "Instant" --browser-model-strategy select` returned `select-instant-ok`.
  - `--model "Thinking Heavy" --browser-model-strategy select` returned `select-thinking-heavy-ok`.
  - `--model gpt-5.5 --browser-model-strategy select` returned `select-gpt55-ok`.
  - `--model gpt-5.5-pro --browser-model-strategy select` returned `pro-extended-ok`.