### PR TITLE
fix: keep polling send button for attachments

### DIFF
--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -483,22 +483,24 @@ async function attemptSendButton(
   // settle slowly for multi-file uploads, but plain text sends should keep the
   // shorter historical deadline.
   const deadline = Date.now() + sendButtonTimeoutMs(attachmentNames);
+  let attachmentReady = !needAttachment;
   while (Date.now() < deadline) {
     if (needAttachment) {
       const ready = await Runtime.evaluate({
         expression: buildAttachmentReadyExpression(attachmentNames),
         returnByValue: true,
       });
-      if (!ready?.result?.value) {
-        await delay(150);
-        continue;
-      }
+      attachmentReady = Boolean(ready?.result?.value);
     }
     const { result } = await Runtime.evaluate({ expression: script, returnByValue: true });
     if (result.value === "clicked") {
       return true;
     }
     if (result.value === "missing") {
+      if (needAttachment) {
+        await delay(attachmentReady ? 250 : 500);
+        continue;
+      }
       break;
     }
     await delay(100);

--- a/tests/browser/promptComposer.test.ts
+++ b/tests/browser/promptComposer.test.ts
@@ -120,6 +120,33 @@ describe("promptComposer", () => {
     }
   });
 
+  test("probes send button while attachment chip readiness is still pending", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtime = {
+        evaluate: vi.fn(async ({ expression }: { expression: string }) => {
+          if (expression.includes("dispatchClickSequence")) {
+            return { result: { value: "clicked" } };
+          }
+          return { result: { value: false } };
+        }),
+      } as unknown as {
+        evaluate: (args: { expression: string; returnByValue?: boolean }) => Promise<unknown>;
+      };
+
+      const promise = promptComposer.attemptSendButton(
+        runtime as never,
+        (() => undefined) as never,
+        ["oracle-attach-verify.txt"],
+      );
+      const assertion = expect(promise).resolves.toBe(true);
+      await vi.advanceTimersByTimeAsync(46_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("only attachment sends get the longer send-button deadline", () => {
     expect(promptComposer.sendButtonTimeoutMs()).toBe(20_000);
     expect(promptComposer.sendButtonTimeoutMs([])).toBe(20_000);


### PR DESCRIPTION
## What changed

- Keep probing ChatGPT's send button during attachment submissions even when the attachment-chip readiness detector has not fired yet.
- Continue waiting for a clickable send button for attachment submissions instead of falling back to Enter.
- Add a regression test for a ready send button with a still-pending attachment readiness signal.

## Why

ChatGPT can enable the send button after attachments finish while Oracle's DOM-based chip detector still reports pending. The old flow skipped the send-button probe until that detector returned true, so browser submissions could hang instead of clicking send.

## Validation

- `pnpm vitest run tests/browser/promptComposer.test.ts tests/browser/promptComposerExpressions.test.ts`
- `pnpm run check`
