### PR TITLE
feat(cli): add docs help check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - API: add `--allow-partial` / `--partial ok` for multi-model runs so advisory panels can exit 0 when at least one model succeeds, while still listing saved outputs and a JSON output manifest before failures.
 - API: classify common provider failures in multi-model summaries and metadata, including auth, expired keys, quota, rate limits, and unavailable models, with secret-safe recovery hints.
 - Sessions: print and persist a compact lifecycle block showing foreground/background execution, detach state, model count, and reattach command.
+- Docs: add `oracle docs check` / `pnpm docs:check` to catch documented flags that are missing from Commander help metadata.
 - API: add `--provider openai` / `--no-azure` to force first-party OpenAI when Azure env/config is present, add `oracle doctor --providers` and `--route` redacted route diagnostics, keep provider-qualified model IDs on OpenRouter/proxy routes instead of accidental Azure/native routes, and fail early when Azure routing lacks a deployment.
 - Browser/MCP: add opt-in ZIP formatting for bundled browser uploads with `--browser-bundle-format zip` / `browserBundleFormat: "zip"`, preserving individual file names in one ChatGPT attachment.
 

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -231,8 +231,11 @@ const isTty = process.stdout.isTTY;
 const doctorArgIndex = userCliArgs.indexOf("doctor");
 const doctorJsonRequested =
   doctorArgIndex >= 0 && userCliArgs.slice(doctorArgIndex).includes("--json");
+const docsArgIndex = userCliArgs.indexOf("docs");
+const docsCheckRequested = docsArgIndex >= 0 && userCliArgs[docsArgIndex + 1] === "check";
 const suppressIntro =
   doctorJsonRequested ||
+  docsCheckRequested ||
   (userCliArgs[0] === "bridge" &&
     (userCliArgs[1] === "codex-config" || userCliArgs[1] === "claude-config"));
 
@@ -1012,6 +1015,27 @@ program
   .action(async function (this: Command) {
     const { runProviderDoctor } = await import("../src/cli/providerDoctor.js");
     await runProviderDoctor(this.optsWithGlobals());
+  });
+
+const docsCommand = program.command("docs").description("Documentation maintenance utilities.");
+
+docsCommand
+  .command("check")
+  .description("Check documented CLI flags against Commander help metadata.")
+  .option(
+    "--docs-path <file...>",
+    "Markdown files to check (default README.md and docs/cli-reference.md).",
+  )
+  .option("--json", "Print structured JSON.", false)
+  .action(async (options: { docsPath?: string[]; json?: boolean }) => {
+    const { checkDocsFlags, printDocsCheckResult } = await import("../src/cli/docsCheck.js");
+    const result = await checkDocsFlags({ command: program, paths: options.docsPath });
+    if (options.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      printDocsCheckResult(result);
+    }
+    process.exitCode = result.issues.length > 0 ? 1 : 0;
   });
 
 program

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -83,13 +83,13 @@ oracle --render --copy -p "$TASK" --file "$RELEVANT_FILES"
 
 …then the agent (or a human) pastes into whichever Pro model they have access to. No keys, no MCP, works everywhere.
 
-For autonomous use, the `--json` envelope is stable:
+For autonomous dry-runs, use the JSON preview to inspect the resolved bundle before spending model time:
 
 ```bash
-oracle --json --model gpt-5.5-pro -p "$TASK" --file "$RELEVANT_FILES"
+oracle --dry-run json --model gpt-5.5-pro -p "$TASK" --file "$RELEVANT_FILES"
 ```
 
