### PR TITLE
fix(browser): tolerate renamed attachment chips before send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Browser: resolve attachment readiness from the active ChatGPT composer so uploaded files do not false-fail with `attachment-send-not-ready` when the Send button is already clickable. Thanks @enieuwy!
+- Browser: tolerate duplicate-renamed or ellipsized ChatGPT attachment chip names during pre-send readiness checks. Thanks @pdurlej!
 
 ## 0.12.1 — 2026-05-17
 

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -401,9 +401,13 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
         if (prefixCandidates.length === 0 || suffixCandidates.length === 0) return false;
         const targets = [item.name, item.stem && item.stem.length >= 4 ? item.stem : ''].filter(Boolean);
         return targets.some((target) => {
-          return (
-            prefixCandidates.some((part) => target.startsWith(part)) &&
-            suffixCandidates.some((part) => target.endsWith(part))
+          return prefixCandidates.some((prefixPart) =>
+            suffixCandidates.some((suffixPart) => {
+              const strongEnough =
+                suffixPart.length >= 2 &&
+                (prefixPart.length >= 3 || (prefixPart.length >= 2 && suffixPart.length >= 4));
+              return strongEnough && target.startsWith(prefixPart) && target.endsWith(suffixPart);
+            }),
           );
         });
       }

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -392,10 +392,16 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
         const [prefixRaw, suffixRaw] = text.split(marker);
         const prefix = normalize(prefixRaw);
         const suffix = normalize(suffixRaw);
-        const target = item.stem && item.stem.length >= 4 ? item.stem : item.name;
-        const matchesPrefix = !prefix || target.includes(prefix);
-        const matchesSuffix = !suffix || target.includes(suffix);
-        return matchesPrefix && matchesSuffix;
+        const prefixParts = prefix.split(' ').filter(Boolean);
+        const suffixParts = suffix.split(' ').filter(Boolean);
+        const prefixes = [prefix, prefixParts[prefixParts.length - 1] || ''];
+        const suffixes = [suffix, suffixParts[0] || ''];
+        const targets = [item.name, item.stem && item.stem.length >= 4 ? item.stem : ''].filter(Boolean);
+        return targets.some((target) => {
+          const matchesPrefix = prefixes.some((part) => !part || target.includes(part));
+          const matchesSuffix = suffixes.some((part) => !part || target.includes(part));
+          return matchesPrefix && matchesSuffix;
+        });
       }
       return false;
     };

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -347,16 +347,43 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
     const expected = ${namesLiteral};
     const sendSelectors = ${JSON.stringify(SEND_BUTTON_SELECTORS)};
     const normalize = (value) => String(value || '').toLowerCase().replace(/\\s+/g, ' ').trim();
