### PR TITLE
feat(cli): show session lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - API: add `--allow-partial` / `--partial ok` for multi-model runs so advisory panels can exit 0 when at least one model succeeds, while still listing saved outputs and a JSON output manifest before failures.
 - API: classify common provider failures in multi-model summaries and metadata, including auth, expired keys, quota, rate limits, and unavailable models, with secret-safe recovery hints.
+- Sessions: print and persist a compact lifecycle block showing foreground/background execution, detach state, model count, and reattach command.
 - API: add `--provider openai` / `--no-azure` to force first-party OpenAI when Azure env/config is present, add `oracle doctor --providers` and `--route` redacted route diagnostics, keep provider-qualified model IDs on OpenRouter/proxy routes instead of accidental Azure/native routes, and fail early when Azure routing lacks a deployment.
 - Browser/MCP: add opt-in ZIP formatting for bundled browser uploads with `--browser-bundle-format zip` / `browserBundleFormat: "zip"`, preserving individual file names in one ChatGPT attachment.
 

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -92,6 +92,7 @@ import {
 } from "../src/oracle/providerRouting.js";
 import { buildProviderRoutePlan } from "../src/oracle/providerRoutePlan.js";
 import { printProviderPlans } from "../src/cli/providerDoctor.js";
+import { buildSessionLifecycle, formatSessionLifecycleBlock } from "../src/cli/sessionLifecycle.js";
 
 interface CliOptions extends OptionValues {
   prompt?: string;
@@ -2150,6 +2151,13 @@ async function runRootCommand(options: CliOptions): Promise<void> {
         );
         return false;
       });
