### PR TITLE
fix(remote): forward browser run options

### DIFF
--- a/src/remote/client.ts
+++ b/src/remote/client.ts
@@ -20,10 +20,18 @@ export function createRemoteBrowserExecutor({ host, token }: RemoteExecutorOptio
     const payload: RemoteRunPayload = {
       prompt: options.prompt,
       attachments: await serializeAttachments(options.attachments ?? []),
+      fallbackSubmission: options.fallbackSubmission
+        ? {
+            prompt: options.fallbackSubmission.prompt,
+            attachments: await serializeAttachments(options.fallbackSubmission.attachments ?? []),
+          }
+        : undefined,
       browserConfig: options.config ?? {},
       options: {
         heartbeatIntervalMs: options.heartbeatIntervalMs,
         verbose: options.verbose,
+        sessionId: options.sessionId,
+        followUpPrompts: options.followUpPrompts,
       },
     };
 

--- a/src/remote/server.ts
+++ b/src/remote/server.ts
@@ -170,6 +170,12 @@ export async function createRemoteServer(
     };
 
     const attachments: BrowserAttachment[] = [];
+    let fallbackSubmission:
+      | {
+          prompt: string;
+          attachments: BrowserAttachment[];
+        }
+      | undefined;
     try {
       const attachmentsPayload = Array.isArray(payload.attachments) ? payload.attachments : [];
       for (const [index, attachment] of attachmentsPayload.entries()) {
@@ -181,6 +187,29 @@ export async function createRemoteServer(
           displayPath: attachment.displayPath,
           sizeBytes: attachment.sizeBytes,
         });
+      }
+
+      if (payload.fallbackSubmission) {
+        const fallbackAttachmentDir = path.join(runDir, "fallback-attachments");
+        await mkdir(fallbackAttachmentDir, { recursive: true });
+        const fallbackAttachments: BrowserAttachment[] = [];
+        const fallbackPayload = Array.isArray(payload.fallbackSubmission.attachments)
+          ? payload.fallbackSubmission.attachments
+          : [];
+        for (const [index, attachment] of fallbackPayload.entries()) {
+          const safeName = sanitizeName(attachment.fileName ?? `fallback-attachment-${index + 1}`);
+          const filePath = path.join(fallbackAttachmentDir, safeName);
+          await writeFile(filePath, Buffer.from(attachment.contentBase64, "base64"));
+          fallbackAttachments.push({
+            path: filePath,
+            displayPath: attachment.displayPath,
+            sizeBytes: attachment.sizeBytes,
+          });
+        }
+        fallbackSubmission = {
+          prompt: payload.fallbackSubmission.prompt,
+          attachments: fallbackAttachments,
+        };
       }
 
       // Reuse the existing browser logger surface so clients see the same log stream.
@@ -215,10 +244,13 @@ export async function createRemoteServer(
       const result = await runBrowser({
         prompt: payload.prompt,
         attachments,
+        fallbackSubmission,
         config: payload.browserConfig,
         log: automationLogger,
         heartbeatIntervalMs: payload.options.heartbeatIntervalMs,
         verbose: payload.options.verbose,
+        sessionId: payload.options.sessionId,
+        followUpPrompts: payload.options.followUpPrompts,
       });
 
       sendEvent({ type: "result", result: sanitizeResult(result) });

--- a/src/remote/types.ts
+++ b/src/remote/types.ts
@@ -12,10 +12,16 @@ export interface RemoteAttachmentPayload {
 export interface RemoteRunPayload {
   prompt: string;
   attachments: RemoteAttachmentPayload[];
+  fallbackSubmission?: {
+    prompt: string;
+    attachments: RemoteAttachmentPayload[];
+  };
   browserConfig: BrowserSessionConfig;
   options: {
     heartbeatIntervalMs?: number;
     verbose?: boolean;
+    sessionId?: string;
+    followUpPrompts?: string[];
   };
 }
 

--- a/tests/remote/server.test.ts
+++ b/tests/remote/server.test.ts
@@ -29,7 +29,9 @@ describe("remote browser service", () => {
     async () => {
       const tmpDir = await mkdtemp(path.join(os.tmpdir(), "oracle-remote-test-"));
       const attachmentPath = path.join(tmpDir, "note.txt");
+      const fallbackAttachmentPath = path.join(tmpDir, "fallback.txt");
       await writeFile(attachmentPath, "hello world", "utf8");
+      await writeFile(fallbackAttachmentPath, "fallback world", "utf8");
 
       const runLog: string[] = [];
       const server = await createRemoteServer(
@@ -37,6 +39,8 @@ describe("remote browser service", () => {
         {
           runBrowser: async (options) => {
             runLog.push(options.prompt);
+            expect(options.sessionId).toBe("remote-session-id");
+            expect(options.followUpPrompts).toEqual(["follow up"]);
             expect(options.attachments).toHaveLength(1);
             const attachment = options.attachments?.[0];
             if (!attachment) {
@@ -44,6 +48,14 @@ describe("remote browser service", () => {
             }
             const stored = await readFile(attachment.path, "utf8");
             expect(stored).toBe("hello world");
+            expect(options.fallbackSubmission?.prompt).toBe("fallback prompt");
+            expect(options.fallbackSubmission?.attachments).toHaveLength(1);
+            const fallbackAttachment = options.fallbackSubmission?.attachments[0];
+            if (!fallbackAttachment) {
+              throw new Error("missing fallback attachment");
+            }
+            const fallbackStored = await readFile(fallbackAttachment.path, "utf8");
+            expect(fallbackStored).toBe("fallback world");
             options.log?.("uploading attachment");
             const result: BrowserRunResult = {
               answerText: "hi",
@@ -65,7 +77,15 @@ describe("remote browser service", () => {
       const result = await executor({
         prompt: "remote",
         attachments: [{ path: attachmentPath, displayPath: "note.txt", sizeBytes: 11 }],
+        fallbackSubmission: {
+          prompt: "fallback prompt",
+          attachments: [
+            { path: fallbackAttachmentPath, displayPath: "fallback.txt", sizeBytes: 14 },
+          ],
+        },
         config: {},
+        sessionId: "remote-session-id",
+        followUpPrompts: ["follow up"],
         log: (message?: string) => {
           if (message) clientLogs.push(message);
         },


### PR DESCRIPTION
## Summary
- Forward browser run metadata through the remote `oracle serve` bridge: `sessionId`, `followUpPrompts`, and fallback submission attachments.
- Rehydrate fallback attachments on the remote host the same way primary attachments are already rehydrated.
- Extend the remote service test so the server-side `runBrowser` receives the same browser options that the local runner supplied.

## Why
A live OpenClaw → Oracle bridge smoke completed successfully, but logged:

```text
[browser] ChatGPT archive skipped (artifact-save-failed).
```

The answer and local session transcript were saved on the caller side, but the remote browser host did not receive the caller `sessionId`, so browser-mode artifact saving on the host could not run before archive decision time. That made auto-archive skip even though the caller later saved the transcript.

Forwarding `sessionId` lets the host-side browser run save its transcript/artifacts before applying the archive safety gate. Forwarding follow-ups and fallback submission also keeps remote browser runs closer to the local execution contract.

## Live Smoke Evidence
OpenClaw remote bridge smoke:

```text
engine: browser
model: gpt-5.5-pro
browserThinkingTime: extended
browserAttachments: always
conversationMode: archive
browserArchive: auto
status: completed
fetch: OK
```

The run returned `CHECK_OPENCLAW_ORACLE_ORGANIC_OK`; the remaining issue was the archive skip noted above.

## Tests
- `pnpm vitest run tests/remote/server.test.ts tests/remote/remoteServiceConfig.test.ts`
- `pnpm run format:check`
- `pnpm run build`
- `pnpm run check`
- `pnpm test`
- `git diff --check`
