### PR TITLE
fix(browser): fail closed on unverified Pro Extended effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Browser: fail closed when GPT-5.5 Pro Extended effort cannot be confirmed instead of silently submitting with the wrong or default effort.
 - Release: write clean checksum files from `scripts/release.sh artifacts` without helper trace lines.
 
 ## 0.12.0 — 2026-05-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixed
 
-- Browser: fail closed when GPT-5.5 Pro Extended effort cannot be confirmed instead of silently submitting with the wrong or default effort.
+- Browser: fail closed when GPT-5.5 Pro Extended effort cannot be confirmed instead of silently submitting with the wrong or default effort. Thanks @pdurlej!
 - Release: write clean checksum files from `scripts/release.sh artifacts` without helper trace lines.
 
 ## 0.12.0 — 2026-05-15

--- a/src/browser/actions/modelSelection.ts
+++ b/src/browser/actions/modelSelection.ts
@@ -262,7 +262,9 @@ function buildModelSelectionExpression(
       const resolved = label || '';
       if (!wantsPro || !hasProComposerPill()) return resolved;
       const normalized = normalizeText(resolved);
-      if (!normalized || normalized.includes('pro')) return resolved;
+      if (!normalized) return resolved;
+      if (normalized.includes('thinking')) return 'Pro';
+      if (normalized.includes('pro')) return resolved;
       return resolved + ' + Pro';
     };
     const getResolvedLabel = (fallback) =>
