### PR TITLE
fix(browser): target current model effort row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Browser: select thinking effort from the currently checked ChatGPT model row so Pro Extended runs do not fall back to the Thinking row's effort control.
 - Browser: record ChatGPT model-selection evidence in session metadata and CLI output so Pro browser runs show the selected model proof (#195). Thanks @pdurlej!
 - Browser: target ChatGPT's renamed bare Pro picker row for Pro browser runs while keeping older Pro CLI aliases mapped to the current browser target (#190, fixes #182). Thanks @jungdaesuh!
 - Browser: recognize current ChatGPT attachment chips without treating stale page-level chips as ready, and keep the longer send-button wait scoped to attachment uploads (#192). Thanks @li-aolong!

--- a/docs/mythical-pro-agents.md
+++ b/docs/mythical-pro-agents.md
@@ -85,16 +85,16 @@ The captured report lands at `~/.oracle/sessions/<id>/artifacts/deep-research-re
 
 Pro / Thinking models in browser mode accept a `--browser-thinking-time` knob:
 
-| Level      | What it maps to in ChatGPT |
-| ---------- | -------------------------- |
-| `light`    | Quick                      |
-| `standard` | Default                    |
-| `extended` | Extended thinking          |
-| `heavy`    | Pro Extended               |
+| Level      | What it maps to in ChatGPT       |
+| ---------- | -------------------------------- |
+| `light`    | Quick                            |
+| `standard` | Default                          |
+| `extended` | Pro Extended / Thinking Extended |
+| `heavy`    | Heavy thinking                   |
 
 ```bash
 oracle --engine browser --model gpt-5.5-pro \
-  --browser-thinking-time heavy \
+  --browser-thinking-time extended \
   -p "Refactor this hot path" --file "src/render/**"
 ```
 

--- a/src/browser/actions/thinkingTime.ts
+++ b/src/browser/actions/thinkingTime.ts
@@ -242,21 +242,36 @@ function buildThinkingTimeExpression(level: ThinkingTimeLevel): string {
 
     const findModelButton = () => document.querySelector(MODEL_BUTTON_SELECTOR);
     const findTrailingButtons = () => Array.from(document.querySelectorAll(TRAILING_SELECTOR));
+    const findEffortRow = (node) => {
+      let current = node instanceof HTMLElement ? node.parentElement : null;
+      while (current && current !== document.body) {
+        if (current.getAttribute?.('data-model-picker-thinking-effort-row') === 'true') {
+          return current;
+        }
+        current = current.parentElement;
+      }
+      return null;
+    };
+    const rowIsSelected = (row) => {
+      if (!(row instanceof HTMLElement)) return false;
+      const modelItem = row.querySelector('[data-model-picker-thinking-effort-menu-item="true"], [role="menuitemradio"]');
+      if (optionIsSelected(modelItem)) return true;
+      return Boolean(
+        row.querySelector(
+          '[aria-checked="true"], [aria-selected="true"], [aria-current="true"], [data-selected="true"], [data-state="checked"], [data-state="selected"], [data-state="on"]',
+        ),
+      );
+    };
     const pickTrailingForCurrentModel = () => {
       const trailings = findTrailingButtons();
       if (trailings.length === 0) return null;
       if (trailings.length === 1) return trailings[0];
       // Prefer the trailing button whose model row is currently selected.
       for (const t of trailings) {
-        const row = t.closest('[role="menuitem"], [role="menuitemradio"], [data-radix-collection-item]');
-        if (row && (optionIsSelected(row) || row.querySelector('[aria-checked="true"]'))) return t;
+        const row = findEffortRow(t);
+        if (rowIsSelected(row)) return t;
       }
-      // Fallback: first one with non-zero box.
-      for (const t of trailings) {
-        const r = t.getBoundingClientRect?.();
-        if (r && r.width > 0 && r.height > 0) return t;
-      }
-      return trailings[0];
+      return null;
     };
 
     const modelBtn = findModelButton();

--- a/tests/browser/thinkingTime.test.ts
+++ b/tests/browser/thinkingTime.test.ts
@@ -28,8 +28,17 @@ describe("browser thinking-time selection expression", () => {
     const expression = buildThinkingTimeExpressionForTest("extended");
     expect(expression).toContain("MODEL_BUTTON_SELECTOR");
     expect(expression).toContain("data-model-picker-thinking-effort-action");
+    expect(expression).toContain("data-model-picker-thinking-effort-row");
     expect(expression).toContain("aria-controls");
     expect(expression).toContain("LEVEL_TOKENS");
+  });
+
+  it("targets the selected model row before opening the effort menu", () => {
+    const expression = buildThinkingTimeExpressionForTest("extended");
+    expect(expression).toContain("const findEffortRow");
+    expect(expression).toContain("const rowIsSelected");
+    expect(expression).toContain("if (rowIsSelected(row)) return t;");
+    expect(expression).toContain("return null;");
   });
 
   it("preserves Chinese thinking-effort labels while normalizing", () => {


### PR DESCRIPTION
## Summary
- select the ChatGPT thinking-effort control from the currently checked model row instead of falling back to the first visible effort button
- prevent Pro Extended browser runs from being flipped back to the Thinking row when applying extended effort
- update the Pro browser thinking-time docs and changelog entry

## Verification
- pnpm run format:check
- pnpm run lint
- pnpm run build
- pnpm vitest run tests/browser/thinkingTime.test.ts

## Live check
Observed ChatGPT DOM after the fix with Pro Extended selected: `model-switcher-gpt-5-5-pro` has `aria-checked="true"`, while the Thinking row is false. A browser run asking the model name returned `GPT-5.5 Pro` with Oracle evidence `resolved=Extended Pro; verified=yes`.