+  const lifecycle = buildSessionLifecycle({
+    engine,
+    detached,
+    reattachCommand: `oracle session ${sessionMeta.id}`,
+  });
+  await sessionStore.updateSession(sessionMeta.id, { lifecycle });
+  const sessionWithLifecycle: SessionMetadata = { ...sessionMeta, lifecycle };
 
   if (!waitPreference) {
     if (!detached) {
@@ -2157,9 +2165,9 @@ async function runRootCommand(options: CliOptions): Promise<void> {
       process.exitCode = 1;
       return;
     }
-    console.log(
-      chalk.blue(`Session running in background. Reattach via: oracle session ${sessionMeta.id}`),
-    );
+    for (const line of formatSessionLifecycleBlock(sessionWithLifecycle)) {
+      console.log(line);
+    }
     console.log(
       chalk.dim("Pro runs can take up to 60 minutes (usually 10-15). Add --wait to stay attached."),
     );
@@ -2168,7 +2176,7 @@ async function runRootCommand(options: CliOptions): Promise<void> {
 
   if (detached === false) {
     await runInteractiveSession(
-      sessionMeta,
+      sessionWithLifecycle,
       liveRunOptions,
       sessionMode,
       browserConfig,
@@ -2219,6 +2227,10 @@ async function runInteractiveSession(
     writeChunk(chunk);
     return true;
   };
+  for (const line of formatSessionLifecycleBlock(sessionMeta)) {
+    console.log(line);
+    logLine(line);
+  }
   try {
     await performSessionRun({
       sessionMeta,
@@ -2414,6 +2426,13 @@ async function restartSession(sessionId: string, options: RestartCommandOptions)
         );
         return false;
       });
+  const lifecycle = buildSessionLifecycle({
+    engine,
+    detached,
+    reattachCommand: `oracle session ${sessionMeta.id}`,
+  });
+  await sessionStore.updateSession(sessionMeta.id, { lifecycle });
+  const sessionWithLifecycle: SessionMetadata = { ...sessionMeta, lifecycle };
 
   if (!waitPreference) {
     if (!detached) {
@@ -2421,9 +2440,9 @@ async function restartSession(sessionId: string, options: RestartCommandOptions)
       process.exitCode = 1;
       return;
     }
-    console.log(
-      chalk.blue(`Session running in background. Reattach via: oracle session ${sessionMeta.id}`),
-    );
+    for (const line of formatSessionLifecycleBlock(sessionWithLifecycle)) {
+      console.log(line);
+    }
     console.log(
       chalk.dim("Pro runs can take up to 60 minutes (usually 10-15). Add --wait to stay attached."),
     );
@@ -2432,7 +2451,7 @@ async function restartSession(sessionId: string, options: RestartCommandOptions)
 
   if (detached === false) {
     await runInteractiveSession(
-      sessionMeta,
+      sessionWithLifecycle,
       liveRunOptions,
       sessionMode,
       browserConfig,

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -56,6 +56,18 @@ oracle status                  # find the running one
 oracle session <id>            # blocks until done, then prints the answer
 ```
 
+Every new run prints a lifecycle block so foreground and detached behavior is explicit:
+
+```text
+Session: 20260515-name-panel
+Mode: api background
+Models: 3 parallel
+Detach: yes, polling
+Reattach: oracle session 20260515-name-panel
+```
+
+`oracle status` uses compact mode labels such as `api/fg`, `api/bg`, and `br/fg`; `oracle session <id>` shows the persisted execution state.
+
 To block in the original command, pass `--wait`:
 
 ```bash

--- a/src/cli/sessionDisplay.ts
+++ b/src/cli/sessionDisplay.ts
@@ -29,6 +29,7 @@ import {
   buildResponseOwnerIndex,
   resolveSessionLineage,
 } from "./sessionLineage.js";
+import { formatSessionExecutionLabel } from "./sessionLifecycle.js";
 
 const isTty = (): boolean => Boolean(process.stdout.isTTY);
 const dim = (text: string): string => (isTty() ? kleur.dim(text) : text);
@@ -373,6 +374,11 @@ export async function attachSession(
     }
     console.log(`Created: ${metadata.createdAt}`);
     console.log(`Status: ${metadata.status}`);
+    if (metadata.lifecycle) {
+      const attached = metadata.lifecycle.attached ? "attached" : "detached";
+      console.log(`Execution: ${formatSessionExecutionLabel(metadata)} (${attached})`);
+      console.log(`Reattach: ${metadata.lifecycle.reattachCommand}`);
+    }
     if (metadata.models && metadata.models.length > 0) {
       console.log("Models:");
       for (const run of metadata.models) {

--- a/src/cli/sessionLifecycle.ts
+++ b/src/cli/sessionLifecycle.ts
@@ -1,0 +1,53 @@
+import type { SessionLifecycleMetadata, SessionMetadata } from "../sessionManager.js";
+import type { EngineMode } from "./engine.js";
+
+export interface BuildSessionLifecycleOptions {
+  engine: EngineMode;
+  detached: boolean;
+  reattachCommand: string;
+}
+
+export function buildSessionLifecycle({
+  engine,
+  detached,
+  reattachCommand,
+}: BuildSessionLifecycleOptions): SessionLifecycleMetadata {
+  return {
+    engine,
+    execution: detached ? "background" : "foreground",
+    attached: !detached,
+    detached,
+    reattachCommand,
+  };
+}
+
+export function formatSessionLifecycleBlock(meta: SessionMetadata): string[] {
+  const lifecycle = meta.lifecycle;
+  if (!lifecycle) {
+    return [];
+  }
+  const modelCount = meta.models?.length ?? (meta.model ? 1 : 0);
+  const detachValue = lifecycle.detached
+    ? lifecycle.execution === "background"
+      ? "yes, polling"
+      : "yes"
+    : "no";
+  const lines = [
+    `Session: ${meta.id}`,
+    `Mode: ${lifecycle.engine} ${lifecycle.execution}`,
+    `Models: ${modelCount > 1 ? `${modelCount} parallel` : String(modelCount || 1)}`,
+    `Detach: ${detachValue}`,
+    `Reattach: ${lifecycle.reattachCommand}`,
+  ];
+  return lines;
+}
+
+export function formatSessionExecutionLabel(meta: SessionMetadata): string {
+  const lifecycle = meta.lifecycle;
+  if (!lifecycle) {
+    return meta.mode ?? meta.options?.mode ?? "api";
+  }
+  const engine = lifecycle.engine === "browser" ? "br" : lifecycle.engine;
+  const execution = lifecycle.execution === "background" ? "bg" : "fg";
+  return `${engine}/${execution}`;
+}

--- a/src/cli/sessionTable.ts
+++ b/src/cli/sessionTable.ts
@@ -3,6 +3,7 @@ import kleur from "kleur";
 import { MODEL_CONFIGS } from "../oracle.js";
 import type { SessionMetadata } from "../sessionStore.js";
 import { estimateUsdCost } from "tokentally";
+import { formatSessionExecutionLabel } from "./sessionLifecycle.js";
 
 const isRich = (rich?: boolean): boolean =>
   rich ?? Boolean(process.stdout.isTTY && chalk.level > 0);
@@ -35,7 +36,7 @@ export function formatSessionTableRow(
   const status = colorStatus(meta.status ?? "unknown", rich);
   const modelLabel = (meta.model ?? "n/a").padEnd(MODEL_PAD);
   const model = rich ? chalk.white(modelLabel) : modelLabel;
-  const modeLabel = (meta.mode ?? meta.options?.mode ?? "api").padEnd(MODE_PAD);
+  const modeLabel = formatSessionExecutionLabel(meta).padEnd(MODE_PAD);
   const mode = rich ? chalk.gray(modeLabel) : modeLabel;
   const timestampLabel = formatTimestampAligned(meta.createdAt).padEnd(TIMESTAMP_PAD);
   const timestamp = rich ? chalk.gray(timestampLabel) : timestampLabel;

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -243,9 +243,18 @@ export interface SessionMetadata {
   response?: SessionResponseMetadata;
   transport?: SessionTransportMetadata;
   error?: SessionUserErrorMetadata;
+  lifecycle?: SessionLifecycleMetadata;
 }
 
 export type SessionStatus = "pending" | "running" | "completed" | "partial" | "error" | "cancelled";
+
+export interface SessionLifecycleMetadata {
+  engine: "api" | "browser";
+  execution: "foreground" | "background";
+  attached: boolean;
+  detached: boolean;
+  reattachCommand: string;
+}
 
 export interface SessionModelRun {
   model: string;

--- a/tests/cli/sessionDisplay.test.ts
+++ b/tests/cli/sessionDisplay.test.ts
@@ -210,6 +210,29 @@ describe("attachSession rendering", () => {
     readSessionRequestMock.mockReset();
   });
 
+  test("prints persisted lifecycle metadata", async () => {
+    const lifecycleMeta: SessionMetadata = {
+      ...baseMeta,
+      status: "completed",
+      lifecycle: {
+        engine: "api",
+        execution: "background",
+        attached: false,
+        detached: true,
+        reattachCommand: "oracle session sess",
+      },
+    } as SessionMetadata;
+    readSessionMetadataMock.mockResolvedValue(lifecycleMeta);
+    readSessionLogMock.mockResolvedValue("");
+    readSessionRequestMock.mockResolvedValue({ prompt: "Prompt here" });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await attachSession("sess", { renderMarkdown: false });
+
+    expect(logSpy).toHaveBeenCalledWith("Execution: api/bg (detached)");
+    expect(logSpy).toHaveBeenCalledWith("Reattach: oracle session sess");
+  });
+
   test("prints chain metadata for follow-up sessions", async () => {
     const followupMeta: SessionMetadata = {
       ...baseMeta,

--- a/tests/cli/sessionLifecycle.test.ts
+++ b/tests/cli/sessionLifecycle.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  buildSessionLifecycle,
+  formatSessionExecutionLabel,
+  formatSessionLifecycleBlock,
+} from "../../src/cli/sessionLifecycle.js";
+import type { SessionMetadata } from "../../src/sessionManager.js";
+
+describe("session lifecycle formatting", () => {
+  test("formats detached API runs with reattach guidance", () => {
+    const lifecycle = buildSessionLifecycle({
+      engine: "api",
+      detached: true,
+      reattachCommand: "oracle session sess-123",
+    });
+    const meta = {
+      id: "sess-123",
+      createdAt: "2026-05-15T00:00:00.000Z",
+      status: "running",
+      mode: "api",
+      options: {},
+      models: [
+        { model: "gpt-5.2-pro", status: "running" },
+        { model: "gemini-3-pro", status: "running" },
+      ],
+      lifecycle,
+    } as SessionMetadata;
+
+    expect(formatSessionLifecycleBlock(meta)).toEqual([
+      "Session: sess-123",
+      "Mode: api background",
+      "Models: 2 parallel",
+      "Detach: yes, polling",
+      "Reattach: oracle session sess-123",
+    ]);
+    expect(formatSessionExecutionLabel(meta)).toBe("api/bg");
+  });
+
+  test("formats attached browser runs compactly", () => {
+    const lifecycle = buildSessionLifecycle({
+      engine: "browser",
+      detached: false,
+      reattachCommand: "oracle session browser-1",
+    });
+    const meta = {
+      id: "browser-1",
+      createdAt: "2026-05-15T00:00:00.000Z",
+      status: "running",
+      mode: "browser",
+      model: "gpt-5.2-pro",
+      options: {},
+      lifecycle,
+    } as SessionMetadata;
+
+    expect(formatSessionLifecycleBlock(meta)).toContain("Mode: browser foreground");
+    expect(formatSessionLifecycleBlock(meta)).toContain("Detach: no");
+    expect(formatSessionExecutionLabel(meta)).toBe("br/fg");
+  });
+
+  test("falls back to stored mode for legacy sessions", () => {
+    const meta = {
+      id: "legacy",
+      createdAt: "2026-05-15T00:00:00.000Z",
+      status: "completed",
+      mode: "api",
+      options: {},
+    } as SessionMetadata;
+
+    expect(formatSessionLifecycleBlock(meta)).toEqual([]);
+    expect(formatSessionExecutionLabel(meta)).toBe("api");
+  });
+});


### PR DESCRIPTION
## Summary
- persist lifecycle metadata for new and restarted sessions after the detach decision is known
- print a compact start block with session id, foreground/background execution, detach state, model count, and reattach command
- show lifecycle state in `oracle session <id>` and compact `oracle status` mode labels

## Tests
- pnpm run format:check
- pnpm run lint
- ./node_modules/.bin/vitest run tests/cli/sessionLifecycle.test.ts tests/cli/sessionDisplay.test.ts tests/cli/sessionDisplay.coverage.test.ts tests/sessionStore.test.ts
- pnpm run build
- codex-review helper clean: no accepted/actionable findings reported
