### PR TITLE
fix(browser): accept authenticated ChatGPT DOM when auth probe is blocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Browser: accept Cloudflare/throttling-blocked ChatGPT auth probes only when the signed-in app shell is visible, while keeping plain 401/403 login failures authoritative. Thanks @orbitingflea!
 - Browser: resolve attachment readiness from the active ChatGPT composer so uploaded files do not false-fail with `attachment-send-not-ready` when the Send button is already clickable. Thanks @enieuwy!
 - Browser: scope ChatGPT model picker scans to the real picker menu while preserving text-only fallback rows, so sidebar/search Radix menus do not block model selection. Thanks @orbitingflea!
 - Browser: tolerate duplicate-renamed or ellipsized ChatGPT attachment chip names during pre-send readiness checks. Thanks @pdurlej!

--- a/src/browser/actions/navigation.ts
+++ b/src/browser/actions/navigation.ts
@@ -614,7 +614,6 @@ function buildLoginProbeExpression(timeoutMs: number): string {
     const apiBlocked =
       cfBlocked ||
       status === 401 ||
-      status === 403 ||
       status === 429 ||
       status === 503 ||
       status === 0;

--- a/src/browser/actions/navigation.ts
+++ b/src/browser/actions/navigation.ts
@@ -592,17 +592,17 @@ function buildLoginProbeExpression(timeoutMs: number): string {
     let error = backend.error;
     let domLoginCta = hasLoginCta();
     let appAuthenticated = hasAppAuthSignal();
+    const isRetryableStatus = () =>
+      status === 0 || status === 401 || status === 403 || status === 503 || status === 429;
     const settleDeadline = Date.now() + Math.min(${timeoutMs}, 2500);
-    while (!domLoginCta && !appAuthenticated && Date.now() < settleDeadline) {
+    while (!domLoginCta && status !== 200 && isRetryableStatus() && Date.now() < settleDeadline) {
       await new Promise((resolve) => setTimeout(resolve, 100));
       domLoginCta = hasLoginCta();
       appAuthenticated = hasAppAuthSignal();
-      if (status === 0 || status === 401 || status === 403 || status === 503 || status === 429) {
-        backend = await readBackendDetail();
-        status = backend.status;
-        cfBlocked = cfBlocked || backend.cfBlocked;
-        error = backend.error;
-      }
+      backend = await readBackendDetail();
+      status = backend.status;
+      cfBlocked = cfBlocked || backend.cfBlocked;
+      error = backend.error;
     }
 
     const loginSignals = domLoginCta || onAuthPage;

--- a/src/browser/actions/navigation.ts
+++ b/src/browser/actions/navigation.ts
@@ -579,14 +579,11 @@ function buildLoginProbeExpression(timeoutMs: number): string {
       if (!rect || rect.width <= 0 || rect.height <= 0 || style.display === 'none' || style.visibility === 'hidden') {
         return false;
       }
-      // Logged-in users always have at least one of: profile button, prior chat history,
-      // or the composer model pill (Heavy/Pro/etc). Anonymous/guest composer lacks all of these.
+      // Logged-in users should have an account affordance or prior chat history. Generic
+      // composer/model pills also appear in guest sessions, so they are not auth proof.
       const profileButton = document.querySelector('[data-testid="accounts-profile-button"]');
       const historyItem = document.querySelector('[data-testid^="history-item-"]');
-      const modelPill = document.querySelector(
-        '[data-testid="model-switcher-dropdown-button"], button.__composer-pill[aria-haspopup="menu"], button.__composer-pill',
-      );
-      return Boolean(profileButton || historyItem || modelPill);
+      return Boolean(profileButton || historyItem);
     };
 
     let backend = await readBackendDetail();

--- a/src/browser/actions/navigation.ts
+++ b/src/browser/actions/navigation.ts
@@ -606,14 +606,12 @@ function buildLoginProbeExpression(timeoutMs: number): string {
     }
 
     const loginSignals = domLoginCta || onAuthPage;
-    // Accept the SPA-level signal whenever the API path is unreachable (CF challenge, 401
-    // Unauthorized from a backend that requires a SPA-only bearer/CSRF, 5xx, throttling,
-    // network shaping) but the DOM shows an authenticated logged-in shell. 401 is
-    // explicitly included because /backend-api/me increasingly returns it for fetch-from-page
-    // calls that lack the SPA's Authorization header even when the user is signed in.
+    // Accept the SPA-level signal only when the API path is blocked or unavailable
+    // (CF challenge, throttling, transient 5xx, network shaping) but the DOM shows
+    // an authenticated logged-in shell. Plain 401/403 remain authoritative because
+    // they can mean the ChatGPT session really expired.
     const apiBlocked =
       cfBlocked ||
-      status === 401 ||
       status === 429 ||
       status === 503 ||
       status === 0;

--- a/src/browser/actions/navigation.ts
+++ b/src/browser/actions/navigation.ts
@@ -206,7 +206,7 @@ export async function ensureLoggedIn(
   const probe = normalizeLoginProbe(outcome.result?.value);
   if (probe.ok) {
     logger(
-      `Login check passed (status=${probe.status}, domLoginCta=${Boolean(probe.domLoginCta)})`,
+      `Login check passed (status=${probe.status}, domLoginCta=${Boolean(probe.domLoginCta)}, appAuthenticated=${Boolean(probe.appAuthenticated)})`,
     );
     return;
   }
@@ -229,14 +229,14 @@ export async function ensureLoggedIn(
     logger(
       `Login retry after Welcome back failed (status=${retryProbe.status}, domLoginCta=${Boolean(
         retryProbe.domLoginCta,
-      )})`,
+      )}, appAuthenticated=${Boolean(retryProbe.appAuthenticated)})`,
     );
   }
 
   logger(
     `Login probe failed (status=${probe.status}, domLoginCta=${Boolean(probe.domLoginCta)}, onAuthPage=${Boolean(
       probe.onAuthPage,
-    )}, url=${probe.pageUrl ?? "n/a"}, error=${probe.error ?? "none"})`,
+    )}, appAuthenticated=${Boolean(probe.appAuthenticated)}, cfBlocked=${Boolean(probe.cfBlocked)}, url=${probe.pageUrl ?? "n/a"}, error=${probe.error ?? "none"})`,
   );
 
   const domLabel = probe.domLoginCta ? " Login button detected on page." : "";
@@ -457,6 +457,8 @@ type LoginProbeResult = {
   pageUrl?: string | null;
   domLoginCta?: boolean;
   onAuthPage?: boolean;
+  appAuthenticated?: boolean;
+  cfBlocked?: boolean;
 };
 
 function buildLoginProbeExpression(timeoutMs: number): string {
@@ -519,51 +521,117 @@ function buildLoginProbeExpression(timeoutMs: number): string {
       return false;
     };
 
-    const readBackendStatus = async () => {
+    // Learned 2026-05-16: ChatGPT's /backend-api/* endpoints now sit behind Cloudflare bot
+    // mitigation. Programmatic fetch from the page can return 403 with cf-mitigated:challenge
+    // even when the user is logged in via cookies and the SPA renders normally. Detect that
+    // case via the response body shape (Cloudflare interstitial HTML) and fall back to a
+    // DOM-based logged-in signal instead of looping waitForLogin until the 20-min timeout.
+    const isCloudflareBody = (body) => {
+      if (typeof body !== 'string' || body.length === 0) return false;
+      const head = body.slice(0, 2000).toLowerCase();
+      return (
+        head.includes('cf-mitigated') ||
+        head.includes('cloudflare') ||
+        (head.includes('<style global>') && head.includes('scale-appear'))
+      );
+    };
+    const readBackendDetail = async () => {
       try {
-        if (typeof fetch === 'function') {
-          const controller = new AbortController();
-          const timeout = setTimeout(() => controller.abort(), ${timeoutMs});
-          try {
-            // Credentials included so we see a 200 only when cookies are valid.
-            const response = await fetch('/backend-api/me', {
-              cache: 'no-store',
-              credentials: 'include',
-              signal: controller.signal,
-            });
-            return { status: response.status || 0, error: null };
-          } finally {
-            clearTimeout(timeout);
+        if (typeof fetch !== 'function') return { status: 0, cfBlocked: false, error: null };
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), ${timeoutMs});
+        try {
+          const response = await fetch('/backend-api/me', {
+            cache: 'no-store',
+            credentials: 'include',
+            signal: controller.signal,
+          });
+          let cfBlocked = false;
+          if (response.status === 403 || response.status === 503 || response.status === 429) {
+            try {
+              const text = await response.clone().text();
+              cfBlocked = isCloudflareBody(text);
+            } catch {}
           }
+          return { status: response.status || 0, cfBlocked, error: null };
+        } finally {
+          clearTimeout(timeout);
         }
       } catch (err) {
-        return { status: 0, error: err ? String(err) : 'unknown' };
+        return { status: 0, cfBlocked: false, error: err ? String(err) : 'unknown' };
       }
-      return { status: 0, error: null };
     };
 
-    let { status, error } = await readBackendStatus();
+    const hasAppAuthSignal = () => {
+      // Composer must be present and visible — the auth/login page never renders one.
+      if (typeof document.querySelector !== 'function') return false;
+      const composerSelectors = [
+        '#prompt-textarea',
+        '.ProseMirror',
+        'textarea[data-id="prompt-textarea"]',
+        'textarea[name="prompt-textarea"]',
+        '[contenteditable="true"][role="textbox"]',
+      ];
+      const composer = composerSelectors.map((s) => document.querySelector(s)).find(Boolean);
+      if (!composer) return false;
+      const rect = composer.getBoundingClientRect && composer.getBoundingClientRect();
+      const style = window.getComputedStyle(composer);
+      if (!rect || rect.width <= 0 || rect.height <= 0 || style.display === 'none' || style.visibility === 'hidden') {
+        return false;
+      }
+      // Logged-in users always have at least one of: profile button, prior chat history,
+      // or the composer model pill (Heavy/Pro/etc). Anonymous/guest composer lacks all of these.
+      const profileButton = document.querySelector('[data-testid="accounts-profile-button"]');
+      const historyItem = document.querySelector('[data-testid^="history-item-"]');
+      const modelPill = document.querySelector(
+        '[data-testid="model-switcher-dropdown-button"], button.__composer-pill[aria-haspopup="menu"], button.__composer-pill',
+      );
+      return Boolean(profileButton || historyItem || modelPill);
+    };
+
+    let backend = await readBackendDetail();
+    let status = backend.status;
+    let cfBlocked = backend.cfBlocked;
+    let error = backend.error;
     let domLoginCta = hasLoginCta();
+    let appAuthenticated = hasAppAuthSignal();
     const settleDeadline = Date.now() + Math.min(${timeoutMs}, 2500);
-    while (!domLoginCta && Date.now() < settleDeadline) {
+    while (!domLoginCta && !appAuthenticated && Date.now() < settleDeadline) {
       await new Promise((resolve) => setTimeout(resolve, 100));
       domLoginCta = hasLoginCta();
-      if (status === 0 || status === 401 || status === 403) {
-        const next = await readBackendStatus();
-        status = next.status;
-        error = next.error;
+      appAuthenticated = hasAppAuthSignal();
+      if (status === 0 || status === 401 || status === 403 || status === 503 || status === 429) {
+        backend = await readBackendDetail();
+        status = backend.status;
+        cfBlocked = cfBlocked || backend.cfBlocked;
+        error = backend.error;
       }
     }
 
     const loginSignals = domLoginCta || onAuthPage;
+    // Accept the SPA-level signal whenever the API path is unreachable (CF challenge, 401
+    // Unauthorized from a backend that requires a SPA-only bearer/CSRF, 5xx, throttling,
+    // network shaping) but the DOM shows an authenticated logged-in shell. 401 is
+    // explicitly included because /backend-api/me increasingly returns it for fetch-from-page
+    // calls that lack the SPA's Authorization header even when the user is signed in.
+    const apiBlocked =
+      cfBlocked ||
+      status === 401 ||
+      status === 403 ||
+      status === 429 ||
+      status === 503 ||
+      status === 0;
+    const ok = !loginSignals && (status === 200 || (apiBlocked && appAuthenticated));
     return {
-      ok: !loginSignals && status === 200,
+      ok,
       status,
       redirected: false,
       url: pageUrl,
       pageUrl,
       domLoginCta,
       onAuthPage,
+      appAuthenticated,
+      cfBlocked,
       error,
     };
   })()`;
@@ -591,6 +659,8 @@ function normalizeLoginProbe(raw: unknown): LoginProbeResult {
     pageUrl: typeof value.pageUrl === "string" ? value.pageUrl : null,
     domLoginCta: Boolean(value.domLoginCta),
     onAuthPage: Boolean(value.onAuthPage),
+    appAuthenticated: Boolean(value.appAuthenticated),
+    cfBlocked: Boolean(value.cfBlocked),
   };
 }
 

--- a/src/browser/actions/navigation.ts
+++ b/src/browser/actions/navigation.ts
@@ -601,7 +601,7 @@ function buildLoginProbeExpression(timeoutMs: number): string {
       appAuthenticated = hasAppAuthSignal();
       backend = await readBackendDetail();
       status = backend.status;
-      cfBlocked = cfBlocked || backend.cfBlocked;
+      cfBlocked = backend.cfBlocked;
       error = backend.error;
     }
 

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -208,24 +208,80 @@ describe("ensureNotBlocked", () => {
 });
 
 describe("ensureLoggedIn", () => {
-  async function runLoginProbeForLabels(labels: string[], fetchStatus = 200) {
+  async function runLoginProbeForLabels(
+    labels: string[],
+    options: {
+      fetchStatus?: number;
+      fetchBody?: string;
+      pathname?: string;
+      composerVisible?: boolean;
+      appSignal?: "profile" | "history" | "model" | null;
+    } = {},
+  ) {
+    const {
+      fetchStatus = 200,
+      fetchBody = "",
+      pathname = "/",
+      composerVisible = false,
+      appSignal = null,
+    } = options;
     class FakeHTMLElement {
-      constructor(public textContent: string) {}
+      constructor(
+        public textContent: string,
+        private readonly visible = true,
+      ) {}
 
       getAttribute() {
         return "";
       }
 
       getBoundingClientRect() {
-        return { width: 120, height: 32 };
+        return { width: this.visible ? 120 : 0, height: this.visible ? 32 : 0 };
       }
     }
 
     const nodes = labels.map((label) => new FakeHTMLElement(label));
-    const document = { querySelectorAll: vi.fn(() => nodes) };
-    const window = { getComputedStyle: vi.fn(() => ({ display: "block", visibility: "visible" })) };
-    const fetch = vi.fn().mockResolvedValue({ status: fetchStatus });
-    const location = { href: "https://chatgpt.com/", pathname: "/" };
+    const composer = composerVisible ? new FakeHTMLElement("") : null;
+    const loggedInSignal = appSignal ? new FakeHTMLElement("") : null;
+    const document = {
+      querySelectorAll: vi.fn(() => nodes),
+      querySelector: vi.fn((selector: string) => {
+        if (
+          composer &&
+          [
+            "#prompt-textarea",
+            ".ProseMirror",
+            'textarea[data-id="prompt-textarea"]',
+            'textarea[name="prompt-textarea"]',
+            '[contenteditable="true"][role="textbox"]',
+          ].includes(selector)
+        ) {
+          return composer;
+        }
+        if (appSignal === "profile" && selector === '[data-testid="accounts-profile-button"]') {
+          return loggedInSignal;
+        }
+        if (appSignal === "history" && selector === '[data-testid^="history-item-"]') {
+          return loggedInSignal;
+        }
+        if (
+          appSignal === "model" &&
+          selector ===
+            '[data-testid="model-switcher-dropdown-button"], button.__composer-pill[aria-haspopup="menu"], button.__composer-pill'
+        ) {
+          return loggedInSignal;
+        }
+        return null;
+      }),
+    };
+    const window = {
+      getComputedStyle: vi.fn(() => ({ display: "block", visibility: "visible" })),
+    };
+    const fetch = vi.fn().mockResolvedValue({
+      status: fetchStatus,
+      clone: () => ({ text: vi.fn().mockResolvedValue(fetchBody) }),
+    });
+    const location = { href: `https://chatgpt.com${pathname}`, pathname };
     const expression = buildLoginProbeExpressionForTest(0);
     const evaluate = new Function(
       "document",
@@ -271,6 +327,77 @@ describe("ensureLoggedIn", () => {
     await expect(runLoginProbeForLabels(["Continue with Google"])).resolves.toMatchObject({
       ok: false,
       domLoginCta: true,
+    });
+  });
+
+  test("accepts a blocked backend probe when authenticated app DOM is visible", async () => {
+    await expect(
+      runLoginProbeForLabels([], {
+        fetchStatus: 401,
+        composerVisible: true,
+        appSignal: "model",
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      status: 401,
+      appAuthenticated: true,
+      domLoginCta: false,
+    });
+  });
+
+  test("does not accept blocked backend probe with only a composer", async () => {
+    await expect(
+      runLoginProbeForLabels([], {
+        fetchStatus: 401,
+        composerVisible: true,
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      status: 401,
+      appAuthenticated: false,
+    });
+  });
+
+  test("keeps auth pages and visible login CTAs authoritative", async () => {
+    await expect(
+      runLoginProbeForLabels([], {
+        fetchStatus: 401,
+        pathname: "/auth/login",
+        composerVisible: true,
+        appSignal: "profile",
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      onAuthPage: true,
+      appAuthenticated: true,
+    });
+
+    await expect(
+      runLoginProbeForLabels(["Log in"], {
+        fetchStatus: 401,
+        composerVisible: true,
+        appSignal: "history",
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      domLoginCta: true,
+      appAuthenticated: true,
+    });
+  });
+
+  test("detects Cloudflare-blocked backend probes and falls back to app DOM", async () => {
+    await expect(
+      runLoginProbeForLabels([], {
+        fetchStatus: 403,
+        fetchBody: "<html><body>cf-mitigated challenge from Cloudflare</body></html>",
+        composerVisible: true,
+        appSignal: "profile",
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      status: 403,
+      cfBlocked: true,
+      appAuthenticated: true,
     });
   });
 

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -335,13 +335,27 @@ describe("ensureLoggedIn", () => {
       runLoginProbeForLabels([], {
         fetchStatus: 401,
         composerVisible: true,
-        appSignal: "model",
+        appSignal: "profile",
       }),
     ).resolves.toMatchObject({
       ok: true,
       status: 401,
       appAuthenticated: true,
       domLoginCta: false,
+    });
+  });
+
+  test("does not accept blocked backend probe with only a model pill", async () => {
+    await expect(
+      runLoginProbeForLabels([], {
+        fetchStatus: 401,
+        composerVisible: true,
+        appSignal: "model",
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      status: 401,
+      appAuthenticated: false,
     });
   });
 

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -214,6 +214,7 @@ describe("ensureLoggedIn", () => {
       fetchStatus?: number;
       fetchStatuses?: number[];
       fetchBody?: string;
+      fetchBodies?: string[];
       pathname?: string;
       composerVisible?: boolean;
       appSignal?: "profile" | "history" | "model" | null;
@@ -224,6 +225,7 @@ describe("ensureLoggedIn", () => {
       fetchStatus = 200,
       fetchStatuses,
       fetchBody = "",
+      fetchBodies,
       pathname = "/",
       composerVisible = false,
       appSignal = null,
@@ -282,11 +284,13 @@ describe("ensureLoggedIn", () => {
       getComputedStyle: vi.fn(() => ({ display: "block", visibility: "visible" })),
     };
     const statuses = [...(fetchStatuses ?? [fetchStatus])];
+    const bodies = [...(fetchBodies ?? [fetchBody])];
     const fetch = vi.fn().mockImplementation(() => {
       const status = statuses.length > 1 ? statuses.shift() : statuses[0];
+      const body = bodies.length > 1 ? bodies.shift() : bodies[0];
       return Promise.resolve({
         status,
-        clone: () => ({ text: vi.fn().mockResolvedValue(fetchBody) }),
+        clone: () => ({ text: vi.fn().mockResolvedValue(body) }),
       });
     });
     const location = { href: `https://chatgpt.com${pathname}`, pathname };
@@ -463,6 +467,23 @@ describe("ensureLoggedIn", () => {
       ok: true,
       status: 403,
       cfBlocked: true,
+      appAuthenticated: true,
+    });
+  });
+
+  test("does not keep stale Cloudflare state after a later unauthorized response", async () => {
+    await expect(
+      runLoginProbeForLabels([], {
+        fetchStatuses: [403, 401],
+        fetchBodies: ["<html><body>cf-mitigated challenge from Cloudflare</body></html>", ""],
+        composerVisible: true,
+        appSignal: "profile",
+        probeTimeoutMs: 500,
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      status: 401,
+      cfBlocked: false,
       appAuthenticated: true,
     });
   });

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -333,15 +333,29 @@ describe("ensureLoggedIn", () => {
   test("accepts a blocked backend probe when authenticated app DOM is visible", async () => {
     await expect(
       runLoginProbeForLabels([], {
-        fetchStatus: 401,
+        fetchStatus: 429,
         composerVisible: true,
         appSignal: "profile",
       }),
     ).resolves.toMatchObject({
       ok: true,
-      status: 401,
+      status: 429,
       appAuthenticated: true,
       domLoginCta: false,
+    });
+  });
+
+  test("does not accept plain unauthorized backend responses with stale app DOM", async () => {
+    await expect(
+      runLoginProbeForLabels([], {
+        fetchStatus: 401,
+        composerVisible: true,
+        appSignal: "profile",
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      status: 401,
+      appAuthenticated: true,
     });
   });
 

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -212,18 +212,22 @@ describe("ensureLoggedIn", () => {
     labels: string[],
     options: {
       fetchStatus?: number;
+      fetchStatuses?: number[];
       fetchBody?: string;
       pathname?: string;
       composerVisible?: boolean;
       appSignal?: "profile" | "history" | "model" | null;
+      probeTimeoutMs?: number;
     } = {},
   ) {
     const {
       fetchStatus = 200,
+      fetchStatuses,
       fetchBody = "",
       pathname = "/",
       composerVisible = false,
       appSignal = null,
+      probeTimeoutMs = 0,
     } = options;
     class FakeHTMLElement {
       constructor(
@@ -277,12 +281,16 @@ describe("ensureLoggedIn", () => {
     const window = {
       getComputedStyle: vi.fn(() => ({ display: "block", visibility: "visible" })),
     };
-    const fetch = vi.fn().mockResolvedValue({
-      status: fetchStatus,
-      clone: () => ({ text: vi.fn().mockResolvedValue(fetchBody) }),
+    const statuses = [...(fetchStatuses ?? [fetchStatus])];
+    const fetch = vi.fn().mockImplementation(() => {
+      const status = statuses.length > 1 ? statuses.shift() : statuses[0];
+      return Promise.resolve({
+        status,
+        clone: () => ({ text: vi.fn().mockResolvedValue(fetchBody) }),
+      });
     });
     const location = { href: `https://chatgpt.com${pathname}`, pathname };
-    const expression = buildLoginProbeExpressionForTest(0);
+    const expression = buildLoginProbeExpressionForTest(probeTimeoutMs);
     const evaluate = new Function(
       "document",
       "window",
@@ -355,6 +363,21 @@ describe("ensureLoggedIn", () => {
     ).resolves.toMatchObject({
       ok: false,
       status: 401,
+      appAuthenticated: true,
+    });
+  });
+
+  test("retries transient unauthorized backend responses before failing", async () => {
+    await expect(
+      runLoginProbeForLabels([], {
+        fetchStatuses: [401, 200],
+        composerVisible: true,
+        appSignal: "profile",
+        probeTimeoutMs: 500,
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      status: 200,
       appAuthenticated: true,
     });
   });

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -372,6 +372,21 @@ describe("ensureLoggedIn", () => {
     });
   });
 
+  test("does not accept plain forbidden backend responses without Cloudflare markers", async () => {
+    await expect(
+      runLoginProbeForLabels([], {
+        fetchStatus: 403,
+        composerVisible: true,
+        appSignal: "profile",
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      status: 403,
+      cfBlocked: false,
+      appAuthenticated: true,
+    });
+  });
+
   test("keeps auth pages and visible login CTAs authoritative", async () => {
     await expect(
       runLoginProbeForLabels([], {


### PR DESCRIPTION
## Summary

ChatGPT browser mode can render a signed-in, usable app shell while a direct `/backend-api/me` probe returns `401`, or while the backend probe is blocked by Cloudflare/bot mitigation. Previously Oracle treated that backend status as a hard logout and stopped before browser automation could proceed.

This updates the login probe to accept blocked/unavailable backend auth only when the visible ChatGPT DOM also shows authenticated app state.

## Details

The login check still rejects auth/login pages and visible login CTAs. It now treats the session as usable when:

- `/backend-api/me` returns 200, or
- the backend probe is blocked/unavailable with 401/403/429/503/0
- and the DOM shows a visible composer plus a logged-in app signal:
  - profile/account button
  - chat history item
  - model picker pill/button

Cloudflare interstitial-like backend responses are also detected from response body markers.

## Tests

Added focused login-probe coverage for:

- normal 200 success
- blocked backend probe plus authenticated DOM
- blocked backend probe with composer only
- auth page and login CTA remaining authoritative failures
- Cloudflare-blocked backend response plus authenticated DOM

## Verification

- `pnpm vitest run tests/browser/pageActions.test.ts`
- `pnpm run build`
- `git diff --check`

## Note

This PR was generated with Codex. (Honestly, I don't understand the code; I encountered this 401 issue when I tested Oracle on a linux machine and this patch helped me fix it.)
