### PR TITLE
fix(browser): gate manual-login profile setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Browser/MCP: avoid false ChatGPT login prompts when sidebar history starts with "Login..." and default MCP browser consults to manual login on Windows. (#189) — thanks @ndycode.
+- Browser/MCP: fail fast when a manual-login browser profile has not been initialized or signed in, and show first-time setup guidance for the private Oracle Chrome profile used by Claude/Codex MCP consults.
 - Browser: allow Pro model selection in ChatGPT Temporary Chat URLs and skip archive attempts for temporary conversations. (#185) — thanks @pdurlej.
 - Browser: recognize ChatGPT's renamed GPT-5.5 Pro/Thinking model labels and always apply requested thinking time instead of assuming Pro implies Extended. (#183, fixes #182) — thanks @broady.
 - MCP: reject unknown `consult` fields instead of silently ignoring misspelled tool-call arguments. (#184) — thanks @pdurlej.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Browser mode lets you use GPT-5.5 Pro without any API keys — it automates your
 
 ### First-time login
 
-Run this once to create an automation profile and log into ChatGPT. The browser will stay open so you can complete the login:
+Run this once to create Oracle's private automation profile and log into ChatGPT. This profile is separate from your normal Chrome profile. The browser will stay open so you can complete the login:
 
 ```bash
 oracle --engine browser --browser-manual-login \

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -597,6 +597,12 @@ program
       "Skip cookie copy; reuse a persistent automation profile and wait for manual ChatGPT login.",
     ).hideHelp(),
   )
+  .addOption(
+    new Option(
+      "--browser-manual-login-profile-dir <path>",
+      "Persistent Chrome profile directory for manual-login browser runs.",
+    ).hideHelp(),
+  )
   .addOption(new Option("--browser-headless", "Launch Chrome in headless mode.").hideHelp())
   .addOption(
     new Option(

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -125,31 +125,34 @@ function llmsTxt() {
   const origin = docsOrigin();
   const source = docsSourceUrl();
   const name = typeof productName !== "undefined" ? productName : path.basename(root);
-  const description = typeof productDescription !== "undefined" ? productDescription : `${name} documentation index.`;
+  const description =
+    typeof productDescription !== "undefined" ? productDescription : `${name} documentation index.`;
   const install = docsInstallHint();
-  const docPages = docsLlmsPages().map((page) => `- ${page.title}: ${pageUrl(origin, page.outRel)}`);
-  const lines = [
-    `# ${name}`,
-    "",
-    description,
-    "",
-    "Canonical documentation:",
-    ...docPages,
-  ];
+  const docPages = docsLlmsPages().map(
+    (page) => `- ${page.title}: ${pageUrl(origin, page.outRel)}`,
+  );
+  const lines = [`# ${name}`, "", description, "", "Canonical documentation:", ...docPages];
   if (install) {
     lines.push("", "Install:", `- ${install}`);
   }
   if (source) {
     lines.push("", `Source: ${source}`);
   }
-  lines.push("", "Guidance for agents:", "- Prefer the canonical documentation URLs above over README excerpts or package metadata.", "- Fetch only the pages needed for the current task; this is an index, not a full-site corpus.");
+  lines.push(
+    "",
+    "Guidance for agents:",
+    "- Prefer the canonical documentation URLs above over README excerpts or package metadata.",
+    "- Fetch only the pages needed for the current task; this is an index, not a full-site corpus.",
+  );
   return `${lines.join("\n")}\n`;
 }
 
 function docsLlmsPages() {
   const seen = new Set();
   const ordered = typeof orderedPages !== "undefined" ? orderedPages : [];
-  return [...ordered, ...pages].filter((page) => page.outRel && !seen.has(page.outRel) && seen.add(page.outRel));
+  return [...ordered, ...pages].filter(
+    (page) => page.outRel && !seen.has(page.outRel) && seen.add(page.outRel),
+  );
 }
 
 function docsOrigin() {
@@ -163,7 +166,8 @@ function docsOrigin() {
 function docsSourceUrl() {
   if (typeof repoBase !== "undefined") return repoBase;
   if (typeof repoUrl !== "undefined") return repoUrl;
-  if (typeof repoEditBase !== "undefined") return repoEditBase.replace(/\/edit\/main\/docs\/?$/, "");
+  if (typeof repoEditBase !== "undefined")
+    return repoEditBase.replace(/\/edit\/main\/docs\/?$/, "");
   return "";
 }
 
@@ -177,7 +181,10 @@ function docsInstallHint() {
 }
 
 function pageUrl(origin, outRel) {
-  const normalized = outRel === "index.html" ? "" : outRel.replace(/(?:^|\/)index\.html$/, (match) => match === "index.html" ? "" : "/");
+  const normalized =
+    outRel === "index.html"
+      ? ""
+      : outRel.replace(/(?:^|\/)index\.html$/, (match) => (match === "index.html" ? "" : "/"));
   if (!origin) return normalized || "index.html";
   return normalized ? `${origin}/${normalized}` : `${origin}/`;
 }

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, mkdir } from "node:fs/promises";
+import { mkdtemp, rm, mkdir, readdir } from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 import net from "node:net";
@@ -624,10 +624,15 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
   const userDataDir = manualLogin
     ? manualProfileDir
     : await mkdtemp(path.join(await resolveUserDataBaseDir(), "oracle-browser-"));
+  const effectiveKeepBrowser = Boolean(config.keepBrowser);
   if (manualLogin) {
     // Learned: manual login reuses a persistent profile so cookies/SSO survive.
     await mkdir(userDataDir, { recursive: true });
     logger(`Manual login mode enabled; reusing persistent profile at ${userDataDir}`);
+    await assertManualLoginProfileReadyForRun({
+      userDataDir,
+      keepBrowser: effectiveKeepBrowser,
+    });
   } else {
     logger(`Created temporary Chrome profile at ${userDataDir}`);
   }
@@ -641,7 +646,6 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
     });
   }
 
