### PR TITLE
feat(config): layer project config defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- Config: layer safe project defaults from `.oracle/config.json` files discovered upward from the current working directory, so repos can pin workflow defaults like ChatGPT Project URLs without copying the user config.
 - Website: point package/homepage metadata and generated site chrome at `https://askoracle.sh` instead of the GitHub repository.
 
 ### Fixed

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -1846,21 +1846,24 @@ async function runRootCommand(options: CliOptions): Promise<void> {
     engineModels.some((model) => isAzureOpenAICandidateModel(model));
   const explicitApiProviderRequested =
     providerMode !== "auto" || hasExplicitAzureOption(optionUsesDefault);
-  const preferredEngine =
-    options.engine ?? (explicitApiProviderRequested ? undefined : userConfig.engine);
+  const envEnginePreference = (process.env.ORACLE_ENGINE ?? "").trim().toLowerCase();
+  const explicitApiEngineRequested =
+    options.engine === "api" || (!options.engine && envEnginePreference === "api");
+  const configBrowserEngineRequested =
+    userConfig.engine === "browser" && !explicitApiEngineRequested && !explicitApiProviderRequested;
   let engine: EngineMode = resolveEngine({
-    engine: preferredEngine,
+    engine: options.engine,
+    configEngine: userConfig.engine,
     browserFlag: options.browser,
     apiProviderRequested: explicitApiProviderRequested,
     env: process.env,
   });
-  const envEnginePreference = (process.env.ORACLE_ENGINE ?? "").trim().toLowerCase();
   const browserEngineRequested =
     options.browser ||
     options.engine === "browser" ||
     Boolean(remoteHost) ||
-    (!explicitApiProviderRequested &&
-      (userConfig.engine === "browser" || envEnginePreference === "browser"));
+    configBrowserEngineRequested ||
+    (!options.engine && !explicitApiProviderRequested && envEnginePreference === "browser");
   if (azureAutoApiRequested && engine === "browser" && !browserEngineRequested) {
     engine = "api";
   }
@@ -1927,7 +1930,7 @@ async function runRootCommand(options: CliOptions): Promise<void> {
   const includesGeminiApiOnly = (
     normalizedMultiModels.length > 0 ? normalizedMultiModels : [resolvedModel]
   ).some((model) => model === "gemini-3.1-pro");
-  if ((userForcedBrowser || userConfig.engine === "browser") && includesGeminiApiOnly) {
+  if (browserExplicitlyRequested && includesGeminiApiOnly) {
     throw new Error(
       "gemini-3.1-pro is API-only today. Use --engine api or switch to gemini-3-pro for Gemini web.",
     );

--- a/docs/browser-mode.md
+++ b/docs/browser-mode.md
@@ -8,7 +8,7 @@ Oracle’s `--engine browser` supports three different execution paths:
 
 If you’re running Gemini, also see `docs/gemini.md`.
 
-`oracle --engine browser` routes the assembled prompt bundle through the ChatGPT web UI instead of the Responses API. (Legacy `--browser` still maps to `--engine browser`, but it will be removed.) If you omit `--engine`, Oracle first honors any `engine` value in `~/.oracle/config.json`, then auto-picks API when `OPENAI_API_KEY` is available and falls back to browser otherwise. The CLI writes the same session metadata/logs as API runs, and by default pastes the payload into ChatGPT via a temporary Chrome profile (manual-login mode can reuse a persistent automation profile).
+`oracle --engine browser` routes the assembled prompt bundle through the ChatGPT web UI instead of the Responses API. (Legacy `--browser` still maps to `--engine browser`, but it will be removed.) If you omit `--engine`, Oracle first honors `ORACLE_ENGINE`, then any `engine` value in the effective config, including project `.oracle/config.json` files layered over `~/.oracle/config.json`. It auto-picks API when `OPENAI_API_KEY` is available and falls back to browser otherwise. The CLI writes the same session metadata/logs as API runs, and by default pastes the payload into ChatGPT via a temporary Chrome profile (manual-login mode can reuse a persistent automation profile).
 
 `--preview` now works with `--engine browser`: it renders the composed prompt, lists which files would be uploaded vs inlined, and shows the bundle location when bundling is enabled, without launching Chrome.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -146,4 +146,4 @@ See [Browser Mode](browser-mode.md) for usage.
 
 - `oracle --help` — short usage.
 - `oracle --help --verbose` — every flag, including hidden ones.
-- [Configuration](configuration.md) — `~/.oracle/config.json` defaults.
+- [Configuration](configuration.md) — `~/.oracle/config.json` and project `.oracle/config.json` defaults.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,9 @@
 # Local configuration (JSON5)
 
-Oracle reads an optional per-user config from `~/.oracle/config.json`. The file uses JSON5 parsing, so trailing commas and comments are allowed.
+Oracle reads an optional per-user config from `~/.oracle/config.json`, then layers
+project configs from `.oracle/config.json` files discovered from your working
+directory upward, stopping before your home directory. All config files use
+JSON5 parsing, so trailing commas and comments are allowed.
 
 ## Example (`~/.oracle/config.json`)
 
@@ -67,11 +70,41 @@ Oracle reads an optional per-user config from `~/.oracle/config.json`. The file 
 }
 ```
 
+## Project configs
+
+Put a project-level config at `.oracle/config.json` inside any project folder:
+
+```json5
+{
+  engine: "browser",
+  model: "gpt-5.5-pro",
+  browser: {
+    chatgptUrl: "https://chatgpt.com/g/g-p-example/project",
+    modelStrategy: "current",
+    archiveConversations: "never",
+  },
+}
+```
+
+Oracle discovers every `.oracle/config.json` from the current directory upward
+until your home directory, then applies them from parent to child after the user
+config. Nested objects are merged, while scalars and arrays replace earlier
+values. This lets a parent folder set broad defaults and override a specific
+ChatGPT Project URL in a package subdirectory.
+
+Project configs intentionally support only workflow defaults. They cannot set
+provider routing or secret/executable fields such as `apiBaseUrl`, `azure`,
+`browser.remoteHost`, `browser.remoteToken`, `browser.chromePath`, or
+`browser.chromeCookiePath`. Keep tokens and machine-local executable/profile
+paths in `~/.oracle/config.json`, environment variables, or explicit CLI flags.
+
 ## Precedence
 
-CLI flags → `config.json` → environment → built-in defaults.
+CLI flags and explicit override environment variables → effective config (project `.oracle/config.json` files over `~/.oracle/config.json`) → auto-detected environment → built-in defaults.
 
-- `engine`, `model`, `search`, `filesReport`, `heartbeatSeconds`, `maxFileSizeBytes`, and `apiBaseUrl` in `config.json` override the auto-detected values unless explicitly set on the CLI.
+- The effective config starts with `~/.oracle/config.json`, then layers project `.oracle/config.json` files from parent to child. `engine`, `model`, `search`, `filesReport`, `heartbeatSeconds`, `maxFileSizeBytes`, and `apiBaseUrl` in the effective config override auto-detected values unless explicitly set on the CLI or through a supported override environment variable.
+- Project `.oracle/config.json` files can override safe workflow defaults such as `engine`, `model`, `search`, `filesReport`, `heartbeatSeconds`, `maxFileSizeBytes`, `promptSuffix`, and allowed `browser.*` workflow settings.
+- Provider routing and machine-local fields (`apiBaseUrl`, `azure`, remote browser host/token defaults, Chrome binary/profile paths, cookie DB paths, and session retention cleanup) are ignored in project configs and are read only from the user config, environment variables, or explicit CLI flags.
 - `ORACLE_ENGINE=api|browser` is a global override for engine selection (useful for MCP/Codex setups); it wins over `config.json`.
 - If `azure.endpoint` (or `--azure-endpoint`) is set, Oracle reads `AZURE_OPENAI_API_KEY` first and falls back to `OPENAI_API_KEY` for GPT models.
 - Remote browser defaults follow the same order: `--remote-host/--remote-token` win, then `browser.remoteHost` / `browser.remoteToken` in the config, then `ORACLE_REMOTE_HOST` / `ORACLE_REMOTE_TOKEN` if still unset.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -10,7 +10,7 @@ Claude Code can call `oracle-mcp` and ask a subscription-backed ChatGPT browser 
 
 ### `consult`
 
-- Inputs: `prompt` (required), `files?: string[]` (globs), `model?: string` (defaults to CLI), `engine?: "api" | "browser"` (optional; Oracle follows CLI defaults: config/`ORACLE_ENGINE` first, then API when `OPENAI_API_KEY` is set, otherwise browser), `slug?: string`.
+- Inputs: `prompt` (required), `files?: string[]` (globs), `model?: string` (defaults to CLI), `engine?: "api" | "browser"` (optional; Oracle follows CLI defaults: `ORACLE_ENGINE` and the effective config first, then API when `OPENAI_API_KEY` is set, otherwise browser), `slug?: string`.
 - Presets: `preset?: "chatgpt-pro-heavy"` applies browser mode + current Pro model alias + extended thinking, unless the request overrides those fields.
 - Browser-only extras: `browserAttachments?: "auto"|"never"|"always"`, `browserBundleFiles?: boolean`, `browserBundleFormat?: "text"|"zip"`, `browserThinkingTime?: "light"|"standard"|"extended"|"heavy"`, `browserResearchMode?: "deep"`, `browserFollowUps?: string[]`, `browserArchive?: "auto"|"always"|"never"`, `browserKeepBrowser?: boolean`, `browserModelLabel?: string`, `browserModelStrategy?: "select"|"current"|"ignore"`.
 - Dry runs: set `dryRun: true` to preview the resolved request without creating a session or touching the browser.
@@ -74,4 +74,4 @@ Browser-backed GPT-5.5 Pro consults can legitimately run for many minutes. Some 
   - Claude Code: `oracle bridge claude-config`
   - Claude Code with local macOS Chrome: `oracle bridge claude-config --local-browser > .mcp.json`
 - Tools and resources operate on the same session store as `oracle status|session`.
-- Defaults (model/engine/etc.) come from your Oracle CLI config; see `docs/configuration.md` or `~/.oracle/config.json`.
+- Defaults (model/engine/etc.) come from the effective Oracle CLI config; see `docs/configuration.md`, `~/.oracle/config.json`, and project `.oracle/config.json` files.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -37,7 +37,7 @@ The bundle Oracle ships is deterministic given the same args and same files. Tha
 Auto-pick rules:
 
 1. If `--engine` is set, use it.
-2. Else if `engine` is set in `~/.oracle/config.json`, use it.
+2. Else if `engine` is set in the effective config, use it. The effective config starts with `~/.oracle/config.json`, then layers project `.oracle/config.json` files from parent folders to the current directory.
 3. Else if `OPENAI_API_KEY` (or another supported API key) is set, use API.
 4. Else use browser.
 

--- a/src/cli/bridge/doctor.ts
+++ b/src/cli/bridge/doctor.ts
@@ -12,8 +12,14 @@ export interface BridgeDoctorCliOptions {
 }
 
 export async function runBridgeDoctor(_options: BridgeDoctorCliOptions): Promise<void> {
-  const { config: userConfig, path: configPath, loaded } = await loadUserConfig();
+  const {
+    config: userConfig,
+    path: configPath,
+    paths: configPaths,
+    loaded: userConfigLoaded,
+  } = await loadUserConfig();
   const version = getCliVersion();
+  const projectConfigPaths = configPaths.filter((entry) => entry !== configPath);
 
   const resolvedRemote = resolveRemoteServiceConfig({
     cliHost: undefined,
@@ -30,7 +36,11 @@ export async function runBridgeDoctor(_options: BridgeDoctorCliOptions): Promise
   lines.push(chalk.dim(`OS: ${process.platform} ${os.release()} (${process.arch})`));
   lines.push(chalk.dim(`Node: ${process.version}`));
   lines.push(chalk.dim(`Oracle: ${version}`));
-  lines.push(chalk.dim(`Config: ${loaded ? configPath : "(missing)"}`));
+  lines.push(chalk.dim(`Config: ${userConfigLoaded ? configPath : `${configPath} (missing)`}`));
+  if (projectConfigPaths.length > 0) {
+    const label = projectConfigPaths.length === 1 ? "Project config" : "Project configs";
+    lines.push(chalk.dim(`${label}: ${projectConfigPaths.join(", ")}`));
+  }
   if (userConfig.engine) {
     lines.push(chalk.dim(`Default engine: ${userConfig.engine}`));
   }

--- a/src/cli/engine.ts
+++ b/src/cli/engine.ts
@@ -18,15 +18,18 @@ export function defaultWaitPreference(model: string, engine: EngineMode): boolea
  * 2) Explicit --engine value.
  * 3) Explicit API provider routing flags force API.
  * 4) ORACLE_ENGINE environment override (api|browser).
- * 5) API environment decides: api when set, otherwise browser.
+ * 5) Config engine value.
+ * 6) API environment decides: api when set, otherwise browser.
  */
 export function resolveEngine({
   engine,
+  configEngine,
   browserFlag,
   apiProviderRequested,
   env,
 }: {
   engine?: EngineMode;
+  configEngine?: EngineMode;
   browserFlag?: boolean;
   apiProviderRequested?: boolean;
   env: NodeJS.ProcessEnv;
@@ -43,6 +46,9 @@ export function resolveEngine({
   const envEngine = normalizeEngineMode(env.ORACLE_ENGINE);
   if (envEngine) {
     return envEngine;
+  }
+  if (configEngine) {
+    return configEngine;
   }
   return hasApiEnvironment(env) ? "api" : "browser";
 }

--- a/src/cli/runOptions.ts
+++ b/src/cli/runOptions.ts
@@ -40,14 +40,17 @@ export function resolveRunOptionsFromConfig({
   userConfig,
   env = process.env,
 }: ResolveRunOptionsInput): ResolvedRunOptions {
-  const resolvedEngine = resolveEngineWithConfig({
+  const resolvedEngine = resolveEngine({
     engine,
     configEngine: userConfig?.engine,
     env,
   });
+  const envEnginePreference = (env.ORACLE_ENGINE ?? "").trim().toLowerCase();
   const browserRequested = engine === "browser";
-  const browserConfigured = userConfig?.engine === "browser";
-  const envBrowserConfigured = (env.ORACLE_ENGINE ?? "").trim().toLowerCase() === "browser";
+  const explicitApiEngineRequested = engine === "api" || (!engine && envEnginePreference === "api");
+  const browserConfigured = userConfig?.engine === "browser" && !explicitApiEngineRequested;
+  const envBrowserConfigured = !engine && envEnginePreference === "browser";
+  const browserEngineRequested = browserRequested || browserConfigured || envBrowserConfigured;
   const requestedModelList = Array.isArray(models) ? models : [];
   const normalizedRequestedModels = requestedModelList
     .map((entry) => normalizeModelOption(entry))
@@ -69,7 +72,7 @@ export function resolveRunOptionsFromConfig({
   const browserCompatibilityModels: ModelName[] =
     normalizedRequestedModels.length > 0 ? allModels : [browserModel];
   const includesGeminiApiOnly = allModels.some((m) => m === "gemini-3.1-pro");
-  if ((browserRequested || browserConfigured) && includesGeminiApiOnly) {
+  if (browserEngineRequested && includesGeminiApiOnly) {
     throw new PromptValidationError(
       "gemini-3.1-pro is API-only today. Use --engine api or switch to gemini-3-pro for Gemini web.",
       { engine: "browser", models: allModels },
@@ -77,8 +80,7 @@ export function resolveRunOptionsFromConfig({
   }
   const isBrowserCompatible = (m: string) => m.startsWith("gpt-") || m.startsWith("gemini");
   const hasNonBrowserCompatibleTarget =
-    (browserRequested || browserConfigured) &&
-    browserCompatibilityModels.some((m) => !isBrowserCompatible(m));
+    browserEngineRequested && browserCompatibilityModels.some((m) => !isBrowserCompatible(m));
   if (hasNonBrowserCompatibleTarget) {
     throw new PromptValidationError(
       "Browser engine only supports GPT and Gemini models. Re-run with --engine api for Grok, Claude, or other models.",
@@ -89,9 +91,7 @@ export function resolveRunOptionsFromConfig({
   const azure = resolveAzureOptions(userConfig, env);
   const azureAutoApi =
     Boolean(azure?.endpoint) &&
-    !browserRequested &&
-    !browserConfigured &&
-    !envBrowserConfigured &&
+    !browserEngineRequested &&
     allModels.some(isAzureOpenAICandidateModel);
   const engineCoercedToApi =
     engineWasBrowser && (isCodex || isClaude || isGrok || isGeminiApiOnly || azureAutoApi);
@@ -149,26 +149,6 @@ export function resolveRunOptionsFromConfig({
   };
 
   return { runOptions, resolvedEngine: fixedEngine, engineCoercedToApi };
-}
-
-function resolveEngineWithConfig({
-  engine,
-  configEngine,
-  apiProviderRequested,
-  env,
-}: {
-  engine?: EngineMode;
-  configEngine?: EngineMode;
-  apiProviderRequested?: boolean;
-  env: NodeJS.ProcessEnv;
-}): EngineMode {
-  if (engine) return engine;
-  const envOverride = (env.ORACLE_ENGINE ?? "").trim().toLowerCase();
-  if (envOverride === "api" || envOverride === "browser") {
-    return envOverride as EngineMode;
-  }
-  if (configEngine) return configEngine;
-  return resolveEngine({ engine: undefined, apiProviderRequested, env });
 }
 
 function resolveAzureOptions(

--- a/src/config.ts
+++ b/src/config.ts
@@ -293,11 +293,30 @@ function sanitizeProjectConfig(config: UserConfig): UserConfig {
     }
 
     const chatgptUrl = browser.chatgptUrl ?? browser.url;
-    if (chatgptUrl !== undefined) {
+    if (
+      chatgptUrl === null ||
+      (chatgptUrl !== undefined && isTrustedProjectChatgptUrl(chatgptUrl))
+    ) {
       sanitized.browser.chatgptUrl = chatgptUrl;
       sanitized.browser.url = chatgptUrl;
     }
   }
 
   return sanitized;
+}
+
+function isTrustedProjectChatgptUrl(rawUrl: string): boolean {
+  if (!rawUrl) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(rawUrl);
+    if (parsed.protocol !== "https:") {
+      return false;
+    }
+    return parsed.hostname === "chatgpt.com" || parsed.hostname === "chat.openai.com";
+  } catch {
+    return false;
+  }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import JSON5 from "json5";
 import { getOracleHomeDir } from "./oracleHome.js";
@@ -96,33 +97,207 @@ export interface UserConfig {
   sessionRetentionHours?: number;
 }
 
-function resolveConfigPath(): string {
+export const PROJECT_CONFIG_RELATIVE_PATH = path.join(".oracle", "config.json");
+
+function resolveUserConfigPath(): string {
   return path.join(getOracleHomeDir(), "config.json");
 }
 
 export interface LoadConfigResult {
   config: UserConfig;
+  /** The user config path; `loaded` refers to this path only. */
+  path: string;
+  /** All config files that were actually loaded, including project configs. */
+  paths: string[];
+  loaded: boolean;
+}
+
+export interface LoadUserConfigOptions {
+  cwd?: string;
+  includeProject?: boolean;
+}
+
+interface ReadConfigResult {
+  config: UserConfig;
   path: string;
   loaded: boolean;
 }
 
-export async function loadUserConfig(): Promise<LoadConfigResult> {
-  const CONFIG_PATH = resolveConfigPath();
+export async function loadUserConfig(
+  options: LoadUserConfigOptions = {},
+): Promise<LoadConfigResult> {
+  const userConfigPath = resolveUserConfigPath();
+  const userConfig = await readConfigFile(userConfigPath);
+  const projectConfigPaths =
+    options.includeProject === false
+      ? []
+      : await discoverProjectConfigPaths({
+          cwd: options.cwd ?? process.cwd(),
+          userConfigPath,
+        });
+
+  const loadedConfigs: ReadConfigResult[] = [];
+  if (userConfig.loaded) {
+    loadedConfigs.push(userConfig);
+  }
+
+  let merged = userConfig.loaded ? userConfig.config : {};
+  for (const projectConfigPath of projectConfigPaths) {
+    const projectConfig = await readConfigFile(projectConfigPath);
+    if (!projectConfig.loaded) continue;
+    loadedConfigs.push(projectConfig);
+    merged = mergeUserConfig(merged, sanitizeProjectConfig(projectConfig.config));
+  }
+
+  const loadedPaths = loadedConfigs.map((entry) => entry.path);
+  return {
+    config: merged,
+    path: userConfigPath,
+    paths: loadedPaths,
+    loaded: userConfig.loaded,
+  };
+}
+
+async function readConfigFile(configPath: string): Promise<ReadConfigResult> {
   try {
-    const raw = await fs.readFile(CONFIG_PATH, "utf8");
+    const raw = await fs.readFile(configPath, "utf8");
     const parsed = JSON5.parse(raw) as UserConfig;
-    return { config: parsed ?? {}, path: CONFIG_PATH, loaded: true };
+    return { config: parsed ?? {}, path: configPath, loaded: true };
   } catch (error) {
     const code = (error as { code?: string }).code;
     if (code === "ENOENT") {
-      return { config: {}, path: CONFIG_PATH, loaded: false };
+      return { config: {}, path: configPath, loaded: false };
     }
     console.warn(
-      `Failed to read ${CONFIG_PATH}: ${error instanceof Error ? error.message : String(error)}`,
+      `Failed to read ${configPath}: ${error instanceof Error ? error.message : String(error)}`,
     );
-    return { config: {}, path: CONFIG_PATH, loaded: false };
+    return { config: {}, path: configPath, loaded: false };
   }
 }
+
 export function configPath(): string {
-  return resolveConfigPath();
+  return resolveUserConfigPath();
+}
+
+async function discoverProjectConfigPaths({
+  cwd,
+  userConfigPath,
+}: {
+  cwd: string;
+  userConfigPath: string;
+}): Promise<string[]> {
+  const start = path.resolve(cwd);
+  const home = os.homedir();
+  const candidates: string[] = [];
+  const seen = new Set<string>([path.resolve(userConfigPath)]);
+  let current = start;
+
+  while (true) {
+    if (current === home) {
+      break;
+    }
+
+    const candidate = path.join(current, PROJECT_CONFIG_RELATIVE_PATH);
+    const resolved = path.resolve(candidate);
+    if (!seen.has(resolved)) {
+      try {
+        const stat = await fs.stat(resolved);
+        if (stat.isFile()) {
+          candidates.unshift(resolved);
+          seen.add(resolved);
+        }
+      } catch (error) {
+        if ((error as { code?: string }).code !== "ENOENT") {
+          console.warn(
+            `Failed to inspect ${resolved}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+
+  return candidates;
+}
+
+function mergeUserConfig(base: UserConfig, override: UserConfig): UserConfig {
+  return deepMerge(base, override) as UserConfig;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function deepMerge(base: unknown, override: unknown): unknown {
+  if (!isRecord(base) || !isRecord(override)) {
+    return override;
+  }
+
+  const result: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(override)) {
+    const existing = result[key];
+    result[key] = isRecord(existing) && isRecord(value) ? deepMerge(existing, value) : value;
+  }
+  return result;
+}
+
+function sanitizeProjectConfig(config: UserConfig): UserConfig {
+  const sanitized: UserConfig = {};
+
+  if (config.engine !== undefined) sanitized.engine = config.engine;
+  if (config.model !== undefined) sanitized.model = config.model;
+  if (config.search !== undefined) sanitized.search = config.search;
+  if (config.maxFileSizeBytes !== undefined) sanitized.maxFileSizeBytes = config.maxFileSizeBytes;
+  if (config.notify !== undefined) sanitized.notify = config.notify;
+  if (config.heartbeatSeconds !== undefined) sanitized.heartbeatSeconds = config.heartbeatSeconds;
+  if (config.filesReport !== undefined) sanitized.filesReport = config.filesReport;
+  if (config.background !== undefined) sanitized.background = config.background;
+  if (config.promptSuffix !== undefined) sanitized.promptSuffix = config.promptSuffix;
+
+  if (config.browser) {
+    sanitized.browser = {};
+    const browser = config.browser;
+    const allowedBrowserKeys: Array<keyof BrowserConfigDefaults> = [
+      "attachRunning",
+      "timeoutMs",
+      "inputTimeoutMs",
+      "assistantRecheckDelayMs",
+      "assistantRecheckTimeoutMs",
+      "reuseChromeWaitMs",
+      "profileLockTimeoutMs",
+      "maxConcurrentTabs",
+      "autoReattachDelayMs",
+      "autoReattachIntervalMs",
+      "autoReattachTimeoutMs",
+      "cookieSyncWaitMs",
+      "hideWindow",
+      "keepBrowser",
+      "modelStrategy",
+      "thinkingTime",
+      "researchMode",
+      "archiveConversations",
+      "manualLogin",
+    ];
+
+    for (const key of allowedBrowserKeys) {
+      if (browser[key] !== undefined) {
+        sanitized.browser[key] = browser[key] as never;
+      }
+    }
+
+    const chatgptUrl = browser.chatgptUrl ?? browser.url;
+    if (chatgptUrl !== undefined) {
+      sanitized.browser.chatgptUrl = chatgptUrl;
+      sanitized.browser.url = chatgptUrl;
+    }
+  }
+
+  return sanitized;
 }

--- a/tests/bridge/doctor.test.ts
+++ b/tests/bridge/doctor.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { setOracleHomeDirOverrideForTest } from "../../src/oracleHome.js";
+import { PROJECT_CONFIG_RELATIVE_PATH } from "../../src/config.js";
 
 // biome-ignore lint/complexity/useRegexLiterals: constructor form avoids control-char lint noise.
 const ansiRegex = new RegExp("\\x1B\\[[0-9;]*m", "g");
@@ -77,5 +78,31 @@ describe("oracle bridge doctor", () => {
     expect(output).toMatch(/remoteToken:\s+missing/i);
     expect(output).toMatch(/Problems:/i);
     expect(process.exitCode).toBe(1);
+  });
+
+  it("reports project-only config separately from the missing user config", async () => {
+    const originalCwd = process.cwd();
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-bridge-project-"));
+    await fs.mkdir(path.join(repoDir, ".oracle"), { recursive: true });
+    const projectConfigPath = path.join(repoDir, PROJECT_CONFIG_RELATIVE_PATH);
+    await fs.writeFile(projectConfigPath, `{ engine: "browser" }`, "utf8");
+    const resolvedProjectConfigPath = await fs.realpath(projectConfigPath);
+
+    const logs: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((msg) => logs.push(String(msg)));
+
+    try {
+      process.chdir(repoDir);
+      await runBridgeDoctor({ verbose: false });
+    } finally {
+      process.chdir(originalCwd);
+      await fs.rm(repoDir, { recursive: true, force: true });
+    }
+
+    const output = stripAnsi(logs.join("\n"));
+    expect(output).toContain(`Config: ${path.join(tempDir, "config.json")} (missing)`);
+    expect(output).toContain(`Project config: ${resolvedProjectConfigPath}`);
+    expect(output).toMatch(/Default engine:\s+browser/i);
+    expect(process.exitCode ?? 0).toBe(0);
   });
 });