-`stdout` carries one JSON object with `answer`, `usage`, `cost`, `sessionId`, `model`, and `lineage`. `stderr` carries human-readable progress that pipes can drop. Exit code is non-zero on failure.
+Completed runs persist answers, usage, cost, session ids, model choices, and lineage under `~/.oracle/sessions/<id>/`. Exit code is non-zero on failure.
 
 ## Multi-agent shared profile (browser mode)
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -13,6 +13,7 @@ This is the curated cheatsheet. The authoritative source is always `oracle --hel
 | `oracle status`                | List recent sessions (see [Sessions](sessions.md)).                |
 | `oracle session <id>`          | Replay or block on a stored session.                               |
 | `oracle restart <id>`          | Re-run with the same prompt + files.                               |
+| `oracle docs check`            | Check documented flags against CLI help metadata.                  |
 | `oracle serve`                 | Run the remote browser host (see [Browser Mode](browser-mode.md)). |
 | `oracle bridge claude-config`  | Emit a `.mcp.json` for Claude Code (see [MCP](mcp.md)).            |
 | `oracle tui`                   | Interactive TUI (humans only).                                     |
@@ -30,7 +31,6 @@ This is the curated cheatsheet. The authoritative source is always `oracle --hel
 | `--slug <name>`                   | Stable session slug.                                                                             |
 | `--render`                        | Print the assembled bundle to stdout.                                                            |
 | `--copy`                          | Copy the bundle to the clipboard.                                                                |
-| `--json`                          | Emit a stable JSON envelope on stdout.                                                           |
 | `--write-output <path>`           | Save the final answer to a file; multi-model runs add per-model files plus `<stem>.oracle.json`. |
 | `--files-report`                  | Print per-file token usage.                                                                      |
 | `--dry-run [summary\|json\|full]` | Preview without sending.                                                                         |

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ oracle session <id> --render
 oracle --followup <id> -p "Re-evaluate with this new context" --file "src/**/*.ts"
 ```
 
-`--json` produces a stable envelope on stdout, `--render` emits the assembled markdown, and progress goes to stderr so pipes stay parseable.
+`--render` emits the assembled markdown, sessions persist machine-readable metadata, and progress stays out of saved answers so pipes remain usable.
 
 ## What Oracle does
 

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -23,7 +23,6 @@ Override the root with `ORACLE_HOME_DIR=/some/path`.
 ```bash
 oracle status                  # last 20 sessions
 oracle status --hours 168      # last week
-oracle status --json           # for scripts
 ```
 
 `status` shows status, model, mode, timestamp, character count, cost, and slug — with a tree of `--followup` lineage:
@@ -42,7 +41,6 @@ pending   gpt-5.2-pro   api     03/01 09:25 AM       900        -  └─ risk-c
 ```bash
 oracle session <id>            # print metadata + answer
 oracle session <id> --render   # print the prompt that was sent
-oracle session <id> --json     # structured output
 ```
 
 Use the slug or a unique id prefix; Oracle resolves both.
@@ -121,7 +119,6 @@ GPT-5.x Pro defaults to background; non-Pro models block by default. Override pe
 
 ```bash
 oracle status --clear --hours 168   # delete sessions older than a week
