### PR TITLE
fix(browser): broaden attachment chip detection for current ChatGPT DOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Browser: target ChatGPT's renamed bare Pro picker row for Pro browser runs while keeping older Pro CLI aliases mapped to the current browser target (#190, fixes #182). Thanks @jungdaesuh!
+- Browser: recognize current ChatGPT attachment chips without treating stale page-level chips as ready, and keep the longer send-button wait scoped to attachment uploads (#192). Thanks @li-aolong!
 
 ## 0.11.1 — 2026-05-10
 

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -385,7 +385,7 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
       '[aria-label*="remove attachment"]',
       'button[aria-label*="remove attachment"]',
     ];
-    const attachmentRoots = Array.from(new Set([composer, document])).filter(Boolean);
+    const attachmentRoots = Array.from(new Set([composer])).filter(Boolean);
     const collectChipNodes = () => {
       const seen = new Set();
       const collected = [];
@@ -443,6 +443,7 @@ async function attemptSendButton(
   _logger?: BrowserLogger,
   attachmentNames?: string[],
 ): Promise<boolean> {
+  const needAttachment = Array.isArray(attachmentNames) && attachmentNames.length > 0;
   const script = `(() => {
     ${buildClickDispatcher()}
     const selectors = ${JSON.stringify(SEND_BUTTON_SELECTORS)};
@@ -476,12 +477,11 @@ async function attemptSendButton(
     return 'clicked';
   })()`;
 
-  // Give attachment-bearing submissions more headroom — ChatGPT's chip render
-  // settles slowly for multi-file uploads (the previous 20s deadline routinely
-  // tripped before the send button became clickable for two .md attachments).
-  const deadline = Date.now() + 45_000;
+  // Give attachment-bearing submissions more headroom. ChatGPT's chip render can
+  // settle slowly for multi-file uploads, but plain text sends should keep the
+  // shorter historical deadline.
+  const deadline = Date.now() + sendButtonTimeoutMs(attachmentNames);
   while (Date.now() < deadline) {
-    const needAttachment = Array.isArray(attachmentNames) && attachmentNames.length > 0;
     if (needAttachment) {
       const ready = await Runtime.evaluate({
         expression: buildAttachmentReadyExpression(attachmentNames),
@@ -512,6 +512,10 @@ async function attemptSendButton(
     );
   }
   return false;
+}
+
+function sendButtonTimeoutMs(attachmentNames?: string[]): number {
+  return Array.isArray(attachmentNames) && attachmentNames.length > 0 ? 45_000 : 20_000;
 }
 
 async function verifyPromptCommitted(
@@ -682,5 +686,6 @@ async function verifyPromptCommitted(
 // biome-ignore lint/style/useNamingConvention: test-only export used in vitest suite
 export const __test__ = {
   attemptSendButton,
+  sendButtonTimeoutMs,
   verifyPromptCommitted,
 };

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -340,17 +340,35 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
       document.querySelector('form') ||
       document.body ||
       document;
-    const labelText = (node) =>
-      [
-        node?.textContent,
-        node?.getAttribute?.('aria-label'),
-        node?.getAttribute?.('title'),
-        node?.getAttribute?.('data-testid'),
-      ]
-        .filter(Boolean)
-        .join(' ')
-        .toLowerCase();
-    const match = (node, name) => labelText(node).includes(name);
+    // Walk node + ancestors (up to grandparent) + descendants to gather every textual hint.
+    // ChatGPT's current chip DOM nests the filename inside truncated child spans, so checking
+    // only the node's own textContent/aria/title misses the match.
+    const collectLabelHaystack = (node) => {
+      if (!node) return '';
+      const pieces = [];
+      const pushAttrs = (el) => {
+        if (!el || typeof el.getAttribute !== 'function') return;
+        for (const attr of ['aria-label', 'title', 'data-testid', 'data-tooltip', 'data-tooltip-content']) {
+          const v = el.getAttribute(attr);
+          if (v) pieces.push(v);
+        }
+      };
+      const pushText = (el) => {
+        if (!el) return;
+        const text = (el.innerText ?? el.textContent ?? '').trim();
+        if (text) pieces.push(text);
+      };
+      pushAttrs(node);
+      pushText(node);
+      const parent = node.parentElement;
+      pushAttrs(parent);
+      pushText(parent);
+      const grandparent = parent?.parentElement;
+      pushAttrs(grandparent);
+      pushText(grandparent);
+      return pieces.join(' ').toLowerCase();
+    };
+    const match = (node, name) => collectLabelHaystack(node).includes(name);
 
     // Restrict to attachment affordances; never scan generic div/span nodes (prompt text can contain the file name).
     const attachmentSelectors = [
@@ -362,13 +380,32 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
       'button[aria-label*="Remove file"]',
       '[aria-label*="remove file"]',
       'button[aria-label*="remove file"]',
+      '[aria-label*="Remove attachment"]',
+      'button[aria-label*="Remove attachment"]',
+      '[aria-label*="remove attachment"]',
+      'button[aria-label*="remove attachment"]',
     ];
     const attachmentRoots = Array.from(new Set([composer, document])).filter(Boolean);
+    const collectChipNodes = () => {
+      const seen = new Set();
+      const collected = [];
+      for (const root of attachmentRoots) {
+        for (const node of Array.from(root.querySelectorAll(attachmentSelectors.join(',')))) {
+          if (!(node instanceof HTMLElement)) continue;
+          // Skip elements clearly inside the editable input (composer textarea may contain
+          // filename text in the user's prompt — avoid mistaking that for a chip).
+          if (node.closest('textarea,[contenteditable="true"]')) continue;
+          if (seen.has(node)) continue;
+          seen.add(node);
+          collected.push(node);
+        }
+      }
+      return collected;
+    };
+    const chipNodes = collectChipNodes();
 
     const chipsReady = names.every((name) =>
-      attachmentRoots.some((root) =>
-        Array.from(root.querySelectorAll(attachmentSelectors.join(','))).some((node) => match(node, name)),
-      ),
+      chipNodes.some((node) => match(node, name)),
     );
     const inputsReady = names.every((name) =>
       attachmentRoots.some((root) =>
@@ -379,8 +416,21 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
         ),
       ),
     );
+    // Count-based fallback: if we cannot match names individually (ChatGPT may strip
+    // the filename out of attribute-readable text into a deeply nested span), but we
+    // do see at least as many distinct chip-shaped nodes as attachments we uploaded,
+    // and a sibling "Remove" affordance exists per chip, trust the upload.
+    const removeAffordanceCount = chipNodes.filter((node) => {
+      const aria = (node.getAttribute?.('aria-label') ?? '').toLowerCase();
+      if (aria.includes('remove')) return true;
+      const removeSibling = node.querySelector?.(
+        '[aria-label*="Remove" i], [aria-label*="remove" i], button[aria-label*="Remove" i], button[aria-label*="remove" i]',
+      );
+      return Boolean(removeSibling);
+    }).length;
+    const countReady = chipNodes.length >= names.length && removeAffordanceCount >= names.length;
 
-    return chipsReady || inputsReady;
+    return chipsReady || inputsReady || countReady;
   })()`;
 }
 
@@ -426,7 +476,10 @@ async function attemptSendButton(
     return 'clicked';
   })()`;
 
-  const deadline = Date.now() + 20_000;
+  // Give attachment-bearing submissions more headroom — ChatGPT's chip render
+  // settles slowly for multi-file uploads (the previous 20s deadline routinely
+  // tripped before the send button became clickable for two .md attachments).
+  const deadline = Date.now() + 45_000;
   while (Date.now() < deadline) {
     const needAttachment = Array.isArray(attachmentNames) && attachmentNames.length > 0;
     if (needAttachment) {

--- a/tests/browser/promptComposer.test.ts
+++ b/tests/browser/promptComposer.test.ts
@@ -111,7 +111,8 @@ describe("promptComposer", () => {
         ["oracle-attach-verify.txt"],
       );
       const assertion = expect(promise).rejects.toThrow(/clickable send button/i);
-      await vi.advanceTimersByTimeAsync(21_000);
+      // Deadline is 45_000ms; advance a bit past it so the timeout fires.
+      await vi.advanceTimersByTimeAsync(46_000);
       await assertion;
     } finally {
       vi.useRealTimers();

--- a/tests/browser/promptComposer.test.ts
+++ b/tests/browser/promptComposer.test.ts
@@ -118,4 +118,10 @@ describe("promptComposer", () => {
       vi.useRealTimers();
     }
   });
+
+  test("only attachment sends get the longer send-button deadline", () => {
+    expect(promptComposer.sendButtonTimeoutMs()).toBe(20_000);
+    expect(promptComposer.sendButtonTimeoutMs([])).toBe(20_000);
+    expect(promptComposer.sendButtonTimeoutMs(["oracle-attach-verify.txt"])).toBe(45_000);
+  });
 });

--- a/tests/browser/promptComposerExpressions.test.ts
+++ b/tests/browser/promptComposerExpressions.test.ts
@@ -8,10 +8,24 @@ describe("prompt composer attachment expressions", () => {
     expect(expression).toContain("attachmentRoots");
     expect(expression).toContain('input[type="file"]');
     expect(expression).toContain('[aria-label*="Remove file"]');
-    expect(expression).toContain("getAttribute?.('aria-label')");
+    // Composer-internal nodes (the editable prompt itself) must not be treated as chips,
+    // otherwise prompt text containing the filename would falsely satisfy the check.
+    expect(expression).toContain("closest('textarea,[contenteditable=\"true\"]')");
     expect(expression).not.toContain("a,div,span");
     expect(expression).not.toContain(
       'document.querySelectorAll(\'[data-testid*="chip"],[data-testid*="attachment"],a,div,span\')',
     );
+  });
+
+  test("attachment ready check tolerates ChatGPT chip DOM that omits filename in attributes", () => {
+    const expression = buildAttachmentReadyExpressionForTest(["paper1_plan_v3.md"]);
+    // Walks into ancestor and descendant text so filenames buried in nested spans are still found.
+    expect(expression).toContain("collectLabelHaystack");
+    expect(expression).toContain("parentElement");
+    // Count-based fallback: when ChatGPT hides the filename entirely, accept that we
+    // see at least as many chip-shaped nodes (each with a Remove affordance) as we
+    // uploaded.
+    expect(expression).toContain("countReady");
+    expect(expression).toContain("removeAffordanceCount");
   });
 });

--- a/tests/browser/promptComposerExpressions.test.ts
+++ b/tests/browser/promptComposerExpressions.test.ts
@@ -28,4 +28,11 @@ describe("prompt composer attachment expressions", () => {
     expect(expression).toContain("countReady");
     expect(expression).toContain("removeAffordanceCount");
   });
+
+  test("attachment ready check stays scoped to the active composer", () => {
+    const expression = buildAttachmentReadyExpressionForTest(["paper1_plan_v3.md"]);
+
+    expect(expression).toContain("const attachmentRoots = Array.from(new Set([composer]))");
+    expect(expression).not.toContain("new Set([composer, document])");
+  });
 });


