### PR TITLE
fix(browser): fail early disconnected sessions without conversation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Browser: mark Chrome disconnects before a recoverable ChatGPT conversation as errors instead of leaving sessions running for impossible reattach. Thanks @pdurlej!
 - Release: write clean checksum files from `scripts/release.sh artifacts` without helper trace lines.
 
 ## 0.12.0 — 2026-05-15

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -28,6 +28,7 @@ export async function submitPrompt(
     attachmentNames?: string[];
     baselineTurns?: number | null;
     inputTimeoutMs?: number | null;
+    onPromptSubmitted?: () => Promise<void> | void;
   },
   prompt: string,
   logger: BrowserLogger,
@@ -217,6 +218,7 @@ export async function submitPrompt(
   } else {
     logger("Clicked send button");
   }
+  await deps.onPromptSubmitted?.();
 
   const commitTimeoutMs = Math.max(60_000, deps.inputTimeoutMs ?? 0);
   // Learned: the send button can succeed but the turn doesn't appear immediately; verify commit via turns/stop button.

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -567,6 +567,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
   const runtimeHintCb = options.runtimeHintCb;
   let lastTargetId: string | undefined;
   let lastUrl: string | undefined;
+  let promptSubmitted = false;
   let tabLease: BrowserTabLease | null = null;
   const emitRuntimeHint = async (): Promise<void> => {
     if (!chrome?.port) {
@@ -580,6 +581,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
       chromeTargetId: lastTargetId,
       tabUrl: lastUrl,
       conversationId,
+      promptSubmitted,
       userDataDir,
       controllerPid: process.pid,
     };
@@ -595,6 +597,13 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
       const message = error instanceof Error ? error.message : String(error);
       logger(`Failed to persist runtime hint: ${message}`);
     }
+  };
+  const markPromptSubmitted = async (): Promise<void> => {
+    if (promptSubmitted) {
+      return;
+    }
+    promptSubmitted = true;
+    await emitRuntimeHint();
   };
   if (config.debug || process.env.CHATGPT_DEVTOOLS_TRACE === "1") {
     logger(
@@ -1115,6 +1124,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
         inputTimeoutMs: config.inputTimeoutMs ?? undefined,
         baselineTurns: baselineTurns ?? undefined,
         attachmentNames,
+        onPromptSubmitted: markPromptSubmitted,
       };
       await runProviderSubmissionFlow(chatgptDomProvider, {
         prompt,
@@ -1123,6 +1133,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
         log: logger,
         state: providerState,
       });
+      await markPromptSubmitted();
       const providerBaselineTurns = providerState.baselineTurns;
       if (typeof providerBaselineTurns === "number" && Number.isFinite(providerBaselineTurns)) {
         baselineTurns = providerBaselineTurns;
@@ -1250,6 +1261,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
         chromeTargetId: lastTargetId,
         tabUrl: lastUrl,
         conversationId: lastUrl ? extractConversationIdFromUrl(lastUrl) : undefined,
+        promptSubmitted,
         controllerPid: process.pid,
       };
     }
@@ -1344,6 +1356,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
               chromeTargetId: lastTargetId,
               tabUrl: lastUrl,
               conversationId: lastUrl ? extractConversationIdFromUrl(lastUrl) : undefined,
+              promptSubmitted,
               controllerPid: process.pid,
             },
           },
@@ -1432,6 +1445,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
               chromeTargetId: lastTargetId,
               tabUrl: lastUrl,
               conversationId: lastUrl ? extractConversationIdFromUrl(lastUrl) : undefined,
+              promptSubmitted,
               controllerPid: process.pid,
             };
             throw new BrowserAutomationError(
@@ -1719,6 +1733,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
       chromeTargetId: lastTargetId,
       tabUrl: lastUrl,
       conversationId: lastUrl ? extractConversationIdFromUrl(lastUrl) : undefined,
+      promptSubmitted,
       controllerPid: process.pid,
     };
   } catch (error) {
@@ -1735,6 +1750,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
         userDataDir,
         chromeTargetId: lastTargetId,
         tabUrl: lastUrl,
+        promptSubmitted,
         controllerPid: process.pid,
       };
       const reuseProfileHint =
@@ -1782,6 +1798,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
           userDataDir,
           chromeTargetId: lastTargetId,
           tabUrl: lastUrl,
