### PR TITLE
feat(cli): classify provider failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - API: add `--allow-partial` / `--partial ok` for multi-model runs so advisory panels can exit 0 when at least one model succeeds, while still listing saved outputs and a JSON output manifest before failures.
+- API: classify common provider failures in multi-model summaries and metadata, including auth, expired keys, quota, rate limits, and unavailable models, with secret-safe recovery hints.
 - API: add `--provider openai` / `--no-azure` to force first-party OpenAI when Azure env/config is present, add `oracle doctor --providers` and `--route` redacted route diagnostics, keep provider-qualified model IDs on OpenRouter/proxy routes instead of accidental Azure/native routes, and fail early when Azure routing lacks a deployment.
 - Browser/MCP: add opt-in ZIP formatting for bundled browser uploads with `--browser-bundle-format zip` / `browserBundleFormat: "zip"`, preserving individual file names in one ChatGPT attachment.
 

--- a/docs/multimodel.md
+++ b/docs/multimodel.md
@@ -53,6 +53,8 @@ The CLI renders per-model logs without interleaving tokens. Aggregate cost/token
 
 With `--write-output /tmp/name.md`, Oracle writes successful answers to per-model files such as `/tmp/name.gpt-5.1.md` and records `/tmp/name.oracle.json`. The manifest includes each model's status, output path, run log path, usage, elapsed time when available, and error category/message for failed models. Terminal summaries print saved outputs first, then run logs, then failures so agents can recover partial results without scraping noisy error blocks.
 
+Common provider failures are normalized before display. Auth, expired-key, quota, rate-limit, and unavailable-model errors include the provider env var name, the provider message, and a short recovery hint; secret values are never printed.
+
 ---
 
 ## Implementation Notes

--- a/src/cli/sessionRunner.ts
+++ b/src/cli/sessionRunner.ts
@@ -9,7 +9,7 @@ import type {
   SessionArtifact,
   SessionModelRun,
 } from "../sessionStore.js";
