### PR TITLE
feat(cli): add provider route diagnostics

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -13,6 +13,7 @@
   "ignorePatterns": [
     "scripts/browser-tools.ts",
     "node_modules/**/*",
+    ".pnpm-store/**/*",
     "coverage/**/*",
     ".bun-check/**/*"
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- API: add `--provider openai` / `--no-azure` to force first-party OpenAI when Azure env/config is present, print redacted provider routing for API runs, and fail early when Azure routing lacks a deployment.
+- API: add `--provider openai` / `--no-azure` to force first-party OpenAI when Azure env/config is present, add `oracle doctor --providers` and `--route` redacted route diagnostics, keep provider-qualified model IDs on OpenRouter/proxy routes instead of accidental Azure/native routes, and fail early when Azure routing lacks a deployment.
 - Browser/MCP: add opt-in ZIP formatting for bundled browser uploads with `--browser-bundle-format zip` / `browserBundleFormat: "zip"`, preserving individual file names in one ChatGPT attachment.
 
 ### Fixed

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -90,6 +90,8 @@ import {
   isAzureOpenAICandidateModel,
   validateProviderRouting,
 } from "../src/oracle/providerRouting.js";
+import { buildProviderRoutePlan } from "../src/oracle/providerRoutePlan.js";
+import { printProviderPlans } from "../src/cli/providerDoctor.js";
 
 interface CliOptions extends OptionValues {
   prompt?: string;
@@ -177,6 +179,7 @@ interface CliOptions extends OptionValues {
   heartbeat?: number;
   status?: boolean;
   dryRun?: boolean;
+  route?: boolean;
   // tri-state: `true` (forced wait), `false` (forced detach), `undefined` (auto)
   wait?: boolean;
   provider?: ApiProviderMode;
@@ -222,9 +225,13 @@ const normalizedArgv = process.argv.map((arg, index) => {
 const rawCliArgs = normalizedArgv.slice(2);
 const userCliArgs = rawCliArgs[0] === CLI_ENTRYPOINT ? rawCliArgs.slice(1) : rawCliArgs;
 const isTty = process.stdout.isTTY;
+const doctorArgIndex = userCliArgs.indexOf("doctor");
+const doctorJsonRequested =
+  doctorArgIndex >= 0 && userCliArgs.slice(doctorArgIndex).includes("--json");
 const suppressIntro =
-  userCliArgs[0] === "bridge" &&
-  (userCliArgs[1] === "codex-config" || userCliArgs[1] === "claude-config");
+  doctorJsonRequested ||
+  (userCliArgs[0] === "bridge" &&
+    (userCliArgs[1] === "codex-config" || userCliArgs[1] === "claude-config"));
 
 const program = new Command();
 let introPrinted = false;
@@ -420,6 +427,7 @@ program
       .preset("summary")
       .default(false),
   )
+  .option("--route", "Print API provider route plan and exit.", false)
   .addOption(new Option("--exec-session <id>").hideHelp())
   .addOption(new Option("--session <id>").hideHelp())
   .addOption(
@@ -976,6 +984,28 @@ program
   });
 
 program
+  .command("doctor")
+  .description("Diagnose Oracle API provider readiness and routing.")
+  .option("--providers", "Inspect API provider keys and route choices.", false)
+  .option("--models <models>", "Comma-separated API model list to inspect.")
+  .option("-m, --model <model>", "Single API model to inspect.")
+  .addOption(
+    new Option("--provider <provider>", "Choose API provider routing: auto, openai, or azure.")
+      .choices(["auto", "openai", "azure"])
+      .default("auto"),
+  )
+  .option("--no-azure", "Disable Azure OpenAI routing for this inspection.")
+  .option("--azure-endpoint <url>", "Azure OpenAI Endpoint.")
+  .option("--azure-deployment <name>", "Azure OpenAI Deployment Name.")
+  .option("--azure-api-version <version>", "Azure OpenAI API Version.")
+  .option("--base-url <url>", "Override OpenAI-compatible base URL.")
+  .option("--json", "Print structured JSON.", false)
+  .action(async function (this: Command) {
+    const { runProviderDoctor } = await import("../src/cli/providerDoctor.js");
+    await runProviderDoctor(this.optsWithGlobals());
+  });
+
+program
   .command("session [id]")
   .description("Attach to a stored session or list recent sessions when no ID is provided.")
   .option(
@@ -1187,6 +1217,10 @@ function hasExplicitAzureOption(optionUsesDefault: (name: string) => boolean): b
     !optionUsesDefault("azureDeployment") ||
     !optionUsesDefault("azureApiVersion")
   );
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  return values.find((value) => value?.trim());
 }
 
 function formatRouteTargetForLog(raw: string | undefined): string {
@@ -1479,17 +1513,14 @@ async function runRootCommand(options: CliOptions): Promise<void> {
   const userConfig = (await loadUserConfig()).config;
   const helpRequested = rawCliArgs.some((arg: string) => arg === "--help" || arg === "-h");
   const multiModelProvided = Array.isArray(options.models) && options.models.length > 0;
-  if (multiModelProvided) {
-    const modelFromConfigOrCli = normalizeModelOption(options.model ?? userConfig.model ?? "");
-    if (modelFromConfigOrCli) {
-      throw new Error("--models cannot be combined with --model.");
-    }
-  }
   const optionUsesDefault = (name: string): boolean => {
     // Commander reports undefined for untouched options, so treat undefined/default the same
     const source = program.getOptionValueSource?.(name);
     return source == null || source === "default";
   };
+  if (multiModelProvided && !optionUsesDefault("model") && normalizeModelOption(options.model)) {
+    throw new Error("--models cannot be combined with --model.");
+  }
   if (helpRequested) {
     if (options.verbose) {
       console.log("");
@@ -1559,10 +1590,6 @@ async function runRootCommand(options: CliOptions): Promise<void> {
     program.outputHelp();
     return;
   }
-  const retentionHours = typeof options.retainHours === "number" ? options.retainHours : undefined;
-  await sessionStore.ensureStorage();
-  await pruneOldSessions(retentionHours, (message) => console.log(chalk.dim(message)));
-
   if (options.debugHelp) {
     printDebugHelp(program.name());
     return;
@@ -1571,7 +1598,7 @@ async function runRootCommand(options: CliOptions): Promise<void> {
     throw new Error("--dry-run cannot be combined with --render-markdown.");
   }
 
-  if (optionUsesDefault("model") && userConfig.model) {
+  if (!multiModelProvided && optionUsesDefault("model") && userConfig.model) {
     options.model = userConfig.model;
   }
   if (optionUsesDefault("search") && userConfig.search) {
@@ -1588,6 +1615,47 @@ async function runRootCommand(options: CliOptions): Promise<void> {
   }
 
   const providerMode = resolveApiProviderMode(options);
+  const engineModels = multiModelProvided
+    ? Array.from(new Set(options.models!.map((entry) => resolveApiModel(entry))))
+    : [resolveApiModel(normalizeModelOption(options.model) || DEFAULT_MODEL)];
+  if (options.route) {
+    const routeAzureEndpoint = firstNonEmpty(
+      options.azureEndpoint,
+      process.env.AZURE_OPENAI_ENDPOINT,
+      userConfig.azure?.endpoint,
+    );
+    const configuredAzureForRoute = routeAzureEndpoint
+      ? {
+          endpoint: routeAzureEndpoint,
+          deployment: firstNonEmpty(
+            options.azureDeployment,
+            process.env.AZURE_OPENAI_DEPLOYMENT,
+            userConfig.azure?.deployment,
+          ),
+          apiVersion: firstNonEmpty(
+            options.azureApiVersion,
+            process.env.AZURE_OPENAI_API_VERSION,
+            userConfig.azure?.apiVersion,
+          ),
+        }
+      : undefined;
+    const plans = engineModels.map((model) =>
+      buildProviderRoutePlan({
+        model,
+        providerMode,
+        azure: configuredAzureForRoute,
+        baseUrl: options.baseUrl,
+        env: process.env,
+      }),
+    );
+    printProviderPlans(plans, { title: "Route plan" });
+    process.exitCode = plans.some((plan) => !plan.ok) ? 1 : 0;
+    return;
+  }
+
+  const retentionHours = typeof options.retainHours === "number" ? options.retainHours : undefined;
+  await sessionStore.ensureStorage();
+  await pruneOldSessions(retentionHours, (message) => console.log(chalk.dim(message)));
   if (providerMode === "openai") {
     if (hasExplicitAzureOption(optionUsesDefault)) {
       throw new Error("--provider openai/--no-azure cannot be combined with Azure options.");
@@ -1622,9 +1690,6 @@ async function runRootCommand(options: CliOptions): Promise<void> {
     }
   }
 
-  const engineModels = multiModelProvided
-    ? Array.from(new Set(options.models!.map((entry) => resolveApiModel(entry))))
-    : [resolveApiModel(normalizeModelOption(options.model) || DEFAULT_MODEL)];
   const azureAutoApiRequested =
     providerMode !== "openai" &&
     Boolean(options.azureEndpoint?.trim()) &&

--- a/docs/refactor/ux.md
+++ b/docs/refactor/ux.md
@@ -1,0 +1,296 @@
+# Oracle UX Refactor Plan
+
+Context: Oracle bundles prompts + files, then sends the bundle to API/browser models for second-model review. Recent multi-model advisory use exposed confusing provider routing, timeout, auth, partial-success, output, and session behaviors.
+
+## Diagnosis
+
+- CLI/docs drift: installed `0.11.1` rejected `--no-azure` while local help/docs mention it. Likely stale published artifact, `pnpm dlx` cache, or docs not verified against packed CLI.
+- Azure routing too implicit: exported `AZURE_OPENAI_ENDPOINT` can steer GPT/OpenAI-family API runs through Azure unless users manually unset env vars or force provider routing.
+- Timeout layering unclear: `--timeout` controls Oracle's overall deadline; `--http-timeout` controls SDK transport. A long overall timeout can still fail early at transport.
+- Multi-model aggregation saves successful outputs, but any failed model makes the command exit 1. Partial success is real but under-communicated.
+- Auth failures are lazy: missing keys fail early; invalid/expired keys fail only after requests start.
+- Output summary ordering is weak: saved outputs can be buried under noisy failures.
+- Session lifecycle vocabulary is inconsistent across API foreground, API background, browser, and Pro runs.
+- Provider/key routing is opaque: users need safe, redacted route/readiness visibility.
+
+## Priorities
+
+### 1. Provider Doctor + Preflight
+
+Add:
+
+```sh
+oracle doctor --providers
+oracle doctor --providers --models gpt-5.4,claude-4.6-sonnet,gemini-3-pro
+oracle --preflight --models gpt-5.4,claude-4.6-sonnet,gemini-3-pro -p "..."
+```
+
+Expected output:
+
+```text
+Provider readiness
+
+OpenAI: ok
+  key: OPENAI_API_KEY=sk-...a91
+  base: api.openai.com
+  route gpt-5.4: OpenAI Responses API
+
+Azure OpenAI: configured, inactive
+  endpoint: my-resource.openai.azure.com
+  key: AZURE_OPENAI_API_KEY=az-...32c
+  route gpt-5.4: ignored because --provider openai
+
+Anthropic: auth failed
+  key: ANTHROPIC_API_KEY=sk-...9bc
+  error: invalid x-api-key
+
+Gemini: auth failed
+  key: GEMINI_API_KEY=AIza...77e
+  error: API key expired
+```
+
+Implementation:
+
+- Add top-level `oracle doctor`; keep `oracle bridge doctor` bridge-specific.
+- Extract provider route/auth logic into `src/oracle/providerDoctor.ts`.
+- Support `local` preflight for env/config/routing and `auth` preflight for cheap provider network checks.
+- Redact all keys. Never print raw env values.
+
+### 2. Explicit Provider Route Plan
+
+Add:
+
+```sh
+oracle --route --models gpt-5.4,gemini-3-pro
+oracle --provider openai --route --model gpt-5.4
+oracle --no-azure --route --model gpt-5.4
+```
+
+Expected output:
+
+```text
+Route plan
+
+gpt-5.4
+  provider: OpenAI
+  base: api.openai.com
+  key: OPENAI_API_KEY=sk-...a91
+  azure: ignored, AZURE_OPENAI_ENDPOINT is set
+
+gemini-3-pro
+  provider: Google Gemini
+  base: generativelanguage.googleapis.com
+  key: GEMINI_API_KEY=AIza...77e
+```
+
+Implementation:
+
+- Make provider routing return a structured `ProviderRoutePlan`.
+- Reuse it in run header, doctor, dry-run JSON, and session metadata.
+- Add route-plan tests for Azure env present plus `--provider openai`.
+
+### 3. Unified Timeout Semantics
+
+Target behavior:
+
+```sh
+oracle --timeout 10m ...
+oracle --timeout 10m --http-timeout 30s ...
+oracle --timeout auto ...
+```
+
+Expected output:
+
+```text
+Timeouts
+  overall: 10m
+  transport: 10m
+  session stale cutoff: 10m
+```
+
+With explicit shorter transport:
+
+```text
+Timeouts
+  overall: 10m
+  transport: 30s
+  note: transport can fail before overall timeout
+```
+
+Implementation:
+
+- If user sets `--timeout` and omits `--http-timeout`, derive HTTP timeout from overall timeout.
+- Keep `--http-timeout` as explicit override.
+- Print timeout plan in verbose and long-running runs.
+- Store resolved timeouts in session metadata.
+
+Migration:
+
+- Keep both flags.
+- Warn when `--http-timeout < --timeout`.
+- Update docs so `--timeout` is the normal user-facing deadline.
+
+### 4. Partial Success Mode
+
+Add:
+
+```sh
+oracle --models gpt-5.4,claude-4.6-sonnet,gemini-3-pro --allow-partial ...
+oracle --models ... --partial fail
+oracle --models ... --partial ok
+```
+
+Expected output:
+
+```text
+Multi-model result: partial success, 1/3 succeeded
+
+Saved outputs:
+- gpt-5.4 -> /tmp/name.gpt-5.4.md
+
+Failures:
+- claude-4.6-sonnet: auth failed, invalid x-api-key
+- gemini-3-pro: auth failed, API key expired
+
+Session:
+- oracle session 20260515-naming-panel
+```
+
+Implementation:
+
+- Add `allowPartial?: boolean` or `partialMode: "fail" | "ok"` to run options.
+- In multi-model runner, if fulfilled > 0 and partial ok, exit 0.
+- Add a `partial` or `completed_with_errors` session status.
+- Keep default exit-1 behavior initially for backcompat, but always print structured partial summary before throwing.
+
+### 5. Output Manifest + Summary Ordering
+
+For multi-model `--write-output`, always print saved outputs first, then logs, then failures:
+
+```text
+Saved outputs:
+- gpt-5.4 -> /tmp/name.gpt-5.4.md
+
+Run logs:
+- gpt-5.4 -> ~/.oracle/sessions/.../logs/gpt-5.4.log
+- claude-4.6-sonnet -> ~/.oracle/sessions/.../logs/claude-4.6-sonnet.log
+
+Failures:
+- gemini-3-pro -> auth failed
+```
+
+Implementation:
+
+- Add optional output manifest next to the requested path, e.g. `/tmp/name.oracle.json`.
+- Include model, status, output path, log path, error category, elapsed, usage.
+- Make manifest useful for agents consuming partial output.
+
+### 6. Auth Error Classification
+
+Expected output:
+
+```text
+Failures:
+- claude-4.6-sonnet: auth failed
+  key: ANTHROPIC_API_KEY=sk-...9bc
+  provider said: invalid x-api-key
+  fix: refresh ANTHROPIC_API_KEY or run `oracle doctor --providers anthropic`
+
+- gemini-3-pro: auth expired
+  key: GEMINI_API_KEY=AIza...77e
+  fix: rotate key, then rerun failed model:
+       oracle session <id> --rerun-failed
+```
+
+Implementation:
+
+- Normalize provider SDK errors into Oracle user errors.
+- Classify auth, expired key, quota, rate limit, model unavailable, and transport separately.
+- Store category in per-model metadata.
+
+### 7. Clear Foreground/Detached Lifecycle
+
+Run start should print a compact lifecycle block:
+
+```text
+Session: 20260515-name-panel
+Mode: api foreground
+Models: 3 parallel
+Detach: no
+Reattach: oracle session 20260515-name-panel
+```
+
+For background/Pro:
+
+```text
+Session: 20260515-pro-review
+Mode: api background
+Detach: yes, polling
+Reattach: oracle session 20260515-pro-review --live
+```
+
+Implementation:
+
+- Add lifecycle fields to session metadata: `engine`, `execution`, `attached`, `reattachCommand`.
+- Use the same fields in `status`, `session`, notifications, and run headers.
+- Avoid special-case wording for Pro unless the behavior truly differs.
+
+### 8. Help/Docs Single Source + Packed CLI Test
+
+Add CI/doc check:
+
+```sh
+oracle docs check
+```
+
+Expected failure:
+
+```text
+Docs/help drift:
+- skills/oracle/SKILL.md mentions --no-azure
+- packed CLI help does not expose --no-azure
+```
+
+Implementation:
+
+- Generate docs snippets from Commander metadata or a shared flag registry.
+- CI smoke:
+  - `pnpm pack`
+  - install packed tarball in a temp dir
+  - run `oracle --help --verbose`
+  - assert documented flags exist.
+- Add skill-doc lint for stale flags.
+
+## Azure Backcompat
+
+- Keep auto Azure initially.
+- Make Azure route reason loud:
+
+```text
+Provider: Azure OpenAI
+Reason: AZURE_OPENAI_ENDPOINT is set
+Opt out: --provider openai or --no-azure
+```
+
+- Add explicit opt-out options:
+
+```sh
+oracle --provider openai
+oracle --no-azure
+ORACLE_AZURE=0 oracle ...
+```
+
+- Longer term: when both first-party OpenAI and Azure env are present, require `--provider azure` to use Azure, or gate stricter routing behind a major version.
+
+## Tests
+
+- Packed CLI exposes every documented flag, especially `--no-azure`.
+- `--timeout 10m` passes `httpTimeoutMs=600000` when `--http-timeout` is omitted.
+- `--timeout 10m --http-timeout 30s` preserves 30s and warns.
+- Azure env plus `--provider openai` routes to OpenAI and omits Azure metadata.
+- Azure env plus auto prints route reason and opt-out hint.
+- `doctor --providers` redacts keys and classifies missing, valid, invalid, and expired.
+- Multi-model partial: one success, two auth failures, `--allow-partial` exits 0 and prints saved outputs first.
+- Multi-model default: same case exits 1 but still prints structured partial summary.
+- `--write-output` multi-model writes per-model files and optional manifest.
+- `oracle status` displays partial sessions and per-model failures cleanly.

--- a/src/cli/promptRequirement.ts
+++ b/src/cli/promptRequirement.ts
@@ -4,6 +4,7 @@ interface PromptCheckOptions {
   execSession?: string;
   status?: boolean;
   debugHelp?: boolean;
+  route?: boolean;
   renderMarkdown?: boolean;
   preview?: boolean | string;
   dryRun?: boolean;
@@ -22,6 +23,7 @@ export function shouldRequirePrompt(rawArgs: string[], options: PromptCheckOptio
     options.execSession ||
     options.status ||
     options.debugHelp ||
+    options.route ||
     firstArg === "status" ||
     firstArg === "session",
   );

--- a/src/cli/providerDoctor.ts
+++ b/src/cli/providerDoctor.ts
@@ -1,0 +1,129 @@
+import chalk from "chalk";
+import { DEFAULT_MODEL } from "../oracle.js";
+import type { ApiProviderMode, AzureOptions, ModelName } from "../oracle.js";
+import { resolveApiModel } from "./options.js";
+import { loadUserConfig, type UserConfig } from "../config.js";
+import { buildProviderRoutePlan, type ProviderRoutePlan } from "../oracle/providerRoutePlan.js";
+
+export interface ProviderDoctorCliOptions {
+  providers?: boolean;
+  models?: string | string[];
+  model?: string;
+  provider?: ApiProviderMode;
+  azure?: boolean;
+  azureEndpoint?: string;
+  azureDeployment?: string;
+  azureApiVersion?: string;
+  baseUrl?: string;
+  json?: boolean;
+}
+
+export async function runProviderDoctor(options: ProviderDoctorCliOptions): Promise<void> {
+  if (!options.providers) {
+    console.log("Run `oracle doctor --providers` to inspect API provider readiness.");
+    return;
+  }
+
+  const { config: userConfig } = await loadUserConfig();
+  const providerMode = resolveProviderMode(options);
+  const azure = resolveAzureOptions(options, userConfig);
+  const models = resolveModels(options, userConfig);
+  const plans = models.map((model) =>
+    buildProviderRoutePlan({
+      model,
+      providerMode,
+      azure,
+      baseUrl: options.baseUrl ?? userConfig.apiBaseUrl,
+      env: process.env,
+    }),
+  );
+
+  if (options.json) {
+    console.log(JSON.stringify({ providers: plans }, null, 2));
+    process.exitCode = plans.some((plan) => !plan.ok) ? 1 : 0;
+    return;
+  }
+
+  printProviderPlans(plans);
+  process.exitCode = plans.some((plan) => !plan.ok) ? 1 : 0;
+}
+
+export function printProviderPlans(
+  plans: ProviderRoutePlan[],
+  { title = "Provider readiness" }: { title?: string } = {},
+): void {
+  console.log(chalk.bold(title));
+  console.log("");
+  for (const plan of plans) {
+    const status = plan.ok ? chalk.green("ok") : chalk.red("not ready");
+    console.log(`${plan.model}: ${status}`);
+    console.log(chalk.dim(`  provider: ${plan.providerLabel}`));
+    console.log(chalk.dim(`  base: ${plan.base || "(none)"}`));
+    console.log(chalk.dim(`  key: ${plan.keyPreview}`));
+    if (plan.isAzureOpenAI || plan.azureDeploymentName) {
+      console.log(chalk.dim(`  azure deployment: ${plan.azureDeploymentName ?? "none"}`));
+    }
+    if (plan.azureNote) {
+      console.log(chalk.dim(`  azure: ${plan.azureNote}`));
+    }
+    if (plan.error) {
+      console.log(chalk.dim(`  error: ${plan.error}`));
+    }
+    console.log("");
+  }
+}
+
+function resolveModels(options: ProviderDoctorCliOptions, userConfig: UserConfig): ModelName[] {
+  const entries =
+    Array.isArray(options.models) && options.models.length > 0
+      ? options.models
+      : typeof options.models === "string" && options.models.trim().length > 0
+        ? options.models
+            .split(",")
+            .map((entry) => entry.trim())
+            .filter(Boolean)
+        : [options.model ?? userConfig.model ?? DEFAULT_MODEL];
+  return Array.from(new Set(entries.map((entry) => resolveApiModel(entry))));
+}
+
+function resolveProviderMode(options: ProviderDoctorCliOptions): ApiProviderMode {
+  const provider = options.provider ?? "auto";
+  if (provider === "azure" && options.azure === false) {
+    throw new Error("--provider azure cannot be combined with --no-azure.");
+  }
+  if (options.azure === false) {
+    return "openai";
+  }
+  return provider;
+}
+
+function resolveAzureOptions(
+  options: ProviderDoctorCliOptions,
+  userConfig: UserConfig,
+): AzureOptions | undefined {
+  const endpoint = firstNonEmpty(
+    options.azureEndpoint,
+    process.env.AZURE_OPENAI_ENDPOINT,
+    userConfig.azure?.endpoint,
+  );
+  if (!endpoint) {
+    return undefined;
+  }
+  return {
+    endpoint,
+    deployment: firstNonEmpty(
+      options.azureDeployment,
+      process.env.AZURE_OPENAI_DEPLOYMENT,
+      userConfig.azure?.deployment,
+    ),
+    apiVersion: firstNonEmpty(
+      options.azureApiVersion,
+      process.env.AZURE_OPENAI_API_VERSION,
+      userConfig.azure?.apiVersion,
+    ),
+  };
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  return values.find((value) => value?.trim());
+}

--- a/src/oracle/providerRoutePlan.ts
+++ b/src/oracle/providerRoutePlan.ts
@@ -1,0 +1,365 @@
+import { isCustomBaseUrl } from "./client.js";
+import { formatBaseUrlForLog, maskApiKey } from "./logging.js";
+import {
+  defaultOpenRouterBaseUrl,
+  isOpenRouterBaseUrl,
+  normalizeOpenRouterBaseUrl,
+} from "./modelResolver.js";
+import { resolveProviderRoutingState, validateProviderRouting } from "./providerRouting.js";
+import type { ApiProviderMode, AzureOptions, ModelConfig, ModelName } from "./types.js";
+
+const DEFAULT_PROVIDER_HOSTS: Record<string, string> = {
+  anthropic: "api.anthropic.com",
+  google: "generativelanguage.googleapis.com",
+  openai: "api.openai.com",
+  xai: "api.x.ai",
+};
+
+export interface ProviderRoutePlanInput {
+  model: ModelName;
+  providerMode?: ApiProviderMode;
+  azure?: AzureOptions;
+  baseUrl?: string;
+  apiKey?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface ProviderRoutePlan {
+  model: ModelName;
+  ok: boolean;
+  provider: NonNullable<ModelConfig["provider"]> | "azure";
+  providerLabel: string;
+  base: string;
+  keySource: string;
+  keyPreview: string;
+  keyPresent: boolean;
+  isAzureOpenAI: boolean;
+  azureConfigured: boolean;
+  azureDeploymentName?: string;
+  azureNote?: string;
+  error?: string;
+}
+
+export function buildProviderRoutePlan(input: ProviderRoutePlanInput): ProviderRoutePlan {
+  const env = input.env ?? process.env;
+  const providerMode = input.providerMode ?? "auto";
+  const azureConfigured = Boolean(input.azure?.endpoint?.trim());
+
+  try {
+    validateProviderRouting({
+      model: input.model,
+      providerMode,
+      azure: input.azure,
+    });
+  } catch (error) {
+    const state = tryResolveProviderRoutingState({
+      model: input.model,
+      providerMode,
+      azure: input.azure,
+    });
+    const provider =
+      state?.provider ??
+      (providerMode === "openai" ? "openai" : inferProviderFromModel(input.model));
+    const isAzureOpenAI = state?.isAzureOpenAI ?? providerMode === "azure";
+    const key = getKeyForRoute({
+      model: input.model,
+      provider,
+      providerMode,
+      isAzureOpenAI,
+      baseUrl: input.baseUrl,
+      openRouterFallback: false,
+      apiKey: input.apiKey,
+      env,
+    });
+    return {
+      model: input.model,
+      ok: false,
+      provider: isAzureOpenAI ? "azure" : provider,
+      providerLabel: isAzureOpenAI ? "Azure OpenAI" : providerLabel(provider),
+      base: isAzureOpenAI
+        ? formatRouteTargetForLog(state?.azureEndpoint ?? input.azure?.endpoint)
+        : formatRouteTargetForLog(input.baseUrl, DEFAULT_PROVIDER_HOSTS[provider]),
+      keySource: key.source,
+      keyPreview: key.preview,
+      keyPresent: key.present,
+      isAzureOpenAI,
+      azureConfigured,
+      azureDeploymentName: state?.azureDeploymentName,
+      azureNote: azureNote(providerMode, azureConfigured, isAzureOpenAI),
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const state = resolveProviderRoutingState({
+    model: input.model,
+    providerMode,
+    azure: input.azure,
+  });
+  const provider = state.provider;
+  const isAzureOpenAI = state.isAzureOpenAI;
+  let baseUrl = input.baseUrl?.trim();
+  const providerQualifiedOpenRouterCandidate =
+    !isAzureOpenAI && providerMode !== "openai" && input.model.includes("/");
+  if (
+    baseUrl &&
+    providerQualifiedOpenRouterCandidate &&
+    !isOpenRouterBaseUrl(baseUrl) &&
+    !isCustomBaseUrl(baseUrl)
+  ) {
+    baseUrl = undefined;
+  }
+  if (!baseUrl) {
+    let envBaseUrl: string | undefined;
+    if (input.model.startsWith("grok")) {
+      envBaseUrl = env.XAI_BASE_URL?.trim() || "https://api.x.ai/v1";
+    } else if (provider === "anthropic") {
+      envBaseUrl = env.ANTHROPIC_BASE_URL?.trim();
+    } else {
+      envBaseUrl = env.OPENAI_BASE_URL?.trim();
+    }
+    if (!providerQualifiedOpenRouterCandidate || (envBaseUrl && isCustomBaseUrl(envBaseUrl))) {
+      baseUrl = envBaseUrl;
+    }
+  }
+
+  const nativeKey = getNativeKey({
+    model: input.model,
+    provider,
+    providerMode,
+    isAzureOpenAI,
+    apiKey: input.apiKey,
+    env,
+  });
+  const providerQualifiedOpenRouterRoute = providerQualifiedOpenRouterCandidate && !baseUrl;
+  const providerKeyMissing =
+    !isAzureOpenAI &&
+    (providerQualifiedOpenRouterRoute
+      ? true
+      : providerMode === "openai"
+        ? !nativeKey.present
+        : (provider === "openai" && !nativeKey.present) ||
+          (provider === "anthropic" && !nativeKey.present) ||
+          (provider === "google" && !nativeKey.present) ||
+          (provider === "xai" && !nativeKey.present) ||
+          provider === "other");
+  const openRouterKey = readKey(["OPENROUTER_API_KEY"], env);
+  const openRouterFallback =
+    !baseUrl &&
+    (providerQualifiedOpenRouterRoute ||
+      (providerMode !== "openai" &&
+        providerKeyMissing &&
+        (provider === "other" || openRouterKey.present)));
+
+  if (openRouterFallback) {
+    baseUrl = defaultOpenRouterBaseUrl();
+  }
+  if (baseUrl && isOpenRouterBaseUrl(baseUrl)) {
+    baseUrl = normalizeOpenRouterBaseUrl(baseUrl);
+  }
+
+  const key = getKeyForRoute({
+    model: input.model,
+    provider,
+    providerMode,
+    isAzureOpenAI,
+    baseUrl,
+    openRouterFallback,
+    apiKey: input.apiKey,
+    env,
+  });
+  const routeProvider = routeProviderLabel({
+    provider,
+    baseUrl,
+    openRouterFallback,
+    isAzureOpenAI,
+  });
+  const fallbackHost = DEFAULT_PROVIDER_HOSTS[provider] ?? DEFAULT_PROVIDER_HOSTS.openai;
+
+  return {
+    model: input.model,
+    ok: key.present,
+    provider: isAzureOpenAI ? "azure" : provider,
+    providerLabel: routeProvider,
+    base: isAzureOpenAI
+      ? formatRouteTargetForLog(state.azureEndpoint)
+      : formatRouteTargetForLog(baseUrl, fallbackHost),
+    keySource: key.source,
+    keyPreview: key.preview,
+    keyPresent: key.present,
+    isAzureOpenAI,
+    azureConfigured,
+    azureDeploymentName: state.azureDeploymentName,
+    azureNote: azureNote(providerMode, azureConfigured, isAzureOpenAI),
+    error: key.present ? undefined : `Missing ${key.source}.`,
+  };
+}
+
+function getNativeKey({
+  model,
+  provider,
+  providerMode,
+  isAzureOpenAI,
+  apiKey,
+  env,
+}: {
+  model: ModelName;
+  provider: NonNullable<ModelConfig["provider"]>;
+  providerMode: ApiProviderMode;
+  isAzureOpenAI: boolean;
+  apiKey?: string;
+  env: NodeJS.ProcessEnv;
+}) {
+  return getKeyForRoute({
+    model,
+    provider,
+    providerMode,
+    isAzureOpenAI,
+    baseUrl: undefined,
+    openRouterFallback: false,
+    apiKey,
+    env,
+  });
+}
+
+function getKeyForRoute({
+  model,
+  provider,
+  providerMode,
+  isAzureOpenAI,
+  baseUrl,
+  openRouterFallback,
+  apiKey,
+  env,
+}: {
+  model: ModelName;
+  provider: NonNullable<ModelConfig["provider"]>;
+  providerMode: ApiProviderMode;
+  isAzureOpenAI: boolean;
+  baseUrl?: string;
+  openRouterFallback: boolean;
+  apiKey?: string;
+  env: NodeJS.ProcessEnv;
+}): { source: string; preview: string; present: boolean } {
+  if (apiKey) {
+    return { source: "apiKey option", preview: maskApiKey(apiKey) ?? "set", present: true };
+  }
+  if (isAzureOpenAI) {
+    return readKey(["AZURE_OPENAI_API_KEY", "OPENAI_API_KEY"], env);
+  }
+  if (providerMode === "openai") {
+    return readKey(["OPENAI_API_KEY"], env);
+  }
+  if (isOpenRouterBaseUrl(baseUrl) || openRouterFallback) {
+    return readKey(["OPENROUTER_API_KEY"], env);
+  }
+  if (model.includes("/")) {
+    return readKey(["OPENROUTER_API_KEY"], env);
+  }
+  if (model.startsWith("gpt")) {
+    return readKey(["OPENAI_API_KEY"], env);
+  }
+  if (model.startsWith("gemini")) {
+    return readKey(["GEMINI_API_KEY"], env);
+  }
+  if (model.startsWith("claude")) {
+    return readKey(["ANTHROPIC_API_KEY"], env);
+  }
+  if (model.startsWith("grok")) {
+    return readKey(["XAI_API_KEY"], env);
+  }
+  if (provider === "other") {
+    return readKey(["OPENROUTER_API_KEY"], env);
+  }
+  return readKey(["OPENAI_API_KEY"], env);
+}
+
+function readKey(
+  names: string[],
+  env: NodeJS.ProcessEnv,
+): { source: string; preview: string; present: boolean } {
+  for (const name of names) {
+    const value = env[name]?.trim();
+    if (value) {
+      return { source: name, preview: `${name}=${maskApiKey(value) ?? "set"}`, present: true };
+    }
+  }
+  return { source: names.join("|"), preview: "missing", present: false };
+}
+
+function routeProviderLabel({
+  provider,
+  baseUrl,
+  openRouterFallback,
+  isAzureOpenAI,
+}: {
+  provider: NonNullable<ModelConfig["provider"]>;
+  baseUrl?: string;
+  openRouterFallback: boolean;
+  isAzureOpenAI: boolean;
+}): string {
+  if (isAzureOpenAI) return "Azure OpenAI";
+  if (isOpenRouterBaseUrl(baseUrl) || openRouterFallback) return "OpenRouter";
+  if (baseUrl && isCustomBaseUrl(baseUrl)) return "OpenAI-compatible";
+  return providerLabel(provider);
+}
+
+function providerLabel(provider: NonNullable<ModelConfig["provider"]>): string {
+  if (provider === "anthropic") return "Anthropic";
+  if (provider === "google") return "Google Gemini";
+  if (provider === "xai") return "xAI";
+  return "OpenAI";
+}
+
+function tryResolveProviderRoutingState(input: {
+  model: ModelName;
+  providerMode: ApiProviderMode;
+  azure?: AzureOptions;
+}): ReturnType<typeof resolveProviderRoutingState> | undefined {
+  try {
+    return resolveProviderRoutingState(input);
+  } catch {
+    return undefined;
+  }
+}
+
+function inferProviderFromModel(model: ModelName): NonNullable<ModelConfig["provider"]> {
+  const prefix = model.includes("/") ? model.split("/", 1)[0] : undefined;
+  if (prefix === "openai") return "openai";
+  if (prefix === "anthropic") return "anthropic";
+  if (prefix === "google") return "google";
+  if (prefix === "xai") return "xai";
+  if (model.startsWith("claude")) return "anthropic";
+  if (model.startsWith("gemini")) return "google";
+  if (model.startsWith("grok")) return "xai";
+  return "other";
+}
+
+function azureNote(
+  providerMode: ApiProviderMode,
+  azureConfigured: boolean,
+  isAzureOpenAI: boolean,
+): string | undefined {
+  if (!azureConfigured) return undefined;
+  if (providerMode === "openai") return "ignored, --provider openai/--no-azure is active";
+  if (isAzureOpenAI) return "active because Azure endpoint is configured";
+  return "configured, not used for this model";
+}
+
+export function formatRouteTargetForLog(raw: string | undefined, fallbackHost = ""): string {
+  if (!raw) return fallbackHost;
+  try {
+    const parsed = new URL(raw);
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    let routePath = "";
+    if (segments.length > 0) {
+      routePath = `/${segments[0]}`;
+      if (segments.length > 1) {
+        routePath += "/...";
+      }
+    }
+    return `${parsed.host}${routePath}`;
+  } catch {
+    const formatted = formatBaseUrlForLog(raw).replace(/^https?:\/\//u, "");
+    return formatted || fallbackHost;
+  }
+}

--- a/src/oracle/providerRouting.ts
+++ b/src/oracle/providerRouting.ts
@@ -33,6 +33,7 @@ export function resolveProviderRoutingState({
   const azureEndpoint = azure?.endpoint?.trim();
   const azureDeploymentOption = azure?.deployment?.trim();
   const isNonOpenAIModel = provider !== "openai" && provider !== "other";
+  const isProviderQualifiedModelId = model.includes("/");
 
   if (providerMode === "azure" && !azureEndpoint) {
     throw new PromptValidationError(
@@ -71,9 +72,8 @@ export function resolveProviderRoutingState({
     providerMode !== "openai" &&
     !isNonOpenAIModel &&
     (providerMode === "azure" ||
-      isOpenAIFamilyModel ||
-      Boolean(azureDeploymentOption) ||
-      isCustomAzureModelId),
+      (!isProviderQualifiedModelId &&
+        (isOpenAIFamilyModel || Boolean(azureDeploymentOption) || isCustomAzureModelId))),
   );
   const implicitAzureDeploymentName =
     isAzureOpenAI &&

--- a/src/oracle/run.ts
+++ b/src/oracle/run.ts
@@ -184,13 +184,27 @@ export async function runOracle(
   const hasXaiKey = Boolean(optionsApiKey) || Boolean(process.env.XAI_API_KEY);
 
   let baseUrl = options.baseUrl?.trim();
+  const providerQualifiedOpenRouterCandidate =
+    !isAzureOpenAI && providerMode !== "openai" && options.model.includes("/");
+  if (
+    baseUrl &&
+    providerQualifiedOpenRouterCandidate &&
+    !isOpenRouterBaseUrl(baseUrl) &&
+    !isCustomBaseUrl(baseUrl)
+  ) {
+    baseUrl = undefined;
+  }
   if (!baseUrl) {
+    let envBaseUrl: string | undefined;
     if (options.model.startsWith("grok")) {
-      baseUrl = resolvedXaiBaseUrl;
+      envBaseUrl = resolvedXaiBaseUrl;
     } else if (provider === "anthropic") {
-      baseUrl = process.env.ANTHROPIC_BASE_URL?.trim();
+      envBaseUrl = process.env.ANTHROPIC_BASE_URL?.trim();
     } else {
-      baseUrl = process.env.OPENAI_BASE_URL?.trim();
+      envBaseUrl = process.env.OPENAI_BASE_URL?.trim();
+    }
+    if (!providerQualifiedOpenRouterCandidate || (envBaseUrl && isCustomBaseUrl(envBaseUrl))) {
+      baseUrl = envBaseUrl;
     }
   }
   const providerKeyMissing =
@@ -202,8 +216,13 @@ export async function runOracle(
         (provider === "google" && !hasGeminiKey) ||
         (provider === "xai" && !hasXaiKey) ||
         provider === "other");
+  const providerQualifiedOpenRouterRoute = providerQualifiedOpenRouterCandidate && !baseUrl;
   const openRouterFallback =
-    providerMode !== "openai" && providerKeyMissing && Boolean(openRouterApiKey);
+    !baseUrl &&
+    (providerQualifiedOpenRouterRoute ||
+      (providerMode !== "openai" &&
+        providerKeyMissing &&
+        (provider === "other" || Boolean(openRouterApiKey))));
   if (!baseUrl || openRouterFallback) {
     if (openRouterFallback) {
       baseUrl = defaultOpenRouterBase;

--- a/tests/cli/providerDoctor.test.ts
+++ b/tests/cli/providerDoctor.test.ts
@@ -1,0 +1,353 @@
+import { describe, expect, test } from "vitest";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const CLI_ENTRY = path.join(process.cwd(), "bin", "oracle-cli.ts");
+const CLI_TIMEOUT = 15_000;
+
+describe("provider doctor CLI", () => {
+  test(
+    "prints redacted provider readiness without a prompt",
+    async () => {
+      const oracleHome = await mkdtemp(path.join(os.tmpdir(), "oracle-doctor-"));
+      const env = {
+        ...process.env,
+        // biome-ignore lint/style/useNamingConvention: env var name
+        OPENAI_API_KEY: "sk-doctor-openai-key",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        AZURE_OPENAI_ENDPOINT: "https://example-resource.openai.azure.com/",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        AZURE_OPENAI_API_KEY: "az-doctor-key",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        ORACLE_HOME_DIR: oracleHome,
+      };
+
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        [
+          "--import",
+          "tsx",
+          CLI_ENTRY,
+          "doctor",
+          "--providers",
+          "--model",
+          "gpt-5.4",
+          "--provider",
+          "openai",
+        ],
+        { env },
+      );
+
+      expect(stdout).toContain("Provider readiness");
+      expect(stdout).toContain("gpt-5.4: ok");
+      expect(stdout).toContain("provider: OpenAI");
+      expect(stdout).toContain("key: OPENAI_API_KEY=sk-d");
+      expect(stdout).toContain("azure: ignored");
+      expect(stdout).not.toContain("sk-doctor-openai-key");
+
+      await rm(oracleHome, { recursive: true, force: true });
+    },
+    CLI_TIMEOUT,
+  );
+
+  test(
+    "prints a route plan from the root command without a prompt",
+    async () => {
+      const oracleHome = await mkdtemp(path.join(os.tmpdir(), "oracle-route-"));
+      const env = {
+        ...process.env,
+        // biome-ignore lint/style/useNamingConvention: env var name
+        OPENAI_API_KEY: "sk-route-openai-key",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        AZURE_OPENAI_ENDPOINT: "https://example-resource.openai.azure.com/",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        ORACLE_HOME_DIR: oracleHome,
+      };
+
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        ["--import", "tsx", CLI_ENTRY, "--route", "--model", "gpt-5.4", "--provider", "openai"],
+        { env },
+      );
+
+      expect(stdout).toContain("Route plan");
+      expect(stdout).toContain("gpt-5.4: ok");
+      expect(stdout).toContain("provider: OpenAI");
+      expect(stdout).toContain("azure: ignored");
+      expect(stdout).not.toContain("sk-route-openai-key");
+
+      await rm(oracleHome, { recursive: true, force: true });
+    },
+    CLI_TIMEOUT,
+  );
+
+  test(
+    "prints a route plan without initializing session storage",
+    async () => {
+      const env = {
+        ...process.env,
+        // biome-ignore lint/style/useNamingConvention: env var name
+        OPENAI_API_KEY: "sk-route-openai-key",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        GEMINI_API_KEY: "gk-route-gemini-key",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        AZURE_OPENAI_ENDPOINT: "",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        AZURE_OPENAI_API_KEY: "",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        AZURE_OPENAI_DEPLOYMENT: "",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        ORACLE_HOME_DIR: "/dev/null",
+      };
+
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        ["--import", "tsx", CLI_ENTRY, "--route", "--model", "gpt-5.4", "--provider", "openai"],
+        { env },
+      );
+
+      expect(stdout).toContain("Route plan");
+      expect(stdout).toContain("gpt-5.4: ok");
+      expect(stdout).toContain("provider: OpenAI");
+    },
+    CLI_TIMEOUT,
+  );
+
+  test(
+    "root route models ignore configured default model",
+    async () => {
+      const oracleHome = await mkdtemp(path.join(os.tmpdir(), "oracle-route-models-config-"));
+      await mkdir(oracleHome, { recursive: true });
+      await writeFile(path.join(oracleHome, "config.json"), JSON.stringify({ model: "gpt-5.1" }));
+      const env = {
+        ...process.env,
+        // biome-ignore lint/style/useNamingConvention: env var name
+        OPENAI_API_KEY: "sk-route-openai-key",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        AZURE_OPENAI_ENDPOINT: "",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        AZURE_OPENAI_API_KEY: "",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        AZURE_OPENAI_DEPLOYMENT: "",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        ORACLE_HOME_DIR: oracleHome,
+      };
+
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        ["--import", "tsx", CLI_ENTRY, "--route", "--models", "gpt-5.4,gemini-3-pro"],
+        { env },
+      );
+
+      expect(stdout).toContain("gpt-5.4: ok");
+      expect(stdout).toContain("gemini-3-pro: ok");
+      expect(stdout).not.toContain("gpt-5.1");
+
+      await rm(oracleHome, { recursive: true, force: true });
+    },
+    CLI_TIMEOUT,
+  );
+
+  test(
+    "prints machine-parseable provider JSON without the banner",
+    async () => {
+      const oracleHome = await mkdtemp(path.join(os.tmpdir(), "oracle-doctor-json-"));
+      const env = {
+        ...process.env,
+        // biome-ignore lint/style/useNamingConvention: env var name
+        OPENAI_API_KEY: "sk-doctor-json-openai-key",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        AZURE_OPENAI_ENDPOINT: "",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        AZURE_OPENAI_API_KEY: "",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        AZURE_OPENAI_DEPLOYMENT: "",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        ORACLE_HOME_DIR: oracleHome,
+      };
+
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        ["--import", "tsx", CLI_ENTRY, "doctor", "--providers", "--json", "--model", "gpt-5.4"],
+        { env },
+      );
+
+      expect(stdout.trimStart().startsWith("{")).toBe(true);
+      expect(stdout).not.toContain("🧿 oracle");
+      const parsed = JSON.parse(stdout) as { providers: Array<{ model: string; ok: boolean }> };
+      expect(parsed.providers).toEqual([expect.objectContaining({ model: "gpt-5.4", ok: true })]);
+
+      await rm(oracleHome, { recursive: true, force: true });
+    },
+    CLI_TIMEOUT,
+  );
+
+  test(
+    "keeps provider JSON parseable with root flags before the subcommand",
+    async () => {
+      const oracleHome = await mkdtemp(path.join(os.tmpdir(), "oracle-doctor-json-leading-"));
+      const env = {
+        ...process.env,
+        // biome-ignore lint/style/useNamingConvention: env var name
+        OPENAI_API_KEY: "sk-doctor-json-openai-key",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        AZURE_OPENAI_ENDPOINT: "https://example-resource.openai.azure.com/",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        ORACLE_HOME_DIR: oracleHome,
+      };
+
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        [
+          "--import",
+          "tsx",
+          CLI_ENTRY,
+          "--provider",
+          "openai",
+          "doctor",
+          "--providers",
+          "--json",
+          "--model",
+          "gpt-5.4",
+        ],
+        { env },
+      );
+
+      expect(stdout.trimStart().startsWith("{")).toBe(true);
+      expect(stdout).not.toContain("🧿 oracle");
+      const parsed = JSON.parse(stdout) as { providers: Array<{ model: string; ok: boolean }> };
+      expect(parsed.providers).toEqual([expect.objectContaining({ model: "gpt-5.4", ok: true })]);
+
+      await rm(oracleHome, { recursive: true, force: true });
+    },
+    CLI_TIMEOUT,
+  );
+
+  test(
+    "provider doctor falls back to Azure config when env endpoint is empty",
+    async () => {
+      const oracleHome = await mkdtemp(path.join(os.tmpdir(), "oracle-doctor-azure-config-"));
+      await mkdir(oracleHome, { recursive: true });
+      await writeFile(
+        path.join(oracleHome, "config.json"),
+        JSON.stringify({
+          azure: {
+            endpoint: "https://configured-resource.openai.azure.com/",
+            deployment: "gpt-prod",
+          },
+        }),
+      );
+      const env = {
+        ...process.env,
+        // biome-ignore lint/style/useNamingConvention: env var name
+        AZURE_OPENAI_API_KEY: "az-config-key",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        AZURE_OPENAI_ENDPOINT: "",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        AZURE_OPENAI_DEPLOYMENT: "",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        ORACLE_HOME_DIR: oracleHome,
+      };
+
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        ["--import", "tsx", CLI_ENTRY, "doctor", "--providers", "--model", "gpt-5.4"],
+        { env },
+      );
+
+      expect(stdout).toContain("gpt-5.4: ok");
+      expect(stdout).toContain("provider: Azure OpenAI");
+      expect(stdout).toContain("base: configured-resource.openai.azure.com");
+      expect(stdout).toContain("azure deployment: gpt-prod");
+
+      await rm(oracleHome, { recursive: true, force: true });
+    },
+    CLI_TIMEOUT,
+  );
+
+  test(
+    "root route prints forced Azure readiness instead of throwing raw validation",
+    async () => {
+      const oracleHome = await mkdtemp(path.join(os.tmpdir(), "oracle-route-azure-"));
+      const env = {
+        ...process.env,
+        // biome-ignore lint/style/useNamingConvention: env var name
+        OPENAI_API_KEY: "sk-route-openai-key",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        AZURE_OPENAI_ENDPOINT: "",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        AZURE_OPENAI_API_KEY: "",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        AZURE_OPENAI_DEPLOYMENT: "",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        ORACLE_HOME_DIR: oracleHome,
+      };
+
+      let stdout = "";
+      try {
+        await execFileAsync(
+          process.execPath,
+          ["--import", "tsx", CLI_ENTRY, "--route", "--provider", "azure", "--model", "gpt-5.4"],
+          { env },
+        );
+      } catch (error) {
+        stdout = (error as { stdout?: string }).stdout ?? "";
+      }
+
+      expect(stdout).toContain("Route plan");
+      expect(stdout).toContain("gpt-5.4: not ready");
+      expect(stdout).toContain("provider: Azure OpenAI");
+      expect(stdout).toContain("--provider azure requires --azure-endpoint");
+
+      await rm(oracleHome, { recursive: true, force: true });
+    },
+    CLI_TIMEOUT,
+  );
+
+  test(
+    "root route falls back to Azure config when env endpoint is empty",
+    async () => {
+      const oracleHome = await mkdtemp(path.join(os.tmpdir(), "oracle-route-azure-config-"));
+      await mkdir(oracleHome, { recursive: true });
+      await writeFile(
+        path.join(oracleHome, "config.json"),
+        JSON.stringify({
+          azure: {
+            endpoint: "https://configured-resource.openai.azure.com/",
+            deployment: "gpt-prod",
+          },
+        }),
+      );
+      const env = {
+        ...process.env,
+        // biome-ignore lint/style/useNamingConvention: env var name
+        AZURE_OPENAI_API_KEY: "az-config-key",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        AZURE_OPENAI_ENDPOINT: "",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        AZURE_OPENAI_DEPLOYMENT: "",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        ORACLE_HOME_DIR: oracleHome,
+      };
+
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        ["--import", "tsx", CLI_ENTRY, "--route", "--model", "gpt-5.4"],
+        { env },
+      );
+
+      expect(stdout).toContain("Route plan");
+      expect(stdout).toContain("gpt-5.4: ok");
+      expect(stdout).toContain("provider: Azure OpenAI");
+      expect(stdout).toContain("base: configured-resource.openai.azure.com");
+      expect(stdout).toContain("azure deployment: gpt-prod");
+
+      await rm(oracleHome, { recursive: true, force: true });
+    },
+    CLI_TIMEOUT,
+  );
+});

--- a/tests/cli/runOracle/runOracle.request-payload.test.ts
+++ b/tests/cli/runOracle/runOracle.request-payload.test.ts
@@ -90,6 +90,41 @@ describe("runOracle request payload", () => {
     expect(captured).toEqual([{ apiKey: "sk-test", baseUrl: "https://litellm.test/v1" }]);
   });
 
+  test("does not fallback to OpenRouter for first-party models with explicit proxy baseUrl", async () => {
+    const originalOpenai = process.env.OPENAI_API_KEY;
+    const originalOpenRouter = process.env.OPENROUTER_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    process.env.OPENROUTER_API_KEY = "or-route-key";
+
+    try {
+      await expect(
+        runOracle(
+          {
+            prompt: "Custom endpoint route",
+            model: "gpt-5.4",
+            baseUrl: "https://litellm.test/v1",
+            background: false,
+          },
+          {
+            log: () => {},
+            write: () => true,
+          },
+        ),
+      ).rejects.toThrow(/Missing OPENAI_API_KEY/);
+    } finally {
+      if (originalOpenai === undefined) {
+        delete process.env.OPENAI_API_KEY;
+      } else {
+        process.env.OPENAI_API_KEY = originalOpenai;
+      }
+      if (originalOpenRouter === undefined) {
+        delete process.env.OPENROUTER_API_KEY;
+      } else {
+        process.env.OPENROUTER_API_KEY = originalOpenRouter;
+      }
+    }
+  });
+
   test("logs the first-party OpenAI route", async () => {
     const stream = new MockStream([], buildResponse());
     const client = new MockClient(stream);
@@ -257,6 +292,288 @@ describe("runOracle request payload", () => {
     expect(logs.join("\n")).toContain(
       "Provider: OpenAI | base: api.openai.com | key: OPENAI_API_KEY",
     );
+  });
+
+  test("routes provider-qualified model ids through OpenRouter even when native keys exist", async () => {
+    const stream = new MockStream([], buildResponse());
+    const client = new MockClient(stream);
+    const originalAnthropic = process.env.ANTHROPIC_API_KEY;
+    const originalAnthropicBaseUrl = process.env.ANTHROPIC_BASE_URL;
+    const originalOpenRouter = process.env.OPENROUTER_API_KEY;
+    const captured: Array<{ apiKey: string; baseUrl?: string; model?: string }> = [];
+    const logs: string[] = [];
+    process.env.ANTHROPIC_API_KEY = "ak-native";
+    delete process.env.ANTHROPIC_BASE_URL;
+    process.env.OPENROUTER_API_KEY = "or-route-key";
+
+    try {
+      await runOracle(
+        {
+          prompt: "Provider qualified route",
+          model: "anthropic/claude-sonnet-4.5",
+          background: false,
+        },
+        {
+          clientFactory: (apiKey, options) => {
+            captured.push({ apiKey, baseUrl: options?.baseUrl, model: options?.model });
+            return client;
+          },
+          log: (message: string) => logs.push(message),
+          write: () => true,
+        },
+      );
+    } finally {
+      if (originalAnthropic === undefined) {
+        delete process.env.ANTHROPIC_API_KEY;
+      } else {
+        process.env.ANTHROPIC_API_KEY = originalAnthropic;
+      }
+      if (originalAnthropicBaseUrl === undefined) {
+        delete process.env.ANTHROPIC_BASE_URL;
+      } else {
+        process.env.ANTHROPIC_BASE_URL = originalAnthropicBaseUrl;
+      }
+      if (originalOpenRouter === undefined) {
+        delete process.env.OPENROUTER_API_KEY;
+      } else {
+        process.env.OPENROUTER_API_KEY = originalOpenRouter;
+      }
+    }
+
+    expect(captured).toEqual([
+      {
+        apiKey: "or-route-key",
+        baseUrl: "https://openrouter.ai/api/v1",
+        model: "anthropic/claude-sonnet-4.5",
+      },
+    ]);
+    expect(client.lastRequest?.model).toBe("anthropic/claude-sonnet-4.5");
+    expect(logs.join("\n")).toContain(
+      "Provider: OpenRouter | base: openrouter.ai/api/... | key: OPENROUTER_API_KEY",
+    );
+  });
+
+  test("routes provider-qualified ids through OpenRouter even when native base env exists", async () => {
+    const stream = new MockStream([], buildResponse());
+    const client = new MockClient(stream);
+    const originalAnthropic = process.env.ANTHROPIC_API_KEY;
+    const originalAnthropicBaseUrl = process.env.ANTHROPIC_BASE_URL;
+    const originalOpenRouter = process.env.OPENROUTER_API_KEY;
+    const captured: Array<{ apiKey: string; baseUrl?: string; model?: string }> = [];
+    process.env.ANTHROPIC_API_KEY = "ak-native";
+    process.env.ANTHROPIC_BASE_URL = "https://api.anthropic.com";
+    process.env.OPENROUTER_API_KEY = "or-route-key";
+
+    try {
+      await runOracle(
+        {
+          prompt: "Provider qualified route",
+          model: "anthropic/claude-sonnet-4.5",
+          background: false,
+        },
+        {
+          clientFactory: (apiKey, options) => {
+            captured.push({ apiKey, baseUrl: options?.baseUrl, model: options?.model });
+            return client;
+          },
+          log: () => {},
+          write: () => true,
+        },
+      );
+    } finally {
+      if (originalAnthropic === undefined) {
+        delete process.env.ANTHROPIC_API_KEY;
+      } else {
+        process.env.ANTHROPIC_API_KEY = originalAnthropic;
+      }
+      if (originalAnthropicBaseUrl === undefined) {
+        delete process.env.ANTHROPIC_BASE_URL;
+      } else {
+        process.env.ANTHROPIC_BASE_URL = originalAnthropicBaseUrl;
+      }
+      if (originalOpenRouter === undefined) {
+        delete process.env.OPENROUTER_API_KEY;
+      } else {
+        process.env.OPENROUTER_API_KEY = originalOpenRouter;
+      }
+    }
+
+    expect(captured).toEqual([
+      {
+        apiKey: "or-route-key",
+        baseUrl: "https://openrouter.ai/api/v1",
+        model: "anthropic/claude-sonnet-4.5",
+      },
+    ]);
+  });
+
+  test("preserves explicit baseUrl for provider-qualified model ids", async () => {
+    const stream = new MockStream([], buildResponse());
+    const client = new MockClient(stream);
+    const originalAnthropic = process.env.ANTHROPIC_API_KEY;
+    const originalOpenRouter = process.env.OPENROUTER_API_KEY;
+    const captured: Array<{ apiKey: string; baseUrl?: string; model?: string }> = [];
+    const logs: string[] = [];
+    delete process.env.ANTHROPIC_API_KEY;
+    process.env.OPENROUTER_API_KEY = "or-route-key";
+
+    try {
+      await runOracle(
+        {
+          prompt: "Provider qualified proxy route",
+          model: "anthropic/claude-sonnet-4.5",
+          baseUrl: "https://litellm.test/v1",
+          background: false,
+        },
+        {
+          clientFactory: (apiKey, options) => {
+            captured.push({ apiKey, baseUrl: options?.baseUrl, model: options?.model });
+            return client;
+          },
+          log: (message: string) => logs.push(message),
+          write: () => true,
+        },
+      );
+    } finally {
+      if (originalAnthropic === undefined) {
+        delete process.env.ANTHROPIC_API_KEY;
+      } else {
+        process.env.ANTHROPIC_API_KEY = originalAnthropic;
+      }
+      if (originalOpenRouter === undefined) {
+        delete process.env.OPENROUTER_API_KEY;
+      } else {
+        process.env.OPENROUTER_API_KEY = originalOpenRouter;
+      }
+    }
+
+    expect(captured).toEqual([
+      {
+        apiKey: "or-route-key",
+        baseUrl: "https://litellm.test/v1",
+        model: "anthropic/claude-sonnet-4.5",
+      },
+    ]);
+    expect(logs.join("\n")).toContain(
+      "Provider: OpenAI-compatible | base: litellm.test/v1 | key: OPENROUTER_API_KEY",
+    );
+  });
+
+  test("routes provider-qualified ids through OpenRouter instead of native base URLs", async () => {
+    const stream = new MockStream([], buildResponse());
+    const client = new MockClient(stream);
+    const originalOpenai = process.env.OPENAI_API_KEY;
+    const originalOpenRouter = process.env.OPENROUTER_API_KEY;
+    const captured: Array<{ apiKey: string; baseUrl?: string; model?: string }> = [];
+    const logs: string[] = [];
+    process.env.OPENAI_API_KEY = "sk-native";
+    process.env.OPENROUTER_API_KEY = "or-route-key";
+
+    try {
+      await runOracle(
+        {
+          prompt: "Provider qualified native base route",
+          model: "openai/gpt-4o-mini",
+          baseUrl: "https://api.openai.com/v1",
+          background: false,
+        },
+        {
+          clientFactory: (apiKey, options) => {
+            captured.push({ apiKey, baseUrl: options?.baseUrl, model: options?.model });
+            return client;
+          },
+          log: (message: string) => logs.push(message),
+          write: () => true,
+        },
+      );
+    } finally {
+      if (originalOpenai === undefined) {
+        delete process.env.OPENAI_API_KEY;
+      } else {
+        process.env.OPENAI_API_KEY = originalOpenai;
+      }
+      if (originalOpenRouter === undefined) {
+        delete process.env.OPENROUTER_API_KEY;
+      } else {
+        process.env.OPENROUTER_API_KEY = originalOpenRouter;
+      }
+    }
+
+    expect(captured).toEqual([
+      {
+        apiKey: "or-route-key",
+        baseUrl: "https://openrouter.ai/api/v1",
+        model: "openai/gpt-4o-mini",
+      },
+    ]);
+    expect(logs.join("\n")).toContain(
+      "Provider: OpenRouter | base: openrouter.ai/api/... | key: OPENROUTER_API_KEY",
+    );
+  });
+
+  test("routes provider-qualified ids to OpenRouter before auto Azure env routing", async () => {
+    const stream = new MockStream([], buildResponse());
+    const client = new MockClient(stream);
+    const originalAzureKey = process.env.AZURE_OPENAI_API_KEY;
+    const originalOpenaiBaseUrl = process.env.OPENAI_BASE_URL;
+    const originalOpenRouter = process.env.OPENROUTER_API_KEY;
+    const captured: Array<{ apiKey: string; azure?: unknown; baseUrl?: string; model?: string }> =
+      [];
+    process.env.AZURE_OPENAI_API_KEY = "az-route-key";
+    delete process.env.OPENAI_BASE_URL;
+    process.env.OPENROUTER_API_KEY = "or-route-key";
+
+    try {
+      await runOracle(
+        {
+          prompt: "Provider qualified OpenAI route",
+          model: "openai/gpt-4o-mini",
+          azure: {
+            endpoint: "https://example-resource.openai.azure.com/",
+            deployment: "gpt-prod",
+          },
+          background: false,
+        },
+        {
+          clientFactory: (apiKey, options) => {
+            captured.push({
+              apiKey,
+              azure: options?.azure,
+              baseUrl: options?.baseUrl,
+              model: options?.model,
+            });
+            return client;
+          },
+          log: () => {},
+          write: () => true,
+        },
+      );
+    } finally {
+      if (originalAzureKey === undefined) {
+        delete process.env.AZURE_OPENAI_API_KEY;
+      } else {
+        process.env.AZURE_OPENAI_API_KEY = originalAzureKey;
+      }
+      if (originalOpenaiBaseUrl === undefined) {
+        delete process.env.OPENAI_BASE_URL;
+      } else {
+        process.env.OPENAI_BASE_URL = originalOpenaiBaseUrl;
+      }
+      if (originalOpenRouter === undefined) {
+        delete process.env.OPENROUTER_API_KEY;
+      } else {
+        process.env.OPENROUTER_API_KEY = originalOpenRouter;
+      }
+    }
+
+    expect(captured).toEqual([
+      {
+        apiKey: "or-route-key",
+        azure: undefined,
+        baseUrl: "https://openrouter.ai/api/v1",
+        model: "openai/gpt-4o-mini",
+      },
+    ]);
   });
 
   test("rejects forced OpenAI provider mode for known non-OpenAI models", async () => {

--- a/tests/oracle/providerRoutePlan.test.ts
+++ b/tests/oracle/providerRoutePlan.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, test } from "vitest";
+import { buildProviderRoutePlan } from "../../src/oracle/providerRoutePlan.js";
+
+describe("provider route plan", () => {
+  test("forced OpenAI ignores configured Azure for GPT models", () => {
+    const plan = buildProviderRoutePlan({
+      model: "gpt-5.4",
+      providerMode: "openai",
+      azure: {
+        endpoint: "https://example-resource.openai.azure.com/",
+        deployment: "gpt-prod",
+      },
+      env: {
+        OPENAI_API_KEY: "sk-openai-test-key",
+        AZURE_OPENAI_API_KEY: "az-test-key",
+      },
+    });
+
+    expect(plan.ok).toBe(true);
+    expect(plan.providerLabel).toBe("OpenAI");
+    expect(plan.base).toBe("api.openai.com");
+    expect(plan.keySource).toBe("OPENAI_API_KEY");
+    expect(plan.keyPreview).toContain("OPENAI_API_KEY=sk-o");
+    expect(plan.azureNote).toContain("ignored");
+  });
+
+  test("auto Azure route reports missing deployment before request dispatch", () => {
+    const plan = buildProviderRoutePlan({
+      model: "gpt-5.4",
+      providerMode: "auto",
+      azure: {
+        endpoint: "https://example-resource.openai.azure.com/",
+      },
+      env: {
+        AZURE_OPENAI_API_KEY: "az-test-key",
+      },
+    });
+
+    expect(plan.ok).toBe(false);
+    expect(plan.providerLabel).toBe("Azure OpenAI");
+    expect(plan.base).toBe("example-resource.openai.azure.com");
+    expect(plan.error).toMatch(/Azure mode requires --azure-deployment/);
+  });
+
+  test("native provider route reports missing Gemini key", () => {
+    const plan = buildProviderRoutePlan({
+      model: "gemini-3-pro",
+      providerMode: "auto",
+      env: {},
+    });
+
+    expect(plan.ok).toBe(false);
+    expect(plan.providerLabel).toBe("Google Gemini");
+    expect(plan.keySource).toBe("GEMINI_API_KEY");
+    expect(plan.error).toBe("Missing GEMINI_API_KEY.");
+  });
+
+  test("forced OpenAI invalid model reports the attempted OpenAI route", () => {
+    const plan = buildProviderRoutePlan({
+      model: "claude-4.6-sonnet",
+      providerMode: "openai",
+      env: {
+        OPENAI_API_KEY: "sk-openai-test-key",
+        ANTHROPIC_API_KEY: "ak-native-test-key",
+      },
+    });
+
+    expect(plan.ok).toBe(false);
+    expect(plan.providerLabel).toBe("OpenAI");
+    expect(plan.keySource).toBe("OPENAI_API_KEY");
+    expect(plan.error).toMatch(/OpenAI provider cannot run claude-4\.6-sonnet/);
+  });
+
+  test("provider-qualified custom ids report OpenRouter readiness in auto mode", () => {
+    const plan = buildProviderRoutePlan({
+      model: "openai/o3",
+      providerMode: "auto",
+      env: {
+        OPENAI_API_KEY: "sk-openai-test-key",
+      },
+    });
+
+    expect(plan.ok).toBe(false);
+    expect(plan.providerLabel).toBe("OpenRouter");
+    expect(plan.base).toBe("openrouter.ai/api/...");
+    expect(plan.keySource).toBe("OPENROUTER_API_KEY");
+    expect(plan.error).toBe("Missing OPENROUTER_API_KEY.");
+  });
+
+  test("provider-qualified ids prefer OpenRouter over native provider keys", () => {
+    const plan = buildProviderRoutePlan({
+      model: "anthropic/claude-sonnet-4.5",
+      providerMode: "auto",
+      env: {
+        ANTHROPIC_API_KEY: "ak-native-test-key",
+        OPENROUTER_API_KEY: "or-openrouter-test-key",
+      },
+    });
+
+    expect(plan.ok).toBe(true);
+    expect(plan.providerLabel).toBe("OpenRouter");
+    expect(plan.base).toBe("openrouter.ai/api/...");
+    expect(plan.keySource).toBe("OPENROUTER_API_KEY");
+  });
+
+  test("provider-qualified ids preserve explicit proxy base URLs", () => {
+    const plan = buildProviderRoutePlan({
+      model: "anthropic/claude-sonnet-4.5",
+      providerMode: "auto",
+      baseUrl: "https://litellm.test/v1",
+      env: {
+        OPENROUTER_API_KEY: "or-openrouter-test-key",
+      },
+    });
+
+    expect(plan.ok).toBe(true);
+    expect(plan.providerLabel).toBe("OpenAI-compatible");
+    expect(plan.base).toBe("litellm.test/v1");
+    expect(plan.keySource).toBe("OPENROUTER_API_KEY");
+  });
+
+  test("explicit proxy base URLs do not fallback to OpenRouter for first-party models", () => {
+    const plan = buildProviderRoutePlan({
+      model: "gpt-5.4",
+      providerMode: "auto",
+      baseUrl: "https://litellm.test/v1",
+      env: {
+        OPENROUTER_API_KEY: "or-openrouter-test-key",
+      },
+    });
+
+    expect(plan.ok).toBe(false);
+    expect(plan.providerLabel).toBe("OpenAI-compatible");
+    expect(plan.base).toBe("litellm.test/v1");
+    expect(plan.keySource).toBe("OPENAI_API_KEY");
+    expect(plan.error).toBe("Missing OPENAI_API_KEY.");
+  });
+
+  test("provider-qualified ids ignore native base URL overrides in auto mode", () => {
+    const plan = buildProviderRoutePlan({
+      model: "openai/gpt-4o-mini",
+      providerMode: "auto",
+      baseUrl: "https://api.openai.com/v1",
+      env: {
+        OPENAI_API_KEY: "sk-openai-test-key",
+        OPENROUTER_API_KEY: "or-openrouter-test-key",
+      },
+    });
+
+    expect(plan.ok).toBe(true);
+    expect(plan.providerLabel).toBe("OpenRouter");
+    expect(plan.base).toBe("openrouter.ai/api/...");
+    expect(plan.keySource).toBe("OPENROUTER_API_KEY");
+  });
+
+  test("provider-qualified ids preserve configured proxy base URLs", () => {
+    const plan = buildProviderRoutePlan({
+      model: "openai/gpt-4o-mini",
+      providerMode: "auto",
+      env: {
+        OPENAI_BASE_URL: "https://litellm.test/v1",
+        OPENROUTER_API_KEY: "or-openrouter-test-key",
+      },
+    });
+
+    expect(plan.ok).toBe(true);
+    expect(plan.providerLabel).toBe("OpenAI-compatible");
+    expect(plan.base).toBe("litellm.test/v1");
+    expect(plan.keySource).toBe("OPENROUTER_API_KEY");
+  });
+
+  test("provider-qualified ids ignore native provider base URLs", () => {
+    const plan = buildProviderRoutePlan({
+      model: "anthropic/claude-sonnet-4.5",
+      providerMode: "auto",
+      env: {
+        ANTHROPIC_BASE_URL: "https://api.anthropic.com",
+        ANTHROPIC_API_KEY: "ak-native-test-key",
+        OPENROUTER_API_KEY: "or-openrouter-test-key",
+      },
+    });
+
+    expect(plan.ok).toBe(true);
+    expect(plan.providerLabel).toBe("OpenRouter");
+    expect(plan.base).toBe("openrouter.ai/api/...");
+    expect(plan.keySource).toBe("OPENROUTER_API_KEY");
+  });
+
+  test("custom model ids report OpenRouter route when its key is missing", () => {
+    const plan = buildProviderRoutePlan({
+      model: "llama-3",
+      providerMode: "auto",
+      env: {},
+    });
+
+    expect(plan.ok).toBe(false);
+    expect(plan.providerLabel).toBe("OpenRouter");
+    expect(plan.base).toBe("openrouter.ai/api/...");
+    expect(plan.keySource).toBe("OPENROUTER_API_KEY");
+    expect(plan.error).toBe("Missing OPENROUTER_API_KEY.");
+  });
+
+  test("provider-qualified ids are not captured by auto Azure routing", () => {
+    const plan = buildProviderRoutePlan({
+      model: "openai/gpt-4o-mini",
+      providerMode: "auto",
+      azure: {
+        endpoint: "https://example-resource.openai.azure.com/",
+        deployment: "gpt-prod",
+      },
+      env: {
+        AZURE_OPENAI_API_KEY: "az-test-key",
+        OPENROUTER_API_KEY: "or-openrouter-test-key",
+      },
+    });
+
+    expect(plan.ok).toBe(true);
+    expect(plan.providerLabel).toBe("OpenRouter");
+    expect(plan.base).toBe("openrouter.ai/api/...");
+    expect(plan.keySource).toBe("OPENROUTER_API_KEY");
+    expect(plan.azureNote).toContain("configured, not used");
+  });
+
+  test("forced Azure route errors still report Azure readiness", () => {
+    const plan = buildProviderRoutePlan({
+      model: "gpt-5.4",
+      providerMode: "azure",
+      env: {},
+    });
+
+    expect(plan.ok).toBe(false);
+    expect(plan.provider).toBe("azure");
+    expect(plan.providerLabel).toBe("Azure OpenAI");
+    expect(plan.keySource).toBe("AZURE_OPENAI_API_KEY|OPENAI_API_KEY");
+    expect(plan.error).toMatch(/--provider azure requires --azure-endpoint/);
+  });
+});


### PR DESCRIPTION
Summary
- Add provider route diagnostics with oracle doctor --providers and root --route.
- Keep provider-qualified model IDs on OpenRouter/proxy routes instead of accidental Azure/native routing.
- Add the requested Oracle UX improvement plan in docs/refactor/ux.md.

Verification
- pnpm run format:check
- pnpm run lint
- pnpm vitest run tests/oracle/providerRoutePlan.test.ts tests/cli/providerDoctor.test.ts tests/cli/runOracle/runOracle.request-payload.test.ts
- pnpm run build
- codex-review helper clean: no accepted/actionable findings reported