--- a/tests/cli/integrationCli.test.ts
+++ b/tests/cli/integrationCli.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, test } from "vitest";
-import { mkdtemp, writeFile, readdir, readFile, rm } from "node:fs/promises";
+import { mkdtemp, writeFile, readdir, readFile, rm, mkdir } from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 import {
@@ -13,6 +13,7 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 const CLI_ENTRY = path.join(process.cwd(), "bin", "oracle-cli.ts");
+const TSX_LOADER = path.join(process.cwd(), "node_modules", "tsx", "dist", "loader.mjs");
 const CLIENT_FACTORY = path.join(process.cwd(), "tests", "fixtures", "mockClientFactory.cjs");
 const INTEGRATION_TIMEOUT = 60000;
 const AZURE_ENV_KEYS = [
@@ -452,6 +453,148 @@ module.exports = () => ({
       expect(stdout).not.toContain("Provider: Azure OpenAI");
 
       await rm(oracleHome, { recursive: true, force: true });
+    },
+    INTEGRATION_TIMEOUT,
+  );
+
+  test(
+    "honors project browser config when Azure env is present",
+    async () => {
+      const oracleHome = await mkdtemp(path.join(os.tmpdir(), "oracle-project-azure-home-"));
+      const repoDir = await mkdtemp(path.join(os.tmpdir(), "oracle-project-azure-repo-"));
+      await mkdir(path.join(repoDir, ".oracle"), { recursive: true });
+      await writeFile(
+        path.join(repoDir, ".oracle", "config.json"),
+        `{ engine: "browser", browser: { chatgptUrl: "https://chatgpt.com/g/g-p-demo/project" } }`,
+        "utf8",
+      );
+      const env: NodeJS.ProcessEnv = { ...process.env };
+      env.AZURE_OPENAI_ENDPOINT = "https://example-resource.openai.azure.com/";
+      env.AZURE_OPENAI_API_KEY = "az-integration";
+      env.AZURE_OPENAI_DEPLOYMENT = "configured-gpt";
+      env.DOTENV_CONFIG_PATH = "/tmp/nonexistent-oracle-env";
+      env.ORACLE_HOME_DIR = oracleHome;
+      env.ORACLE_DISABLE_KEYTAR = "1";
+      delete env.ORACLE_ENGINE;
+      delete env.OPENAI_API_KEY;
+      delete env.GEMINI_API_KEY;
+      delete env.OPENROUTER_API_KEY;
+
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        [
+          "--import",
+          TSX_LOADER,
+          CLI_ENTRY,
+          "--dry-run",
+          "--prompt",
+          "Project browser route check",
+          "--model",
+          "gpt-5.1",
+        ],
+        { env, cwd: repoDir },
+      );
+
+      expect(stdout).toContain("[preview] Oracle");
+      expect(stdout).toContain("browser mode (gpt-5.1)");
+      expect(stdout).not.toContain("Provider: Azure OpenAI");
+
+      await rm(oracleHome, { recursive: true, force: true });
+      await rm(repoDir, { recursive: true, force: true });
+    },
+    INTEGRATION_TIMEOUT,
+  );
+
+  test(
+    "honors ORACLE_ENGINE api over project config engine",
+    async () => {
+      const oracleHome = await mkdtemp(path.join(os.tmpdir(), "oracle-project-engine-home-"));
+      const repoDir = await mkdtemp(path.join(os.tmpdir(), "oracle-project-engine-repo-"));
+      await mkdir(path.join(repoDir, ".oracle"), { recursive: true });
+      await writeFile(
+        path.join(repoDir, ".oracle", "config.json"),
+        `{ engine: "browser", model: "gpt-5.5-pro" }`,
+        "utf8",
+      );
+      const env: NodeJS.ProcessEnv = { ...process.env };
+      env.DOTENV_CONFIG_PATH = "/tmp/nonexistent-oracle-env";
+      env.ORACLE_HOME_DIR = oracleHome;
+      env.ORACLE_ENGINE = "api";
+      env.ORACLE_DISABLE_KEYTAR = "1";
+      delete env.OPENAI_API_KEY;
+      delete env.GEMINI_API_KEY;
+      delete env.OPENROUTER_API_KEY;
+
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        ["--import", TSX_LOADER, CLI_ENTRY, "--dry-run", "--prompt", "Engine env route check"],
+        { env, cwd: repoDir },
+      );
+
+      expect(stdout).toContain("[dry-run] Oracle");
+      expect(stdout).toContain("would call gpt-5.5-pro");
+      expect(stdout).not.toContain("browser mode");
+
+      await rm(oracleHome, { recursive: true, force: true });
+      await rm(repoDir, { recursive: true, force: true });
+    },
+    INTEGRATION_TIMEOUT,
+  );
+
+  test(
+    "honors API engine overrides over project browser config for API-only models",
+    async () => {
+      const oracleHome = await mkdtemp(path.join(os.tmpdir(), "oracle-project-api-home-"));
+      const repoDir = await mkdtemp(path.join(os.tmpdir(), "oracle-project-api-repo-"));
+      await mkdir(path.join(repoDir, ".oracle"), { recursive: true });
+      await writeFile(
+        path.join(repoDir, ".oracle", "config.json"),
+        `{ engine: "browser" }`,
+        "utf8",
+      );
+      const env: NodeJS.ProcessEnv = { ...process.env };
+      env.DOTENV_CONFIG_PATH = "/tmp/nonexistent-oracle-env";
+      env.ORACLE_HOME_DIR = oracleHome;
+      env.ORACLE_DISABLE_KEYTAR = "1";
+      delete env.ORACLE_ENGINE;
+      delete env.OPENAI_API_KEY;
+      delete env.GEMINI_API_KEY;
+      delete env.OPENROUTER_API_KEY;
+
+      for (const scenario of [
+        { args: ["--engine", "api"], envEngine: undefined },
+        { args: [], envEngine: "api" },
+      ]) {
+        const scenarioEnv = { ...env };
+        if (scenario.envEngine) {
+          scenarioEnv.ORACLE_ENGINE = scenario.envEngine;
+        } else {
+          delete scenarioEnv.ORACLE_ENGINE;
+        }
+
+        const { stdout } = await execFileAsync(
+          process.execPath,
+          [
+            "--import",
+            TSX_LOADER,
+            CLI_ENTRY,
+            "--dry-run",
+            ...scenario.args,
+            "--model",
+            "claude-4.6-sonnet",
+            "--prompt",
+            "Explicit API route check",
+          ],
+          { env: scenarioEnv, cwd: repoDir, timeout: INTEGRATION_TIMEOUT },
+        );
+
+        expect(stdout).toContain("[dry-run] Oracle");
+        expect(stdout).toContain("would call claude-4.6-sonnet");
+        expect(stdout).not.toContain("browser mode");
+      }
+
+      await rm(oracleHome, { recursive: true, force: true });
+      await rm(repoDir, { recursive: true, force: true });
     },
     INTEGRATION_TIMEOUT,
   );

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -148,6 +148,34 @@ describe("loadUserConfig", () => {
     expect(result.config.browser?.url).toBe("https://chatgpt.com/g/g-p-project/project");
   });
 