+          promptSubmitted,
           controllerPid: process.pid,
         },
       },
@@ -2235,6 +2252,7 @@ async function runRemoteBrowserMode(
   let remoteTargetId: string | null = null;
   let tabLease: BrowserTabLease | null = null;
   let lastUrl: string | undefined;
+  let promptSubmitted = false;
   let attachedExistingTab = false;
   let ownsTarget = true;
   const runtimeHintCb = options.runtimeHintCb;
@@ -2249,6 +2267,7 @@ async function runRemoteBrowserMode(
         chromeTargetId: remoteTargetId ?? undefined,
         tabUrl: lastUrl,
         conversationId: lastUrl ? extractConversationIdFromUrl(lastUrl) : undefined,
+        promptSubmitted,
         controllerPid: process.pid,
       });
       await tabLease?.update({
@@ -2261,6 +2280,13 @@ async function runRemoteBrowserMode(
       const message = error instanceof Error ? error.message : String(error);
       logger(`Failed to persist runtime hint: ${message}`);
     }
+  };
+  const markPromptSubmitted = async (): Promise<void> => {
+    if (promptSubmitted) {
+      return;
+    }
+    promptSubmitted = true;
+    await emitRuntimeHint();
   };
   const startedAt = Date.now();
   let answerText = "";
@@ -2458,6 +2484,7 @@ async function runRemoteBrowserMode(
         inputTimeoutMs: config.inputTimeoutMs ?? undefined,
         baselineTurns: baselineTurns ?? undefined,
         attachmentNames,
+        onPromptSubmitted: markPromptSubmitted,
       };
       await runProviderSubmissionFlow(chatgptDomProvider, {
         prompt,
@@ -2466,6 +2493,7 @@ async function runRemoteBrowserMode(
         log: logger,
         state: providerState,
       });
+      await markPromptSubmitted();
       const providerBaselineTurns = providerState.baselineTurns;
       if (typeof providerBaselineTurns === "number" && Number.isFinite(providerBaselineTurns)) {
         baselineTurns = providerBaselineTurns;
@@ -2555,6 +2583,7 @@ async function runRemoteBrowserMode(
         chromeTargetId: remoteTargetId ?? undefined,
         tabUrl: lastUrl,
         conversationId: lastUrl ? extractConversationIdFromUrl(lastUrl) : undefined,
+        promptSubmitted,
         controllerPid: process.pid,
       };
     }
@@ -2648,6 +2677,7 @@ async function runRemoteBrowserMode(
               chromeTargetId: remoteTargetId ?? undefined,
               tabUrl: lastUrl,
               conversationId: lastUrl ? extractConversationIdFromUrl(lastUrl) : undefined,
+              promptSubmitted,
               controllerPid: process.pid,
             },
           },
@@ -2744,6 +2774,7 @@ async function runRemoteBrowserMode(
               chromeTargetId: remoteTargetId ?? undefined,
               tabUrl: lastUrl,
               conversationId: lastUrl ? extractConversationIdFromUrl(lastUrl) : undefined,
+              promptSubmitted,
               controllerPid: process.pid,
             };
             throw new BrowserAutomationError(
@@ -2984,6 +3015,7 @@ async function runRemoteBrowserMode(
       chromeTargetId: remoteTargetId ?? undefined,
       tabUrl: lastUrl,
       conversationId: lastUrl ? extractConversationIdFromUrl(lastUrl) : undefined,
+      promptSubmitted,
       artifacts: savedArtifacts,
       archive,
       modelSelection: modelSelectionEvidence,
@@ -3011,6 +3043,7 @@ async function runRemoteBrowserMode(
         chromeProfileRoot,
         chromeTargetId: remoteTargetId ?? undefined,
         tabUrl: lastUrl,
+        promptSubmitted,
         controllerPid: process.pid,
       },
     });

--- a/src/browser/providers/chatgptDomProvider.ts
+++ b/src/browser/providers/chatgptDomProvider.ts
@@ -13,6 +13,7 @@ interface ChatgptDomProviderState {
   baselineTurns?: number | null;
   attachmentNames?: string[];
   committedTurns?: number | null;
+  onPromptSubmitted?: () => Promise<void> | void;
 }
 
 function requireState(ctx: ProviderDomFlowContext): ChatgptDomProviderState {
@@ -41,6 +42,7 @@ async function submitPromptViaAdapter(ctx: ProviderDomFlowContext): Promise<void
       attachmentNames: state.attachmentNames ?? [],
       baselineTurns: state.baselineTurns ?? undefined,
       inputTimeoutMs: state.inputTimeoutMs ?? undefined,
+      onPromptSubmitted: state.onPromptSubmitted,
     },
     ctx.prompt,
     state.logger,

--- a/src/browser/reattachability.ts
+++ b/src/browser/reattachability.ts
@@ -1,0 +1,25 @@
+import type { BrowserRuntimeMetadata } from "../sessionStore.js";
+
+export function hasRecoverableChatGptConversation(
+  runtime: BrowserRuntimeMetadata | null | undefined,
+): boolean {
+  if (!runtime) {
+    return false;
+  }
+  if (runtime.conversationId?.trim()) {
+    return true;
+  }
+  const tabUrl = runtime.tabUrl?.trim();
+  if (!tabUrl) {
+    return false;
+  }
+  try {
+    const url = new URL(tabUrl);
+    if (url.hostname !== "chatgpt.com") {
+      return false;
+    }
+    return /^\/c\/[^/]+/.test(url.pathname);
+  } catch {
+    return false;
+  }
+}

--- a/src/browser/reattachability.ts
+++ b/src/browser/reattachability.ts
@@ -15,10 +15,10 @@ export function hasRecoverableChatGptConversation(
   }
   try {
     const url = new URL(tabUrl);
-    if (url.hostname !== "chatgpt.com") {
+    if (url.hostname !== "chatgpt.com" && url.hostname !== "chat.openai.com") {
       return false;
     }
-    return /^\/c\/[^/]+/.test(url.pathname);
+    return /(?:^|\/)c\/[^/]+/.test(url.pathname);
   } catch {
     return false;
   }

--- a/src/browser/sessionRunner.ts
+++ b/src/browser/sessionRunner.ts
@@ -301,6 +301,7 @@ export async function runBrowserSessionExecution(
       chromeTargetId: browserResult.chromeTargetId,
       tabUrl: browserResult.tabUrl,
       conversationId: browserResult.conversationId,
+      promptSubmitted: browserResult.promptSubmitted,
       controllerPid: browserResult.controllerPid ?? process.pid,
     },
     archive: browserResult.archive,

--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -152,6 +152,7 @@ export interface BrowserRunResult {
   chromeTargetId?: string;
   tabUrl?: string;
   conversationId?: string;
+  promptSubmitted?: boolean;
   controllerPid?: number;
 }
 

--- a/src/cli/sessionDisplay.ts
+++ b/src/cli/sessionDisplay.ts
@@ -264,11 +264,18 @@ export async function attachSession(
   const completedDeepResearchPlaceholder =
     metadata.status === "completed" && deepResearchPlaceholderCapture;
   const hasRecoverableConversation = hasRecoverableChatGptConversation(runtime);
+  const hasLiveChromeFallback = Boolean(
+    (metadata.status === "running" || hasIncompleteCapture || completedDeepResearchPlaceholder) &&
+    (runtime?.chromePort || runtime?.chromeBrowserWSEndpoint || runtime?.chromeProfileRoot),
+  );
   const canReattach =
     (statusAllowsReattach || completedDeepResearchPlaceholder) &&
     metadata.mode === "browser" &&
     hasFallbackSessionInfo &&
-    hasRecoverableConversation &&
+    (hasRecoverableConversation ||
+      runtime?.promptSubmitted ||
+      hasLiveChromeFallback ||
+      completedDeepResearchPlaceholder) &&
     (hasChromeDisconnect ||
       hasIncompleteCapture ||
       completedDeepResearchPlaceholder ||

--- a/src/cli/sessionDisplay.ts
+++ b/src/cli/sessionDisplay.ts
@@ -13,6 +13,7 @@ import { sessionStore, wait } from "../sessionStore.js";
 import { formatTokenCount, formatTokenValue } from "../oracle/runUtils.js";
 import type { BrowserLogger } from "../browser/types.js";
 import { resumeBrowserSession } from "../browser/reattach.js";
+import { hasRecoverableChatGptConversation } from "../browser/reattachability.js";
 import {
   appendArtifacts,
   saveBrowserTranscriptArtifact,
@@ -262,10 +263,12 @@ export async function attachSession(
     );
   const completedDeepResearchPlaceholder =
     metadata.status === "completed" && deepResearchPlaceholderCapture;
+  const hasRecoverableConversation = hasRecoverableChatGptConversation(runtime);
   const canReattach =
     (statusAllowsReattach || completedDeepResearchPlaceholder) &&
     metadata.mode === "browser" &&
     hasFallbackSessionInfo &&
+    hasRecoverableConversation &&
     (hasChromeDisconnect ||
       hasIncompleteCapture ||
       completedDeepResearchPlaceholder ||

--- a/src/cli/sessionRunner.ts
+++ b/src/cli/sessionRunner.ts
@@ -509,7 +509,10 @@ export async function performSessionRun({
       const runtime = (userError.details as { runtime?: BrowserRuntimeMetadata } | undefined)
         ?.runtime;
       const recoverableRuntime = runtime ?? sessionMeta.browser?.runtime;
-      if (!hasRecoverableChatGptConversation(recoverableRuntime)) {
+      if (
+        !hasRecoverableChatGptConversation(recoverableRuntime) &&
+        recoverableRuntime?.promptSubmitted !== true
+      ) {
         log(
           dim(
             "Chrome disconnected before a ChatGPT conversation was created; marking session error.",
@@ -543,7 +546,7 @@ export async function performSessionRun({
             details: userError.details,
           },
         });
-        return;
+        throw error;
       }
       log(dim("Chrome disconnected before completion; keeping session running for reattach."));
       if (modelForStatus) {

--- a/src/cli/sessionRunner.ts
+++ b/src/cli/sessionRunner.ts
@@ -46,6 +46,7 @@ import { sanitizeOscProgress } from "./oscUtils.js";
 import { readFiles } from "../oracle/files.js";
 import { cwd as getCwd } from "node:process";
 import { resumeBrowserSession } from "../browser/reattach.js";
+import { hasRecoverableChatGptConversation } from "../browser/reattachability.js";
 import { estimateTokenCount } from "../browser/utils.js";
 import type { BrowserLogger } from "../browser/types.js";
 import { formatElapsed } from "../oracle/format.js";
@@ -507,6 +508,43 @@ export async function performSessionRun({
     if (connectionLost && mode === "browser") {
       const runtime = (userError.details as { runtime?: BrowserRuntimeMetadata } | undefined)
         ?.runtime;
+      const recoverableRuntime = runtime ?? sessionMeta.browser?.runtime;
+      if (!hasRecoverableChatGptConversation(recoverableRuntime)) {
+        log(
+          dim(
+            "Chrome disconnected before a ChatGPT conversation was created; marking session error.",
+          ),
+        );
+        if (modelForStatus) {
+          await sessionStore.updateModelRun(sessionMeta.id, modelForStatus, {
+            status: "error",
+            completedAt: new Date().toISOString(),
+            response: { status: "error", incompleteReason: "chrome-disconnected" },
+            error: {
+              category: userError.category,
+              message: userError.message,
+              details: userError.details,
+            },
+          });
+        }
+        await sessionStore.updateSession(sessionMeta.id, {
+          status: "error",
+          completedAt: new Date().toISOString(),
+          errorMessage: message,
+          mode,
+          browser: {
+            config: browserConfig,
+            runtime: recoverableRuntime,
+          },
+          response: { status: "error", incompleteReason: "chrome-disconnected" },
+          error: {
+            category: userError.category,
+            message: userError.message,
+            details: userError.details,
+          },
+        });
+        return;
+      }
       log(dim("Chrome disconnected before completion; keeping session running for reattach."));
       if (modelForStatus) {
         await sessionStore.updateModelRun(sessionMeta.id, modelForStatus, {

--- a/src/oracle/client.ts
+++ b/src/oracle/client.ts
@@ -4,7 +4,7 @@ import type {
   ChatCompletionChunk,
   ChatCompletionCreateParamsStreaming,
   ChatCompletionCreateParamsNonStreaming,
-} from "openai/resources/chat/completions";
+} from "openai/resources/chat";
 import path from "node:path";
 import { createRequire } from "node:module";
 import type {

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -88,6 +88,8 @@ export interface BrowserRuntimeMetadata {
   chromeTargetId?: string;
   tabUrl?: string;
   conversationId?: string;
+  /** True after Oracle has submitted the prompt to ChatGPT. */
+  promptSubmitted?: boolean;
   /** PID of the controller process that launched this browser run. Helps detect orphaned sessions. */
   controllerPid?: number;
 }

--- a/tests/browser/promptComposer.test.ts
+++ b/tests/browser/promptComposer.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from "vitest";
 import {
   __test__ as promptComposer,
   clearPromptComposer,
+  submitPrompt,
 } from "../../src/browser/actions/promptComposer.js";
 
 describe("promptComposer", () => {
@@ -123,5 +124,58 @@ describe("promptComposer", () => {
     expect(promptComposer.sendButtonTimeoutMs()).toBe(20_000);
     expect(promptComposer.sendButtonTimeoutMs([])).toBe(20_000);
     expect(promptComposer.sendButtonTimeoutMs(["oracle-attach-verify.txt"])).toBe(45_000);
+  });
+
+  test("marks prompt submitted before commit verification finishes", async () => {
+    const onPromptSubmitted = vi.fn();
+    const runtime = {
+      evaluate: vi.fn(async ({ expression }: { expression: string }) => {
+        if (expression.includes("document.readyState")) {
+          return { result: { value: { ready: true, composer: true, fileInput: false } } };
+        }
+        if (expression.includes("focused: true")) {
+          return { result: { value: { focused: true } } };
+        }
+        if (expression.includes("editorText")) {
+          return {
+            result: { value: { editorText: "hello", fallbackValue: "", activeValue: "hello" } },
+          };
+        }
+        if (expression.includes("dispatchClickSequence(button)")) {
+          return { result: { value: "clicked" } };
+        }
+        return {
+          result: {
+            value: {
+              baseline: 0,
+              turnsCount: 1,
+              userMatched: true,
+              prefixMatched: false,
+              lastMatched: true,
+              hasNewTurn: true,
+              stopVisible: true,
+              assistantVisible: false,
+              composerCleared: true,
+              inConversation: true,
+            },
+          },
+        };
+      }),
+    };
+    const input = { insertText: vi.fn(), dispatchKeyEvent: vi.fn() };
+    const logger = Object.assign(vi.fn(), { verbose: false });
+
+    await submitPrompt(
+      {
+        runtime: runtime as never,
+        input: input as never,
+        baselineTurns: 0,
+        onPromptSubmitted,
+      },
+      "hello",
+      logger as never,
+    );
+
+    expect(onPromptSubmitted).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/browser/reattach.e2e.test.ts
+++ b/tests/browser/reattach.e2e.test.ts
@@ -78,6 +78,58 @@ describe("browser reattach end-to-end (simulated)", () => {
     }
   }, 20_000);
 
+  test("does not reattach a chrome-disconnected session without a conversation URL", async () => {
+    const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-reattach-"));
+    const { setOracleHomeDirOverrideForTest } = await import("../../src/oracleHome.js");
+    setOracleHomeDirOverrideForTest(tmpHome);
+
+    try {
+      const { resumeBrowserSession } = await import("../../src/browser/reattach.js");
+      const resumeMock = vi.mocked(resumeBrowserSession);
+      resumeMock.mockResolvedValue({ answerText: "should not happen", answerMarkdown: "nope" });
+
+      const { sessionStore } = await import("../../src/sessionStore.js");
+      const { attachSession } = await import("../../src/cli/sessionDisplay.js");
+
+      await sessionStore.ensureStorage();
+      const sessionMeta = await sessionStore.createSession(
+        {
+          prompt: "Test prompt",
+          model: "gpt-5.2-pro",
+          mode: "browser",
+          browserConfig: {},
+        },
+        "/repo",
+      );
+      await sessionStore.updateSession(sessionMeta.id, {
+        status: "running",
+        startedAt: new Date().toISOString(),
+        mode: "browser",
+        browser: {
+          config: {},
+          runtime: {
+            chromePort: 51559,
+            chromeHost: "127.0.0.1",
+            chromeTargetId: "t-1",
+            tabUrl: "https://chatgpt.com/",
+          },
+        },
+        response: { status: "running", incompleteReason: "chrome-disconnected" },
+      });
+
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      await attachSession(sessionMeta.id, { suppressMetadata: true, renderPrompt: false });
+
+      logSpy.mockRestore();
+
+      expect(resumeMock).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(tmpHome, { recursive: true, force: true });
+      setOracleHomeDirOverrideForTest(null);
+    }
+  }, 20_000);
+
   test("reattaches completed Deep Research sessions that only captured a tool placeholder", async () => {
     const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-reattach-"));
     const { setOracleHomeDirOverrideForTest } = await import("../../src/oracleHome.js");

--- a/tests/browser/reattach.e2e.test.ts
+++ b/tests/browser/reattach.e2e.test.ts
@@ -78,7 +78,7 @@ describe("browser reattach end-to-end (simulated)", () => {
     }
   }, 20_000);
 
-  test("does not reattach a chrome-disconnected session without a conversation URL", async () => {
+  test("does not reattach an errored chrome-disconnected session without a conversation URL", async () => {
     const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-reattach-"));
     const { setOracleHomeDirOverrideForTest } = await import("../../src/oracleHome.js");
     setOracleHomeDirOverrideForTest(tmpHome);
@@ -102,8 +102,9 @@ describe("browser reattach end-to-end (simulated)", () => {
         "/repo",
       );
       await sessionStore.updateSession(sessionMeta.id, {
-        status: "running",
+        status: "error",
         startedAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
         mode: "browser",
         browser: {
           config: {},
@@ -112,6 +113,59 @@ describe("browser reattach end-to-end (simulated)", () => {
             chromeHost: "127.0.0.1",
             chromeTargetId: "t-1",
             tabUrl: "https://chatgpt.com/",
+          },
+        },
+        response: { status: "error", incompleteReason: "chrome-disconnected" },
+      });
+
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      await attachSession(sessionMeta.id, { suppressMetadata: true, renderPrompt: false });
+
+      logSpy.mockRestore();
+
+      expect(resumeMock).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(tmpHome, { recursive: true, force: true });
+      setOracleHomeDirOverrideForTest(null);
+    }
+  }, 20_000);
+
+  test("reattaches a live chrome-disconnected session with a stale cached URL", async () => {
+    const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-reattach-"));
+    const { setOracleHomeDirOverrideForTest } = await import("../../src/oracleHome.js");
+    setOracleHomeDirOverrideForTest(tmpHome);
+
+    try {
+      const { resumeBrowserSession } = await import("../../src/browser/reattach.js");
+      const resumeMock = vi.mocked(resumeBrowserSession);
+      resumeMock.mockResolvedValue({ answerText: "ok text", answerMarkdown: "ok markdown" });
+
+      const { sessionStore } = await import("../../src/sessionStore.js");
+      const { attachSession } = await import("../../src/cli/sessionDisplay.js");
+
+      await sessionStore.ensureStorage();
+      const sessionMeta = await sessionStore.createSession(
+        {
+          prompt: "Test prompt",
+          model: "gpt-5.2-pro",
+          mode: "browser",
+          browserConfig: {},
+        },
+        "/repo",
+      );
+      await sessionStore.updateSession(sessionMeta.id, {
+        status: "running",
+        startedAt: new Date().toISOString(),
+        mode: "browser",
+        browser: {
+          config: {},
+          runtime: {
+            chromeProfileRoot: path.join(tmpHome, "chrome-profile"),
+            chromeHost: "127.0.0.1",
+            chromeTargetId: "t-1",
+            tabUrl: "https://chatgpt.com/",
+            promptSubmitted: true,
           },
         },
         response: { status: "running", incompleteReason: "chrome-disconnected" },
@@ -123,7 +177,9 @@ describe("browser reattach end-to-end (simulated)", () => {
 
       logSpy.mockRestore();
 
-      expect(resumeMock).not.toHaveBeenCalled();
+      expect(resumeMock).toHaveBeenCalledTimes(1);
+      const updated = await sessionStore.readSession(sessionMeta.id);
+      expect(updated?.status).toBe("completed");
     } finally {
       await fs.rm(tmpHome, { recursive: true, force: true });
       setOracleHomeDirOverrideForTest(null);
@@ -191,6 +247,60 @@ describe("browser reattach end-to-end (simulated)", () => {
       expect(resumeMock).toHaveBeenCalledTimes(1);
       expect(log).toContain("Recovered report body");
       expect(log).not.toContain("Called tool");
+    } finally {
+      await fs.rm(tmpHome, { recursive: true, force: true });
+      setOracleHomeDirOverrideForTest(null);
+    }
+  }, 20_000);
+
+  test("reattaches completed Deep Research placeholders from a project URL", async () => {
+    const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-reattach-"));
+    const { setOracleHomeDirOverrideForTest } = await import("../../src/oracleHome.js");
+    setOracleHomeDirOverrideForTest(tmpHome);
+
+    try {
+      const { resumeBrowserSession } = await import("../../src/browser/reattach.js");
+      const resumeMock = vi.mocked(resumeBrowserSession);
+      resumeMock.mockResolvedValue({
+        answerText: "# Deep report\n\nRecovered report body.",
+        answerMarkdown: "# Deep report\n\nRecovered report body.",
+      });
+
+      const { sessionStore } = await import("../../src/sessionStore.js");
+      const { attachSession } = await import("../../src/cli/sessionDisplay.js");
+
+      await sessionStore.ensureStorage();
+      const sessionMeta = await sessionStore.createSession(
+        {
+          prompt: "Deep research prompt",
+          model: "gpt-5.5-pro",
+          mode: "browser",
+          browserConfig: { researchMode: "deep" },
+        },
+        "/repo",
+      );
+      await sessionStore.updateSession(sessionMeta.id, {
+        status: "completed",
+        mode: "browser",
+        usage: { inputTokens: 0, outputTokens: 3, reasoningTokens: 0, totalTokens: 3 },
+        browser: {
+          config: { researchMode: "deep" },
+          runtime: {
+            tabUrl: "https://chatgpt.com/g/g-p-demo/project",
+          },
+        },
+        response: { status: "completed" },
+      });
+      const paths = await sessionStore.getPaths(sessionMeta.id);
+      await fs.writeFile(paths.log, "Answer:\nCalled tool\n", "utf8");
+
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      await attachSession(sessionMeta.id, { suppressMetadata: true, renderPrompt: false });
+
+      logSpy.mockRestore();
+
+      expect(resumeMock).toHaveBeenCalledTimes(1);
     } finally {
       await fs.rm(tmpHome, { recursive: true, force: true });
       setOracleHomeDirOverrideForTest(null);

--- a/tests/browser/reattachability.test.ts
+++ b/tests/browser/reattachability.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest";
+import { hasRecoverableChatGptConversation } from "../../src/browser/reattachability.js";
+
+describe("hasRecoverableChatGptConversation", () => {
+  test("accepts explicit conversation ids", () => {
+    expect(hasRecoverableChatGptConversation({ conversationId: "abc" })).toBe(true);
+  });
+
+  test("accepts ChatGPT conversation URLs", () => {
+    expect(hasRecoverableChatGptConversation({ tabUrl: "https://chatgpt.com/c/abc123" })).toBe(
+      true,
+    );
+  });
+
+  test("rejects ChatGPT home and project shell URLs", () => {
+    expect(hasRecoverableChatGptConversation({ tabUrl: "https://chatgpt.com/" })).toBe(false);
+    expect(
+      hasRecoverableChatGptConversation({
+        tabUrl: "https://chatgpt.com/g/g-p-demo/project",
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects malformed or non-ChatGPT URLs", () => {
+    expect(hasRecoverableChatGptConversation({ tabUrl: "not a url" })).toBe(false);
+    expect(hasRecoverableChatGptConversation({ tabUrl: "https://example.com/c/abc" })).toBe(false);
+  });
+});

--- a/tests/browser/reattachability.test.ts
+++ b/tests/browser/reattachability.test.ts
@@ -10,6 +10,14 @@ describe("hasRecoverableChatGptConversation", () => {
     expect(hasRecoverableChatGptConversation({ tabUrl: "https://chatgpt.com/c/abc123" })).toBe(
       true,
     );
+    expect(
+      hasRecoverableChatGptConversation({
+        tabUrl: "https://chatgpt.com/g/g-p-demo/project/c/abc123",
+      }),
+    ).toBe(true);
+    expect(hasRecoverableChatGptConversation({ tabUrl: "https://chat.openai.com/c/abc123" })).toBe(
+      true,
+    );
   });
 
   test("rejects ChatGPT home and project shell URLs", () => {

--- a/tests/cli/sessionRunner.test.ts
+++ b/tests/cli/sessionRunner.test.ts
@@ -1244,6 +1244,51 @@ describe("performSessionRun", () => {
     );
   });
 
+  test("marks early browser disconnect as error before a conversation exists", async () => {
+    const automationError = new BrowserAutomationError(
+      "Chrome window closed before oracle reached the composer.",
+      {
+        stage: "connection-lost",
+        runtime: {
+          chromePort: 9222,
+          chromeHost: "127.0.0.1",
+          tabUrl: "https://chatgpt.com/",
+        },
+      },
+    );
+    vi.mocked(runBrowserSessionExecution).mockRejectedValueOnce(automationError);
+
+    await performSessionRun({
+      sessionMeta: baseSessionMeta,
+      runOptions: baseRunOptions,
+      mode: "browser",
+      browserConfig: { chromePath: null },
+      cwd: "/tmp",
+      log,
+      write,
+      version: cliVersion,
+    });
+
+    const finalUpdate = sessionStoreMock.updateSession.mock.calls.at(-1)?.[1];
+    expect(finalUpdate).toMatchObject({
+      status: "error",
+      response: { status: "error", incompleteReason: "chrome-disconnected" },
+      browser: expect.objectContaining({ runtime: expect.objectContaining({ chromePort: 9222 }) }),
+    });
+    expect(sessionStoreMock.updateModelRun).toHaveBeenCalledWith(
+      baseSessionMeta.id,
+      "gpt-5.2-pro",
+      expect.objectContaining({
+        status: "error",
+        response: { status: "error", incompleteReason: "chrome-disconnected" },
+      }),
+    );
+    const logLines = log.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(logLines).toContain(
+      "Chrome disconnected before a ChatGPT conversation was created; marking session error.",
+    );
+  });
+
   test("marks browser capture incomplete when assistant response times out", async () => {
     const automationError = new BrowserAutomationError("assistant timed out", {
       stage: "assistant-timeout",

--- a/tests/cli/sessionRunner.test.ts
+++ b/tests/cli/sessionRunner.test.ts
@@ -1258,16 +1258,18 @@ describe("performSessionRun", () => {
     );
     vi.mocked(runBrowserSessionExecution).mockRejectedValueOnce(automationError);
 
-    await performSessionRun({
-      sessionMeta: baseSessionMeta,
-      runOptions: baseRunOptions,
-      mode: "browser",
-      browserConfig: { chromePath: null },
-      cwd: "/tmp",
-      log,
-      write,
-      version: cliVersion,
-    });
+    await expect(
+      performSessionRun({
+        sessionMeta: baseSessionMeta,
+        runOptions: baseRunOptions,
+        mode: "browser",
+        browserConfig: { chromePath: null },
+        cwd: "/tmp",
+        log,
+        write,
+        version: cliVersion,
+      }),
+    ).rejects.toThrow(/Chrome window closed/);
 
     const finalUpdate = sessionStoreMock.updateSession.mock.calls.at(-1)?.[1];
     expect(finalUpdate).toMatchObject({


### PR DESCRIPTION
## Summary
- mark browser runs as failed when Chrome disconnects before ChatGPT creates a recoverable conversation
- prevent `oracle session <id>` from launching a new browser to reattach sessions whose runtime only points at `https://chatgpt.com/`
- add focused coverage for recoverable vs non-recoverable browser runtime metadata

## Why
We hit a real browser-mode failure where Chrome launched, acquired a tab slot, then disconnected before model selection/prompt send. The stored runtime had `tabUrl: https://chatgpt.com/` and no `conversationId`, so there was no ChatGPT conversation to recover. Keeping that session `running` made downstream agents think Oracle was still in-flight and `oracle session <id>` tried to reattach to a non-existent conversation.

Recoverable disconnects still behave the old way when the runtime has a ChatGPT conversation URL or conversation id.

## Test Plan
- `pnpm vitest run tests/browser/reattachability.test.ts tests/cli/sessionRunner.test.ts tests/browser/reattach.e2e.test.ts`
- `pnpm run check`
- `pnpm run build`
- `git diff --check`

## Live Smoke
- `oracle-profile-recovery-smoke` completed after local profile cleanup.
- Model evidence: `requested=Pro; resolved=Extended Pro; status=already-selected; strategy=select; verified=yes`.
- Final answer contained `CHECK_ORACLE_PROFILE_RECOVERY_OK`.