### PR DESCRIPTION
## Summary

Browser-mode runs with `--browser-attachments always` were tripping the 20s deadline in `attemptSendButton` even when the chips were clearly uploaded and the prompt was visible — only the send button never appeared clickable. The user-visible failure is `Attachments never reached a clickable send button before timeout.` (the explicit error from #163).

Root cause: ChatGPT's current attachment chip nests the filename inside truncated descendant spans. The existing `labelText` helper in `buildAttachmentReadyExpression` only reads the chip node's own `textContent` / `aria-label` / `title` / `data-testid`, so the per-file name match in `chipsReady` always returns false. The fallback `inputsReady` path also misses, because the chip's `<input type=\"file\">` element no longer carries `.files` after the upload completes. Net effect: the polling loop returns false until the deadline fires.

You can see the new chip text in the existing `attachments.ts` verbose log (`Attachment wait state`):

\`\`\`
attachedNames: [\"remove file 1: paper1_plan_v3.md\", \"remove file 2: tier_pilot_v0.2.8.md\", ...]
\`\`\`

That value comes from walking parent/grandparent text — exactly the leniency `promptComposer.ts` is missing.

## Changes

\`src/browser/actions/promptComposer.ts\`

- Replace the single-node `labelText` with `collectLabelHaystack`, which scans the node plus its parent and grandparent. For each level it collects `innerText`/`textContent` and the `aria-label` / `title` / `data-testid` / `data-tooltip` / `data-tooltip-content` attributes. Filenames buried in nested spans are now discovered.
- Add a `collectChipNodes` helper that de-duplicates chip candidates and **skips any node nested inside a `textarea` or `[contenteditable=\"true\"]`** so a user prompt mentioning the filename cannot pose as a chip (this preserves the protection the original comment described).
- Add a **count-based fallback**: when name matching fails (ChatGPT can strip the filename out of every readable attribute), accept the readiness signal if we see at least `attachmentNames.length` distinct chip-shaped nodes, each carrying a Remove affordance. This mirrors the leniency already used by `attachments.ts:waitForAttachmentCompletion` (the `filesAttached || fileCount > 0` branch) and rescues uploads where the chip is entirely opaque to attribute inspection.
- Recognize the `aria-label*=\"Remove attachment\"` variant in addition to the existing `Remove file`.
- Raise the post-upload deadline in `attemptSendButton` from 20s to 45s. Two ~10kB markdown attachments routinely needed >20s for the send button to flip out of the disabled state on slower networks; the previous deadline tripped before the legitimate ready state.

\`tests/browser/promptComposerExpressions.test.ts\`

- Update the existing test to assert on the new `closest('textarea,[contenteditable=\"true\"]')` guard (the prompt-text protection we kept) instead of a now-removed attribute literal.
- Add a second test that pins the new tolerance: the expression must walk `parentElement`, must collect via `collectLabelHaystack`, and must contain a `countReady` fallback gated on `removeAffordanceCount`.

\`tests/browser/promptComposer.test.ts\`

- The attachment-timeout test now advances 46_000ms instead of 21_000ms to match the new deadline.

## Verification

- \`pnpm exec vitest run tests/browser/\` — all 317 browser tests pass (1 pre-existing skip).
- \`pnpm run check\` — typecheck + lint + format clean.
- \`pnpm run build\` — produces working CLI.
- Live browser smoke test against the current ChatGPT UI: \`gpt-5-pro --browser-attachments always\` with two ~5kB / ~5kB markdown attachments (combined ~9.3k input tokens) now reaches \`Clicked send button\` and submits successfully. Without this patch the same invocation fails consistently with \`Attachments never reached a clickable send button before timeout.\`

## Notes / open questions

- The new `aria-label*=\"Remove attachment\"` selector is additive — it doesn't replace `Remove file`, since older sessions and the \`attachments.ts\` heuristics still depend on that variant.
- The 45s deadline is still a hard cap. If reviewers prefer a configurable knob I'm happy to add a flag, but the current value matches the upload-completion wait already used in `attachments.ts` and avoids growing the public CLI surface.