### PR TITLE
fix(browser): target renamed ChatGPT Pro model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.11.2 — Unreleased
+
+### Fixed
+
+- Browser: target ChatGPT's renamed bare Pro picker row for Pro browser runs while keeping older Pro CLI aliases mapped to the current browser target (#190, fixes #182). Thanks @jungdaesuh!
+
 ## 0.11.1 — 2026-05-10
 
 ### Changed

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -125,31 +125,34 @@ function llmsTxt() {
   const origin = docsOrigin();
   const source = docsSourceUrl();
   const name = typeof productName !== "undefined" ? productName : path.basename(root);
-  const description = typeof productDescription !== "undefined" ? productDescription : `${name} documentation index.`;
+  const description =
+    typeof productDescription !== "undefined" ? productDescription : `${name} documentation index.`;
   const install = docsInstallHint();
-  const docPages = docsLlmsPages().map((page) => `- ${page.title}: ${pageUrl(origin, page.outRel)}`);
-  const lines = [
-    `# ${name}`,
-    "",
-    description,
-    "",
-    "Canonical documentation:",
-    ...docPages,
-  ];
+  const docPages = docsLlmsPages().map(
+    (page) => `- ${page.title}: ${pageUrl(origin, page.outRel)}`,
+  );
+  const lines = [`# ${name}`, "", description, "", "Canonical documentation:", ...docPages];
   if (install) {
     lines.push("", "Install:", `- ${install}`);
   }
   if (source) {
     lines.push("", `Source: ${source}`);
   }
-  lines.push("", "Guidance for agents:", "- Prefer the canonical documentation URLs above over README excerpts or package metadata.", "- Fetch only the pages needed for the current task; this is an index, not a full-site corpus.");
+  lines.push(
+    "",
+    "Guidance for agents:",
+    "- Prefer the canonical documentation URLs above over README excerpts or package metadata.",
+    "- Fetch only the pages needed for the current task; this is an index, not a full-site corpus.",
+  );
   return `${lines.join("\n")}\n`;
 }
 
 function docsLlmsPages() {
   const seen = new Set();
   const ordered = typeof orderedPages !== "undefined" ? orderedPages : [];
-  return [...ordered, ...pages].filter((page) => page.outRel && !seen.has(page.outRel) && seen.add(page.outRel));
+  return [...ordered, ...pages].filter(
+    (page) => page.outRel && !seen.has(page.outRel) && seen.add(page.outRel),
+  );
 }
 
 function docsOrigin() {
@@ -163,7 +166,8 @@ function docsOrigin() {
 function docsSourceUrl() {
   if (typeof repoBase !== "undefined") return repoBase;
   if (typeof repoUrl !== "undefined") return repoUrl;
-  if (typeof repoEditBase !== "undefined") return repoEditBase.replace(/\/edit\/main\/docs\/?$/, "");
+  if (typeof repoEditBase !== "undefined")
+    return repoEditBase.replace(/\/edit\/main\/docs\/?$/, "");
   return "";
 }
 
@@ -177,7 +181,10 @@ function docsInstallHint() {
 }
 
 function pageUrl(origin, outRel) {
-  const normalized = outRel === "index.html" ? "" : outRel.replace(/(?:^|\/)index\.html$/, (match) => match === "index.html" ? "" : "/");
+  const normalized =
+    outRel === "index.html"
+      ? ""
+      : outRel.replace(/(?:^|\/)index\.html$/, (match) => (match === "index.html" ? "" : "/"));
   if (!origin) return normalized || "index.html";
   return normalized ? `${origin}/${normalized}` : `${origin}/`;
 }

--- a/src/browser/actions/modelSelection.ts
+++ b/src/browser/actions/modelSelection.ts
@@ -8,6 +8,9 @@ import {
 import { logDomFailure } from "../domDebug.js";
 import { buildClickDispatcher } from "./domEvents.js";
 
+const LEGACY_PRO_VERSION_WORD_TOKENS = ["5 4", "5 2", "5 1", "5 0", "gpt 5 pro"] as const;
+const LEGACY_PRO_VERSION_COMPACT_TOKENS = ["gpt54", "gpt52", "gpt51", "gpt50"] as const;
+
 export async function ensureModelSelection(
   Runtime: ChromeClient["Runtime"],
   desiredModel: string,
@@ -66,6 +69,8 @@ function assertResolvedModelSelection(desiredModel: string, resolvedLabel: strin
   const desired = desiredModel.toLowerCase();
   const resolved = resolvedLabel.toLowerCase();
   const wantsGpt55Pro =
+    desired === "pro" ||
+    desired === "chatgpt pro" ||
     desired === "gpt-5.5-pro" ||
     desired.includes("5.5 pro") ||
     desired.includes("5-5 pro") ||
@@ -73,18 +78,41 @@ function assertResolvedModelSelection(desiredModel: string, resolvedLabel: strin
   if (!wantsGpt55Pro || !resolved) {
     return;
   }
-  const hasProSignal =
+  if (
+    !hasCurrentProSignal(resolved) ||
+    hasLegacyProVersionLabel(resolved) ||
+    (resolved.includes("thinking") && !resolved.includes("pro"))
+  ) {
+    throw new Error(
+      `Model picker selected "${resolvedLabel}" while "${desiredModel}" requires GPT-5.5 Pro. Use model "gpt-5.5" with browser thinking time for the Thinking variant.`,
+    );
+  }
+}
+
+function normalizeResolvedModelLabel(value: string): string {
+  return value
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function hasCurrentProSignal(resolved: string): boolean {
+  return (
     resolved.includes(" pro") ||
     resolved.endsWith("pro") ||
     resolved.includes("pro ") ||
     resolved.includes("extended") ||
     resolved.includes("gpt-5.5-pro") ||
-    resolved.includes("gpt 5 5 pro");
-  if (!hasProSignal || (resolved.includes("thinking") && !resolved.includes("pro"))) {
-    throw new Error(
-      `Model picker selected "${resolvedLabel}" while "${desiredModel}" requires GPT-5.5 Pro. Use model "gpt-5.5" with browser thinking time for the Thinking variant.`,
-    );
-  }
+    resolved.includes("gpt 5 5 pro")
+  );
+}
+
+function hasLegacyProVersionLabel(resolved: string): boolean {
+  const normalized = normalizeResolvedModelLabel(resolved);
+  return (
+    LEGACY_PRO_VERSION_WORD_TOKENS.some((token) => normalized.includes(token)) ||
+    LEGACY_PRO_VERSION_COMPACT_TOKENS.some((token) => resolved.includes(token))
+  );
 }
 
 export function assertResolvedModelSelectionForTest(
@@ -160,8 +188,16 @@ function buildModelSelectionExpression(
     const wantsPro = normalizedTarget.includes(' pro') || normalizedTarget.endsWith(' pro') || normalizedTokens.includes('pro');
     const wantsInstant = normalizedTarget.includes('instant');
     const wantsThinking = normalizedTarget.includes('thinking');
+    const targetUsesCurrentGpt55Alias =
+      desiredVersion === '5-5' || normalizedTarget === 'pro' || normalizedTarget === 'chatgpt pro';
+    const labelHasProWord = (label) => label === 'pro' || label.startsWith('pro ') || label.includes(' pro ') || label.endsWith(' pro');
+    const legacyProVersionTokens = ['5 4', '5 2', '5 1', '5 0', 'gpt54', 'gpt52', 'gpt51', 'gpt50', 'gpt 5 pro'];
+    const labelHasLegacyProVersion = (value) => {
+      const label = normalizeText(value);
+      return legacyProVersionTokens.some((token) => label.includes(token));
+    };
     const isTargetGpt55VisibleAlias = (value) => {
-      if (desiredVersion !== '5-5') return false;
+      if (!targetUsesCurrentGpt55Alias) return false;
       const label = normalizeText(value);
       if (wantsPro) {
         // ChatGPT UI as of 2026-05: the picker shows just "Pro" (no longer "Pro Extended").
@@ -239,7 +275,8 @@ function buildModelSelectionExpression(
         if (desiredVersion === '5-1' && !normalizedLabel.includes('5 1')) return false;
         if (desiredVersion === '5-0' && !normalizedLabel.includes('5 0')) return false;
       }
-      if (wantsPro && !normalizedLabel.includes(' pro')) return false;
+      if (wantsPro && labelHasLegacyProVersion(normalizedLabel)) return false;
+      if (wantsPro && !labelHasProWord(normalizedLabel)) return false;
       if (wantsInstant && !normalizedLabel.includes('instant')) return false;
       if (wantsThinking && !normalizedLabel.includes('thinking')) return false;
       // Also reject if button has variants we DON'T want
@@ -256,6 +293,9 @@ function buildModelSelectionExpression(
       const signal = readComposerModelSignal();
       if (!signal) {
         return COMPOSER_SIGNAL_ALLOW_BLANK;
+      }
+      if (wantsPro && labelHasLegacyProVersion(signal)) {
+        return false;
       }
       if (COMPOSER_SIGNAL_EXCLUDES.some((token) => token && signal.includes(token))) {
         return false;
@@ -395,15 +435,15 @@ function buildModelSelectionExpression(
       const candidateGpt55VisibleAlias = isTargetGpt55VisibleAlias(normalizedText);
       const candidateHasThinking =
         normalizedText.includes('thinking') || normalizedTestId.includes('thinking');
+      const candidateHasLegacyProVersion =
+        labelHasLegacyProVersion(normalizedText) || labelHasLegacyProVersion(normalizedTestId);
       const candidateHasPro =
         candidateGpt55VisibleAlias ||
-        normalizedText === 'pro' ||
-        normalizedText.startsWith('pro ') ||
-        normalizedText.includes(' pro ') ||
-        normalizedText.endsWith(' pro') ||
+        labelHasProWord(normalizedText) ||
         normalizedText.includes('proresearch') ||
         normalizedTestId.includes('pro');
       if (wantsPro && candidateHasThinking) return 0;
+      if (wantsPro && candidateHasLegacyProVersion) return 0;
       if (wantsPro && !candidateHasPro) return 0;
       if (wantsThinking && candidateHasPro) return 0;
       if (desiredVersion === '5-5' && normalizedText && !candidateGpt55VisibleAlias) {
@@ -446,10 +486,10 @@ function buildModelSelectionExpression(
       }
       // If the caller didn't explicitly ask for Pro, prefer non-Pro options when both exist.
       if (wantsPro) {
-        if (!normalizedText.includes(' pro')) {
+        if (!labelHasProWord(normalizedText)) {
           score -= 80;
         }
-      } else if (normalizedText.includes(' pro')) {
+      } else if (labelHasProWord(normalizedText)) {
         score -= 40;
       }
       // Similarly for Thinking variant

--- a/src/browser/actions/modelSelection.ts
+++ b/src/browser/actions/modelSelection.ts
@@ -435,8 +435,7 @@ function buildModelSelectionExpression(
       const candidateGpt55VisibleAlias = isTargetGpt55VisibleAlias(normalizedText);
       const candidateHasThinking =
         normalizedText.includes('thinking') || normalizedTestId.includes('thinking');
-      const candidateHasLegacyProVersion =
-        labelHasLegacyProVersion(normalizedText) || labelHasLegacyProVersion(normalizedTestId);
+      const candidateHasLegacyProVersion = labelHasLegacyProVersion(normalizedText);
       const candidateHasPro =
         candidateGpt55VisibleAlias ||
         labelHasProWord(normalizedText) ||

--- a/src/browser/constants.ts
+++ b/src/browser/constants.ts
@@ -1,7 +1,7 @@
 import type { BrowserModelStrategy } from "./types.js";
 
 export const CHATGPT_URL = "https://chatgpt.com/";
-export const DEFAULT_MODEL_TARGET = "GPT-5.5 Pro";
+export const DEFAULT_MODEL_TARGET = "Pro";
 export const DEFAULT_MODEL_STRATEGY: BrowserModelStrategy = "select";
 export const COOKIE_URLS = [
   "https://chatgpt.com",

--- a/src/cli/browserConfig.ts
+++ b/src/cli/browserConfig.ts
@@ -28,14 +28,14 @@ const DEFAULT_CHROME_PROFILE = "Default";
 // The browser label is passed to the model picker which fuzzy-matches against ChatGPT's UI.
 const BROWSER_MODEL_LABELS: [ModelName, string][] = [
   // Most specific first (e.g., "gpt-5.2-thinking" before "gpt-5.2")
-  ["gpt-5.5-pro", "GPT-5.5 Pro"],
+  ["gpt-5.5-pro", "Pro"],
   ["gpt-5.5", "Thinking 5.5"],
-  ["gpt-5.4-pro", "GPT-5.4 Pro"],
+  ["gpt-5.4-pro", "Pro"],
   ["gpt-5.2-thinking", "GPT-5.2 Thinking"],
   ["gpt-5.2-instant", "GPT-5.2 Instant"],
-  ["gpt-5.2-pro", "GPT-5.5 Pro"],
-  ["gpt-5.1-pro", "GPT-5.5 Pro"],
-  ["gpt-5-pro", "GPT-5.5 Pro"],
+  ["gpt-5.2-pro", "Pro"],
+  ["gpt-5.1-pro", "Pro"],
+  ["gpt-5-pro", "Pro"],
   // Base models last (least specific)
   ["gpt-5.4", "Thinking 5.4"],
   ["gpt-5.2", "GPT-5.2"], // Selects "Auto" in ChatGPT UI
@@ -92,17 +92,17 @@ export function normalizeChatGptModelForBrowser(model: ModelName): ModelName {
     return model;
   }
 
-  if (
-    normalized === "gpt-5.5-pro" ||
-    normalized === "gpt-5.5" ||
-    normalized === "gpt-5.4-pro" ||
-    normalized === "gpt-5.4"
-  ) {
+  if (normalized === "gpt-5.5-pro" || normalized === "gpt-5.5" || normalized === "gpt-5.4") {
     return normalized;
   }
 
   // Pro variants: resolve to the latest Pro model in ChatGPT.
-  if (normalized === "gpt-5-pro" || normalized === "gpt-5.1-pro" || normalized === "gpt-5.2-pro") {
+  if (
+    normalized === "gpt-5-pro" ||
+    normalized === "gpt-5.1-pro" ||
+    normalized === "gpt-5.2-pro" ||
+    normalized === "gpt-5.4-pro"
+  ) {
     return "gpt-5.5-pro";
   }
 

--- a/tests/browser/modelSelection.test.ts
+++ b/tests/browser/modelSelection.test.ts
@@ -67,6 +67,120 @@ const evaluateImmediateModelSelectionExpression = (
   );
 };
 
+const evaluateMenuModelSelectionExpression = async (
+  targetModel: string,
+  option: { label: string; testId: string },
+): Promise<unknown> => {
+  class FakeEventTarget {
+    dispatchEvent(_event: unknown): boolean {
+      return true;
+    }
+  }
+
+  class FakeElement extends FakeEventTarget {
+    constructor(
+      public textContent: string,
+      private readonly attributes: Readonly<Record<string, string>> = {},
+      private readonly children: readonly FakeElement[] = [],
+      private readonly onDispatch?: () => void,
+    ) {
+      super();
+    }
+
+    getAttribute(name: string): string | null {
+      return this.attributes[name] ?? null;
+    }
+
+    querySelector(_selector: string): FakeElement | null {
+      return null;
+    }
+
+    querySelectorAll(_selector: string): FakeElement[] {
+      return [...this.children];
+    }
+
+    closest(_selector: string): FakeElement | null {
+      return null;
+    }
+
+    override dispatchEvent(event: unknown): boolean {
+      this.onDispatch?.();
+      return super.dispatchEvent(event);
+    }
+  }
+
+  class FakeMouseEvent {
+    constructor(_type: string, _init?: unknown) {}
+  }
+
+  const expression = buildModelSelectionExpressionForTest(targetModel);
+  const modelButton = new FakeElement("ChatGPT", {
+    "data-testid": "model-switcher-dropdown-button",
+  });
+  const modelOption = new FakeElement(option.label, { "data-testid": option.testId }, [], () => {
+    modelButton.textContent = option.label;
+  });
+  const menu = new FakeElement("", { role: "menu" }, [modelOption]);
+  const documentStub = {
+    querySelector: (selector: string) => {
+      if (selector.includes("model-switcher-dropdown-button")) {
+        return modelButton;
+      }
+      if (selector.includes('role="menu"') || selector.includes("data-radix")) {
+        return menu;
+      }
+      return null;
+    },
+    querySelectorAll: (selector: string) => {
+      if (selector.includes('role="menu"') || selector.includes("data-radix")) {
+        return [menu];
+      }
+      return [];
+    },
+    title: "",
+    body: { innerText: "" },
+    dispatchEvent: () => true,
+  };
+  const performanceStub = { now: () => 0 };
+  const windowStub = { location: { href: "https://chatgpt.com/" } };
+  const immediateSetTimeout = (handler: TimerHandler): number => {
+    if (typeof handler === "function") {
+      handler();
+    }
+    return 0;
+  };
+  const evaluate = new Function(
+    "document",
+    "performance",
+    "setTimeout",
+    "window",
+    "EventTarget",
+    "MouseEvent",
+    "HTMLElement",
+    `return ${expression};`,
+  ) as (
+    document: unknown,
+    performance: unknown,
+    setTimeout: unknown,
+    window: unknown,
+    EventTarget: unknown,
+    MouseEvent: unknown,
+    HTMLElement: unknown,
+  ) => unknown;
+
+  return await Promise.resolve(
+    evaluate(
+      documentStub,
+      performanceStub,
+      immediateSetTimeout,
+      windowStub,
+      FakeEventTarget,
+      FakeMouseEvent,
+      FakeElement,
+    ),
+  );
+};
+
 describe("browser model selection matchers", () => {
   it("includes pro + 5.5 tokens for gpt-5.5-pro", () => {
     const { labelTokens, testIdTokens } = buildModelMatchersLiteralForTest("gpt-5.5-pro");
@@ -163,6 +277,15 @@ describe("browser model selection matchers", () => {
   it("does not accept stale versioned Pro composer signals under a generic header", () => {
     const result = evaluateImmediateModelSelectionExpression("Pro", "ChatGPT", "GPT-5.4 Pro");
     expect(result).toBeInstanceOf(Promise);
+  });
+
+  it("selects the current bare Pro row even when its test id still looks legacy", async () => {
+    await expect(
+      evaluateMenuModelSelectionExpression("Pro", {
+        label: "Pro",
+        testId: "model-switcher-gpt-5-pro",
+      }),
+    ).resolves.toEqual({ status: "switched", label: "Pro" });
   });
 
   it("recognizes ChatGPT plus the Pro composer pill as the current Pro model", () => {

--- a/tests/browser/modelSelection.test.ts
+++ b/tests/browser/modelSelection.test.ts
@@ -11,6 +11,62 @@ const expectContains = (arr: string[], value: string) => {
   expect(arr).toContain(value);
 };
 
+const evaluateImmediateModelSelectionExpression = (
+  targetModel: string,
+  buttonLabel: string,
+  composerLabel = "",
+): unknown => {
+  const expression = buildModelSelectionExpressionForTest(targetModel);
+  const modelButton = { textContent: buttonLabel };
+  const composerSignal = composerLabel ? { textContent: composerLabel } : null;
+  const documentStub = {
+    querySelector: (selector: string) => {
+      if (selector.includes("model-switcher-dropdown-button")) {
+        return modelButton;
+      }
+      if (selector.includes("__composer-pill") || selector.includes("Pro, click to remove")) {
+        return null;
+      }
+      if (selector.includes("composer")) {
+        return composerSignal;
+      }
+      return null;
+    },
+    querySelectorAll: () => [],
+    title: "",
+    body: { innerText: "" },
+  };
+  const performanceStub = { now: () => 0 };
+  const windowStub = { location: { href: "https://chatgpt.com/" } };
+  const EventTargetStub = class {};
+  const MouseEventStub = class {};
+  const evaluate = new Function(
+    "document",
+    "performance",
+    "setTimeout",
+    "window",
+    "EventTarget",
+    "MouseEvent",
+    `return ${expression};`,
+  ) as (
+    document: unknown,
+    performance: unknown,
+    setTimeout: unknown,
+    window: unknown,
+    EventTarget: unknown,
+    MouseEvent: unknown,
+  ) => unknown;
+
+  return evaluate(
+    documentStub,
+    performanceStub,
+    () => 0,
+    windowStub,
+    EventTargetStub,
+    MouseEventStub,
+  );
+};
+
 describe("browser model selection matchers", () => {
   it("includes pro + 5.5 tokens for gpt-5.5-pro", () => {
     const { labelTokens, testIdTokens } = buildModelMatchersLiteralForTest("gpt-5.5-pro");
@@ -94,6 +150,21 @@ describe("browser model selection matchers", () => {
     expect(expression).toContain("desiredVersion === '5-5'");
   });
 
+  it("recognizes bare Pro as already selected when Pro is the browser target", () => {
+    const result = evaluateImmediateModelSelectionExpression("Pro", "Pro");
+    expect(result).toEqual({ status: "already-selected", label: "Pro" });
+  });
+
+  it("does not accept stale versioned Pro labels for the current Pro target", () => {
+    const result = evaluateImmediateModelSelectionExpression("Pro", "GPT-5.4 Pro");
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  it("does not accept stale versioned Pro composer signals under a generic header", () => {
+    const result = evaluateImmediateModelSelectionExpression("Pro", "ChatGPT", "GPT-5.4 Pro");
+    expect(result).toBeInstanceOf(Promise);
+  });
+
   it("recognizes ChatGPT plus the Pro composer pill as the current Pro model", () => {
     const expression = buildModelSelectionExpressionForTest("gpt-5.5-pro");
     expect(expression).toContain("const hasProComposerPill = () =>");
@@ -139,6 +210,13 @@ describe("browser model selection matchers", () => {
     // Both the new bare "Pro" label and the legacy "GPT-5.5 Pro" should pass.
     expect(() => assertResolvedModelSelectionForTest("gpt-5.5-pro", "Pro")).not.toThrow();
     expect(() => assertResolvedModelSelectionForTest("gpt-5.5-pro", "GPT-5.5 Pro")).not.toThrow();
+    expect(() => assertResolvedModelSelectionForTest("Pro", "Thinking 5.5 Heavy")).toThrow(
+      /requires GPT-5.5 Pro/,
+    );
+    expect(() => assertResolvedModelSelectionForTest("Pro", "GPT-5.4 Pro")).toThrow(
+      /requires GPT-5.5 Pro/,
+    );
+    expect(() => assertResolvedModelSelectionForTest("Pro", "Pro")).not.toThrow();
   });
 
   it("does not validate the active picker label when strategy keeps current selection", async () => {

--- a/tests/browser/modelSelection.test.ts
+++ b/tests/browser/modelSelection.test.ts
@@ -110,7 +110,13 @@ const evaluateMenuModelSelectionExpression = async (
   }
 
   class FakeMouseEvent {
-    constructor(_type: string, _init?: unknown) {}
+    readonly type: string;
+    readonly init?: unknown;
+
+    constructor(type: string, init?: unknown) {
+      this.type = type;
+      this.init = init;
+    }
   }
 
   const expression = buildModelSelectionExpressionForTest(targetModel);

--- a/tests/cli/browserConfig.test.ts
+++ b/tests/cli/browserConfig.test.ts
@@ -15,7 +15,7 @@ describe("buildBrowserConfig", () => {
       headless: undefined,
       keepBrowser: undefined,
       hideWindow: undefined,
-      desiredModel: "GPT-5.5 Pro",
+      desiredModel: "Pro",
       debug: undefined,
       allowCookieErrors: true,
       researchMode: "off",
@@ -96,7 +96,7 @@ describe("buildBrowserConfig", () => {
       model: "gpt-5.2-pro",
       browserModelLabel: "Instant",
     });
-    expect(config.desiredModel).toBe("GPT-5.5 Pro");
+    expect(config.desiredModel).toBe("Pro");
   });
 
   test("rejects invalid browser max concurrent tabs", async () => {
@@ -245,7 +245,7 @@ describe("buildBrowserConfig", () => {
       chatgptUrl: "https://chatgpt.com/?temporary-chat=true",
     });
     expect(config.url).toBe("https://chatgpt.com/?temporary-chat=true");
-    expect(config.desiredModel).toBe("GPT-5.5 Pro");
+    expect(config.desiredModel).toBe("Pro");
     expect(config.modelStrategy).toBe("select");
   });
 
@@ -306,13 +306,13 @@ describe("buildBrowserConfig", () => {
 
 describe("resolveBrowserModelLabel", () => {
   test("returns canonical ChatGPT label when CLI value matches API model", () => {
-    expect(resolveBrowserModelLabel("gpt-5.5-pro", "gpt-5.5-pro")).toBe("GPT-5.5 Pro");
+    expect(resolveBrowserModelLabel("gpt-5.5-pro", "gpt-5.5-pro")).toBe("Pro");
     expect(resolveBrowserModelLabel("gpt-5.5", "gpt-5.5")).toBe("Thinking 5.5");
-    expect(resolveBrowserModelLabel("gpt-5.4-pro", "gpt-5.4-pro")).toBe("GPT-5.4 Pro");
+    expect(resolveBrowserModelLabel("gpt-5.4-pro", "gpt-5.4-pro")).toBe("Pro");
     expect(resolveBrowserModelLabel("gpt-5.4", "gpt-5.4")).toBe("Thinking 5.4");
-    expect(resolveBrowserModelLabel("gpt-5-pro", "gpt-5-pro")).toBe("GPT-5.5 Pro");
-    expect(resolveBrowserModelLabel("gpt-5.2-pro", "gpt-5.2-pro")).toBe("GPT-5.5 Pro");
-    expect(resolveBrowserModelLabel("gpt-5.1-pro", "gpt-5.1-pro")).toBe("GPT-5.5 Pro");
+    expect(resolveBrowserModelLabel("gpt-5-pro", "gpt-5-pro")).toBe("Pro");
+    expect(resolveBrowserModelLabel("gpt-5.2-pro", "gpt-5.2-pro")).toBe("Pro");
+    expect(resolveBrowserModelLabel("gpt-5.1-pro", "gpt-5.1-pro")).toBe("Pro");
     expect(resolveBrowserModelLabel("GPT-5.1", "gpt-5.1")).toBe("GPT-5.2");
   });
 
@@ -325,7 +325,7 @@ describe("resolveBrowserModelLabel", () => {
   });
 
   test("supports undefined or whitespace-only input", () => {
-    expect(resolveBrowserModelLabel(undefined, "gpt-5.2-pro")).toBe("GPT-5.5 Pro");
+    expect(resolveBrowserModelLabel(undefined, "gpt-5.2-pro")).toBe("Pro");
     expect(resolveBrowserModelLabel("   ", "gpt-5.1")).toBe("GPT-5.2");
   });
 

--- a/tests/live/browser-model-selection-live.test.ts
+++ b/tests/live/browser-model-selection-live.test.ts
@@ -47,25 +47,15 @@ function isMissingChatGptSessionError(error: unknown): boolean {
 
 const CASES = [
   {
-    name: "auto",
-    desiredModel: "GPT-5.2",
-    expected: ["5.2"],
-  },
-  {
-    name: "thinking",
-    desiredModel: "GPT-5.2 Thinking",
-    expected: ["5.2", "thinking"],
-  },
-  {
-    name: "instant",
-    desiredModel: "GPT-5.2 Instant",
-    expected: ["5.2", "instant"],
+    name: "pro",
+    desiredModel: "Pro",
+    expected: ["pro"],
   },
 ];
 
 (LIVE ? describe : describe.skip)("ChatGPT browser live model selection", () => {
   test(
-    "selects GPT-5.2 variants reliably",
+    "selects the current bare Pro picker row reliably",
     async () => {
       if (!(await hasChatGptCookies())) return;
       // Learned: serialize live browser tests to avoid Chrome profile contention.

--- a/tests/mcp/consult.test.ts
+++ b/tests/mcp/consult.test.ts
@@ -239,7 +239,7 @@ describe("summarizeModelRunsForConsult", () => {
         resolvedEngine: "browser",
         model: "gpt-5.5-pro",
         browser: expect.objectContaining({
-          desiredModel: "GPT-5.5 Pro",
+          desiredModel: "Pro",
           thinkingTime: "extended",
           modelStrategy: "select",
         }),

--- a/tests/runOptions.test.ts
+++ b/tests/runOptions.test.ts
@@ -183,6 +183,26 @@ describe("resolveRunOptionsFromConfig", () => {
     expect(runOptions.model).toBe("gpt-5.5-pro");
   });
 
+  it("maps browser engine gpt-5.4-pro to the current ChatGPT Pro target", () => {
+    const { resolvedEngine, runOptions } = resolveRunOptionsFromConfig({
+      prompt: basePrompt,
+      model: "gpt-5.4-pro",
+      engine: "browser",
+    });
+    expect(resolvedEngine).toBe("browser");
+    expect(runOptions.model).toBe("gpt-5.5-pro");
+  });
+
+  it("keeps gpt-5.4-pro unchanged for API engine runs", () => {
+    const { resolvedEngine, runOptions } = resolveRunOptionsFromConfig({
+      prompt: basePrompt,
+      model: "gpt-5.4-pro",
+      engine: "api",
+    });
+    expect(resolvedEngine).toBe("api");
+    expect(runOptions.model).toBe("gpt-5.4-pro");
+  });
+
   it("forces api engine for gpt-5.1-codex when engine is auto-detected", () => {
     const { resolvedEngine, runOptions } = resolveRunOptionsFromConfig({
       prompt: basePrompt,


### PR DESCRIPTION
## Summary
- Target ChatGPT's renamed bare `Pro` picker label for GPT-5.5 Pro browser runs.
- Keep older Pro aliases normalized to the current browser Pro target while preserving API model ids.
- Reject stale versioned Pro labels such as `GPT-5.4 Pro` when current Pro is required.

## Tests
- `pnpm exec vitest run tests/browser/modelSelection.test.ts tests/cli/browserConfig.test.ts tests/runOptions.test.ts tests/mcp/consult.test.ts tests/browser/pageActions.test.ts tests/browser/modelSelection.label.test.ts`
- `pnpm exec oxfmt --check src/browser/actions/modelSelection.ts tests/browser/modelSelection.test.ts tests/mcp/consult.test.ts tests/runOptions.test.ts src/browser/constants.ts src/cli/browserConfig.ts tests/cli/browserConfig.test.ts`
- `git diff --check`
- `pnpm run build`
- Live browser smoke with local dist: `ORACLE_PRO_SELECTOR_FINAL_OK`
- Live browser smoke with global `oracle`: `ORACLE_GLOBAL_PRO_SELECTOR_FINAL_OK`