### PR TITLE
fix(browser): click ready send button for large attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.12.2 — Unreleased
 
+### Fixed
+
+- Browser: click ChatGPT's enabled send button for attachment prompts even when large-file chip matching is stale, and honor the input timeout while waiting for attachment sends.
+
 ## 0.12.1 — 2026-05-17
 
 ### Changed

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -202,7 +202,12 @@ export async function submitPrompt(
     );
   }
 
-  const clicked = await attemptSendButton(runtime, logger, deps?.attachmentNames);
+  const clicked = await attemptSendButton(
+    runtime,
+    logger,
+    deps?.attachmentNames,
+    deps.inputTimeoutMs ?? undefined,
+  );
   if (!clicked) {
     await input.dispatchKeyEvent({
       type: "keyDown",
@@ -444,6 +449,7 @@ async function attemptSendButton(
   Runtime: ChromeClient["Runtime"],
   _logger?: BrowserLogger,
   attachmentNames?: string[],
+  timeoutMs?: number | null,
 ): Promise<boolean> {
   const needAttachment = Array.isArray(attachmentNames) && attachmentNames.length > 0;
   const script = `(() => {
@@ -480,23 +486,21 @@ async function attemptSendButton(
   })()`;
 
   // Give attachment-bearing submissions more headroom. ChatGPT's chip render can
-  // settle slowly for multi-file uploads, but plain text sends should keep the
-  // shorter historical deadline.
-  const deadline = Date.now() + sendButtonTimeoutMs(attachmentNames);
+  // settle slowly for large or multi-file uploads, but plain text sends should
+  // keep the shorter historical deadline.
+  const deadline = Date.now() + sendButtonTimeoutMs(attachmentNames, timeoutMs);
   while (Date.now() < deadline) {
+    const { result } = await Runtime.evaluate({ expression: script, returnByValue: true });
+    if (result.value === "clicked") {
+      return true;
+    }
     if (needAttachment) {
       const ready = await Runtime.evaluate({
         expression: buildAttachmentReadyExpression(attachmentNames),
         returnByValue: true,
       });
-      if (!ready?.result?.value) {
-        await delay(150);
-        continue;
-      }
-    }
-    const { result } = await Runtime.evaluate({ expression: script, returnByValue: true });
-    if (result.value === "clicked") {
-      return true;
+      await delay(ready?.result?.value ? 100 : 150);
+      continue;
     }
     if (result.value === "missing") {
       break;
@@ -516,8 +520,13 @@ async function attemptSendButton(
   return false;
 }
 
-function sendButtonTimeoutMs(attachmentNames?: string[]): number {
-  return Array.isArray(attachmentNames) && attachmentNames.length > 0 ? 45_000 : 20_000;
+function sendButtonTimeoutMs(attachmentNames?: string[], timeoutMs?: number | null): number {
+  if (!Array.isArray(attachmentNames) || attachmentNames.length === 0) {
+    return 20_000;
+  }
+  const configuredTimeout =
+    typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 0;
+  return Math.max(120_000, configuredTimeout);
 }
 
 async function verifyPromptCommitted(

--- a/tests/browser/promptComposer.test.ts
+++ b/tests/browser/promptComposer.test.ts
@@ -112,18 +112,40 @@ describe("promptComposer", () => {
         ["oracle-attach-verify.txt"],
       );
       const assertion = expect(promise).rejects.toThrow(/clickable send button/i);
-      // Deadline is 45_000ms; advance a bit past it so the timeout fires.
-      await vi.advanceTimersByTimeAsync(46_000);
+      // Deadline is 120_000ms; advance a bit past it so the timeout fires.
+      await vi.advanceTimersByTimeAsync(121_000);
       await assertion;
     } finally {
       vi.useRealTimers();
     }
   });
 
+  test("clicks enabled send button even when attachment ready matching is stale", async () => {
+    const runtime = {
+      evaluate: vi.fn(async ({ expression }: { expression: string }) => {
+        if (expression.includes("dispatchClickSequence")) {
+          return { result: { value: "clicked" } };
+        }
+        return { result: { value: false } };
+      }),
+    } as unknown as {
+      evaluate: (args: { expression: string; returnByValue?: boolean }) => Promise<unknown>;
+    };
+
+    await expect(
+      promptComposer.attemptSendButton(runtime as never, (() => undefined) as never, [
+        "oracle-large-attachment-20260518.txt",
+      ]),
+    ).resolves.toBe(true);
+    expect(runtime.evaluate).toHaveBeenCalledTimes(1);
+  });
+
   test("only attachment sends get the longer send-button deadline", () => {
     expect(promptComposer.sendButtonTimeoutMs()).toBe(20_000);
     expect(promptComposer.sendButtonTimeoutMs([])).toBe(20_000);
-    expect(promptComposer.sendButtonTimeoutMs(["oracle-attach-verify.txt"])).toBe(45_000);
+    expect(promptComposer.sendButtonTimeoutMs(["oracle-attach-verify.txt"])).toBe(120_000);
+    expect(promptComposer.sendButtonTimeoutMs(["large.txt"], 600_000)).toBe(600_000);
+    expect(promptComposer.sendButtonTimeoutMs(["large.txt"], 30_000)).toBe(120_000);
   });
 
   test("marks prompt submitted before commit verification finishes", async () => {


### PR DESCRIPTION
## Summary
- click ChatGPT's enabled send button before re-checking attachment chip readiness so truncated or renamed large-file chips do not block submission
- honor browser input timeout for attachment send readiness while keeping plain-text sends on the shorter deadline
- add regression coverage for stale attachment readiness and large-attachment timeout handling

## Verification
- pnpm run format:check
- pnpm run lint
- pnpm run build
- pnpm vitest run tests/browser/promptComposer.test.ts tests/browser/attachmentsCompletion.test.ts

## Live check
- Uploaded a 2.36 MB text attachment through ChatGPT browser mode with --browser-attachments always
- Oracle clicked the send button automatically and ChatGPT returned the sentinel ORACLE_LARGE_UPLOAD_OK_20260518
- Session evidence showed resolved=Extended Pro; verified=yes and files=1