-import type { RunOracleOptions, UsageSummary } from "../oracle.js";
+import type { ProviderFailureContext, RunOracleOptions, UsageSummary } from "../oracle.js";
 import {
   runOracle,
   OracleResponseError,
@@ -17,6 +17,7 @@ import {
   extractResponseMetadata,
   asOracleUserError,
   extractTextOutput,
+  classifyProviderFailure,
 } from "../oracle.js";
 import {
   ensureSessionArtifacts,
@@ -399,6 +400,7 @@ export async function performSessionRun({
           savedOutputs,
           modelRuns: sessionWithRuns.models,
           runLogs,
+          runOptions,
           log,
         });
         if (savedOutputs.length > 0) {
@@ -421,11 +423,19 @@ export async function performSessionRun({
       if (hasFailure) {
         log(dim("Failures:"));
         for (const item of summary.rejected) {
-          log(dim(`- ${item.model}: ${formatMultiModelFailure(item.reason)}`));
+          const providerContext = providerFailureContextForModel(item.model, runOptions);
+          log(dim(`- ${item.model}: ${formatMultiModelFailure(item.reason, providerContext)}`));
+          for (const line of formatMultiModelFailureDetails(item.reason, providerContext)) {
+            log(dim(line));
+          }
         }
       }
       if (hasFailure && !allowPartial) {
-        throw summary.rejected[0].reason;
+        const firstFailure = summary.rejected[0];
+        throw sanitizeMultiModelFailureForThrow(
+          firstFailure.reason,
+          providerFailureContextForModel(firstFailure.model, runOptions),
+        );
       }
       return;
     }
@@ -644,10 +654,30 @@ function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function formatMultiModelFailure(error: unknown): string {
+function providerFailureContextForModel(
+  model: string,
+  runOptions: RunOracleOptions,
+): ProviderFailureContext {
+  return {
+    model,
+    providerMode: runOptions.provider,
+    azure: runOptions.azure,
+    baseUrl: runOptions.baseUrl,
+    apiKey: runOptions.apiKey,
+  };
+}
+
+function formatMultiModelFailure(
+  error: unknown,
+  context?: string | ProviderFailureContext,
+): string {
   const userError = asOracleUserError(error);
   if (userError) {
     return `${userError.category}, ${userError.message}`;
+  }
+  const providerFailure = classifyProviderFailure(error, context);
+  if (providerFailure) {
+    return providerFailure.label;
   }
   if (error instanceof OracleTransportError) {
     return `${error.reason}, ${error.message}`;
@@ -656,6 +686,45 @@ function formatMultiModelFailure(error: unknown): string {
     return error.message;
   }
   return formatError(error);
+}
+
+function formatMultiModelFailureDetails(
+  error: unknown,
+  context?: string | ProviderFailureContext,
+): string[] {
+  const providerFailure = classifyProviderFailure(error, context);
+  if (!providerFailure) {
+    return [];
+  }
+  const lines: string[] = [];
+  if (providerFailure.keyEnv) {
+    lines.push(`  key: ${providerFailure.keyEnv}`);
+  }
+  lines.push(`  provider said: ${providerFailure.providerMessage}`);
+  lines.push(`  fix: ${providerFailure.fix}`);
+  return lines;
+}
+
+function sanitizeMultiModelFailureForThrow(
+  error: unknown,
+  context?: string | ProviderFailureContext,
+): unknown {
+  const providerFailure = classifyProviderFailure(error, context);
+  if (!providerFailure) {
+    return error;
+  }
+  const modelPrefix = typeof context === "object" && context?.model ? `${context.model}: ` : "";
+  const message = `${modelPrefix}${providerFailure.label}: ${providerFailure.providerMessage}`;
+  if (!(error instanceof Error)) {
+    return new Error(message);
+  }
+  error.message = message;
+  if (error.stack) {
+    const [firstLine, ...rest] = error.stack.split("\n");
+    const prefix = firstLine.includes(":") ? firstLine.split(":", 1)[0] : error.name;
+    error.stack = [prefix ? `${prefix}: ${message}` : message, ...rest].join("\n");
+  }
+  return error;
 }
 
 interface MultiModelManifestRunLog {
@@ -716,6 +785,7 @@ async function writeMultiModelOutputManifest({
   savedOutputs,
   modelRuns,
   runLogs,
+  runOptions,
   log,
 }: {
   baseOutputPath: string;
@@ -725,6 +795,7 @@ async function writeMultiModelOutputManifest({
   savedOutputs: Array<{ model: string; path: string }>;
   modelRuns?: SessionModelRun[];
   runLogs: MultiModelManifestRunLog[];
+  runOptions: RunOracleOptions;
   log: (message: string) => void;
 }): Promise<string | undefined> {
   const manifestPath = deriveOutputManifestPath(baseOutputPath);
@@ -749,6 +820,7 @@ async function writeMultiModelOutputManifest({
     savedOutputs,
     modelRuns,
     runLogs,
+    runOptions,
   });
   try {
     await fs.mkdir(path.dirname(normalizedTarget), { recursive: true });
@@ -769,6 +841,7 @@ function buildMultiModelOutputManifest({
   savedOutputs,
   modelRuns,
   runLogs,
+  runOptions,
 }: {
   baseOutputPath: string;
   sessionId: string;
@@ -777,6 +850,7 @@ function buildMultiModelOutputManifest({
   savedOutputs: Array<{ model: string; path: string }>;
   modelRuns?: SessionModelRun[];
   runLogs: MultiModelManifestRunLog[];
+  runOptions: RunOracleOptions;
 }): MultiModelOutputManifest {
   const outputByModel = new Map(savedOutputs.map((entry) => [entry.model, entry.path]));
   const logsByModel = new Map(runLogs.map((entry) => [entry.model, entry.path]));
@@ -798,14 +872,20 @@ function buildMultiModelOutputManifest({
       const fulfilled = fulfilledByModel.get(model);
       const reason = rejectedByModel.get(model);
       const userError = reason ? asOracleUserError(reason) : undefined;
+      const providerFailure = reason
+        ? classifyProviderFailure(reason, providerFailureContextForModel(model, runOptions))
+        : undefined;
       return {
         model,
         status: fulfilled ? "completed" : reason ? "error" : (run?.status ?? "error"),
         outputPath: outputByModel.get(model),
         logPath: logsByModel.get(model),
-        errorCategory: run?.error?.category ?? userError?.category,
+        errorCategory: run?.error?.category ?? userError?.category ?? providerFailure?.category,
         errorMessage:
-          run?.error?.message ?? userError?.message ?? (reason ? formatError(reason) : undefined),
+          run?.error?.message ??
+          userError?.message ??
+          providerFailure?.label ??
+          (reason ? formatError(reason) : undefined),
         elapsedMs: calculateModelElapsedMs(run),
         usage: run?.usage ?? fulfilled?.usage,
       };

--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -27,3 +27,8 @@ export {
 export { createDefaultClientFactory } from "./oracle/client.js";
 export { runOracle, extractTextOutput } from "./oracle/run.js";
 export { resolveGeminiModelId } from "./oracle/gemini.js";
+export { classifyProviderFailure } from "./oracle/providerFailures.js";
+export type {
+  ProviderFailureClassification,
+  ProviderFailureContext,
+} from "./oracle/providerFailures.js";

--- a/src/oracle/multiModelRunner.ts
+++ b/src/oracle/multiModelRunner.ts
@@ -9,6 +9,7 @@ import {
   extractResponseMetadata,
   asOracleUserError,
   extractTextOutput,
+  classifyProviderFailure,
 } from "../oracle.js";
 import type { SessionStore } from "../sessionStore.js";
 import { sessionStore } from "../sessionStore.js";
@@ -187,6 +188,13 @@ function startModelExecution({
   })()
     .catch(async (error) => {
       const userError = asOracleUserError(error);
+      const providerFailure = classifyProviderFailure(error, {
+        model,
+        providerMode: runOptions.provider,
+        azure: runOptions.azure,
+        baseUrl: runOptions.baseUrl,
+        apiKey: runOptions.apiKey,
+      });
       const responseMetadata = error instanceof OracleResponseError ? error.metadata : undefined;
       const transportMetadata =
         error instanceof OracleTransportError ? { reason: error.reason } : undefined;
@@ -201,7 +209,18 @@ function startModelExecution({
               message: userError.message,
               details: userError.details,
             }
-          : undefined,
+          : providerFailure
+            ? {
+                category: providerFailure.category,
+                message: providerFailure.label,
+                details: {
+                  provider: providerFailure.provider,
+                  keyEnv: providerFailure.keyEnv,
+                  providerMessage: providerFailure.providerMessage,
+                  fix: providerFailure.fix,
+                },
+              }
+            : undefined,
         log: await describeLog(sessionMeta.id, logWriter.logPath, store),
       });
       throw error;

--- a/src/oracle/providerFailures.ts
+++ b/src/oracle/providerFailures.ts
@@ -1,0 +1,262 @@
+import { OracleTransportError, asOracleUserError } from "./errors.js";
+import { buildProviderRoutePlan } from "./providerRoutePlan.js";
+import type { ApiProviderMode, AzureOptions, ModelName } from "./types.js";
+
+export type ProviderFailureCategory =
+  | "auth-failed"
+  | "auth-expired"
+  | "quota-exceeded"
+  | "rate-limited"
+  | "model-unavailable";
+
+export interface ProviderFailureClassification {
+  category: ProviderFailureCategory;
+  label: string;
+  provider: string;
+  keyEnv?: string;
+  providerMessage: string;
+  fix: string;
+}
+
+export interface ProviderFailureContext {
+  model?: string;
+  providerMode?: ApiProviderMode;
+  azure?: AzureOptions;
+  baseUrl?: string;
+  apiKey?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export function classifyProviderFailure(
+  error: unknown,
+  context?: string | ProviderFailureContext,
+): ProviderFailureClassification | null {
+  const userError = asOracleUserError(error);
+  if (userError) {
+    return null;
+  }
+  const normalizedContext = normalizeContext(context);
+  const route = inferFailureRoute(normalizedContext);
+  const rawProviderMessage = extractProviderMessage(error);
+  const lower = rawProviderMessage.toLowerCase();
+  const category = classifyMessage(lower, error);
+  if (!category) {
+    return null;
+  }
+  const providerMessage = sanitizeProviderMessage(rawProviderMessage);
+  return {
+    category,
+    label: labelForCategory(category),
+    provider: route.provider,
+    keyEnv: route.keySource,
+    providerMessage,
+    fix: fixForCategory(category, route.provider, normalizedContext.model, route.keySource),
+  };
+}
+
+function classifyMessage(lower: string, error: unknown): ProviderFailureCategory | null {
+  if (isLocalPermissionError(error, lower)) {
+    return null;
+  }
+  if (
+    lower.includes("expired") &&
+    (lower.includes("api key") || lower.includes("credential") || lower.includes("token"))
+  ) {
+    return "auth-expired";
+  }
+  if (
+    lower.includes("invalid x-api-key") ||
+    lower.includes("invalid api key") ||
+    lower.includes("api key is invalid") ||
+    lower.includes("api key not valid") ||
+    lower.includes("incorrect api key") ||
+    lower.includes("unauthorized") ||
+    lower.includes("unauthenticated") ||
+    hasStatusCode(lower, "401")
+  ) {
+    return "auth-failed";
+  }
+  if (
+    lower.includes("insufficient_quota") ||
+    lower.includes("quota exceeded") ||
+    lower.includes("billing") ||
+    lower.includes("resource_exhausted")
+  ) {
+    return "quota-exceeded";
+  }
+  if (lower.includes("rate limit") || lower.includes("rate_limit") || hasStatusCode(lower, "429")) {
+    return "rate-limited";
+  }
+  if (error instanceof OracleTransportError && error.reason === "model-unavailable") {
+    return "model-unavailable";
+  }
+  if (
+    lower.includes("model not available") ||
+    lower.includes("model_not_found") ||
+    lower.includes("unknown model") ||
+    lower.includes("does not exist")
+  ) {
+    return "model-unavailable";
+  }
+  return null;
+}
+
+function hasStatusCode(lower: string, status: string): boolean {
+  return new RegExp(`(^|\\D)${status}(\\D|$)`).test(lower);
+}
+
+function isLocalPermissionError(error: unknown, lower: string): boolean {
+  const code =
+    typeof error === "object" && error !== null && "code" in error
+      ? String((error as { code?: unknown }).code).toUpperCase()
+      : "";
+  return (
+    code === "EACCES" ||
+    code === "EPERM" ||
+    lower.includes("eacces:") ||
+    lower.includes("eperm:") ||
+    /permission denied, (open|scandir|mkdir|access|unlink|rename)\b/.test(lower)
+  );
+}
+
+function extractProviderMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function sanitizeProviderMessage(message: string): string {
+  return message
+    .replace(/\bBearer\s+[A-Za-z0-9._\-+/=]+/gi, "Bearer [redacted]")
+    .replace(/\b(api[-_ ]?key\s+provided)(\s*[:=]?\s*)["']?[^"',;\s]+/gi, "$1$2[redacted]")
+    .replace(
+      /\b(api[-_ ]?key|x-api-key|authorization|token)(\s*[:=]\s*)["']?[^"',;\s]+/gi,
+      "$1$2[redacted]",
+    )
+    .replace(/\bsk-(?:ant-|or-)?[A-Za-z0-9_-]{8,}\b/g, "sk-...[redacted]")
+    .replace(/\bxai-[A-Za-z0-9_-]{8,}\b/g, "xai-...[redacted]")
+    .replace(/\bAIza[0-9A-Za-z_-]{8,}\b/g, "AIza...[redacted]");
+}
+
+function normalizeContext(context?: string | ProviderFailureContext): ProviderFailureContext {
+  if (typeof context === "string") {
+    return { model: context };
+  }
+  return context ?? {};
+}
+
+function inferFailureRoute(context: ProviderFailureContext): {
+  provider: string;
+  keySource?: string;
+} {
+  if (context.model) {
+    const plan = buildProviderRoutePlan({
+      model: context.model as ModelName,
+      providerMode: context.providerMode,
+      azure: context.azure,
+      baseUrl: context.baseUrl,
+      apiKey: context.apiKey,
+      env: context.env,
+    });
+    const keySource = normalizeKeySource(plan.keySource);
+    if (plan.providerLabel === "OpenRouter" || plan.keySource.includes("OPENROUTER_API_KEY")) {
+      return { provider: "openrouter", keySource };
+    }
+    if (plan.provider === "azure") return { provider: "azure", keySource };
+    if (plan.provider === "google") return { provider: "gemini", keySource };
+    return { provider: plan.provider, keySource };
+  }
+  const normalized = context.model?.toLowerCase() ?? "";
+  const baseUrl = context.baseUrl?.toLowerCase() ?? "";
+  if (baseUrl.includes("openrouter.ai") || (normalized.includes("/") && !baseUrl)) {
+    return { provider: "openrouter", keySource: keyEnvForProvider("openrouter") };
+  }
+  if (
+    context.azure?.endpoint?.trim() &&
+    context.providerMode !== "openai" &&
+    (normalized.startsWith("gpt") || normalized.startsWith("openai/") || !normalized.includes("/"))
+  ) {
+    return { provider: "azure", keySource: keyEnvForProvider("azure") };
+  }
+  if (normalized.startsWith("anthropic/")) return providerRoute("anthropic");
+  if (normalized.startsWith("google/")) return providerRoute("gemini");
+  if (normalized.startsWith("xai/")) return providerRoute("xai");
+  if (normalized.startsWith("openai/")) return providerRoute("openai");
+  if (normalized.startsWith("claude")) return providerRoute("anthropic");
+  if (normalized.startsWith("gemini")) return providerRoute("gemini");
+  if (normalized.startsWith("grok")) return providerRoute("xai");
+  return providerRoute("openai");
+}
+
+function providerRoute(provider: string): { provider: string; keySource?: string } {
+  return { provider, keySource: keyEnvForProvider(provider) };
+}
+
+function normalizeKeySource(keySource: string): string | undefined {
+  if (!keySource || keySource.includes("|")) {
+    return undefined;
+  }
+  return keySource;
+}
+
+function keyEnvForProvider(provider: string): string | undefined {
+  switch (provider) {
+    case "anthropic":
+      return "ANTHROPIC_API_KEY";
+    case "gemini":
+      return "GEMINI_API_KEY";
+    case "xai":
+      return "XAI_API_KEY";
+    case "azure":
+      return "AZURE_OPENAI_API_KEY";
+    case "openrouter":
+      return "OPENROUTER_API_KEY";
+    case "openai":
+      return "OPENAI_API_KEY";
+    default:
+      return undefined;
+  }
+}
+
+function doctorCommand(model?: string): string {
+  return model ? `oracle doctor --providers --models ${model}` : "oracle doctor --providers";
+}
+
+function labelForCategory(category: ProviderFailureCategory): string {
+  switch (category) {
+    case "auth-failed":
+      return "auth failed";
+    case "auth-expired":
+      return "auth expired";
+    case "quota-exceeded":
+      return "quota exceeded";
+    case "rate-limited":
+      return "rate limited";
+    case "model-unavailable":
+      return "model unavailable";
+  }
+}
+
+function fixForCategory(
+  category: ProviderFailureCategory,
+  provider: string,
+  model?: string,
+  keySource?: string,
+): string {
+  const doctor = doctorCommand(model);
+  const key = keySource ?? keyEnvForProvider(provider) ?? "the provider API key";
+  switch (category) {
+    case "auth-failed":
+      return key === "apiKey option"
+        ? `check --api-key value or run \`${doctor}\``
+        : `refresh ${key} or run \`${doctor}\``;
+    case "auth-expired":
+      return key === "apiKey option"
+        ? "replace --api-key value, then rerun the failed model"
+        : `rotate ${key}, then rerun the failed model`;
+    case "quota-exceeded":
+      return `check ${provider} billing/quota, then rerun the failed model`;
+    case "rate-limited":
+      return "retry later or reduce parallel model fan-out";
+    case "model-unavailable":
+      return `check model access/ID with \`${doctor}\``;
+  }
+}

--- a/tests/cli/sessionRunner.test.ts
+++ b/tests/cli/sessionRunner.test.ts
@@ -92,6 +92,33 @@ const write = vi.fn(() => true);
 const cliVersion = getCliVersion();
 const originalPlatform = process.platform;
 
+async function withExactEnv<T>(
+  updates: Record<string, string | undefined>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const originals = new Map<string, string | undefined>();
+  for (const name of Object.keys(updates)) {
+    originals.set(name, process.env[name]);
+    const value = updates[name];
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const [name, value] of originals) {
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+  }
+}
+
 beforeAll(() => {
   // Force macOS platform so browser-mode paths are reachable in Linux/Windows CI
   Object.defineProperty(process, "platform", { value: "darwin" });
@@ -651,6 +678,180 @@ describe("performSessionRun", () => {
     const logsCombined = log.mock.calls.map((c) => c[0]).join("\n");
     expect(logsCombined).toContain("Multi-model result: partial success, 1/2 succeeded");
     expect(logsCombined).toContain("Failures:");
+  });
+
+  test("prints classified provider failures with recovery hints", async () => {
+    const sessionMeta = {
+      ...baseSessionMeta,
+      models: [
+        { model: "gpt-5.1", status: "running" },
+        { model: "claude-4.6-sonnet", status: "running" },
+      ],
+    } as SessionMetadata;
+
+    sessionStoreMock.readSession.mockResolvedValue(sessionMeta);
+    sessionStoreMock.readModelLog.mockResolvedValue("Answer:\npartial");
+
+    const summary: MultiModelRunSummary = {
+      fulfilled: [
+        {
+          model: "gpt-5.1" as ModelName,
+          usage: { inputTokens: 1, outputTokens: 1, reasoningTokens: 0, totalTokens: 2, cost: 0 },
+          answerText: "ok",
+          logPath: "log-ok",
+        },
+      ],
+      rejected: [
+        {
+          model: "claude-4.6-sonnet" as ModelName,
+          reason: new Error("invalid x-api-key: sk-ant-secret123456789"),
+        },
+      ],
+      elapsedMs: 500,
+    };
+    vi.mocked(runMultiModelApiSession).mockResolvedValue(summary);
+
+    await withExactEnv(
+      {
+        ANTHROPIC_API_KEY: "ak-native-test-key",
+        OPENROUTER_API_KEY: undefined,
+      },
+      () =>
+        performSessionRun({
+          sessionMeta,
+          runOptions: {
+            ...baseRunOptions,
+            models: ["gpt-5.1", "claude-4.6-sonnet"],
+            partialMode: "ok",
+          },
+          mode: "api",
+          cwd: "/tmp",
+          log,
+          write,
+          version: cliVersion,
+        }),
+    );
+
+    const logsCombined = log.mock.calls.map((c) => c[0]).join("\n");
+    expect(logsCombined).toContain("claude-4.6-sonnet: auth failed");
+    expect(logsCombined).toContain("key: ANTHROPIC_API_KEY");
+    expect(logsCombined).toContain("provider said: invalid x-api-key: [redacted]");
+    expect(logsCombined).toContain("fix: refresh ANTHROPIC_API_KEY");
+    expect(logsCombined).toContain("oracle doctor --providers --models claude-4.6-sonnet");
+    expect(logsCombined).not.toContain("sk-ant-secret123456789");
+  });
+
+  test("sanitizes rethrown provider failures when partial success is not allowed", async () => {
+    const sessionMeta = {
+      ...baseSessionMeta,
+      models: [
+        { model: "gpt-5.1", status: "running" },
+        { model: "claude-4.6-sonnet", status: "running" },
+      ],
+    } as SessionMetadata;
+
+    sessionStoreMock.readSession.mockResolvedValue(sessionMeta);
+    sessionStoreMock.readModelLog.mockResolvedValue("Answer:\npartial");
+
+    const summary: MultiModelRunSummary = {
+      fulfilled: [
+        {
+          model: "gpt-5.1" as ModelName,
+          usage: { inputTokens: 1, outputTokens: 1, reasoningTokens: 0, totalTokens: 2, cost: 0 },
+          answerText: "ok",
+          logPath: "log-ok",
+        },
+      ],
+      rejected: [
+        {
+          model: "claude-4.6-sonnet" as ModelName,
+          reason: new Error("invalid x-api-key: sk-ant-secret123456789"),
+        },
+      ],
+      elapsedMs: 500,
+    };
+    vi.mocked(runMultiModelApiSession).mockResolvedValue(summary);
+
+    await expect(
+      withExactEnv(
+        {
+          ANTHROPIC_API_KEY: "ak-native-test-key",
+          OPENROUTER_API_KEY: undefined,
+        },
+        () =>
+          performSessionRun({
+            sessionMeta,
+            runOptions: {
+              ...baseRunOptions,
+              models: ["gpt-5.1", "claude-4.6-sonnet"],
+            },
+            mode: "api",
+            cwd: "/tmp",
+            log,
+            write,
+            version: cliVersion,
+          }),
+      ),
+    ).rejects.toThrow("claude-4.6-sonnet: auth failed");
+
+    const logsCombined = log.mock.calls.map((c) => c[0]).join("\n");
+    expect(logsCombined).toContain("ERROR: claude-4.6-sonnet: auth failed");
+    expect(logsCombined).toContain("provider said: invalid x-api-key: [redacted]");
+    expect(logsCombined).not.toContain("sk-ant-secret123456789");
+  });
+
+  test("preserves transport metadata when sanitizing rethrown provider failures", async () => {
+    const sessionMeta = {
+      ...baseSessionMeta,
+      models: [{ model: "gpt-5.2-pro", status: "running" }],
+    } as SessionMetadata;
+
+    sessionStoreMock.readSession.mockResolvedValue(sessionMeta);
+    sessionStoreMock.readModelLog.mockResolvedValue("");
+
+    const summary: MultiModelRunSummary = {
+      fulfilled: [],
+      rejected: [
+        {
+          model: "gpt-5.2-pro" as ModelName,
+          reason: new OracleTransportError(
+            "model-unavailable",
+            "The requested model does not exist for sk-secret123456789",
+          ),
+        },
+      ],
+      elapsedMs: 500,
+    };
+    vi.mocked(runMultiModelApiSession).mockResolvedValue(summary);
+
+    await expect(
+      performSessionRun({
+        sessionMeta,
+        runOptions: {
+          ...baseRunOptions,
+          models: ["gpt-5.2-pro", "gpt-5.1"],
+        },
+        mode: "api",
+        cwd: "/tmp",
+        log,
+        write,
+        version: cliVersion,
+      }),
+    ).rejects.toMatchObject({
+      reason: "model-unavailable",
+      message: expect.stringContaining("gpt-5.2-pro: model unavailable"),
+    });
+
+    const finalUpdate = sessionStoreMock.updateSession.mock.calls.at(-1)?.[1];
+    expect(finalUpdate).toMatchObject({
+      status: "error",
+      transport: { reason: "model-unavailable" },
+    });
+    expect(finalUpdate?.errorMessage).toContain("gpt-5.2-pro: model unavailable");
+    expect(finalUpdate?.errorMessage).not.toContain("sk-secret123456789");
+    const logsCombined = log.mock.calls.map((c) => c[0]).join("\n");
+    expect(logsCombined).toContain("Transport: model-unavailable");
+    expect(logsCombined).not.toContain("sk-secret123456789");
   });
 
   test("prints tips before the first model heading in multi-model TTY streaming", async () => {

--- a/tests/oracle/multiModelRunner.test.ts
+++ b/tests/oracle/multiModelRunner.test.ts
@@ -131,6 +131,18 @@ describe("runMultiModelApiSession", () => {
     expect(statusUpdatesFor("gpt-5.2-pro")).toContain("error");
     expect(statusUpdatesFor("gpt-5.1")).toContain("completed");
     expect(statusUpdatesFor("gemini-3-pro")).toContain("completed");
+    const failedUpdate = updateModelRun.mock.calls
+      .filter(([, model]) => model === "gpt-5.2-pro")
+      .map(([, , updates]) => updates)
+      .find((updates) => updates?.status === "error");
+    expect(failedUpdate?.error).toMatchObject({
+      category: "model-unavailable",
+      message: "model unavailable",
+      details: {
+        provider: "openai",
+        keyEnv: "OPENAI_API_KEY",
+      },
+    });
   });
 
   test("runs grok alongside other models and logs per-model output", async () => {

--- a/tests/oracle/providerFailures.test.ts
+++ b/tests/oracle/providerFailures.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  classifyProviderFailure,
+  sanitizeProviderMessage,
+} from "../../src/oracle/providerFailures.js";
+
+describe("provider failure classification", () => {
+  test("redacts provider messages before surfacing them", () => {
+    expect(
+      sanitizeProviderMessage(
+        "invalid x-api-key: sk-ant-secret123456789 and Bearer token-abc123456789",
+      ),
+    ).toBe("invalid x-api-key: [redacted] and Bearer [redacted]");
+    expect(sanitizeProviderMessage("401 Incorrect API key provided: xai-secret123456789")).toBe(
+      "401 Incorrect API key provided: [redacted]",
+    );
+    expect(sanitizeProviderMessage("API key is invalid: xai-secret123456789")).toBe(
+      "API key is invalid: xai-...[redacted]",
+    );
+  });
+
+  test("does not classify local permission errors as provider auth failures", () => {
+    const error = Object.assign(new Error("EACCES: permission denied, open '/tmp/input.md'"), {
+      code: "EACCES",
+    });
+
+    expect(classifyProviderFailure(error, "gpt-5.1")).toBeNull();
+  });
+
+  test("does not classify embedded status-code digits as provider failures", () => {
+    expect(
+      classifyProviderFailure(new Error("ECONNREFUSED 127.0.0.1:4010"), {
+        model: "gpt-5.1",
+        env: {},
+      }),
+    ).toBeNull();
+    expect(
+      classifyProviderFailure(new Error("proxy failed at /v1/routes/4290"), {
+        model: "gpt-5.1",
+        env: {},
+      }),
+    ).toBeNull();
+  });
+
+  test("uses Azure route context for OpenAI model auth hints", () => {
+    expect(
+      classifyProviderFailure(new Error("401 invalid api key"), {
+        model: "gpt-5.1",
+        providerMode: "auto",
+        azure: { endpoint: "https://example.openai.azure.com" },
+        env: { AZURE_OPENAI_API_KEY: "az-secret123456789" },
+      }),
+    ).toMatchObject({
+      category: "auth-failed",
+      provider: "azure",
+      keyEnv: "AZURE_OPENAI_API_KEY",
+      fix: expect.stringContaining("oracle doctor --providers --models gpt-5.1"),
+    });
+  });
+
+  test("classifies incorrect API key messages without a 401 prefix", () => {
+    expect(
+      classifyProviderFailure(new Error("Incorrect API key provided: sk-proj-secret123456789"), {
+        model: "gpt-5.1",
+        env: {},
+      }),
+    ).toMatchObject({
+      category: "auth-failed",
+      provider: "openai",
+      keyEnv: "OPENAI_API_KEY",
+      providerMessage: "Incorrect API key provided: [redacted]",
+    });
+  });
+
+  test("classifies auth messages before display redaction", () => {
+    expect(
+      classifyProviderFailure(new Error("API key is expired"), {
+        model: "gemini-3-pro",
+        env: { GEMINI_API_KEY: "gm-secret123456789" },
+      }),
+    ).toMatchObject({
+      category: "auth-expired",
+      provider: "gemini",
+      keyEnv: "GEMINI_API_KEY",
+      providerMessage: "API key is expired",
+    });
+
+    expect(
+      classifyProviderFailure(new Error("API key is invalid: xai-secret123456789"), {
+        model: "grok-4.1",
+        env: { XAI_API_KEY: "xai-secret123456789" },
+      }),
+    ).toMatchObject({
+      category: "auth-failed",
+      provider: "xai",
+      keyEnv: "XAI_API_KEY",
+      providerMessage: "API key is invalid: xai-...[redacted]",
+    });
+  });
+
+  test("uses OpenRouter key hints for provider-qualified model routes", () => {
+    expect(
+      classifyProviderFailure(new Error("invalid api key"), {
+        model: "anthropic/claude-3.5-sonnet",
+        env: {},
+      }),
+    ).toMatchObject({
+      category: "auth-failed",
+      provider: "openrouter",
+      keyEnv: "OPENROUTER_API_KEY",
+    });
+  });
+
+  test("uses OpenRouter key hints when fallback routes a plain model through OpenRouter", () => {
+    expect(
+      classifyProviderFailure(new Error("401 invalid api key"), {
+        model: "gpt-5.1",
+        env: { OPENROUTER_API_KEY: "sk-or-secret123456789" },
+      }),
+    ).toMatchObject({
+      category: "auth-failed",
+      provider: "openrouter",
+      keyEnv: "OPENROUTER_API_KEY",
+    });
+  });
+
+  test("uses actual key source in recovery hints", () => {
+    expect(
+      classifyProviderFailure(new Error("401 invalid api key"), {
+        model: "gpt-5.1",
+        apiKey: "sk-explicit-secret123456789",
+        env: {},
+      }),
+    ).toMatchObject({
+      category: "auth-failed",
+      provider: "openai",
+      keyEnv: "apiKey option",
+      fix: expect.stringContaining("check --api-key value"),
+    });
+
+    expect(
+      classifyProviderFailure(new Error("401 invalid api key"), {
+        model: "gpt-5.1",
+        azure: { endpoint: "https://example.openai.azure.com" },
+        env: { OPENAI_API_KEY: "sk-fallback-secret123456789" },
+      }),
+    ).toMatchObject({
+      category: "auth-failed",
+      provider: "azure",
+      keyEnv: "OPENAI_API_KEY",
+      fix: expect.stringContaining("refresh OPENAI_API_KEY"),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- classify common provider auth, expired-key, quota, rate-limit, and model-unavailable failures in multi-model summaries and model metadata
- use route-aware provider/key-source hints for OpenAI, Azure, OpenRouter, Anthropic, Gemini, xAI, and --api-key
- sanitize provider messages before display/rethrow and preserve transport/response metadata on failed sessions

## Tests
- pnpm run format:check
- pnpm run lint
- ./node_modules/.bin/vitest run tests/cli/sessionRunner.test.ts tests/oracle/multiModelRunner.test.ts tests/oracle/providerFailures.test.ts
- pnpm run build
- codex-review helper clean: no accepted/actionable findings reported