@@ -278,7 +280,15 @@ function buildModelSelectionExpression(
       const normalizedLabel = normalizeText(getButtonLabel());
       if (!normalizedLabel) return false;
       if (isTargetGpt55VisibleAlias(normalizedLabel)) return true;
-      if (wantsPro && normalizedLabel === 'chatgpt' && hasProComposerPill()) {
+      if (
+        wantsPro &&
+        hasProComposerPill() &&
+        (normalizedLabel === 'chatgpt' ||
+          normalizedLabel === 'extended' ||
+          normalizedLabel === 'standard' ||
+          normalizedLabel === 'heavy' ||
+          normalizedLabel === 'light')
+      ) {
         return true;
       }
       if (desiredVersion) {

--- a/src/browser/actions/modelSelection.ts
+++ b/src/browser/actions/modelSelection.ts
@@ -90,7 +90,7 @@ function assertResolvedModelSelection(desiredModel: string, resolvedLabel: strin
   if (
     !hasCurrentProSignal(resolved) ||
     hasLegacyProVersionLabel(resolved) ||
-    (resolved.includes("thinking") && !resolved.includes("pro"))
+    resolved.includes("thinking")
   ) {
     throw new Error(
       `Model picker selected "${resolvedLabel}" while "${desiredModel}" requires GPT-5.5 Pro. Use model "gpt-5.5" with browser thinking time for the Thinking variant.`,
@@ -106,14 +106,7 @@ function normalizeResolvedModelLabel(value: string): string {
 }
 
 function hasCurrentProSignal(resolved: string): boolean {
-  return (
-    resolved.includes(" pro") ||
-    resolved.endsWith("pro") ||
-    resolved.includes("pro ") ||
-    resolved.includes("extended") ||
-    resolved.includes("gpt-5.5-pro") ||
-    resolved.includes("gpt 5 5 pro")
-  );
+  return normalizeResolvedModelLabel(resolved).split(" ").includes("pro");
 }
 
 function hasLegacyProVersionLabel(resolved: string): boolean {
@@ -177,6 +170,7 @@ function buildModelSelectionExpression(
         .replace(/\\s+/g, ' ')
         .trim();
     };
+    const hasToken = (value, token) => normalizeText(value).split(' ').includes(token);
     // Normalize every candidate token to keep fuzzy matching deterministic.
     const normalizedTarget = normalizeText(PRIMARY_LABEL);
     const normalizedTokens = Array.from(new Set([normalizedTarget, ...LABEL_TOKENS]))
@@ -222,7 +216,17 @@ function buildModelSelectionExpression(
       return false;
     };
     const hasProComposerPill = () => Boolean(
-      document.querySelector('button.__composer-pill, button[aria-label="Pro, click to remove"]')
+      Array.from(document.querySelectorAll('button.__composer-pill, button[aria-label]'))
+        .filter((node) => {
+          const label = normalizeText(node.getAttribute?.('aria-label') ?? '');
+          return node.matches?.('button.__composer-pill') || label.includes('click to remove');
+        })
+        .some((node) => {
+          const label = normalizeText(
+            (node.getAttribute?.('aria-label') ?? '') + ' ' + (node.textContent ?? '')
+          );
+          return hasToken(label, 'pro') && !hasToken(label, 'thinking');
+        })
     );
 
     const button = document.querySelector(BUTTON_SELECTOR);

--- a/src/browser/actions/thinkingTime.ts
+++ b/src/browser/actions/thinkingTime.ts
@@ -56,10 +56,7 @@ export async function ensureThinkingTime(
             ? ` for ${targetModelKind}`
             : "";
       const message = `Thinking time: ${result.status.replaceAll("-", " ")}${kindHint} (requested ${capitalizedLevel})`;
-      if (
-        strictProEffort &&
-        (result.status === "option-not-found" || result.status === "model-kind-not-found")
-      ) {
+      if (strictProEffort) {
         throw new Error(`${message}; refusing to submit without confirmed Pro Extended.`);
       }
       logger(`${message}; continuing with ChatGPT default.`);
@@ -67,6 +64,11 @@ export async function ensureThinkingTime(
     }
     default: {
       await logDomFailure(Runtime, logger, "thinking-time-unknown");
+      if (strictProEffort) {
+        throw new Error(
+          `Thinking time: unknown outcome selecting ${capitalizedLevel}; refusing to submit without confirmed Pro Extended.`,
+        );
+      }
       logger(
         `Thinking time: unknown outcome selecting ${capitalizedLevel}; continuing with ChatGPT default.`,
       );
@@ -360,19 +362,6 @@ function buildThinkingTimeExpression(
     if (!modelBtn) {
       return { status: 'chip-not-found' };
     }
-    const modelButtonLabel = normalize(
-      (modelBtn.getAttribute?.('aria-label') ?? '') + ' ' + (modelBtn.textContent ?? '')
-    );
-    if (
-      TARGET_MODEL_KIND === 'pro' &&
-      TARGET_LEVEL === 'extended' &&
-      hasToken(modelButtonLabel, 'pro') &&
-      hasToken(modelButtonLabel, 'extended') &&
-      !hasToken(modelButtonLabel, 'thinking')
-    ) {
-      return { status: 'already-selected', label: modelBtn.textContent?.trim?.() || null };
-    }
-
     // Open model menu (idempotent — leaves it open if already open).
     if (modelBtn.getAttribute('aria-expanded') !== 'true') {
       dispatchClickSequence(modelBtn);

--- a/src/browser/actions/thinkingTime.ts
+++ b/src/browser/actions/thinkingTime.ts
@@ -13,7 +13,8 @@ type ThinkingTimeOutcome =
   | { status: "switched"; label?: string | null }
   | { status: "chip-not-found" }
   | { status: "menu-not-found" }
-  | { status: "option-not-found" };
+  | { status: "option-not-found" }
+  | { status: "model-kind-not-found"; modelKind?: string | null };
 
 /**
  * Selects a specific thinking time level in ChatGPT's composer.
@@ -29,9 +30,12 @@ export async function ensureThinkingTime(
   Runtime: ChromeClient["Runtime"],
   level: ThinkingTimeLevel,
   logger: BrowserLogger,
+  desiredModel?: string | null,
 ) {
-  const result = await evaluateThinkingTimeSelection(Runtime, level);
+  const result = await evaluateThinkingTimeSelection(Runtime, level, desiredModel);
   const capitalizedLevel = level.charAt(0).toUpperCase() + level.slice(1);
+  const targetModelKind = inferThinkingTargetModelKind(desiredModel);
+  const strictProEffort = targetModelKind === "pro" && level === "extended";
 
   switch (result?.status) {
     case "already-selected":
@@ -42,11 +46,23 @@ export async function ensureThinkingTime(
       return;
     case "chip-not-found":
     case "menu-not-found":
-    case "option-not-found": {
+    case "option-not-found":
+    case "model-kind-not-found": {
       await logDomFailure(Runtime, logger, `thinking-${result.status}`);
-      logger(
-        `Thinking time: ${result.status.replaceAll("-", " ")} (requested ${capitalizedLevel}); continuing with ChatGPT default.`,
-      );
+      const kindHint =
+        result.status === "model-kind-not-found" && result.modelKind
+          ? ` for ${result.modelKind}`
+          : targetModelKind
+            ? ` for ${targetModelKind}`
+            : "";
+      const message = `Thinking time: ${result.status.replaceAll("-", " ")}${kindHint} (requested ${capitalizedLevel})`;
+      if (
+        strictProEffort &&
+        (result.status === "option-not-found" || result.status === "model-kind-not-found")
+      ) {
+        throw new Error(`${message}; refusing to submit without confirmed Pro Extended.`);
+      }
+      logger(`${message}; continuing with ChatGPT default.`);
       return;
     }
     default: {
@@ -68,9 +84,10 @@ export async function ensureThinkingTimeIfAvailable(
   Runtime: ChromeClient["Runtime"],
   level: ThinkingTimeLevel,
   logger: BrowserLogger,
+  desiredModel?: string | null,
 ): Promise<boolean> {
   try {
-    const result = await evaluateThinkingTimeSelection(Runtime, level);
+    const result = await evaluateThinkingTimeSelection(Runtime, level, desiredModel);
     const capitalizedLevel = level.charAt(0).toUpperCase() + level.slice(1);
 
     switch (result?.status) {
@@ -83,6 +100,7 @@ export async function ensureThinkingTimeIfAvailable(
       case "chip-not-found":
       case "menu-not-found":
       case "option-not-found":
+      case "model-kind-not-found":
         if (logger.verbose) {
           logger(`Thinking time: ${result.status.replaceAll("-", " ")}; continuing with default.`);
         }
@@ -106,9 +124,10 @@ export async function ensureThinkingTimeIfAvailable(
 async function evaluateThinkingTimeSelection(
   Runtime: ChromeClient["Runtime"],
   level: ThinkingTimeLevel,
+  desiredModel?: string | null,
 ): Promise<ThinkingTimeOutcome | undefined> {
   const outcome = await Runtime.evaluate({
-    expression: buildThinkingTimeExpression(level),
+    expression: buildThinkingTimeExpression(level, desiredModel),
     awaitPromise: true,
     returnByValue: true,
   });
@@ -116,11 +135,15 @@ async function evaluateThinkingTimeSelection(
   return outcome.result?.value as ThinkingTimeOutcome | undefined;
 }
 
-function buildThinkingTimeExpression(level: ThinkingTimeLevel): string {
+function buildThinkingTimeExpression(
+  level: ThinkingTimeLevel,
+  desiredModel?: string | null,
+): string {
   const menuContainerLiteral = JSON.stringify(MENU_CONTAINER_SELECTOR);
   const menuItemLiteral = JSON.stringify(MENU_ITEM_SELECTOR);
   const modelButtonLiteral = JSON.stringify(MODEL_BUTTON_SELECTOR);
   const targetLevelLiteral = JSON.stringify(level.toLowerCase());
+  const targetModelKindLiteral = JSON.stringify(inferThinkingTargetModelKind(desiredModel));
 
   return `(async () => {
     ${buildClickDispatcher()}
@@ -129,6 +152,7 @@ function buildThinkingTimeExpression(level: ThinkingTimeLevel): string {
     const MENU_ITEM_SELECTOR = ${menuItemLiteral};
     const MODEL_BUTTON_SELECTOR = ${modelButtonLiteral};
     const TARGET_LEVEL = ${targetLevelLiteral};
+    const TARGET_MODEL_KIND = ${targetModelKindLiteral};
 
     // Bilingual matchers: English level token + observed Chinese variants.
     const LEVEL_TOKENS = {
@@ -154,6 +178,7 @@ function buildThinkingTimeExpression(level: ThinkingTimeLevel): string {
       const t = normalize(text);
       return targetTokens.some((tok) => t.includes(String(tok).toLowerCase()));
     };
+    const hasToken = (text, token) => normalize(text).split(' ').includes(token);
     const optionIsSelected = (node) => {
       if (!(node instanceof HTMLElement)) return false;
       const ariaChecked = node.getAttribute('aria-checked');
@@ -242,6 +267,7 @@ function buildThinkingTimeExpression(level: ThinkingTimeLevel): string {
 
     const findModelButton = () => document.querySelector(MODEL_BUTTON_SELECTOR);
     const findTrailingButtons = () => Array.from(document.querySelectorAll(TRAILING_SELECTOR));
+    const KIND_NOT_FOUND = { kindNotFound: true };
     const findEffortRow = (node) => {
       let current = node instanceof HTMLElement ? node.parentElement : null;
       while (current && current !== document.body) {
@@ -262,6 +288,58 @@ function buildThinkingTimeExpression(level: ThinkingTimeLevel): string {
         ),
       );
     };
+    const rowForTrailing = (trailing) =>
+      trailing.closest('[role="menuitem"], [role="menuitemradio"], [data-radix-collection-item]');
+    const rowTextForTrailing = (trailing) => {
+      const row = rowForTrailing(trailing) || findEffortRow(trailing);
+      return normalize(
+        (row?.getAttribute?.('aria-label') ?? '') + ' ' +
+        (row?.getAttribute?.('data-testid') ?? '') + ' ' +
+        (row?.textContent ?? '') + ' ' +
+        (trailing.getAttribute?.('aria-label') ?? '') + ' ' +
+        (trailing.getAttribute?.('data-testid') ?? '')
+      );
+    };
+    const testIdTextForTrailing = (trailing) => {
+      const row = rowForTrailing(trailing) || findEffortRow(trailing);
+      return normalize(
+        (row?.getAttribute?.('data-testid') ?? '') + ' ' +
+        (trailing.getAttribute?.('data-testid') ?? '')
+      );
+    };
+    const modelKindFromTrailing = (trailing) => {
+      const idText = testIdTextForTrailing(trailing);
+      if (!idText.includes('model switcher')) return null;
+      const modelPart = normalize(idText.replace(/\\bthinking effort\\b.*$/, ''));
+      if (hasToken(modelPart, 'pro')) return 'pro';
+      if (hasToken(modelPart, 'thinking')) return 'thinking';
+      if (hasToken(modelPart, 'instant')) return 'instant';
+      return null;
+    };
+    const trailingMatchesTargetModelKind = (trailing) => {
+      if (!TARGET_MODEL_KIND) return false;
+      const idKind = modelKindFromTrailing(trailing);
+      if (idKind) return idKind === TARGET_MODEL_KIND;
+      const text = rowTextForTrailing(trailing);
+      if (TARGET_MODEL_KIND === 'pro') {
+        return hasToken(text, 'pro') && !hasToken(text, 'thinking');
+      }
+      if (TARGET_MODEL_KIND === 'thinking') {
+        return hasToken(text, 'thinking') && !hasToken(text, 'pro');
+      }
+      if (TARGET_MODEL_KIND === 'instant') {
+        return hasToken(text, 'instant') && !hasToken(text, 'thinking') && !hasToken(text, 'pro');
+      }
+      return false;
+    };
+    const hasStableBox = (node) => {
+      const r = node.getBoundingClientRect?.();
+      return Boolean(r && r.width > 0 && r.height > 0 && node.getAttribute?.('aria-hidden') !== 'true');
+    };
+    const pickSingleStableTrailing = (trailings) => {
+      const visible = trailings.filter((t) => hasStableBox(t));
+      return visible.length === 1 ? visible[0] : null;
+    };
     const pickTrailingForCurrentModel = () => {
       const trailings = findTrailingButtons();
       if (trailings.length === 0) return null;
@@ -271,12 +349,28 @@ function buildThinkingTimeExpression(level: ThinkingTimeLevel): string {
         const row = findEffortRow(t);
         if (rowIsSelected(row)) return t;
       }
+      if (TARGET_MODEL_KIND) {
+        const targetTrailings = trailings.filter((t) => trailingMatchesTargetModelKind(t));
+        return pickSingleStableTrailing(targetTrailings) || KIND_NOT_FOUND;
+      }
       return null;
     };
 
     const modelBtn = findModelButton();
     if (!modelBtn) {
       return { status: 'chip-not-found' };
+    }
+    const modelButtonLabel = normalize(
+      (modelBtn.getAttribute?.('aria-label') ?? '') + ' ' + (modelBtn.textContent ?? '')
+    );
+    if (
+      TARGET_MODEL_KIND === 'pro' &&
+      TARGET_LEVEL === 'extended' &&
+      hasToken(modelButtonLabel, 'pro') &&
+      hasToken(modelButtonLabel, 'extended') &&
+      !hasToken(modelButtonLabel, 'thinking')
+    ) {
+      return { status: 'already-selected', label: modelBtn.textContent?.trim?.() || null };
     }
 
     // Open model menu (idempotent — leaves it open if already open).
@@ -295,6 +389,10 @@ function buildThinkingTimeExpression(level: ThinkingTimeLevel): string {
     if (!trailing) {
       closeOpenMenus();
       return { status: 'chip-not-found' };
+    }
+    if (trailing.kindNotFound) {
+      closeOpenMenus();
+      return { status: 'model-kind-not-found', modelKind: TARGET_MODEL_KIND };
     }
 
     dispatchClickSequence(trailing);
@@ -349,6 +447,31 @@ function buildThinkingTimeExpression(level: ThinkingTimeLevel): string {
   })()`;
 }
 
-export function buildThinkingTimeExpressionForTest(level: ThinkingTimeLevel = "extended"): string {
-  return buildThinkingTimeExpression(level);
+export function buildThinkingTimeExpressionForTest(
+  level: ThinkingTimeLevel = "extended",
+  desiredModel?: string | null,
+): string {
+  return buildThinkingTimeExpression(level, desiredModel);
+}
+
+function inferThinkingTargetModelKind(
+  desiredModel?: string | null,
+): "pro" | "thinking" | "instant" | null {
+  const normalized = (desiredModel ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!normalized) return null;
+  const tokens = normalized.split(" ");
+  if (tokens.includes("pro")) return "pro";
+  if (tokens.includes("thinking")) return "thinking";
+  if (tokens.includes("instant")) return "instant";
+  return null;
+}
+
+export function inferThinkingTargetModelKindForTest(
+  desiredModel?: string | null,
+): "pro" | "thinking" | "instant" | null {
+  return inferThinkingTargetModelKind(desiredModel);
 }

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1018,8 +1018,9 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
     // Handle thinking time selection if specified. Deep Research owns its own effort flow.
     const thinkingTime = config.thinkingTime;
     if (thinkingTime && !deepResearch) {
+      const thinkingTargetModel = modelStrategy === "select" ? config.desiredModel : null;
       await raceWithDisconnect(
-        withRetries(() => ensureThinkingTime(Runtime, thinkingTime, logger, config.desiredModel), {
+        withRetries(() => ensureThinkingTime(Runtime, thinkingTime, logger, thinkingTargetModel), {
           retries: 2,
           delayMs: 300,
           onRetry: (attempt, error) => {
@@ -1031,25 +1032,6 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
           },
         }),
       );
-      if (config.desiredModel && modelStrategy !== "ignore") {
-        modelSelectionEvidence = await raceWithDisconnect(
-          withRetries(
-            () =>
-              ensureModelSelection(Runtime, config.desiredModel as string, logger, modelStrategy),
-            {
-              retries: 2,
-              delayMs: 300,
-              onRetry: (attempt, error) => {
-                if (options.verbose) {
-                  logger(
-                    `[retry] Model picker post-thinking verification attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
-                  );
-                }
-              },
-            },
-          ),
-        );
-      }
     }
     if (deepResearch) {
       await raceWithDisconnect(
@@ -2412,8 +2394,9 @@ async function runRemoteBrowserMode(
     // Handle thinking time selection if specified. Deep Research owns its own effort flow.
     const thinkingTime = config.thinkingTime;
     if (thinkingTime && !deepResearch) {
+      const thinkingTargetModel = modelStrategy === "select" ? config.desiredModel : null;
       await withRetries(
-        () => ensureThinkingTime(Runtime, thinkingTime, logger, config.desiredModel),
+        () => ensureThinkingTime(Runtime, thinkingTime, logger, thinkingTargetModel),
         {
           retries: 2,
           delayMs: 300,
@@ -2426,22 +2409,6 @@ async function runRemoteBrowserMode(
           },
         },
       );
-      if (config.desiredModel && modelStrategy !== "ignore") {
-        modelSelectionEvidence = await withRetries(
-          () => ensureModelSelection(Runtime, config.desiredModel as string, logger, modelStrategy),
-          {
-            retries: 2,
-            delayMs: 300,
-            onRetry: (attempt, error) => {
-              if (options.verbose) {
-                logger(
-                  `[retry] Model picker post-thinking verification attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
-                );
-              }
-            },
-          },
-        );
-      }
     }
     if (deepResearch) {
       await withRetries(() => activateDeepResearch(Runtime, Input, logger), {

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1019,7 +1019,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
     const thinkingTime = config.thinkingTime;
     if (thinkingTime && !deepResearch) {
       await raceWithDisconnect(
-        withRetries(() => ensureThinkingTime(Runtime, thinkingTime, logger), {
+        withRetries(() => ensureThinkingTime(Runtime, thinkingTime, logger, config.desiredModel), {
           retries: 2,
           delayMs: 300,
           onRetry: (attempt, error) => {
@@ -1031,6 +1031,25 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
           },
         }),
       );
+      if (config.desiredModel && modelStrategy !== "ignore") {
+        modelSelectionEvidence = await raceWithDisconnect(
+          withRetries(
+            () =>
+              ensureModelSelection(Runtime, config.desiredModel as string, logger, modelStrategy),
+            {
+              retries: 2,
+              delayMs: 300,
+              onRetry: (attempt, error) => {
+                if (options.verbose) {
+                  logger(
+                    `[retry] Model picker post-thinking verification attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
+                  );
+                }
+              },
+            },
+          ),
+        );
+      }
     }
     if (deepResearch) {
       await raceWithDisconnect(
@@ -2393,17 +2412,36 @@ async function runRemoteBrowserMode(
     // Handle thinking time selection if specified. Deep Research owns its own effort flow.
     const thinkingTime = config.thinkingTime;
     if (thinkingTime && !deepResearch) {
-      await withRetries(() => ensureThinkingTime(Runtime, thinkingTime, logger), {
-        retries: 2,
-        delayMs: 300,
-        onRetry: (attempt, error) => {
-          if (options.verbose) {
-            logger(
-              `[retry] Thinking time (${thinkingTime}) attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
-            );
-          }
+      await withRetries(
+        () => ensureThinkingTime(Runtime, thinkingTime, logger, config.desiredModel),
+        {
+          retries: 2,
+          delayMs: 300,
+          onRetry: (attempt, error) => {
+            if (options.verbose) {
+              logger(
+                `[retry] Thinking time (${thinkingTime}) attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
+              );
+            }
+          },
         },
-      });
+      );
+      if (config.desiredModel && modelStrategy !== "ignore") {
+        modelSelectionEvidence = await withRetries(
+          () => ensureModelSelection(Runtime, config.desiredModel as string, logger, modelStrategy),
+          {
+            retries: 2,
+            delayMs: 300,
+            onRetry: (attempt, error) => {
+              if (options.verbose) {
+                logger(
+                  `[retry] Model picker post-thinking verification attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
+                );
+              }
+            },
+          },
+        );
+      }
     }
     if (deepResearch) {
       await withRetries(() => activateDeepResearch(Runtime, Input, logger), {

--- a/src/oracle/client.ts
+++ b/src/oracle/client.ts
@@ -4,7 +4,7 @@ import type {
   ChatCompletionChunk,
   ChatCompletionCreateParamsStreaming,
   ChatCompletionCreateParamsNonStreaming,
-} from "openai/resources/chat/completions";
+} from "openai/resources/chat";
 import path from "node:path";
 import { createRequire } from "node:module";
 import type {

--- a/tests/browser/modelSelection.test.ts
+++ b/tests/browser/modelSelection.test.ts
@@ -15,10 +15,18 @@ const evaluateImmediateModelSelectionExpression = (
   targetModel: string,
   buttonLabel: string,
   composerLabel = "",
+  proPillLabel = "",
 ): unknown => {
   const expression = buildModelSelectionExpressionForTest(targetModel);
   const modelButton = { textContent: buttonLabel };
   const composerSignal = composerLabel ? { textContent: composerLabel } : null;
+  const proPill = proPillLabel
+    ? {
+        textContent: proPillLabel,
+        getAttribute: (name: string) => (name === "aria-label" ? proPillLabel : null),
+        matches: (selector: string) => selector.includes("__composer-pill"),
+      }
+    : null;
   const documentStub = {
     querySelector: (selector: string) => {
       if (selector.includes("model-switcher-dropdown-button")) {
@@ -32,7 +40,7 @@ const evaluateImmediateModelSelectionExpression = (
       }
       return null;
     },
-    querySelectorAll: () => [],
+    querySelectorAll: () => (proPill ? [proPill] : []),
     title: "",
     body: { innerText: "" },
   };
@@ -299,9 +307,31 @@ describe("browser model selection matchers", () => {
     expect(expression).toContain("const hasProComposerPill = () =>");
     expect(expression).toContain("const withProPillSignal = (label) =>");
     expect(expression).toContain("return resolved + ' + Pro'");
+    expect(expression).toContain("if (normalized.includes('thinking')) return 'Pro'");
+    expect(expression).toContain("normalizedLabel === 'extended'");
     expect(expression).toContain("hasToken(label, 'pro') && !hasToken(label, 'thinking')");
     expect(expression).not.toContain('button[aria-label*="Pro"]');
-    expect(expression).toContain("normalizedLabel === 'chatgpt' && hasProComposerPill()");
+    expect(expression).toContain("hasProComposerPill()");
+  });
+
+  it("does not let a standalone thinking chip pollute Pro model verification", () => {
+    const result = evaluateImmediateModelSelectionExpression(
+      "gpt-5.5-pro",
+      "ChatGPT",
+      "Thinking Extended",
+      "Pro, click to remove",
+    );
+    expect(result).toEqual({ status: "already-selected", label: "Pro" });
+  });
+
+  it("accepts a Pro pill plus effort label as the current Pro model", () => {
+    const result = evaluateImmediateModelSelectionExpression(
+      "gpt-5.5-pro",
+      "Extended",
+      "",
+      "Pro, click to remove",
+    );
+    expect(result).toEqual({ status: "already-selected", label: "Extended + Pro" });
   });
 
   it("hard-rejects Thinking candidates when targeting Pro", () => {

--- a/tests/browser/modelSelection.test.ts
+++ b/tests/browser/modelSelection.test.ts
@@ -299,6 +299,8 @@ describe("browser model selection matchers", () => {
     expect(expression).toContain("const hasProComposerPill = () =>");
     expect(expression).toContain("const withProPillSignal = (label) =>");
     expect(expression).toContain("return resolved + ' + Pro'");
+    expect(expression).toContain("hasToken(label, 'pro') && !hasToken(label, 'thinking')");
+    expect(expression).not.toContain('button[aria-label*="Pro"]');
     expect(expression).toContain("normalizedLabel === 'chatgpt' && hasProComposerPill()");
   });
 
@@ -333,12 +335,22 @@ describe("browser model selection matchers", () => {
     expect(() => assertResolvedModelSelectionForTest("gpt-5.5-pro", "GPT-5.5")).toThrow(
       /requires GPT-5.5 Pro/,
     );
+    expect(() => assertResolvedModelSelectionForTest("gpt-5.5-pro", "Extended")).toThrow(
+      /requires GPT-5.5 Pro/,
+    );
+    expect(() => assertResolvedModelSelectionForTest("gpt-5.5-pro", "Thinking Extended")).toThrow(
+      /requires GPT-5.5 Pro/,
+    );
+    expect(() => assertResolvedModelSelectionForTest("gpt-5.5-pro", "Thinking Pro")).toThrow(
+      /requires GPT-5.5 Pro/,
+    );
     expect(() => assertResolvedModelSelectionForTest("gpt-5.5-pro", "ChatGPT")).toThrow(
       /requires GPT-5.5 Pro/,
     );
     // Both the new bare "Pro" label and the legacy "GPT-5.5 Pro" should pass.
     expect(() => assertResolvedModelSelectionForTest("gpt-5.5-pro", "Pro")).not.toThrow();
     expect(() => assertResolvedModelSelectionForTest("gpt-5.5-pro", "GPT-5.5 Pro")).not.toThrow();
+    expect(() => assertResolvedModelSelectionForTest("gpt-5.5-pro", "Extended Pro")).not.toThrow();
     expect(() => assertResolvedModelSelectionForTest("Pro", "Thinking 5.5 Heavy")).toThrow(
       /requires GPT-5.5 Pro/,
     );

--- a/tests/browser/thinkingTime.test.ts
+++ b/tests/browser/thinkingTime.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildThinkingTimeExpressionForTest,
+  ensureThinkingTime,
   inferThinkingTargetModelKindForTest,
 } from "../../src/browser/actions/thinkingTime.js";
 
@@ -216,5 +217,61 @@ describe("browser thinking-time selection expression", () => {
     ).resolves.toEqual({ status: "menu-not-found" });
     expect(proClicks).toBeGreaterThan(0);
     expect(thinkingClicks).toBe(0);
+  });
+
+  it("does not trust the model button label as Pro Extended effort proof", () => {
+    const expression = buildThinkingTimeExpressionForTest("extended", "gpt-5.5-pro");
+    expect(expression).not.toContain("const modelButtonLabel = normalize");
+    expect(expression).not.toContain("hasToken(modelButtonLabel, 'extended')");
+  });
+
+  it("fails closed for any unconfirmed Pro Extended effort status", async () => {
+    const statuses = [
+      "chip-not-found",
+      "menu-not-found",
+      "option-not-found",
+      "model-kind-not-found",
+      "unknown-status",
+      undefined,
+    ] as const;
+
+    for (const status of statuses) {
+      const runtime = {
+        evaluate: async () => ({
+          result: {
+            value:
+              status === undefined
+                ? undefined
+                : status === "model-kind-not-found"
+                  ? { status, modelKind: "pro" }
+                  : { status },
+          },
+        }),
+      };
+
+      await expect(
+        ensureThinkingTime(runtime as never, "extended", (() => {}) as never, "gpt-5.5-pro"),
+      ).rejects.toThrow(/refusing to submit without confirmed Pro Extended/);
+    }
+  });
+
+  it("keeps thinking effort best-effort when no target model kind is provided", async () => {
+    const runtime = {
+      evaluate: async () => ({
+        result: { value: { status: "model-kind-not-found", modelKind: null } },
+      }),
+    };
+    const logs: string[] = [];
+
+    await expect(
+      ensureThinkingTime(
+        runtime as never,
+        "extended",
+        ((message: string) => logs.push(message)) as never,
+        null,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(logs.at(-1)).toContain("continuing with ChatGPT default");
   });
 });

--- a/tests/browser/thinkingTime.test.ts
+++ b/tests/browser/thinkingTime.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildThinkingTimeExpressionForTest } from "../../src/browser/actions/thinkingTime.js";
+import {
+  buildThinkingTimeExpressionForTest,
+  inferThinkingTargetModelKindForTest,
+} from "../../src/browser/actions/thinkingTime.js";
 
 describe("browser thinking-time selection expression", () => {
   it("uses centralized menu selectors and normalized matching", () => {
@@ -38,12 +41,180 @@ describe("browser thinking-time selection expression", () => {
     expect(expression).toContain("const findEffortRow");
     expect(expression).toContain("const rowIsSelected");
     expect(expression).toContain("if (rowIsSelected(row)) return t;");
-    expect(expression).toContain("return null;");
+    expect(expression).toContain("modelKindFromTrailing");
+    expect(expression).toContain("model-kind-not-found");
   });
 
   it("preserves Chinese thinking-effort labels while normalizing", () => {
     const expression = buildThinkingTimeExpressionForTest("heavy");
     expect(expression).toContain("\\u4e00-\\u9fa5");
     expect(expression).toContain("'重度'");
+  });
+
+  it("infers target model kind with token matching", () => {
+    expect(inferThinkingTargetModelKindForTest("gpt-5.5-pro")).toBe("pro");
+    expect(inferThinkingTargetModelKindForTest("Thinking 5.5")).toBe("thinking");
+    expect(inferThinkingTargetModelKindForTest("Instant")).toBe("instant");
+    expect(inferThinkingTargetModelKindForTest("gpt-5.5")).toBeNull();
+    expect(inferThinkingTargetModelKindForTest("profile")).toBeNull();
+    expect(inferThinkingTargetModelKindForTest("prototype")).toBeNull();
+    expect(inferThinkingTargetModelKindForTest("project")).toBeNull();
+  });
+
+  it("uses current ChatGPT data-testid shape to target the Pro effort row", async () => {
+    class FakeEventTarget {
+      dispatchEvent(_event: unknown): boolean {
+        return true;
+      }
+    }
+
+    class FakeElement extends FakeEventTarget {
+      constructor(
+        public textContent: string,
+        private readonly attributes: Readonly<Record<string, string>> = {},
+        private readonly parent: FakeElement | null = null,
+        private readonly onDispatch?: () => void,
+      ) {
+        super();
+      }
+
+      get parentElement(): FakeElement | null {
+        return this.parent;
+      }
+
+      getAttribute(name: string): string | null {
+        return this.attributes[name] ?? null;
+      }
+
+      querySelector(selector: string): FakeElement | null {
+        if (selector.includes("data-model-picker-thinking-effort-menu-item")) {
+          return this.attributes["aria-checked"] ? this : null;
+        }
+        return null;
+      }
+
+      querySelectorAll(_selector: string): FakeElement[] {
+        return [];
+      }
+
+      closest(_selector: string): FakeElement | null {
+        return this.parent;
+      }
+
+      matches(_selector: string): boolean {
+        return false;
+      }
+
+      getBoundingClientRect(): { width: number; height: number } {
+        return { width: 24, height: 24 };
+      }
+
+      override dispatchEvent(event: unknown): boolean {
+        this.onDispatch?.();
+        return super.dispatchEvent(event);
+      }
+    }
+
+    class FakeMouseEvent {
+      constructor(
+        public readonly type: string,
+        public readonly init?: unknown,
+      ) {}
+    }
+
+    let proClicks = 0;
+    let thinkingClicks = 0;
+    let now = 0;
+    const modelButton = new FakeElement("Extended", {
+      "data-testid": "model-switcher-dropdown-button",
+      "aria-expanded": "true",
+    });
+    const thinkingRow = new FakeElement("", {
+      "data-model-picker-thinking-effort-row": "true",
+      "data-testid": "model-switcher-gpt-5-5-thinking-thinking-effort",
+    });
+    const thinkingTrailing = new FakeElement(
+      "",
+      {
+        "data-model-picker-thinking-effort-action": "true",
+        "data-testid": "model-switcher-gpt-5-5-thinking-thinking-effort",
+      },
+      thinkingRow,
+      () => {
+        thinkingClicks += 1;
+      },
+    );
+    const proRow = new FakeElement("", {
+      "data-model-picker-thinking-effort-row": "true",
+      "data-testid": "model-switcher-gpt-5-5-pro-thinking-effort",
+    });
+    const proTrailing = new FakeElement(
+      "",
+      {
+        "data-model-picker-thinking-effort-action": "true",
+        "data-testid": "model-switcher-gpt-5-5-pro-thinking-effort",
+      },
+      proRow,
+      () => {
+        proClicks += 1;
+      },
+    );
+    const documentStub = {
+      body: new FakeElement(""),
+      querySelector: (selector: string) =>
+        selector.includes("model-switcher-dropdown-button") ? modelButton : null,
+      querySelectorAll: (selector: string) =>
+        selector.includes("data-model-picker-thinking-effort-action")
+          ? [thinkingTrailing, proTrailing]
+          : [],
+      dispatchEvent: () => true,
+    };
+    const performanceStub = {
+      now: () => {
+        now += 500;
+        return now;
+      },
+    };
+    const expression = buildThinkingTimeExpressionForTest("extended", "gpt-5.5-pro");
+    const windowStub = {
+      PointerEvent: FakeMouseEvent,
+      MouseEvent: FakeMouseEvent,
+      Event: FakeMouseEvent,
+    };
+    const evaluate = new Function(
+      "document",
+      "performance",
+      "setTimeout",
+      "window",
+      "EventTarget",
+      "PointerEvent",
+      "MouseEvent",
+      "HTMLElement",
+      `return ${expression};`,
+    ) as (
+      document: unknown,
+      performance: unknown,
+      setTimeout: unknown,
+      window: unknown,
+      EventTarget: unknown,
+      PointerEvent: unknown,
+      MouseEvent: unknown,
+      HTMLElement: unknown,
+    ) => Promise<unknown>;
+
+    await expect(
+      evaluate(
+        documentStub,
+        performanceStub,
+        (callback: () => void) => callback(),
+        windowStub,
+        FakeEventTarget,
+        FakeMouseEvent,
+        FakeMouseEvent,
+        FakeElement,
+      ),
+    ).resolves.toEqual({ status: "menu-not-found" });
+    expect(proClicks).toBeGreaterThan(0);
+    expect(thinkingClicks).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- tighten GPT-5.5 Pro browser-mode verification so bare `Extended` / `Thinking Extended` is not accepted as Pro
- pass the desired browser model into thinking-effort selection and fail closed when Pro Extended cannot be confirmed
- add a post-effort model verification pass, plus tests for current ChatGPT `gpt-5-5-pro-thinking-effort` DOM shape

## Context
This is a follow-up hardening patch on top of #196. That PR correctly targets the currently selected model row when choosing thinking effort. This patch keeps that behavior, then adds stricter verification so `--model gpt-5.5-pro` cannot silently submit with the wrong or unverified effort state.

The motivating failure was a browser run invoked with `--model gpt-5.5-pro` and resolved config `desiredModel=Pro`, `thinkingTime=extended`, while the ChatGPT UI evidence showed the answer came from `Thinking • Extended`. The current UI also uses IDs like `model-switcher-gpt-5-5-pro-thinking-effort`, where `thinking-effort` is the control name rather than the model kind; the new test covers that exact shape.

## Validation
- `pnpm vitest run tests/browser/modelSelection.test.ts tests/browser/thinkingTime.test.ts tests/mcp/consult.test.ts` → 40 passed
- `pnpm run check`
- `pnpm run build`
- `git diff --check`

## Live smoke
Ran from this branch's built CLI, not the local wrapper:

```sh
node ./dist/bin/oracle-cli.js \
  --engine browser \
  --model gpt-5.5-pro \
  --browser-keep-browser \
  --slug oracle-pro-extended-upstream-main-smoke \
  -p 'Smoke test for PR follow-up after #196. Return exactly CHECK_PRO_EXTENDED_FOLLOWUP_OK and one short sentence saying whether the prompt arrived.'
```

Result:

```text
[browser] Model selection evidence: requested=Pro; resolved=Extended Pro; status=already-selected; strategy=select; verified=yes.
CHECK_PRO_EXTENDED_FOLLOWUP_OK
The prompt arrived.
```
