### PR TITLE
Fix ChatGPT attachment readiness scoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.12.2 — Unreleased
 
+### Fixed
+
+- Browser: resolve attachment readiness from the actual ChatGPT composer form so image uploads do not stall after matching composer child buttons.
+
 ## 0.12.1 — 2026-05-17
 
 ### Changed

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -337,11 +337,21 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
   const namesLiteral = JSON.stringify(attachmentNames.map((name) => name.toLowerCase()));
   return `(() => {
     const names = ${namesLiteral};
-    const composer =
-      document.querySelector('[data-testid*="composer"]') ||
-      document.querySelector('form') ||
-      document.body ||
-      document;
+    const resolveComposerRoot = () => {
+      const promptNode =
+        document.querySelector('#prompt-textarea') ||
+        document.querySelector('[name="prompt-textarea"]') ||
+        document.querySelector('[contenteditable="true"][aria-label*="Chat"]');
+      const promptForm = promptNode?.closest?.('form');
+      const form =
+        document.querySelector('form[data-type="unified-composer"]') ||
+        promptForm ||
+        document.querySelector('form');
+      if (form) return form;
+      const composerLike = document.querySelector('[data-testid*="composer"]');
+      return composerLike?.closest?.('form') || composerLike || document.body || document;
+    };
+    const composer = resolveComposerRoot();
     // Walk node + ancestors (up to grandparent) + descendants to gather every textual hint.
     // ChatGPT's current chip DOM nests the filename inside truncated child spans, so checking
     // only the node's own textContent/aria/title misses the match.

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -335,13 +335,12 @@ async function waitForDomReady(
 
 function buildAttachmentReadyExpression(attachmentNames: string[]): string {
   const namesLiteral = JSON.stringify(attachmentNames.map((name) => name.toLowerCase()));
+  const inputSelectorsLiteral = JSON.stringify(INPUT_SELECTORS);
   return `(() => {
     const names = ${namesLiteral};
+    const inputSelectors = ${inputSelectorsLiteral};
     const resolveComposerRoot = () => {
-      const promptNode =
-        document.querySelector('#prompt-textarea') ||
-        document.querySelector('[name="prompt-textarea"]') ||
-        document.querySelector('[contenteditable="true"][aria-label*="Chat"]');
+      const promptNode = inputSelectors.map((selector) => document.querySelector(selector)).find(Boolean);
       const promptForm = promptNode?.closest?.('form');
       const form =
         document.querySelector('form[data-type="unified-composer"]') ||

--- a/tests/browser/promptComposerExpressions.test.ts
+++ b/tests/browser/promptComposerExpressions.test.ts
@@ -5,7 +5,11 @@ describe("prompt composer attachment expressions", () => {
   test("attachment ready check does not match prompt text", () => {
     const expression = buildAttachmentReadyExpressionForTest(["oracle-attach-verify.txt"]);
     expect(expression).toContain("resolveComposerRoot");
+    expect(expression).toContain("const inputSelectors =");
     expect(expression).toContain("document.querySelector('form[data-type=\"unified-composer\"]')");
+    expect(expression).toContain(
+      "inputSelectors.map((selector) => document.querySelector(selector))",
+    );
     expect(expression).toContain("promptNode?.closest?.('form')");
     expect(expression).toContain("attachmentRoots");
     expect(expression).toContain('input[type="file"]');
@@ -40,14 +44,15 @@ describe("prompt composer attachment expressions", () => {
 
   test("attachment ready check does not scope to composer child buttons", () => {
     const expression = buildAttachmentReadyExpressionForTest(["figure-review.jpg"]);
+    const compactExpression = expression.replace(/\s+/g, " ");
 
     expect(expression).toContain("const composer = resolveComposerRoot()");
     expect(expression).toContain(
       "const composerLike = document.querySelector('[data-testid*=\"composer\"]')",
     );
     expect(expression).toContain("return composerLike?.closest?.('form') || composerLike");
-    expect(expression).not.toContain(
-      "const composer =\n      document.querySelector('[data-testid*=\"composer\"]')",
+    expect(compactExpression).not.toMatch(
+      /const composer = document\.querySelector\('\[data-testid\*="composer"\]'\)/,
     );
   });
 });

--- a/tests/browser/promptComposerExpressions.test.ts
+++ b/tests/browser/promptComposerExpressions.test.ts
@@ -4,7 +4,9 @@ import { buildAttachmentReadyExpressionForTest } from "../../src/browser/actions
 describe("prompt composer attachment expressions", () => {
   test("attachment ready check does not match prompt text", () => {
     const expression = buildAttachmentReadyExpressionForTest(["oracle-attach-verify.txt"]);
-    expect(expression).toContain("document.querySelector('[data-testid*=\"composer\"]')");
+    expect(expression).toContain("resolveComposerRoot");
+    expect(expression).toContain("document.querySelector('form[data-type=\"unified-composer\"]')");
+    expect(expression).toContain("promptNode?.closest?.('form')");
     expect(expression).toContain("attachmentRoots");
     expect(expression).toContain('input[type="file"]');
     expect(expression).toContain('[aria-label*="Remove file"]');
@@ -34,5 +36,18 @@ describe("prompt composer attachment expressions", () => {
 
     expect(expression).toContain("const attachmentRoots = Array.from(new Set([composer]))");
     expect(expression).not.toContain("new Set([composer, document])");
+  });
+
+  test("attachment ready check does not scope to composer child buttons", () => {
+    const expression = buildAttachmentReadyExpressionForTest(["figure-review.jpg"]);
+
+    expect(expression).toContain("const composer = resolveComposerRoot()");
+    expect(expression).toContain(
+      "const composerLike = document.querySelector('[data-testid*=\"composer\"]')",
+    );
+    expect(expression).toContain("return composerLike?.closest?.('form') || composerLike");
+    expect(expression).not.toContain(
+      "const composer =\n      document.querySelector('[data-testid*=\"composer\"]')",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Resolve ChatGPT attachment readiness from the actual composer form instead of the first `[data-testid*=composer]` match.
- Keep attachment-chip matching scoped to that composer root, preserving the existing guard against matching filenames in prompt text.
- Add regression coverage and an unreleased changelog note for image/file upload stalls.

## Root cause

Current ChatGPT can expose `data-testid="composer-plus-btn"` on the add-files button. The old readiness expression selected `[data-testid*="composer"]` before `form`, so attachment readiness was scoped to the plus button. Image uploads could succeed and leave an enabled send button in the real composer, but Oracle never saw the attached file under the wrong root and timed out with `attachment-send-not-ready`.

## Validation

- `pnpm vitest run tests/browser/promptComposerExpressions.test.ts tests/browser/promptComposer.test.ts`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm test`
- Live browser smoke against local patched 0.12.1 Homebrew install: `oracle-image-attach-smoke-fixed` returned `IMAGE_ATTACHED_OK` with `files=1`.
- Live visual-review rerun against the same image path: `figure2-v06-visual-review-fixed` completed with `files=1` and Pro evidence `resolved=Extended Pro; verified=yes`.