+  it("ignores project config browser URLs outside trusted ChatGPT hosts", async () => {
+    await fs.writeFile(
+      path.join(tempDir, "config.json"),
+      `{
+        browser: {
+          chatgptUrl: "https://chatgpt.com/g/g-p-user/project",
+        },
+      }`,
+      "utf8",
+    );
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-repo-"));
+    await fs.mkdir(path.join(repoDir, ".oracle"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoDir, PROJECT_CONFIG_RELATIVE_PATH),
+      `{
+        browser: {
+          chatgptUrl: "https://attacker.example/project",
+        },
+      }`,
+      "utf8",
+    );
+
+    const result = await loadUserConfig({ cwd: repoDir });
+
+    expect(result.config.browser?.chatgptUrl).toBe("https://chatgpt.com/g/g-p-user/project");
+    expect(result.config.browser?.url).toBeUndefined();
+  });
+
   it("does not let project configs set provider routing or local state paths", async () => {
     await fs.writeFile(
       path.join(tempDir, "config.json"),

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { loadUserConfig } from "../src/config.js";
+import { loadUserConfig, PROJECT_CONFIG_RELATIVE_PATH } from "../src/config.js";
 import { setOracleHomeDirOverrideForTest } from "../src/oracleHome.js";
 
 describe("loadUserConfig", () => {
@@ -57,6 +57,182 @@ describe("loadUserConfig", () => {
     const result = await loadUserConfig();
     expect(result.loaded).toBe(false);
     expect(result.config).toEqual({});
+    expect(result.paths).toEqual([]);
+  });
+
+  it("merges project configs from parent to child over user config", async () => {
+    await fs.writeFile(
+      path.join(tempDir, "config.json"),
+      `{
+        engine: "api",
+        model: "gpt-5.5-pro",
+        browser: {
+          chatgptUrl: "https://chatgpt.com/",
+          modelStrategy: "select",
+          archiveConversations: "auto",
+        },
+      }`,
+      "utf8",
+    );
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-repo-"));
+    const nestedDir = path.join(repoDir, "packages", "web");
+    await fs.mkdir(path.join(repoDir, ".oracle"), { recursive: true });
+    await fs.mkdir(path.join(nestedDir, ".oracle"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoDir, PROJECT_CONFIG_RELATIVE_PATH),
+      `{
+        model: "gpt-5.4",
+        browser: {
+          chatgptUrl: "https://chatgpt.com/g/g-p-root/project",
+          modelStrategy: "current",
+        },
+      }`,
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(nestedDir, PROJECT_CONFIG_RELATIVE_PATH),
+      `{
+        engine: "browser",
+        browser: {
+          archiveConversations: "never",
+        },
+      }`,
+      "utf8",
+    );
+
+    const result = await loadUserConfig({ cwd: nestedDir });
+
+    expect(result.loaded).toBe(true);
+    expect(result.config).toMatchObject({
+      engine: "browser",
+      model: "gpt-5.4",
+      browser: {
+        chatgptUrl: "https://chatgpt.com/g/g-p-root/project",
+        modelStrategy: "current",
+        archiveConversations: "never",
+      },
+    });
+    expect(result.paths).toEqual([
+      path.join(tempDir, "config.json"),
+      path.join(repoDir, PROJECT_CONFIG_RELATIVE_PATH),
+      path.join(nestedDir, PROJECT_CONFIG_RELATIVE_PATH),
+    ]);
+    expect(result.path).toBe(path.join(tempDir, "config.json"));
+  });
+
+  it("treats browser.chatgptUrl and browser.url as the same project setting", async () => {
+    await fs.writeFile(
+      path.join(tempDir, "config.json"),
+      `{
+        browser: {
+          chatgptUrl: "https://chatgpt.com/g/g-p-user/project",
+        },
+      }`,
+      "utf8",
+    );
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-repo-"));
+    await fs.mkdir(path.join(repoDir, ".oracle"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoDir, PROJECT_CONFIG_RELATIVE_PATH),
+      `{
+        browser: {
+          url: "https://chatgpt.com/g/g-p-project/project",
+        },
+      }`,
+      "utf8",
+    );
+
+    const result = await loadUserConfig({ cwd: repoDir });
+
+    expect(result.config.browser?.chatgptUrl).toBe("https://chatgpt.com/g/g-p-project/project");
+    expect(result.config.browser?.url).toBe("https://chatgpt.com/g/g-p-project/project");
+  });
+
+  it("does not let project configs set provider routing or local state paths", async () => {
+    await fs.writeFile(
+      path.join(tempDir, "config.json"),
+      `{
+        apiBaseUrl: "https://api.openai.com/v1",
+        azure: { endpoint: "https://safe.openai.azure.com/" },
+        sessionRetentionHours: 72,
+        browser: {
+          chromePath: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+          remoteHost: "safe-host:9473",
+          remoteToken: "safe-token",
+          chatgptUrl: "https://chatgpt.com/",
+          manualLoginProfileDir: "/tmp/safe-profile",
+        },
+      }`,
+      "utf8",
+    );
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-repo-"));
+    await fs.mkdir(path.join(repoDir, ".oracle"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoDir, PROJECT_CONFIG_RELATIVE_PATH),
+      `{
+        apiBaseUrl: "https://evil.example/v1",
+        azure: { endpoint: "https://evil.azure.example/" },
+        sessionRetentionHours: 1,
+        browser: {
+          chromePath: "./fake-chrome",
+          chromeCookiePath: "./Cookies",
+          remoteHost: "evil.example:9473",
+          remoteToken: "evil-token",
+          chatgptUrl: "https://chatgpt.com/g/g-p-project/project",
+          manualLoginProfileDir: "./profile",
+        },
+      }`,
+      "utf8",
+    );
+
+    const result = await loadUserConfig({ cwd: repoDir });
+
+    expect(result.config.apiBaseUrl).toBe("https://api.openai.com/v1");
+    expect(result.config.azure?.endpoint).toBe("https://safe.openai.azure.com/");
+    expect(result.config.sessionRetentionHours).toBe(72);
+    expect(result.config.browser).toMatchObject({
+      chromePath: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+      remoteHost: "safe-host:9473",
+      remoteToken: "safe-token",
+      chatgptUrl: "https://chatgpt.com/g/g-p-project/project",
+      manualLoginProfileDir: "/tmp/safe-profile",
+    });
+    expect(result.config.browser?.chromeCookiePath).toBeUndefined();
+  });
+
+  it("inherits project configs from arbitrary parent folders", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-workspace-"));
+    const repoDir = path.join(workspaceDir, "repo");
+    await fs.mkdir(path.join(workspaceDir, ".oracle"), { recursive: true });
+    await fs.mkdir(repoDir, { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceDir, PROJECT_CONFIG_RELATIVE_PATH),
+      `{ model: "gpt-5.4" }`,
+      "utf8",
+    );
+
+    const result = await loadUserConfig({ cwd: repoDir });
+
+    expect(result.loaded).toBe(false);
+    expect(result.path).toBe(path.join(tempDir, "config.json"));
+    expect(result.config.model).toBe("gpt-5.4");
+    expect(result.paths).toEqual([path.join(workspaceDir, PROJECT_CONFIG_RELATIVE_PATH)]);
+  });
+
+  it("can disable project discovery", async () => {
+    await fs.writeFile(path.join(tempDir, "config.json"), `{ model: "gpt-5.5-pro" }`, "utf8");
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-repo-"));
+    await fs.mkdir(path.join(repoDir, ".oracle"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoDir, PROJECT_CONFIG_RELATIVE_PATH),
+      `{ model: "gpt-5.4" }`,
+      "utf8",
+    );
+
+    const result = await loadUserConfig({ cwd: repoDir, includeProject: false });
+
+    expect(result.config.model).toBe("gpt-5.5-pro");
+    expect(result.paths).toEqual([path.join(tempDir, "config.json")]);
   });
 
   afterAll(() => {

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -40,6 +40,28 @@ describe("resolveEngine", () => {
     expect(engine).toBe<EngineMode>("api");
   });
 
+  it("lets ORACLE_ENGINE override config engine", () => {
+    const env = { ...envWithoutKey } as NodeJS.ProcessEnv;
+    env.ORACLE_ENGINE = "api";
+    const engine = resolveEngine({
+      engine: undefined,
+      configEngine: "browser",
+      browserFlag: false,
+      env,
+    });
+    expect(engine).toBe<EngineMode>("api");
+  });
+
+  it("uses config engine before auto-detecting from API keys", () => {
+    const engine = resolveEngine({
+      engine: undefined,
+      configEngine: "browser",
+      browserFlag: false,
+      env: envWithKey,
+    });
+    expect(engine).toBe<EngineMode>("browser");
+  });
+
   it("does not let Azure env choose API before a model is known", () => {
     const env = { ...envWithoutKey, AZURE_OPENAI_ENDPOINT: "https://example.openai.azure.com/" };
     const engine = resolveEngine({ engine: undefined, browserFlag: false, env });

--- a/tests/runOptions.test.ts
+++ b/tests/runOptions.test.ts
@@ -24,6 +24,29 @@ describe("resolveRunOptionsFromConfig", () => {
     expect(resolvedEngine).toBe("api");
   });
 
+  it("does not treat a browser config default as explicit when API is requested", () => {
+    const { runOptions, resolvedEngine } = resolveRunOptionsFromConfig({
+      prompt: basePrompt,
+      model: "claude-4.6-sonnet",
+      engine: "api",
+      userConfig: { engine: "browser" },
+    });
+    expect(resolvedEngine).toBe("api");
+    expect(runOptions.model).toBe("claude-4.6-sonnet");
+  });
+
+  it("lets ORACLE_ENGINE=api override a browser config default for API-only models", () => {
+    const env = { ORACLE_ENGINE: "api" } as NodeJS.ProcessEnv;
+    const { runOptions, resolvedEngine } = resolveRunOptionsFromConfig({
+      prompt: basePrompt,
+      model: "gemini-3.1-pro",
+      userConfig: { engine: "browser" },
+      env,
+    });
+    expect(resolvedEngine).toBe("api");
+    expect(runOptions.model).toBe("gemini-3.1-pro");
+  });
+
   it("defaults to gpt-5.5-pro when model not provided", () => {
     const { runOptions } = resolveRunOptionsFromConfig({
       prompt: basePrompt,
@@ -159,6 +182,21 @@ describe("resolveRunOptionsFromConfig", () => {
     expect(runOptions.model).toBe("gpt-5.2");
   });
 
+  it("honors browser config instead of auto-selecting Azure API", () => {
+    const env = {
+      AZURE_OPENAI_ENDPOINT: "https://example-resource.openai.azure.com/",
+      AZURE_OPENAI_DEPLOYMENT: "configured-gpt",
+    } as NodeJS.ProcessEnv;
+    const { runOptions, resolvedEngine } = resolveRunOptionsFromConfig({
+      prompt: basePrompt,
+      model: "gpt-5.1",
+      userConfig: { engine: "browser" },
+      env,
+    });
+    expect(resolvedEngine).toBe("browser");
+    expect(runOptions.model).toBe("gpt-5.2");
+  });
+
   it("keeps browser-capable Gemini in browser mode when Azure endpoint comes from config", () => {
     const { runOptions, resolvedEngine } = resolveRunOptionsFromConfig({
       prompt: basePrompt,
@@ -228,6 +266,17 @@ describe("resolveRunOptionsFromConfig", () => {
     expect(engineCoercedToApi).toBe(true);
     expect(runOptions.model).toBe("gemini-3.1-pro");
     expect(runOptions.effectiveModelId).toBe("gemini-3.1-pro-preview");
+  });
+
+  it("rejects browser config defaults for gemini-3.1-pro", () => {
+    expect(() =>
+      resolveRunOptionsFromConfig({
+        prompt: basePrompt,
+        model: "gemini-3.1-pro",
+        userConfig: { engine: "browser" },
+        env: {},
+      }),
+    ).toThrow("gemini-3.1-pro is API-only today");
   });
 
   it("rejects browser engine explicitly set for gemini-3.1-pro", () => {
@@ -327,6 +376,17 @@ describe("resolveRunOptionsFromConfig", () => {
       engine: "browser",
     });
     expect(resolvedEngine).toBe("api");
+  });
+
+  it("rejects browser config defaults for multi-model non-browser runs", () => {
+    expect(() =>
+      resolveRunOptionsFromConfig({
+        prompt: basePrompt,
+        models: ["gpt-5.1", "claude-4.6-sonnet"],
+        userConfig: { engine: "browser" },
+        env: {},
+      }),
+    ).toThrow(/Browser engine only supports GPT and Gemini/);
   });
 
   it("normalizes shorthand multi-model entries", () => {


### PR DESCRIPTION
## Summary

- load `~/.oracle/config.json`, then layer `.oracle/config.json` files discovered from parent folders to the working directory
- deep-merge project defaults while filtering repo-local provider routing, remote browser credentials, executable/profile, cookie, and retention fields
- preserve engine precedence so explicit API/provider choices still win, while project browser defaults are not overridden by ambient Azure config
- document project config behavior and cover merge order, opt-out, blocked fields, bridge doctor reporting, and engine-routing cases

## Why

Project-specific Oracle workflows often need shared defaults such as a ChatGPT Project URL, browser engine, model, and browser behavior. Keeping those only in each user's global config makes repo workflows harder to reproduce.

This adds repo-local workflow defaults while keeping provider routing, remote browser credentials, Chrome executables, cookie paths, and cleanup policy in user config, environment variables, or explicit CLI flags.

## Verification

- `pnpm run check`
- `pnpm docs:check`
- `pnpm vitest run tests/config.test.ts tests/cli/browserDefaults.test.ts`
- previous PR sweep: `pnpm vitest run tests/config.test.ts tests/runOptions.test.ts tests/engine.test.ts tests/cli/integrationCli.test.ts tests/mcp/consult.test.ts tests/mcp/utils.test.ts tests/cli/providerDoctor.test.ts tests/bridge/doctor.test.ts`
- manual dry-run: project `engine: "browser"` with Azure env resolves to browser mode; `ORACLE_ENGINE=api` stays API
- `git diff --check`