+    const hasNameBoundary = (text, name) => {
+      if (!name) return false;
+      let from = 0;
+      while (from < text.length) {
+        const index = text.indexOf(name, from);
+        if (index === -1) return false;
+        const previous = text[index - 1] || '';
+        const next = text[index + name.length] || '';
+        const previousOk = !previous || !/[a-z0-9]/.test(previous);
+        const nextOk = !next || !/[a-z0-9]/.test(next);
+        if (previousOk && nextOk) return true;
+        from = index + name.length;
+      }
+      return false;
+    };
+    const hasExtensionBoundary = (text, extension) => {
+      if (!extension) return false;
+      let from = 0;
+      while (from < text.length) {
+        const index = text.indexOf(extension, from);
+        if (index === -1) return false;
+        const next = text[index + extension.length] || '';
+        if (!next || !/[a-z0-9]/.test(next)) return true;
+        from = index + extension.length;
+      }
+      return false;
+    };
     const matchesExpected = (value, item) => {
       const text = normalize(value);
       if (!text) return false;
-      if (text.includes(item.name)) return true;
+      if (hasNameBoundary(text, item.name)) return true;
       if (
         item.stem &&
         item.stem.length >= 4 &&
         item.extension &&
         text.includes(item.stem + '(') &&
-        text.includes(item.extension)
+        hasExtensionBoundary(text, item.extension)
       ) {
         return true;
       }
@@ -422,7 +449,7 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
     // Walk node + ancestors (up to grandparent) + descendants to gather every textual hint.
     // ChatGPT's current chip DOM nests the filename inside truncated child spans, so checking
     // only the node's own textContent/aria/title misses the match.
-    const collectLabelHaystack = (node) => {
+    const collectOwnLabelHaystack = (node) => {
       if (!node) return '';
       const pieces = [];
       const pushAttrs = (el) => {
@@ -439,15 +466,21 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
       };
       pushAttrs(node);
       pushText(node);
-      const parent = node.parentElement;
-      pushAttrs(parent);
-      pushText(parent);
-      const grandparent = parent?.parentElement;
-      pushAttrs(grandparent);
-      pushText(grandparent);
       return pieces.join(' ').toLowerCase();
     };
-    const match = (node, item) => matchesExpected(collectLabelHaystack(node), item);
+    const collectLabelHaystack = (node) => {
+      if (!node) return '';
+      const pieces = [collectOwnLabelHaystack(node)];
+      const push = (el) => {
+        const text = collectOwnLabelHaystack(el);
+        if (text) pieces.push(text);
+      };
+      const parent = node.parentElement;
+      push(parent);
+      const grandparent = parent?.parentElement;
+      push(grandparent);
+      return pieces.join(' ').toLowerCase();
+    };
     const attachmentRoots = Array.from(new Set([composer])).filter(Boolean);
     const collectChipNodes = () => {
       const seen = new Set();
@@ -466,10 +499,26 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
       return collected;
     };
     const chipNodes = collectChipNodes();
-
-    const chipsReady = expected.every((item) =>
-      chipNodes.some((node) => match(node, item)),
+    const chipLabels = chipNodes.map((node) => collectLabelHaystack(node));
+    const chipOwnLabels = chipNodes.map((node) => collectOwnLabelHaystack(node));
+    const chipOwnLabelsWithExtensions = chipOwnLabels.filter((label) =>
+      /\\.[a-z][a-z0-9]{0,9}(?:\\b|$)/i.test(label),
     );
+    const visibleExtensionLabelsMatchExpected = chipOwnLabelsWithExtensions.every((label) =>
+      expected.some((item) => matchesExpected(label, item)),
+    );
+
+    const chipsReady = (() => {
+      const used = new Set();
+      return expected.every((item) => {
+        const index = chipLabels.findIndex((label, candidateIndex) =>
+          !used.has(candidateIndex) && matchesExpected(label, item),
+        );
+        if (index === -1) return false;
+        used.add(index);
+        return true;
+      });
+    })();
     const inputsReady = expected.every((item) =>
       attachmentRoots.some((root) =>
         Array.from(root.querySelectorAll('input[type="file"]')).some((el) =>
@@ -502,7 +551,8 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
         removeAffordances.push(node);
       }
     }
-    const countReady = removeAffordances.length >= expected.length;
+    const countReady =
+      visibleExtensionLabelsMatchExpected && removeAffordances.length >= expected.length;
 
     return chipsReady || inputsReady || countReady;
   })()`;

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -394,13 +394,17 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
         const suffix = normalize(suffixRaw);
         const prefixParts = prefix.split(' ').filter(Boolean);
         const suffixParts = suffix.split(' ').filter(Boolean);
-        const prefixes = [prefix, prefixParts[prefixParts.length - 1] || ''];
-        const suffixes = [suffix, suffixParts[0] || ''];
+        const prefixCandidates = prefixParts.map((_, index) => prefixParts.slice(index).join(' '));
+        const suffixCandidates = suffixParts.map((_, index) =>
+          suffixParts.slice(0, suffixParts.length - index).join(' '),
+        );
+        if (prefixCandidates.length === 0 || suffixCandidates.length === 0) return false;
         const targets = [item.name, item.stem && item.stem.length >= 4 ? item.stem : ''].filter(Boolean);
         return targets.some((target) => {
-          const matchesPrefix = prefixes.some((part) => !part || target.includes(part));
-          const matchesSuffix = suffixes.some((part) => !part || target.includes(part));
-          return matchesPrefix && matchesSuffix;
+          return (
+            prefixCandidates.some((part) => target.startsWith(part)) &&
+            suffixCandidates.some((part) => target.endsWith(part))
+          );
         });
       }
       return false;
@@ -507,10 +511,16 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
     const chipNodes = collectChipNodes();
     const chipLabels = chipNodes.map((node) => collectLabelHaystack(node));
     const chipOwnLabels = chipNodes.map((node) => collectOwnLabelHaystack(node));
-    const chipOwnLabelsWithExtensions = chipOwnLabels.filter((label) =>
-      /\\.[a-z][a-z0-9]{0,9}(?:\\b|$)/i.test(label),
+    const hasEllipsisSuffix = (label) => {
+      const marker = label.includes('…') ? '…' : label.includes('...') ? '...' : '';
+      if (!marker) return false;
+      return normalize(label.split(marker)[1] || '').length > 0;
+    };
+    const chipOwnLabelsWithVisibleNames = chipOwnLabels.filter((label) =>
+      /\\.[a-z][a-z0-9]{0,9}(?:\\b|$)/i.test(label) ||
+      hasEllipsisSuffix(label),
     );
-    const visibleExtensionLabelsMatchExpected = chipOwnLabelsWithExtensions.every((label) =>
+    const visibleExtensionLabelsMatchExpected = chipOwnLabelsWithVisibleNames.every((label) =>
       expected.some((item) => matchesExpected(label, item)),
     );
 

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -334,10 +334,35 @@ async function waitForDomReady(
 }
 
 function buildAttachmentReadyExpression(attachmentNames: string[]): string {
-  const namesLiteral = JSON.stringify(attachmentNames.map((name) => name.toLowerCase()));
+  const attachmentExpectations = attachmentNames.map((name) => {
+    const normalized = name.toLowerCase().replace(/\s+/g, " ").trim();
+    return {
+      name: normalized,
+      stem: normalized.replace(/\.[a-z0-9]{1,10}$/i, ""),
+    };
+  });
+  const namesLiteral = JSON.stringify(attachmentExpectations);
   return `(() => {
-    const names = ${namesLiteral};
+    const expected = ${namesLiteral};
     const sendSelectors = ${JSON.stringify(SEND_BUTTON_SELECTORS)};
+    const normalize = (value) => String(value || '').toLowerCase().replace(/\\s+/g, ' ').trim();
+    const matchesExpected = (value, item) => {
+      const text = normalize(value);
+      if (!text) return false;
+      if (text.includes(item.name)) return true;
+      if (item.stem && item.stem.length >= 4 && text.includes(item.stem)) return true;
+      if (text.includes('…') || text.includes('...')) {
+        const marker = text.includes('…') ? '…' : '...';
+        const [prefixRaw, suffixRaw] = text.split(marker);
+        const prefix = normalize(prefixRaw);
+        const suffix = normalize(suffixRaw);
+        const target = item.stem && item.stem.length >= 4 ? item.stem : item.name;
+        const matchesPrefix = !prefix || target.includes(prefix);
+        const matchesSuffix = !suffix || target.includes(suffix);
+        return matchesPrefix && matchesSuffix;
+      }
+      return false;
+    };
     // Restrict to attachment affordances; never scan generic div/span nodes (prompt text can contain the file name).
     const attachmentSelectors = [
       '[data-testid*="chip"]',
@@ -413,7 +438,7 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
       pushText(grandparent);
       return pieces.join(' ').toLowerCase();
     };
-    const match = (node, name) => collectLabelHaystack(node).includes(name);
+    const match = (node, item) => matchesExpected(collectLabelHaystack(node), item);
     const attachmentRoots = Array.from(new Set([composer])).filter(Boolean);
     const collectChipNodes = () => {
       const seen = new Set();
@@ -433,14 +458,14 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
     };
     const chipNodes = collectChipNodes();
 
-    const chipsReady = names.every((name) =>
-      chipNodes.some((node) => match(node, name)),
+    const chipsReady = expected.every((item) =>
+      chipNodes.some((node) => match(node, item)),
     );
-    const inputsReady = names.every((name) =>
+    const inputsReady = expected.every((item) =>
       attachmentRoots.some((root) =>
         Array.from(root.querySelectorAll('input[type="file"]')).some((el) =>
           Array.from((el instanceof HTMLInputElement ? el.files : []) || []).some((file) =>
-            file?.name?.toLowerCase?.().includes(name),
+            matchesExpected(file?.name, item),
           ),
         ),
       ),
@@ -457,7 +482,7 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
       );
       return Boolean(removeSibling);
     }).length;
-    const countReady = chipNodes.length >= names.length && removeAffordanceCount >= names.length;
+    const countReady = chipNodes.length >= expected.length && removeAffordanceCount >= expected.length;
 
     return chipsReady || inputsReady || countReady;
   })()`;

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -339,6 +339,7 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
     return {
       name: normalized,
       stem: normalized.replace(/\.[a-z0-9]{1,10}$/i, ""),
+      extension: normalized.match(/(\.[a-z0-9]{1,10})$/i)?.[1] ?? "",
     };
   });
   const namesLiteral = JSON.stringify(attachmentExpectations);
@@ -350,7 +351,15 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
       const text = normalize(value);
       if (!text) return false;
       if (text.includes(item.name)) return true;
-      if (item.stem && item.stem.length >= 4 && text.includes(item.stem)) return true;
+      if (
+        item.stem &&
+        item.stem.length >= 4 &&
+        item.extension &&
+        text.includes(item.stem + '(') &&
+        text.includes(item.extension)
+      ) {
+        return true;
+      }
       if (text.includes('…') || text.includes('...')) {
         const marker = text.includes('…') ? '…' : '...';
         const [prefixRaw, suffixRaw] = text.split(marker);
@@ -472,17 +481,28 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
     );
     // Count-based fallback: if we cannot match names individually (ChatGPT may strip
     // the filename out of attribute-readable text into a deeply nested span), but we
-    // do see at least as many distinct chip-shaped nodes as attachments we uploaded,
-    // and a sibling "Remove" affordance exists per chip, trust the upload.
-    const removeAffordanceCount = chipNodes.filter((node) => {
-      const aria = (node.getAttribute?.('aria-label') ?? '').toLowerCase();
-      if (aria.includes('remove')) return true;
-      const removeSibling = node.querySelector?.(
+    // do see at least as many distinct "Remove" affordances as attachments we
+    // uploaded, trust the upload without double-counting nested chip/remove nodes.
+    const removeAffordances = [];
+    const removeSeen = new Set();
+    for (const root of attachmentRoots) {
+      for (const node of Array.from(root.querySelectorAll(
         '[aria-label*="Remove" i], [aria-label*="remove" i], button[aria-label*="Remove" i], button[aria-label*="remove" i]',
-      );
-      return Boolean(removeSibling);
-    }).length;
-    const countReady = chipNodes.length >= expected.length && removeAffordanceCount >= expected.length;
+      ))) {
+        if (!(node instanceof HTMLElement)) continue;
+        if (node.closest('textarea,[contenteditable="true"]')) continue;
+        const aria = (node.getAttribute?.('aria-label') ?? '').toLowerCase();
+        const fileSpecific = aria.includes('remove file') || aria.includes('remove attachment');
+        const attachmentOwner = node.closest(
+          '[data-testid*="chip"], [data-testid*="attachment"], [data-testid*="upload"], [data-testid*="file"]',
+        );
+        if (!fileSpecific && !attachmentOwner) continue;
+        if (removeSeen.has(node)) continue;
+        removeSeen.add(node);
+        removeAffordances.push(node);
+      }
+    }
+    const countReady = removeAffordances.length >= expected.length;
 
     return chipsReady || inputsReady || countReady;
   })()`;

--- a/tests/browser/promptComposerExpressions.test.ts
+++ b/tests/browser/promptComposerExpressions.test.ts
@@ -266,6 +266,32 @@ describe("prompt composer attachment expressions", () => {
     expect(evaluateAttachmentReadyExpression(["README.md", "README.txt"], document)).toBe(false);
   });
 
+  test("attachment ready check does not match extension prefixes in duplicate-renamed chips", () => {
+    const document = new FakeDocument([
+      new FakeElement("div", { "data-testid": "unified-composer" }, [
+        new FakeElement("div", { "data-testid": "attachment-chip" }, [
+          new FakeElement("span", {}, [], "README(1).mdx"),
+          new FakeElement("button", { "aria-label": "Remove file 1: README(1).mdx" }),
+        ]),
+      ]),
+    ]);
+
+    expect(evaluateAttachmentReadyExpression(["README.md"], document)).toBe(false);
+  });
+
+  test("attachment ready check does not match extension prefixes in visible chip names", () => {
+    const document = new FakeDocument([
+      new FakeElement("div", { "data-testid": "unified-composer" }, [
+        new FakeElement("div", { "data-testid": "attachment-chip" }, [
+          new FakeElement("span", {}, [], "README.mdx"),
+          new FakeElement("button", { "aria-label": "Remove file 1: README.mdx" }),
+        ]),
+      ]),
+    ]);
+
+    expect(evaluateAttachmentReadyExpression(["README.md"], document)).toBe(false);
+  });
+
   test("attachment ready count fallback counts remove affordances inside one wrapper", () => {
     const document = new FakeDocument([
       new FakeElement("div", { "data-testid": "unified-composer" }, [
@@ -288,6 +314,53 @@ describe("prompt composer attachment expressions", () => {
       new FakeElement("div", { "data-testid": "unified-composer" }, [
         new FakeElement("div", { "data-testid": "attachment-chip" }, [
           new FakeElement("button", { "aria-label": "Remove" }),
+        ]),
+      ]),
+    ]);
+
+    expect(evaluateAttachmentReadyExpression(["one.txt"], document)).toBe(true);
+  });
+
+  test("attachment ready count fallback allows mixed visible and hidden chip labels", () => {
+    const document = new FakeDocument([
+      new FakeElement("div", { "data-testid": "unified-composer" }, [
+        new FakeElement("div", { "data-testid": "attachment-chip" }, [
+          new FakeElement("span", {}, [], "one.txt"),
+          new FakeElement("button", { "aria-label": "Remove file 1: one.txt" }),
+        ]),
+        new FakeElement("div", { "data-testid": "attachment-chip" }, [
+          new FakeElement("button", { "aria-label": "Remove file 2" }),
+        ]),
+      ]),
+    ]);
+
+    expect(evaluateAttachmentReadyExpression(["one.txt", "two.txt"], document)).toBe(true);
+  });
+
+  test("attachment ready count fallback ignores prompt text extensions", () => {
+    const document = new FakeDocument([
+      new FakeElement("div", { "data-testid": "unified-composer" }, [
+        new FakeElement(
+          "div",
+          { id: "prompt-textarea", contenteditable: "true", role: "textbox" },
+          [],
+          "Please compare this with notes.md",
+        ),
+        new FakeElement("div", { "data-testid": "attachment-chip" }, [
+          new FakeElement("button", { "aria-label": "Remove file 1" }),
+        ]),
+      ]),
+    ]);
+
+    expect(evaluateAttachmentReadyExpression(["one.txt"], document)).toBe(true);
+  });
+
+  test("attachment ready count fallback ignores decimal size text", () => {
+    const document = new FakeDocument([
+      new FakeElement("div", { "data-testid": "unified-composer" }, [
+        new FakeElement("div", { "data-testid": "attachment-chip" }, [
+          new FakeElement("span", {}, [], "1.2 MB"),
+          new FakeElement("button", { "aria-label": "Remove file 1" }),
         ]),
       ]),
     ]);

--- a/tests/browser/promptComposerExpressions.test.ts
+++ b/tests/browser/promptComposerExpressions.test.ts
@@ -145,12 +145,12 @@ describe("prompt composer attachment expressions", () => {
     // ChatGPT can rename duplicate uploads as e.g. README(1).md; matching on the
     // expected basename stem keeps the send check aligned with the upload check.
     expect(expression).toContain("item.stem");
-    expect(expression).toContain("text.includes(item.stem)");
+    expect(expression).toContain("text.includes(item.stem + '(')");
     // Count-based fallback: when ChatGPT hides the filename entirely, accept that we
     // see at least as many chip-shaped nodes (each with a Remove affordance) as we
     // uploaded.
     expect(expression).toContain("countReady");
-    expect(expression).toContain("removeAffordanceCount");
+    expect(expression).toContain("removeAffordances");
   });
 
   test("attachment ready check stays scoped to the active composer", () => {
@@ -251,6 +251,58 @@ describe("prompt composer attachment expressions", () => {
     ]);
 
     expect(evaluateAttachmentReadyExpression(["README.md"], document)).toBe(true);
+  });
+
+  test("attachment ready check does not let one duplicate-renamed chip satisfy same-stem files", () => {
+    const document = new FakeDocument([
+      new FakeElement("div", { "data-testid": "unified-composer" }, [
+        new FakeElement("div", { "data-testid": "attachment-chip" }, [
+          new FakeElement("span", {}, [], "README(1).md"),
+          new FakeElement("button", { "aria-label": "Remove file 1: README(1).md" }),
+        ]),
+      ]),
+    ]);
+
+    expect(evaluateAttachmentReadyExpression(["README.md", "README.txt"], document)).toBe(false);
+  });
+
+  test("attachment ready count fallback counts remove affordances inside one wrapper", () => {
+    const document = new FakeDocument([
+      new FakeElement("div", { "data-testid": "unified-composer" }, [
+        new FakeElement("div", { "data-testid": "attachment-list" }, [
+          new FakeElement("div", { "data-testid": "attachment-chip" }, [
+            new FakeElement("button", { "aria-label": "Remove file 1" }),
+          ]),
+          new FakeElement("div", { "data-testid": "attachment-chip" }, [
+            new FakeElement("button", { "aria-label": "Remove file 2" }),
+          ]),
+        ]),
+      ]),
+    ]);
+
+    expect(evaluateAttachmentReadyExpression(["one.txt", "two.txt"], document)).toBe(true);
+  });
+
+  test("attachment ready count fallback accepts generic remove controls under chips", () => {
+    const document = new FakeDocument([
+      new FakeElement("div", { "data-testid": "unified-composer" }, [
+        new FakeElement("div", { "data-testid": "attachment-chip" }, [
+          new FakeElement("button", { "aria-label": "Remove" }),
+        ]),
+      ]),
+    ]);
+
+    expect(evaluateAttachmentReadyExpression(["one.txt"], document)).toBe(true);
+  });
+
+  test("attachment ready count fallback ignores unrelated remove controls", () => {
+    const document = new FakeDocument([
+      new FakeElement("div", { "data-testid": "unified-composer" }, [
+        new FakeElement("button", { "aria-label": "Remove item" }),
+      ]),
+    ]);
+
+    expect(evaluateAttachmentReadyExpression(["one.txt"], document)).toBe(false);
   });
 
   test("attachment ready check tolerates ellipsized chip names", () => {

--- a/tests/browser/promptComposerExpressions.test.ts
+++ b/tests/browser/promptComposerExpressions.test.ts
@@ -391,6 +391,19 @@ describe("prompt composer attachment expressions", () => {
     expect(evaluateAttachmentReadyExpression(["paper1_plan_v3.md"], document)).toBe(true);
   });
 
+  test("attachment ready check tolerates ellipsized chip names with extensions", () => {
+    const document = new FakeDocument([
+      new FakeElement("div", { "data-testid": "unified-composer" }, [
+        new FakeElement("div", { "data-testid": "attachment-chip" }, [
+          new FakeElement("span", {}, [], "paper1…v3.md"),
+          new FakeElement("button", { "aria-label": "Remove file 1: paper1…v3.md" }),
+        ]),
+      ]),
+    ]);
+
+    expect(evaluateAttachmentReadyExpression(["paper1_plan_v3.md"], document)).toBe(true);
+  });
+
   test("attachment ready check still rejects prompt-only filename matches", () => {
     const fileName = "oracle-diagnostic-unique-20260521.txt";
     const document = new FakeDocument([

--- a/tests/browser/promptComposerExpressions.test.ts
+++ b/tests/browser/promptComposerExpressions.test.ts
@@ -142,6 +142,10 @@ describe("prompt composer attachment expressions", () => {
     // Walks into ancestor and descendant text so filenames buried in nested spans are still found.
     expect(expression).toContain("collectLabelHaystack");
     expect(expression).toContain("parentElement");
+    // ChatGPT can rename duplicate uploads as e.g. README(1).md; matching on the
+    // expected basename stem keeps the send check aligned with the upload check.
+    expect(expression).toContain("item.stem");
+    expect(expression).toContain("text.includes(item.stem)");
     // Count-based fallback: when ChatGPT hides the filename entirely, accept that we
     // see at least as many chip-shaped nodes (each with a Remove affordance) as we
     // uploaded.
@@ -234,6 +238,32 @@ describe("prompt composer attachment expressions", () => {
     ]);
 
     expect(evaluateAttachmentReadyExpression([fileName], document)).toBe(true);
+  });
+
+  test("attachment ready check tolerates duplicate-renamed chips", () => {
+    const document = new FakeDocument([
+      new FakeElement("div", { "data-testid": "unified-composer" }, [
+        new FakeElement("div", { "data-testid": "attachment-chip" }, [
+          new FakeElement("span", {}, [], "README(1).md"),
+          new FakeElement("button", { "aria-label": "Remove file 1: README(1).md" }),
+        ]),
+      ]),
+    ]);
+
+    expect(evaluateAttachmentReadyExpression(["README.md"], document)).toBe(true);
+  });
+
+  test("attachment ready check tolerates ellipsized chip names", () => {
+    const document = new FakeDocument([
+      new FakeElement("div", { "data-testid": "unified-composer" }, [
+        new FakeElement("div", { "data-testid": "attachment-chip" }, [
+          new FakeElement("span", {}, [], "paper1…v3"),
+          new FakeElement("button", { "aria-label": "Remove file 1: paper1…v3" }),
+        ]),
+      ]),
+    ]);
+
+    expect(evaluateAttachmentReadyExpression(["paper1_plan_v3.md"], document)).toBe(true);
   });
 
   test("attachment ready check still rejects prompt-only filename matches", () => {

--- a/tests/browser/promptComposerExpressions.test.ts
+++ b/tests/browser/promptComposerExpressions.test.ts
@@ -443,6 +443,32 @@ describe("prompt composer attachment expressions", () => {
     expect(evaluateAttachmentReadyExpression(["scrapegoat.md"], document)).toBe(false);
   });
 
+  test("attachment ready check rejects ambiguous short ellipsized prefixes", () => {
+    const document = new FakeDocument([
+      new FakeElement("div", { "data-testid": "unified-composer" }, [
+        new FakeElement("div", { "data-testid": "attachment-chip" }, [
+          new FakeElement("span", {}, [], "a…md"),
+          new FakeElement("button", { "aria-label": "Remove file 1: a…md" }),
+        ]),
+      ]),
+    ]);
+
+    expect(evaluateAttachmentReadyExpression(["anything.md"], document)).toBe(false);
+  });
+
+  test("attachment ready check accepts short ellipsized prefixes with strong suffixes", () => {
+    const document = new FakeDocument([
+      new FakeElement("div", { "data-testid": "unified-composer" }, [
+        new FakeElement("div", { "data-testid": "attachment-chip" }, [
+          new FakeElement("span", {}, [], "qa…v1.md"),
+          new FakeElement("button", { "aria-label": "Remove file 1: qa…v1.md" }),
+        ]),
+      ]),
+    ]);
+
+    expect(evaluateAttachmentReadyExpression(["qa-quarterly-report-v1.md"], document)).toBe(true);
+  });
+
   test("attachment ready count fallback allows prefix-only ellipsized labels", () => {
     const document = new FakeDocument([
       new FakeElement("div", { "data-testid": "unified-composer" }, [

--- a/tests/browser/promptComposerExpressions.test.ts
+++ b/tests/browser/promptComposerExpressions.test.ts
@@ -404,6 +404,58 @@ describe("prompt composer attachment expressions", () => {
     expect(evaluateAttachmentReadyExpression(["paper1_plan_v3.md"], document)).toBe(true);
   });
 
+  test("attachment ready check tolerates ellipsized chip names with spaced prefixes", () => {
+    const document = new FakeDocument([
+      new FakeElement("div", { "data-testid": "unified-composer" }, [
+        new FakeElement("div", { "data-testid": "attachment-chip" }, [
+          new FakeElement("span", {}, [], "my paper…v3.md"),
+          new FakeElement("button", { "aria-label": "Remove file 1: my paper…v3.md" }),
+        ]),
+      ]),
+    ]);
+
+    expect(evaluateAttachmentReadyExpression(["my paper_plan_v3.md"], document)).toBe(true);
+  });
+
+  test("attachment ready check rejects ambiguous ellipsis placeholders", () => {
+    const document = new FakeDocument([
+      new FakeElement("div", { "data-testid": "unified-composer" }, [
+        new FakeElement("div", { "data-testid": "attachment-chip" }, [
+          new FakeElement("span", {}, [], "...md"),
+          new FakeElement("button", { "aria-label": "Remove file 1: ...md" }),
+        ]),
+      ]),
+    ]);
+
+    expect(evaluateAttachmentReadyExpression(["paper.md"], document)).toBe(false);
+  });
+
+  test("attachment ready check rejects unrelated ellipsized chip names", () => {
+    const document = new FakeDocument([
+      new FakeElement("div", { "data-testid": "unified-composer" }, [
+        new FakeElement("div", { "data-testid": "attachment-chip" }, [
+          new FakeElement("span", {}, [], "ape…md"),
+          new FakeElement("button", { "aria-label": "Remove file 1: ape…md" }),
+        ]),
+      ]),
+    ]);
+
+    expect(evaluateAttachmentReadyExpression(["scrapegoat.md"], document)).toBe(false);
+  });
+
+  test("attachment ready count fallback allows prefix-only ellipsized labels", () => {
+    const document = new FakeDocument([
+      new FakeElement("div", { "data-testid": "unified-composer" }, [
+        new FakeElement("div", { "data-testid": "attachment-chip" }, [
+          new FakeElement("span", {}, [], "paper1…"),
+          new FakeElement("button", { "aria-label": "Remove file 1" }),
+        ]),
+      ]),
+    ]);
+
+    expect(evaluateAttachmentReadyExpression(["paper1_plan_v3.md"], document)).toBe(true);
+  });
+
   test("attachment ready check still rejects prompt-only filename matches", () => {
     const fileName = "oracle-diagnostic-unique-20260521.txt";
     const document = new FakeDocument([


### PR DESCRIPTION
## Summary
- Fixes a browser-mode attachment send readiness false negative observed in a live Oracle/Claude Code run after #211 merged.
- ChatGPT can display uploaded duplicate filenames as `README(1).md` / `RESEARCH(1).md`, while Oracle still expects `README.md` / `RESEARCH.md`. The upload phase had already succeeded, but the pre-send readiness check kept waiting and failed with `attachment-send-not-ready`.
- Aligns the pre-send attachment check with the existing upload-completion behavior by locating the active composer from the prompt/send context and accepting basename-stem matches while staying scoped away from prompt text.

## Live Evidence
- Session: `mirror-mirror-v03-consult-v2`
- Failure: `Attachments never reached a clickable send button before timeout.`
- UI evidence from the operator showed the prompt staged, `Extended Pro` selected, and attachments rendered with duplicate-renamed filenames.

## Tests
- `pnpm vitest run tests/browser/promptComposerExpressions.test.ts tests/browser/promptComposer.test.ts tests/browser/attachmentsCompletion.test.ts tests/browser/pageActions.test.ts`
- `pnpm run check`
- `pnpm run build`
- `git diff --check upstream/main..HEAD`