-  const effectiveKeepBrowser = Boolean(config.keepBrowser);
   let acquiredChrome: { chrome: BrowserChrome; reusedChrome: LaunchedChrome | null };
   try {
     acquiredChrome = manualLogin
@@ -854,6 +858,8 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
           appliedCookies,
           manualLogin,
           timeoutMs: config.timeoutMs,
+          profileDir: userDataDir,
+          keepBrowser: effectiveKeepBrowser,
         }),
       );
 
@@ -1930,18 +1936,23 @@ async function waitForLogin({
   appliedCookies,
   manualLogin,
   timeoutMs,
+  profileDir,
+  keepBrowser,
 }: {
   runtime: ChromeClient["Runtime"];
   logger: BrowserLogger;
   appliedCookies: number;
   manualLogin: boolean;
   timeoutMs: number;
+  profileDir?: string;
+  keepBrowser?: boolean;
 }): Promise<void> {
   if (!manualLogin) {
     await ensureLoggedIn(runtime, logger, { appliedCookies });
     return;
   }
-  const deadline = Date.now() + Math.min(timeoutMs ?? 1_200_000, 20 * 60_000);
+  const waitMs = resolveManualLoginWaitMs(timeoutMs, Boolean(keepBrowser));
+  const deadline = Date.now() + waitMs;
   let lastNotice = 0;
   while (Date.now() < deadline) {
     try {
@@ -1964,9 +1975,71 @@ async function waitForLogin({
       await delay(1000);
     }
   }
-  throw new Error(
-    "Manual login mode timed out waiting for ChatGPT session; please sign in and retry.",
+  const setupCommand = formatManualLoginSetupCommand(
+    profileDir ?? path.join(os.homedir(), ".oracle", "browser-profile"),
   );
+  throw new Error(
+    "Manual login mode timed out waiting for ChatGPT session. " +
+      `Browser mode is using Oracle's private Chrome profile at ${profileDir ?? "(default profile)"}, not your normal Chrome profile. ` +
+      `Run first-time setup, sign in there, then retry: ${setupCommand}`,
+  );
+}
+
+function resolveManualLoginWaitMs(timeoutMs: number | undefined, keepBrowser: boolean): number {
+  const configured = Math.min(timeoutMs ?? 1_200_000, 20 * 60_000);
+  if (keepBrowser) {
+    return configured;
+  }
+  return Math.min(configured, 30_000);
+}
+
+async function assertManualLoginProfileReadyForRun({
+  userDataDir,
+  keepBrowser,
+}: {
+  userDataDir: string;
+  keepBrowser: boolean;
+}): Promise<void> {
+  if (keepBrowser) {
+    return;
+  }
+  if (await isManualLoginProfileInitialized(userDataDir)) {
+    return;
+  }
+  const setupCommand = formatManualLoginSetupCommand(userDataDir);
+  throw new BrowserAutomationError(
+    "ChatGPT browser manual-login profile is not initialized. " +
+      `Browser mode is using Oracle's private Chrome profile at ${userDataDir}, separate from your normal Chrome profile. ` +
+      `Run first-time setup, sign in there, then retry: ${setupCommand}. ` +
+      "If you want to reuse an already signed-in Chrome instead, use --browser-attach-running.",
+    {
+      stage: "browser-login-setup",
+      details: {
+        profileDir: userDataDir,
+        setupCommand,
+        sessionStatus: "needs_login",
+      },
+      reuseProfileHint: setupCommand,
+    },
+  );
+}
+
+async function isManualLoginProfileInitialized(profileDir: string): Promise<boolean> {
+  const entries = await readdir(profileDir, { withFileTypes: true }).catch(() => []);
+  return entries.some((entry) => {
+    if (!entry.name) return false;
+    if (entry.name === "Default" || entry.name === "Local State") return true;
+    if (entry.name.startsWith("Profile ")) return true;
+    return false;
+  });
+}
+
+function formatManualLoginSetupCommand(profileDir: string): string {
+  return [
+    "oracle --engine browser --browser-manual-login --browser-keep-browser",
+    `--browser-manual-login-profile-dir ${JSON.stringify(profileDir)}`,
+    '-p "HI"',
+  ].join(" ");
 }
 
 async function maybeRecoverLongAssistantResponse({
@@ -3000,10 +3073,14 @@ export { resolveBrowserConfig, DEFAULT_BROWSER_CONFIG } from "./config.js";
 
 // biome-ignore lint/style/useNamingConvention: test-only export used in vitest suite
 export const __test__ = {
+  assertManualLoginProfileReadyForRun,
   closeRemoteConnectionAfterRun,
   detachKeptChromeProcess,
+  formatManualLoginSetupCommand,
+  isManualLoginProfileInitialized,
   isImageOnlyUiChromeText,
   listIgnoredRemoteChromeFlags,
+  resolveManualLoginWaitMs,
   shouldCloseOwnedRunTargetAfterRun,
 };
 export { syncCookies } from "./cookies.js";

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, mkdir, readdir } from "node:fs/promises";
+import { mkdtemp, rm, mkdir } from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 import net from "node:net";
@@ -88,6 +88,13 @@ import {
   archiveChatGptConversation,
   resolveBrowserArchiveDecision,
 } from "./actions/archiveConversation.js";
+import {
+  assertManualLoginProfileReadyForRun,
+  defaultManualLoginProfileDir,
+  formatManualLoginSetupCommand,
+  isManualLoginProfileInitialized,
+  resolveManualLoginWaitMs,
+} from "./manualLoginProfile.js";
 import { describeBrowserControlPlan, formatBrowserControlPlan } from "./controlPlan.js";
 
 export type { BrowserAutomationConfig, BrowserRunOptions, BrowserRunResult } from "./types.js";
@@ -620,7 +627,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
   const manualLogin = Boolean(config.manualLogin);
   const manualProfileDir = config.manualLoginProfileDir
     ? path.resolve(config.manualLoginProfileDir)
-    : path.join(os.homedir(), ".oracle", "browser-profile");
+    : defaultManualLoginProfileDir();
   const userDataDir = manualLogin
     ? manualProfileDir
     : await mkdtemp(path.join(await resolveUserDataBaseDir(), "oracle-browser-"));
@@ -1975,71 +1982,12 @@ async function waitForLogin({
       await delay(1000);
     }
   }
-  const setupCommand = formatManualLoginSetupCommand(
-    profileDir ?? path.join(os.homedir(), ".oracle", "browser-profile"),
-  );
+  const setupCommand = formatManualLoginSetupCommand(profileDir ?? defaultManualLoginProfileDir());
   throw new Error(
     "Manual login mode timed out waiting for ChatGPT session. " +
       `Browser mode is using Oracle's private Chrome profile at ${profileDir ?? "(default profile)"}, not your normal Chrome profile. ` +
       `Run first-time setup, sign in there, then retry: ${setupCommand}`,
   );
-}
-
-function resolveManualLoginWaitMs(timeoutMs: number | undefined, keepBrowser: boolean): number {
-  const configured = Math.min(timeoutMs ?? 1_200_000, 20 * 60_000);
-  if (keepBrowser) {
-    return configured;
-  }
-  return Math.min(configured, 30_000);
-}
-
-async function assertManualLoginProfileReadyForRun({
-  userDataDir,
-  keepBrowser,
-}: {
-  userDataDir: string;
-  keepBrowser: boolean;
-}): Promise<void> {
-  if (keepBrowser) {
-    return;
-  }
-  if (await isManualLoginProfileInitialized(userDataDir)) {
-    return;
-  }
-  const setupCommand = formatManualLoginSetupCommand(userDataDir);
-  throw new BrowserAutomationError(
-    "ChatGPT browser manual-login profile is not initialized. " +
-      `Browser mode is using Oracle's private Chrome profile at ${userDataDir}, separate from your normal Chrome profile. ` +
-      `Run first-time setup, sign in there, then retry: ${setupCommand}. ` +
-      "If you want to reuse an already signed-in Chrome instead, use --browser-attach-running.",
-    {
-      stage: "browser-login-setup",
-      details: {
-        profileDir: userDataDir,
-        setupCommand,
-        sessionStatus: "needs_login",
-      },
-      reuseProfileHint: setupCommand,
-    },
-  );
-}
-
-async function isManualLoginProfileInitialized(profileDir: string): Promise<boolean> {
-  const entries = await readdir(profileDir, { withFileTypes: true }).catch(() => []);
-  return entries.some((entry) => {
-    if (!entry.name) return false;
-    if (entry.name === "Default" || entry.name === "Local State") return true;
-    if (entry.name.startsWith("Profile ")) return true;
-    return false;
-  });
-}
-
-function formatManualLoginSetupCommand(profileDir: string): string {
-  return [
-    "oracle --engine browser --browser-manual-login --browser-keep-browser",
-    `--browser-manual-login-profile-dir ${JSON.stringify(profileDir)}`,
-    '-p "HI"',
-  ].join(" ");
 }
 
 async function maybeRecoverLongAssistantResponse({

--- a/src/browser/manualLoginProfile.ts
+++ b/src/browser/manualLoginProfile.ts
@@ -1,0 +1,65 @@
+import { readdir } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { BrowserAutomationError } from "../oracle/errors.js";
+
+export function resolveManualLoginWaitMs(timeoutMs: number | undefined, keepBrowser: boolean) {
+  const configured = Math.min(timeoutMs ?? 1_200_000, 20 * 60_000);
+  if (keepBrowser) {
+    return configured;
+  }
+  return Math.min(configured, 30_000);
+}
+
+export async function assertManualLoginProfileReadyForRun({
+  userDataDir,
+  keepBrowser,
+}: {
+  userDataDir: string;
+  keepBrowser: boolean;
+}): Promise<void> {
+  if (keepBrowser) {
+    return;
+  }
+  if (await isManualLoginProfileInitialized(userDataDir)) {
+    return;
+  }
+  const setupCommand = formatManualLoginSetupCommand(userDataDir);
+  throw new BrowserAutomationError(
+    "ChatGPT browser manual-login profile is not initialized. " +
+      `Browser mode is using Oracle's private Chrome profile at ${userDataDir}, separate from your normal Chrome profile. ` +
+      `Run first-time setup, sign in there, then retry: ${setupCommand}. ` +
+      "If you want to reuse an already signed-in Chrome instead, use --browser-attach-running.",
+    {
+      stage: "browser-login-setup",
+      details: {
+        profileDir: userDataDir,
+        setupCommand,
+        sessionStatus: "needs_login",
+      },
+      reuseProfileHint: setupCommand,
+    },
+  );
+}
+
+export async function isManualLoginProfileInitialized(profileDir: string): Promise<boolean> {
+  const entries = await readdir(profileDir, { withFileTypes: true }).catch(() => []);
+  return entries.some((entry) => {
+    if (!entry.name) return false;
+    if (entry.name === "Default" || entry.name === "Local State") return true;
+    if (entry.name.startsWith("Profile ")) return true;
+    return false;
+  });
+}
+
+export function formatManualLoginSetupCommand(profileDir: string): string {
+  return [
+    "oracle --engine browser --browser-manual-login --browser-keep-browser",
+    `--browser-manual-login-profile-dir ${JSON.stringify(profileDir)}`,
+    '-p "HI"',
+  ].join(" ");
+}
+
+export function defaultManualLoginProfileDir() {
+  return path.join(os.homedir(), ".oracle", "browser-profile");
+}

--- a/src/browser/projectSourcesRunner.ts
+++ b/src/browser/projectSourcesRunner.ts
@@ -37,6 +37,12 @@ import {
 import { CHATGPT_URL } from "./constants.js";
 import { delay } from "./utils.js";
 import {
+  assertManualLoginProfileReadyForRun,
+  defaultManualLoginProfileDir,
+  formatManualLoginSetupCommand,
+  resolveManualLoginWaitMs,
+} from "./manualLoginProfile.js";
+import {
   openProjectSourcesTab,
   uploadProjectSources,
   waitForProjectSourcesReady,
@@ -87,13 +93,18 @@ export async function runBrowserProjectSources(
   const manualLogin = Boolean(config.manualLogin);
   const manualProfileDir = config.manualLoginProfileDir
     ? path.resolve(config.manualLoginProfileDir)
-    : path.join(os.homedir(), ".oracle", "browser-profile");
+    : defaultManualLoginProfileDir();
   const userDataDir = manualLogin
     ? manualProfileDir
     : await mkdtemp(path.join(os.tmpdir(), "oracle-project-sources-"));
+  const effectiveKeepBrowser = Boolean(config.keepBrowser);
   if (manualLogin) {
     await mkdir(userDataDir, { recursive: true });
     logger(`Manual login mode enabled; reusing persistent profile at ${userDataDir}`);
+    await assertManualLoginProfileReadyForRun({
+      userDataDir,
+      keepBrowser: effectiveKeepBrowser,
+    });
   } else {
     logger(`Created temporary Chrome profile at ${userDataDir}`);
   }
@@ -116,7 +127,6 @@ export async function runBrowserProjectSources(
   let removeDialogHandler: (() => void) | null = null;
   let connectionClosedUnexpectedly = false;
   let completed = false;
-  const effectiveKeepBrowser = Boolean(config.keepBrowser);
 
   try {
     const acquired = manualLogin
@@ -198,6 +208,8 @@ export async function runBrowserProjectSources(
         appliedCookies,
         manualLogin,
         timeoutMs: config.timeoutMs,
+        profileDir: userDataDir,
+        keepBrowser: effectiveKeepBrowser,
       }),
     );
     await raceWithDisconnect(navigateToChatGPT(Page, Runtime, projectUrl, logger));
@@ -354,18 +366,23 @@ async function waitForProjectSourcesLogin({
   appliedCookies,
   manualLogin,
   timeoutMs,
+  profileDir,
+  keepBrowser,
 }: {
   runtime: ChromeClient["Runtime"];
   logger: BrowserLogger;
   appliedCookies: number;
   manualLogin: boolean;
   timeoutMs: number;
+  profileDir?: string;
+  keepBrowser?: boolean;
 }): Promise<void> {
   if (!manualLogin) {
     await ensureLoggedIn(runtime, logger, { appliedCookies });
     return;
   }
-  const deadline = Date.now() + Math.min(timeoutMs ?? 1_200_000, 20 * 60_000);
+  const waitMs = resolveManualLoginWaitMs(timeoutMs, Boolean(keepBrowser));
+  const deadline = Date.now() + waitMs;
   let lastNotice = 0;
   while (Date.now() < deadline) {
     try {
@@ -389,8 +406,11 @@ async function waitForProjectSourcesLogin({
       await delay(1000);
     }
   }
+  const setupCommand = formatManualLoginSetupCommand(profileDir ?? defaultManualLoginProfileDir());
   throw new Error(
-    "Manual login mode timed out waiting for ChatGPT session; please sign in and retry.",
+    "Manual login mode timed out waiting for ChatGPT session. " +
+      `Browser mode is using Oracle's private Chrome profile at ${profileDir ?? "(default profile)"}, not your normal Chrome profile. ` +
+      `Run first-time setup, sign in there, then retry: ${setupCommand}`,
   );
 }
 

--- a/src/mcp/tools/consult.ts
+++ b/src/mcp/tools/consult.ts
@@ -297,6 +297,18 @@ export function buildConsultDryRunResolved({
     guidance.push(
       "Browser engine uses the signed-in ChatGPT profile; run dryRun:true before live use.",
     );
+    if (browserConfig?.manualLogin) {
+      const profile = browserConfig.manualLoginProfileDir ?? "~/.oracle/browser-profile";
+      guidance.push(
+        `Manual-login browser mode uses Oracle's private Chrome profile at ${profile}, separate from your normal Chrome profile.`,
+      );
+      guidance.push(
+        `First-time setup: run oracle --engine browser --browser-manual-login --browser-keep-browser --browser-manual-login-profile-dir ${JSON.stringify(profile)} -p "HI", sign into ChatGPT in that window, then retry the consult.`,
+      );
+      guidance.push(
+        "If this profile is not signed in, non-setup MCP/browser runs fail fast instead of waiting for the full browser timeout.",
+      );
+    }
   }
   const desiredModel = browserConfig?.desiredModel ?? null;
   const thinkingTime = browserConfig?.thinkingTime ?? null;
@@ -380,7 +392,7 @@ export function registerConsultTool(server: McpServer): void {
     {
       title: "Run an oracle session",
       description:
-        'Run an Oracle session (API or ChatGPT browser automation). Use `files` to attach project context. If `engine` is omitted, Oracle follows CLI defaults: config/ORACLE_ENGINE first, then API when OPENAI_API_KEY is set, otherwise browser. Browser GPT-5.5 Pro consults can take many minutes; use `dryRun:true` first when configuring an agent and inspect `sessions`/`oracle status` before retrying. For browser-based image/file uploads, set `browserAttachments:"always"`. Browser consults can include `browserFollowUps` for a multi-turn ChatGPT review in one conversation. Sessions are stored under `ORACLE_HOME_DIR` (shared with the CLI).',
+        'Run an Oracle session (API or ChatGPT browser automation). Use `files` to attach project context. If `engine` is omitted, Oracle follows CLI defaults: config/ORACLE_ENGINE first, then API when OPENAI_API_KEY is set, otherwise browser. Browser GPT-5.5 Pro consults can take many minutes; use `dryRun:true` first when configuring an agent and inspect `sessions`/`oracle status` before retrying. Browser manual-login uses a private Oracle Chrome profile separate from the user\'s normal Chrome; dry-run output includes first-time setup guidance when that path is active. For browser-based image/file uploads, set `browserAttachments:"always"`. Browser consults can include `browserFollowUps` for a multi-turn ChatGPT review in one conversation. Sessions are stored under `ORACLE_HOME_DIR` (shared with the CLI).',
       // Cast to any to satisfy SDK typings across differing Zod versions.
       inputSchema: consultInputShape,
       outputSchema: consultOutputShape,

--- a/tests/browser/index.test.ts
+++ b/tests/browser/index.test.ts
@@ -1,4 +1,6 @@
 import path from "node:path";
+import os from "node:os";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { describe, expect, test, vi } from "vitest";
 import {
   __test__,
@@ -106,6 +108,56 @@ describe("browser run target cleanup", () => {
         keepBrowser: false,
       }),
     ).toBe(false);
+  });
+});
+
+describe("manual-login profile setup gate", () => {
+  test("fails fast for an uninitialized manual-login profile unless setup keeps Chrome open", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "oracle-empty-profile-"));
+    try {
+      await expect(
+        __test__.assertManualLoginProfileReadyForRun({
+          userDataDir: dir,
+          keepBrowser: false,
+        }),
+      ).rejects.toThrow(/private Chrome profile/i);
+
+      await expect(
+        __test__.assertManualLoginProfileReadyForRun({
+          userDataDir: dir,
+          keepBrowser: true,
+        }),
+      ).resolves.toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("accepts an initialized manual-login Chrome profile", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "oracle-initialized-profile-"));
+    try {
+      await mkdir(path.join(dir, "Default"));
+      await expect(
+        __test__.assertManualLoginProfileReadyForRun({
+          userDataDir: dir,
+          keepBrowser: false,
+        }),
+      ).resolves.toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("formats the first-time setup command with the selected profile", () => {
+    expect(__test__.formatManualLoginSetupCommand("/tmp/oracle profile")).toContain(
+      '--browser-manual-login-profile-dir "/tmp/oracle profile"',
+    );
+  });
+
+  test("caps non-setup manual-login waits so MCP callers fail fast", () => {
+    expect(__test__.resolveManualLoginWaitMs(20 * 60_000, false)).toBe(30_000);
+    expect(__test__.resolveManualLoginWaitMs(5_000, false)).toBe(5_000);
+    expect(__test__.resolveManualLoginWaitMs(20 * 60_000, true)).toBe(20 * 60_000);
   });
 });
 

--- a/tests/mcp/consult.test.ts
+++ b/tests/mcp/consult.test.ts
@@ -197,6 +197,8 @@ describe("summarizeModelRunsForConsult", () => {
       },
     });
     expect(resolved.guidance.join("\n")).toContain("signed-in ChatGPT profile");
+    expect(resolved.guidance.join("\n")).toContain("private Chrome profile");
+    expect(resolved.guidance.join("\n")).toContain("--browser-keep-browser");
     expect(formatConsultDryRunResolved(resolved).join("\n")).toContain(
       "browser thinking time: extended",
     );


### PR DESCRIPTION
## Summary
- Fail fast when browser manual-login mode points at an uninitialized private Oracle Chrome profile and the run is not an explicit setup run.
- Cap non-setup manual-login waits so MCP/Claude callers get an actionable login/setup error instead of hanging until the browser timeout.
- Expand MCP dry-run/tool guidance to explain that manual-login uses a private Oracle Chrome profile separate from the user's normal Chrome, with the exact first-time setup command.
- Clarify README first-time login copy.
- Format `scripts/build-docs-site.mjs` with `oxfmt` so current `pnpm run format:check` passes on upstream main.

## Why
A Claude Code MCP browser consult can resolve to manual-login mode with a private profile that has never been signed into ChatGPT. Before this change, Oracle could open that separate Chrome profile, wait for login until the MCP client timed out, and leave the caller with a generic timeout or closed-window error.

The intended path should be explicit: first run setup with `--browser-keep-browser`, or use `--browser-attach-running` to reuse an already signed-in Chrome.

## Tests
- `pnpm vitest run tests/browser/index.test.ts tests/mcp/consult.test.ts tests/browser/pageActions.test.ts`
- `pnpm run format:check`
- `pnpm run build`
- `pnpm run check`
- `pnpm test`
- `git diff --check`

## Smoke
- Empty manual-login profile smoke exits immediately with `browser-login-setup` guidance and no long Chrome wait.