### PR TITLE
Fix ChatGPT login CTA detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Browser/MCP: avoid false ChatGPT login prompts when sidebar history starts with "Login..." and default MCP browser consults to manual login on Windows. (#189) — thanks @ndycode.
 - Browser: allow Pro model selection in ChatGPT Temporary Chat URLs and skip archive attempts for temporary conversations. (#185) — thanks @pdurlej.
 - Browser: recognize ChatGPT's renamed GPT-5.5 Pro/Thinking model labels and always apply requested thinking time instead of assuming Pro implies Extended. (#183, fixes #182) — thanks @broady.
 - MCP: reject unknown `consult` fields instead of silently ignoring misspelled tool-call arguments. (#184) — thanks @pdurlej.

--- a/docs/windows-work.md
+++ b/docs/windows-work.md
@@ -9,3 +9,5 @@ Read this file whenever you're working from Windows and add new findings so the 
 - Prefer PowerShell + pnpm directly; watch for CRLF warnings when touching tracked files.
 
 Future Windows gotchas belong here. Update this doc when you learn something new.
+
+- ChatGPT sidebar/history labels can include phrases like "Login setup instruction"; login probes must match exact auth CTAs, not any visible text starting with login, or manual-login automation loops forever before typing.

--- a/src/browser/actions/navigation.ts
+++ b/src/browser/actions/navigation.ts
@@ -489,9 +489,8 @@ function buildLoginProbeExpression(timeoutMs: number): string {
         if (!text) return false;
         const normalized = text.toLowerCase().trim();
         return (
-          ['log in', 'login', 'sign in', 'signin', 'continue with', 'sign up for free'].some(
-            (needle) => normalized.startsWith(needle),
-          ) ||
+          ['log in', 'login', 'sign in', 'signin', 'sign up for free'].includes(normalized) ||
+          normalized.startsWith('continue with') ||
           normalized.includes('get responses tailored to you') ||
           normalized.includes('log in to get answers')
         );
@@ -593,4 +592,8 @@ function normalizeLoginProbe(raw: unknown): LoginProbeResult {
     domLoginCta: Boolean(value.domLoginCta),
     onAuthPage: Boolean(value.onAuthPage),
   };
+}
+
+export function buildLoginProbeExpressionForTest(timeoutMs = LOGIN_CHECK_TIMEOUT_MS): string {
+  return buildLoginProbeExpression(timeoutMs);
 }

--- a/src/mcp/tools/consult.ts
+++ b/src/mcp/tools/consult.ts
@@ -253,7 +253,9 @@ export function buildConsultBrowserConfig({
     ? mapModelToBrowserLabel(runModel)
     : resolveBrowserModelLabel(preferredLabel, runModel);
   const configuredUrl = configuredBrowser.chatgptUrl ?? configuredBrowser.url ?? CHATGPT_URL;
-  const manualLogin = hasProfileDir ? true : (configuredBrowser.manualLogin ?? false);
+  const manualLogin = hasProfileDir
+    ? true
+    : (configuredBrowser.manualLogin ?? process.platform === "win32");
 
   return {
     ...configuredBrowser,

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -202,6 +202,43 @@ describe("ensureNotBlocked", () => {
 });
 
 describe("ensureLoggedIn", () => {
+  async function runLoginProbeForLabels(labels: string[], fetchStatus = 200) {
+    class FakeHTMLElement {
+      constructor(public textContent: string) {}
+
+      getAttribute() {
+        return "";
+      }
+
+      getBoundingClientRect() {
+        return { width: 120, height: 32 };
+      }
+    }
+
+    const nodes = labels.map((label) => new FakeHTMLElement(label));
+    const document = { querySelectorAll: vi.fn(() => nodes) };
+    const window = { getComputedStyle: vi.fn(() => ({ display: "block", visibility: "visible" })) };
+    const fetch = vi.fn().mockResolvedValue({ status: fetchStatus });
+    const location = { href: "https://chatgpt.com/", pathname: "/" };
+    const expression = buildLoginProbeExpressionForTest(0);
+    const evaluate = new Function(
+      "document",
+      "window",
+      "HTMLElement",
+      "fetch",
+      "location",
+      `return ${expression};`,
+    ) as (
+      document: unknown,
+      window: unknown,
+      HTMLElement: typeof FakeHTMLElement,
+      fetch: unknown,
+      location: unknown,
+    ) => Promise<{ ok: boolean; domLoginCta: boolean; status: number }>;
+
+    return evaluate(document, window, FakeHTMLElement, fetch, location);
+  }
+
   test("logs success when session is present", async () => {
     const runtime = {
       evaluate: vi.fn().mockResolvedValue({
@@ -212,13 +249,23 @@ describe("ensureLoggedIn", () => {
     expect(logger).toHaveBeenCalledWith(expect.stringContaining("Login check passed"));
   });
 
-  test("does not treat history items starting with login as login CTAs", () => {
-    const expression = buildLoginProbeExpressionForTest();
-    expect(expression).toContain(
-      "['log in', 'login', 'sign in', 'signin', 'sign up for free'].includes(normalized)",
-    );
-    expect(expression).toContain("normalized.startsWith('continue with')");
-    expect(expression).not.toContain("normalized.startsWith(needle)");
+  test("does not treat history items starting with login as login CTAs", async () => {
+    await expect(runLoginProbeForLabels(["Login setup instruction"])).resolves.toMatchObject({
+      ok: true,
+      domLoginCta: false,
+      status: 200,
+    });
+  });
+
+  test("still detects exact and provider login CTAs", async () => {
+    await expect(runLoginProbeForLabels(["Log in"])).resolves.toMatchObject({
+      ok: false,
+      domLoginCta: true,
+    });
+    await expect(runLoginProbeForLabels(["Continue with Google"])).resolves.toMatchObject({
+      ok: false,
+      domLoginCta: true,
+    });
   });
 
   test("throws with cookie guidance when cookies missing", async () => {

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -10,6 +10,7 @@ import {
   ensureNotBlocked,
   ensureLoggedIn,
 } from "../../src/browser/pageActions.js";
+import { buildLoginProbeExpressionForTest } from "../../src/browser/actions/navigation.js";
 import * as attachments from "../../src/browser/actions/attachments.js";
 import * as attachmentDataTransfer from "../../src/browser/actions/attachmentDataTransfer.js";
 import type { ChromeClient } from "../../src/browser/types.js";
@@ -209,6 +210,15 @@ describe("ensureLoggedIn", () => {
     } as unknown as ChromeClient["Runtime"];
     await expect(ensureLoggedIn(runtime, logger, { appliedCookies: 2 })).resolves.toBeUndefined();
     expect(logger).toHaveBeenCalledWith(expect.stringContaining("Login check passed"));
+  });
+
+  test("does not treat history items starting with login as login CTAs", () => {
+    const expression = buildLoginProbeExpressionForTest();
+    expect(expression).toContain(
+      "['log in', 'login', 'sign in', 'signin', 'sign up for free'].includes(normalized)",
+    );
+    expect(expression).toContain("normalized.startsWith('continue with')");
+    expect(expression).not.toContain("normalized.startsWith(needle)");
   });
 
   test("throws with cookie guidance when cookies missing", async () => {

--- a/tests/mcp/consult.test.ts
+++ b/tests/mcp/consult.test.ts
@@ -112,6 +112,18 @@ describe("summarizeModelRunsForConsult", () => {
     });
   });
 
+  test("defaults MCP browser consults to manual login on Windows", () => {
+    const config = buildConsultBrowserConfig({
+      userConfig: {},
+      env: {},
+      runModel: "gpt-5.5-pro",
+      inputModel: "gpt-5.5-pro",
+    });
+
+    expect(config.manualLogin).toBe(process.platform === "win32");
+    expect(config.cookieSync).toBe(process.platform !== "win32");
+  });
+
   test("lets explicit consult inputs override config defaults", () => {
     const config = buildConsultBrowserConfig({
       userConfig: {


### PR DESCRIPTION
﻿Summary:
- Tighten ChatGPT login CTA detection so history/sidebar entries like "Login setup instruction" do not look like auth buttons.
- Keep prefix matching only for "continue with" provider buttons.
- Default MCP browser consults to manual-login mode on Windows, matching CLI behavior and avoiding broken cookie sync for agent callers.
- Add regression tests and a Windows note for the manual-login loop failure.

Risk:
- Low. Login CTA matching is narrowed after the backend login probe already runs.
- Exact login, sign in, and sign up labels are still detected.
- MCP change only affects Windows default browser mode; explicit config/env overrides still win.

Verification:
- pnpm install --frozen-lockfile
- pnpm vitest run tests/browser/pageActions.test.ts tests/browser/config.test.ts tests/cli/browserConfig.test.ts tests/cli/browserDefaults.test.ts tests/mcp/consult.test.ts
- pnpm run typecheck
- pnpm run build
- Live local smoke: oracle --engine browser --browser-manual-login --browser-model-strategy current --browser-thinking-time extended --browser-archive never --browser-keep-browser --verbose --timeout 3m --slug oracle-visible-click-debug-fixed -p "Say ORACLE_VISIBLE_CLICK_DEBUG_FIXED_OK."