-oracle status --clear --slug pattern   # delete by slug match
 ```
 
 `--clear` is destructive — preview without it first. Sessions are local files, so `rm -rf ~/.oracle/sessions/<id>` works too.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -9,7 +9,7 @@ This page captures the design constraints. The README and the rest of the docs d
 
 1. **One CLI to every Pro model.** Same flags, same session store, same bundling rules whether the answer comes from GPT-5.5 Pro, Gemini 3 Pro, or Claude Opus.
 2. **Runs on every box.** macOS first, Linux and Windows supported. Browser mode optional.
-3. **Stable output.** `--json` is contracted; `--render` is contracted; stderr is for humans.
+3. **Stable artifacts.** `--render` is contracted; session metadata stays machine-readable; stderr is for humans.
 4. **Bundles, not chats.** Oracle assembles a deterministic prompt+files bundle and ships it once. Chat-style interactivity is the agent's job, not Oracle's.
 5. **Storage owned by the user.** Sessions are local files under `~/.oracle/sessions/` (override with `ORACLE_HOME_DIR`). No cloud account, no telemetry.
 6. **Built for agents.** Coding agents (Claude Code, Codex, Cursor) and any MCP host should be able to call Oracle without friction.
@@ -55,10 +55,10 @@ Browser engine handles ChatGPT (GPT-\* models) and Gemini (Gemini-\*); everythin
 
 ## Compatibility commitments
 
-- `--json` envelope schema is stable across minor releases. Keys may be added; existing keys won't change shape without a major bump.
+- Session metadata schema is stable across minor releases. Keys may be added; existing keys won't change shape without a major bump.
 - Session folder layout (`meta.json` / `prompt.md` / `response.md` / `log.jsonl` / `artifacts/`) is stable.
 - Top-level commands (`status`, `session`, `restart`, `serve`, `bridge`, `tui`) are stable.
-- Flag names are stable; deprecated flags get `--legacy-name still works` warnings before removal.
+- Flag names are stable; deprecated flags get compatibility warnings before removal.
 
 ## Versioning
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "main": "dist/bin/oracle-cli.js",
   "scripts": {
     "docs:list": "tsx scripts/docs-list.ts",
+    "docs:check": "node --no-deprecation --import tsx bin/oracle-cli.ts docs check",
     "docs:site": "node scripts/build-docs-site.mjs",
     "build": "tsgo -p tsconfig.build.json && pnpm run build:vendor",
     "build:vendor": "node -e \"const fs=require('fs'); const path=require('path'); const vendorRoot=path.join('dist','vendor'); fs.rmSync(vendorRoot,{recursive:true,force:true}); const vendors=[['oracle-notifier']]; vendors.forEach(([name])=>{const src=path.join('vendor',name); const dest=path.join(vendorRoot,name); fs.mkdirSync(dest,{recursive:true}); if(fs.existsSync(src)){fs.cpSync(src,dest,{recursive:true,force:true});}});\"",

--- a/src/cli/docsCheck.ts
+++ b/src/cli/docsCheck.ts
@@ -1,0 +1,234 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { Command } from "commander";
+
+export interface DocsCheckIssue {
+  file: string;
+  flag: string;
+  section?: string;
+  command?: string;
+}
+
+export interface DocsCheckResult {
+  checkedFiles: string[];
+  checkedFlags: string[];
+  issues: DocsCheckIssue[];
+}
+
+const DEFAULT_DOC_PATHS = [
+  "README.md",
+  "docs/index.md",
+  "docs/agents.md",
+  "docs/sessions.md",
+  "docs/spec.md",
+  "docs/cli-reference.md",
+];
+const FLAG_RE = /(^|[\s`([{|,])(--[a-z][a-z0-9-]*)(?=$|[\s`)[\].,;:|=<>}])/g;
+const SLASH_FLAG_RE = /--[a-z][a-z0-9-]*(?:\/(?:--[a-z][a-z0-9-]*|-[a-z][a-z0-9-]*))+/g;
+const ROOT_ONLY_SECTIONS = new Set(["Core consult flags"]);
+
+export async function checkDocsFlags({
+  command,
+  cwd = process.cwd(),
+  paths,
+}: {
+  command: Command;
+  cwd?: string;
+  paths?: string[];
+}): Promise<DocsCheckResult> {
+  const availableFlags = collectCommanderFlags(command);
+  const rootFlags = collectCommanderFlags(command, { recursive: false });
+  const commandFlags = collectCommandFlags(command);
+  const docPaths = await resolveDocPaths(cwd, paths);
+  const issues: DocsCheckIssue[] = [];
+  const checkedFlags = new Set<string>();
+
+  for (const docPath of docPaths) {
+    const body = await fs.readFile(path.resolve(cwd, docPath), "utf8");
+    for (const reference of extractMarkdownFlagReferences(body)) {
+      const { command: commandPath, flag, section } = reference;
+      checkedFlags.add(flag);
+      const scopedFlags = commandPath
+        ? (commandFlags.get(commandPath) ?? availableFlags)
+        : section && ROOT_ONLY_SECTIONS.has(section)
+          ? rootFlags
+          : availableFlags;
+      if (!scopedFlags.has(flag)) {
+        issues.push({ file: docPath, flag, section, command: commandPath });
+      }
+    }
+  }
+
+  return {
+    checkedFiles: docPaths,
+    checkedFlags: [...checkedFlags].sort(),
+    issues: issues.sort((a, b) => a.file.localeCompare(b.file) || a.flag.localeCompare(b.flag)),
+  };
+}
+
+export function printDocsCheckResult(result: DocsCheckResult, log = console.log): void {
+  if (result.issues.length === 0) {
+    log(
+      `Docs/help check: ok (${result.checkedFlags.length} flags, ${result.checkedFiles.length} files)`,
+    );
+    return;
+  }
+  log("Docs/help drift:");
+  for (const issue of result.issues) {
+    const scopes = [issue.section, issue.command].filter(Boolean);
+    const scope = scopes.length > 0 ? ` (${scopes.join(", ")})` : "";
+    log(
+      `- ${issue.file}${scope} mentions ${issue.flag}, but CLI help does not expose ${issue.flag}`,
+    );
+  }
+}
+
+export function collectCommanderFlags(
+  command: Command,
+  options?: { recursive?: boolean },
+): Set<string> {
+  const flags = new Set<string>(["--help", "--version"]);
+  for (const option of command.options) {
+    for (const flag of extractOptionFlags(option.flags)) {
+      flags.add(flag);
+    }
+  }
+  if (options?.recursive === false) {
+    return flags;
+  }
+  for (const subcommand of command.commands) {
+    for (const flag of collectCommanderFlags(subcommand)) {
+      flags.add(flag);
+    }
+  }
+  return flags;
+}
+
+function collectCommandFlags(command: Command, pathParts = ["oracle"]): Map<string, Set<string>> {
+  const flags = new Map<string, Set<string>>();
+  flags.set(pathParts.join(" "), collectCommanderFlags(command, { recursive: false }));
+  for (const subcommand of command.commands) {
+    for (const [path, subcommandFlags] of collectCommandFlags(subcommand, [
+      ...pathParts,
+      subcommand.name(),
+    ])) {
+      flags.set(path, subcommandFlags);
+    }
+  }
+  return flags;
+}
+
+export function extractMarkdownFlags(markdown: string): string[] {
+  return [
+    ...new Set(extractMarkdownFlagReferences(markdown).map((reference) => reference.flag)),
+  ].sort();
+}
+
+interface MarkdownFlagReference {
+  flag: string;
+  section?: string;
+  command?: string;
+}
+
+function extractMarkdownFlagReferences(markdown: string): MarkdownFlagReference[] {
+  const references: MarkdownFlagReference[] = [];
+  let section: string | undefined;
+  for (const line of markdown.split(/\r?\n/)) {
+    const heading = line.match(/^##+\s+(.+?)\s*$/);
+    if (heading) {
+      section = heading[1];
+    }
+    const commandPath = extractOracleCommandPath(line);
+    const lineFlags = new Set<string>();
+    for (const match of line.matchAll(FLAG_RE)) {
+      const flag = match[2];
+      if (!flag || flag.endsWith("-")) {
+        continue;
+      }
+      lineFlags.add(flag);
+    }
+    for (const flag of expandSlashFlagReferences(line)) {
+      lineFlags.add(flag);
+    }
+    for (const flag of lineFlags) {
+      references.push({ flag, section, command: commandPath });
+    }
+  }
+  return references.sort(
+    (a, b) => a.flag.localeCompare(b.flag) || (a.section ?? "").localeCompare(b.section ?? ""),
+  );
+}
+
+function extractOracleCommandPath(line: string): string | undefined {
+  const trimmed = line.trim().replace(/^[$>]\s+/, "");
+  if (!trimmed.startsWith("oracle ") && !trimmed.startsWith("npx ")) {
+    return undefined;
+  }
+  const tokens = trimmed.split(/\s+/);
+  let oracleIndex = tokens[0] === "oracle" ? 0 : -1;
+  if (oracleIndex === -1) {
+    oracleIndex = tokens.findIndex((token) => token === "@steipete/oracle");
+  }
+  if (oracleIndex === -1) {
+    return undefined;
+  }
+  const pathParts = ["oracle"];
+  for (const token of tokens.slice(oracleIndex + 1)) {
+    if (token.startsWith("-") || !/^[a-z][a-z0-9-]*$/.test(token)) {
+      break;
+    }
+    pathParts.push(token);
+  }
+  return pathParts.join(" ");
+}
+
+function extractOptionFlags(flagsText: string): string[] {
+  const flags = new Set<string>();
+  for (const match of flagsText.matchAll(/--\[no-\]([a-z][a-z0-9-]*)/g)) {
+    flags.add(`--${match[1]}`);
+    flags.add(`--no-${match[1]}`);
+  }
+  for (const match of flagsText.matchAll(/--[a-z][a-z0-9-]*/g)) {
+    flags.add(match[0]);
+  }
+  return [...flags];
+}
+
+function expandSlashFlagReferences(line: string): string[] {
+  const flags: string[] = [];
+  for (const match of line.matchAll(SLASH_FLAG_RE)) {
+    const parts = match[0].split("/");
+    const base = parts[0];
+    const basePrefix = base.slice(0, base.lastIndexOf("-") + 1);
+    flags.push(base);
+    for (const part of parts.slice(1)) {
+      if (part.startsWith("--")) {
+        flags.push(part);
+      } else if (part.startsWith("-") && basePrefix) {
+        flags.push(`${basePrefix}${part.slice(1)}`);
+      }
+    }
+  }
+  return flags;
+}
+
+async function resolveDocPaths(cwd: string, paths?: string[]): Promise<string[]> {
+  const candidates = paths && paths.length > 0 ? paths : DEFAULT_DOC_PATHS;
+  const existing: string[] = [];
+  for (const candidate of candidates) {
+    try {
+      const stat = await fs.stat(path.resolve(cwd, candidate));
+      if (stat.isFile()) {
+        existing.push(candidate);
+      }
+    } catch {
+      if (paths && paths.length > 0) {
+        throw new Error(`Docs check path not found: ${candidate}`);
+      }
+    }
+  }
+  if (existing.length === 0) {
+    throw new Error("No docs found to check. Run from the repo root or pass --docs-path <file>.");
+  }
+  return existing;
+}

--- a/tests/cli/docsCheck.test.ts
+++ b/tests/cli/docsCheck.test.ts
@@ -1,0 +1,130 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { Command } from "commander";
+import { describe, expect, test } from "vitest";
+
+import {
+  checkDocsFlags,
+  collectCommanderFlags,
+  extractMarkdownFlags,
+} from "../../src/cli/docsCheck.js";
+
+const execFileAsync = promisify(execFile);
+const CLI_ENTRY = path.join(process.cwd(), "bin", "oracle-cli.ts");
+const CLI_TIMEOUT = 15_000;
+
+describe("docs check", () => {
+  test("extracts documented flags without prefix fragments", () => {
+    expect(
+      extractMarkdownFlags(
+        "Use `--no-azure`, `--http-timeout <ms>`, --browser-inline-cookies[(-file)], --remote-host/--remote-token, --browser-auto-reattach-delay/-interval/-timeout, and --browser-auto-reattach-*",
+      ),
+    ).toEqual([
+      "--browser-auto-reattach-delay",
+      "--browser-auto-reattach-interval",
+      "--browser-auto-reattach-timeout",
+      "--browser-inline-cookies",
+      "--http-timeout",
+      "--no-azure",
+      "--remote-host",
+      "--remote-token",
+    ]);
+  });
+
+  test("collects root and subcommand flags from Commander", () => {
+    const program = new Command();
+    program.option("--no-azure");
+    program.option("--[no-]background");
+    program.command("session").option("--render");
+
+    expect(collectCommanderFlags(program)).toEqual(
+      new Set(["--help", "--version", "--no-azure", "--background", "--no-background", "--render"]),
+    );
+  });
+
+  test("reports documented flags missing from CLI metadata", async () => {
+    const tmp = await mkdtemp(path.join(os.tmpdir(), "oracle-docs-check-"));
+    await writeFile(
+      path.join(tmp, "flags.md"),
+      "Documented: `--known` and `--stale-flag`.",
+      "utf8",
+    );
+    const program = new Command();
+    program.option("--known");
+
+    const result = await checkDocsFlags({
+      command: program,
+      cwd: tmp,
+      paths: ["flags.md"],
+    });
+
+    expect(result.issues).toEqual([{ file: "flags.md", flag: "--stale-flag" }]);
+  });
+
+  test("checks Core consult flags against root options, not unrelated subcommands", async () => {
+    const tmp = await mkdtemp(path.join(os.tmpdir(), "oracle-docs-check-"));
+    await writeFile(path.join(tmp, "flags.md"), "## Core consult flags\n`--json`\n", "utf8");
+    const program = new Command();
+    program.command("doctor").option("--json");
+
+    const result = await checkDocsFlags({
+      command: program,
+      cwd: tmp,
+      paths: ["flags.md"],
+    });
+
+    expect(result.issues).toEqual([
+      { file: "flags.md", flag: "--json", section: "Core consult flags" },
+    ]);
+  });
+
+  test("checks command examples against that command's options", async () => {
+    const tmp = await mkdtemp(path.join(os.tmpdir(), "oracle-docs-check-"));
+    await writeFile(path.join(tmp, "flags.md"), "```bash\noracle status --json\n```\n", "utf8");
+    const program = new Command();
+    program.command("doctor").option("--json");
+    program.command("status").option("--hours <hours>");
+
+    const result = await checkDocsFlags({
+      command: program,
+      cwd: tmp,
+      paths: ["flags.md"],
+    });
+
+    expect(result.issues).toEqual([{ file: "flags.md", flag: "--json", command: "oracle status" }]);
+  });
+
+  test(
+    "honors custom docs path from the CLI",
+    async () => {
+      const tmp = await mkdtemp(path.join(os.tmpdir(), "oracle-docs-check-"));
+      const missing = path.join(tmp, "missing.md");
+
+      await expect(
+        execFileAsync(
+          process.execPath,
+          [
+            "--no-deprecation",
+            "--import",
+            "tsx",
+            CLI_ENTRY,
+            "docs",
+            "check",
+            "--docs-path",
+            missing,
+          ],
+          { timeout: CLI_TIMEOUT },
+        ),
+      ).rejects.toMatchObject({
+        code: 1,
+        stderr: expect.stringContaining(`Docs check path not found: ${missing}`),
+      });
+
+      await rm(tmp, { recursive: true, force: true });
+    },
+    CLI_TIMEOUT,
+  );
+});


### PR DESCRIPTION
## Summary
- add `oracle docs check` and `pnpm docs:check` to compare documented flags with Commander metadata
- scan the core shipped docs by default, with command-aware checks for examples like `oracle status --flag`
- remove stale root/status/session `--json` docs and keep docs-check JSON output banner-free

## Tests
- pnpm run format:check
- pnpm docs:check
- ./node_modules/.bin/vitest run tests/cli/docsCheck.test.ts
- pnpm run lint
- pnpm run build
- node dist/bin/oracle-cli.js docs check
- node dist/bin/oracle-cli.js --verbose docs check --json
- node dist/bin/oracle-cli.js docs check --docs-path /tmp/oracle-docs-check-missing.md
- codex-review helper clean: no accepted/actionable findings reported
