### PR TITLE
Fix ChatGPT attachment send readiness root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Website: point package/homepage metadata and generated site chrome at `https://askoracle.sh` instead of the GitHub repository.
 
+### Fixed
+
+- Browser: resolve attachment readiness from the active ChatGPT composer so uploaded files do not false-fail with `attachment-send-not-ready` when the Send button is already clickable. Thanks @enieuwy!
+
 ## 0.12.1 — 2026-05-17
 
 ### Changed

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -337,9 +337,29 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
   const namesLiteral = JSON.stringify(attachmentNames.map((name) => name.toLowerCase()));
   return `(() => {
     const names = ${namesLiteral};
+    const sendSelectors = ${JSON.stringify(SEND_BUTTON_SELECTORS)};
+    // Restrict to attachment affordances; never scan generic div/span nodes (prompt text can contain the file name).
+    const attachmentSelectors = [
+      '[data-testid*="chip"]',
+      '[data-testid*="attachment"]',
+      '[data-testid*="upload"]',
+      '[data-testid*="file"]',
+      '[aria-label*="Remove file"]',
+      'button[aria-label*="Remove file"]',
+      '[aria-label*="remove file"]',
+      'button[aria-label*="remove file"]',
+      '[aria-label*="Remove attachment"]',
+      'button[aria-label*="Remove attachment"]',
+      '[aria-label*="remove attachment"]',
+      'button[aria-label*="remove attachment"]',
+    ];
+    const sendButton = sendSelectors
+      .map((selector) => document.querySelector(selector))
+      .find(Boolean);
     const composer =
-      document.querySelector('[data-testid*="composer"]') ||
+      sendButton?.closest?.('form') ||
       document.querySelector('form') ||
+      document.querySelector('[data-testid*="composer"]:not(button)') ||
       document.body ||
       document;
     // Walk node + ancestors (up to grandparent) + descendants to gather every textual hint.
@@ -371,22 +391,6 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
       return pieces.join(' ').toLowerCase();
     };
     const match = (node, name) => collectLabelHaystack(node).includes(name);
-
-    // Restrict to attachment affordances; never scan generic div/span nodes (prompt text can contain the file name).
-    const attachmentSelectors = [
-      '[data-testid*="chip"]',
-      '[data-testid*="attachment"]',
-      '[data-testid*="upload"]',
-      '[data-testid*="file"]',
-      '[aria-label*="Remove file"]',
-      'button[aria-label*="Remove file"]',
-      '[aria-label*="remove file"]',
-      'button[aria-label*="remove file"]',
-      '[aria-label*="Remove attachment"]',
-      'button[aria-label*="Remove attachment"]',
-      '[aria-label*="remove attachment"]',
-      'button[aria-label*="remove attachment"]',
-    ];
     const attachmentRoots = Array.from(new Set([composer])).filter(Boolean);
     const collectChipNodes = () => {
       const seen = new Set();

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -357,6 +357,7 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
       .map((selector) => document.querySelector(selector))
       .find(Boolean);
     const composer =
+      sendButton?.closest?.('[data-testid*="composer"]:not(button)') ||
       sendButton?.closest?.('form') ||
       document.querySelector('[data-testid*="composer"]:not(button)') ||
       document.querySelector('form') ||

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -358,8 +358,8 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
       .find(Boolean);
     const composer =
       sendButton?.closest?.('form') ||
-      document.querySelector('form') ||
       document.querySelector('[data-testid*="composer"]:not(button)') ||
+      document.querySelector('form') ||
       document.body ||
       document;
     // Walk node + ancestors (up to grandparent) + descendants to gather every textual hint.

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -356,10 +356,32 @@ function buildAttachmentReadyExpression(attachmentNames: string[]): string {
     const sendButton = sendSelectors
       .map((selector) => document.querySelector(selector))
       .find(Boolean);
+    const isUsableComposerRoot = (node) => {
+      if (!(node instanceof HTMLElement)) return false;
+      if (String(node.tagName || '').toLowerCase() === 'button') return false;
+      const testId = String(node.getAttribute?.('data-testid') || '').toLowerCase();
+      if (!testId.includes('composer')) return false;
+      return !(
+        testId.includes('footer') ||
+        testId.includes('action') ||
+        testId.includes('plus') ||
+        testId.includes('send')
+      );
+    };
+    const closestComposerRoot = (node) => {
+      let current = node instanceof HTMLElement ? node : null;
+      while (current) {
+        if (isUsableComposerRoot(current)) return current;
+        current = current.parentElement;
+      }
+      return null;
+    };
+    const firstComposerRoot = () =>
+      Array.from(document.querySelectorAll('[data-testid*="composer"]')).find(isUsableComposerRoot) || null;
     const composer =
-      sendButton?.closest?.('[data-testid*="composer"]:not(button)') ||
+      closestComposerRoot(sendButton) ||
       sendButton?.closest?.('form') ||
-      document.querySelector('[data-testid*="composer"]:not(button)') ||
+      firstComposerRoot() ||
       document.querySelector('form') ||
       document.body ||
       document;

--- a/tests/browser/promptComposerExpressions.test.ts
+++ b/tests/browser/promptComposerExpressions.test.ts
@@ -198,6 +198,26 @@ describe("prompt composer attachment expressions", () => {
     expect(evaluateAttachmentReadyExpression([fileName], document)).toBe(true);
   });
 
+  test("attachment ready check uses send button composer wrapper before its form", () => {
+    const fileName = "oracle-diagnostic-unique-20260521.txt";
+    const document = new FakeDocument([
+      new FakeElement("div", { "data-testid": "unified-composer" }, [
+        new FakeElement("div", { "data-testid": "attachment-chip" }, [
+          new FakeElement("span", {}, [], fileName),
+          new FakeElement("button", { "aria-label": `Remove file 1: ${fileName}` }),
+        ]),
+        new FakeElement("form", {}, [
+          new FakeElement("button", {
+            "aria-label": "Send prompt",
+            "data-testid": "send-button",
+          }),
+        ]),
+      ]),
+    ]);
+
+    expect(evaluateAttachmentReadyExpression([fileName], document)).toBe(true);
+  });
+
   test("attachment ready check still rejects prompt-only filename matches", () => {
     const fileName = "oracle-diagnostic-unique-20260521.txt";
     const document = new FakeDocument([

--- a/tests/browser/promptComposerExpressions.test.ts
+++ b/tests/browser/promptComposerExpressions.test.ts
@@ -122,10 +122,8 @@ function evaluateAttachmentReadyExpression(
 describe("prompt composer attachment expressions", () => {
   test("attachment ready check does not match prompt text", () => {
     const expression = buildAttachmentReadyExpressionForTest(["oracle-attach-verify.txt"]);
-    expect(expression).toContain("sendButton?.closest?.('form')");
-    expect(expression).toContain(
-      "document.querySelector('[data-testid*=\"composer\"]:not(button)')",
-    );
+    expect(expression).toContain("closestComposerRoot(sendButton)");
+    expect(expression).toContain("firstComposerRoot()");
     expect(expression).not.toContain("document.querySelector('[data-testid*=\"composer\"]') ||");
     expect(expression).toContain("attachmentRoots");
     expect(expression).toContain('input[type="file"]');
@@ -207,6 +205,26 @@ describe("prompt composer attachment expressions", () => {
           new FakeElement("button", { "aria-label": `Remove file 1: ${fileName}` }),
         ]),
         new FakeElement("form", {}, [
+          new FakeElement("button", {
+            "aria-label": "Send prompt",
+            "data-testid": "send-button",
+          }),
+        ]),
+      ]),
+    ]);
+
+    expect(evaluateAttachmentReadyExpression([fileName], document)).toBe(true);
+  });
+
+  test("attachment ready check skips footer action wrappers around send button", () => {
+    const fileName = "oracle-diagnostic-unique-20260521.txt";
+    const document = new FakeDocument([
+      new FakeElement("div", { "data-testid": "unified-composer" }, [
+        new FakeElement("div", { "data-testid": "attachment-chip" }, [
+          new FakeElement("span", {}, [], fileName),
+          new FakeElement("button", { "aria-label": `Remove file 1: ${fileName}` }),
+        ]),
+        new FakeElement("div", { "data-testid": "composer-footer-actions" }, [
           new FakeElement("button", {
             "aria-label": "Send prompt",
             "data-testid": "send-button",

--- a/tests/browser/promptComposerExpressions.test.ts
+++ b/tests/browser/promptComposerExpressions.test.ts
@@ -1,10 +1,132 @@
 import { describe, expect, test } from "vitest";
 import { buildAttachmentReadyExpressionForTest } from "../../src/browser/actions/promptComposer.ts";
 
+class FakeElement {
+  parentElement: FakeElement | null = null;
+  readonly children: FakeElement[];
+  readonly tagName: string;
+
+  constructor(
+    tagName: string,
+    private readonly attributes: Record<string, string> = {},
+    children: FakeElement[] = [],
+    private readonly ownText = "",
+  ) {
+    this.tagName = tagName.toUpperCase();
+    this.children = children;
+    for (const child of children) {
+      child.parentElement = this;
+    }
+  }
+
+  get innerText(): string {
+    return this.textContent;
+  }
+
+  get textContent(): string {
+    return `${this.ownText}${this.children.map((child) => child.textContent).join("")}`;
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes[name] ?? null;
+  }
+
+  closest(selector: string): FakeElement | null {
+    if (matchesSelector(this, selector)) return this;
+    return this.parentElement?.closest(selector) ?? null;
+  }
+
+  querySelector(selector: string): FakeElement | null {
+    return this.querySelectorAll(selector)[0] ?? null;
+  }
+
+  querySelectorAll(selector: string): FakeElement[] {
+    return flattenElements(this.children).filter((element) => matchesSelector(element, selector));
+  }
+}
+
+class FakeInputElement extends FakeElement {
+  constructor(readonly files: Array<{ name: string }>) {
+    super("input", { type: "file" });
+  }
+}
+
+class FakeDocument {
+  readonly body: FakeElement;
+
+  constructor(children: FakeElement[]) {
+    this.body = new FakeElement("body", {}, children);
+  }
+
+  querySelector(selector: string): FakeElement | null {
+    return this.querySelectorAll(selector)[0] ?? null;
+  }
+
+  querySelectorAll(selector: string): FakeElement[] {
+    return this.body.querySelectorAll(selector);
+  }
+}
+
+function flattenElements(elements: FakeElement[]): FakeElement[] {
+  return elements.flatMap((element) => [element, ...flattenElements(element.children)]);
+}
+
+function matchesSelector(element: FakeElement, selector: string): boolean {
+  return selector
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .some((part) => matchesSingleSelector(element, part));
+}
+
+function matchesSingleSelector(element: FakeElement, selector: string): boolean {
+  const normalized = selector.replace(/:not\([^)]*\)/g, "");
+  const tag = normalized.match(/^[a-z][a-z0-9-]*/i)?.[0];
+  if (tag && element.tagName.toLowerCase() !== tag.toLowerCase()) return false;
+
+  const id = normalized.match(/#([a-z0-9_-]+)/i)?.[1];
+  if (id && element.getAttribute("id") !== id) return false;
+
+  const attrPattern = /\[([^\]\s~|^$*!=]+)(\*?=)?(?:"([^"]*)"|'([^']*)')?\s*i?\]/g;
+  for (const match of normalized.matchAll(attrPattern)) {
+    const [, name, operator, doubleQuotedValue, singleQuotedValue] = match;
+    const expected = doubleQuotedValue ?? singleQuotedValue ?? "";
+    const actual = element.getAttribute(name);
+    if (actual === null) return false;
+    if (operator === "=" && actual !== expected) return false;
+    if (operator === "*=" && !actual.toLowerCase().includes(expected.toLowerCase())) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function evaluateAttachmentReadyExpression(
+  attachmentNames: string[],
+  document: FakeDocument,
+): boolean {
+  const expression = buildAttachmentReadyExpressionForTest(attachmentNames);
+  const evaluate = new Function(
+    "document",
+    "HTMLElement",
+    "HTMLInputElement",
+    `return ${expression};`,
+  ) as (
+    document: FakeDocument,
+    HTMLElement: typeof FakeElement,
+    HTMLInputElement: typeof FakeInputElement,
+  ) => boolean;
+  return evaluate(document, FakeElement, FakeInputElement);
+}
+
 describe("prompt composer attachment expressions", () => {
   test("attachment ready check does not match prompt text", () => {
     const expression = buildAttachmentReadyExpressionForTest(["oracle-attach-verify.txt"]);
-    expect(expression).toContain("document.querySelector('[data-testid*=\"composer\"]')");
+    expect(expression).toContain("sendButton?.closest?.('form')");
+    expect(expression).toContain(
+      "document.querySelector('[data-testid*=\"composer\"]:not(button)')",
+    );
+    expect(expression).not.toContain("document.querySelector('[data-testid*=\"composer\"]') ||");
     expect(expression).toContain("attachmentRoots");
     expect(expression).toContain('input[type="file"]');
     expect(expression).toContain('[aria-label*="Remove file"]');
@@ -34,5 +156,51 @@ describe("prompt composer attachment expressions", () => {
 
     expect(expression).toContain("const attachmentRoots = Array.from(new Set([composer]))");
     expect(expression).not.toContain("new Set([composer, document])");
+  });
+
+  test("attachment ready check ignores a composer-plus button before the real form", () => {
+    const fileName = "oracle-diagnostic-unique-20260521.txt";
+    const document = new FakeDocument([
+      new FakeElement("form", {}, [
+        new FakeElement("button", { "data-testid": "composer-plus-btn" }),
+        new FakeElement("div", { "data-testid": "attachment-chip" }, [
+          new FakeElement("span", {}, [], fileName),
+          new FakeElement("button", { "aria-label": `Remove file 1: ${fileName}` }),
+        ]),
+        new FakeElement(
+          "div",
+          { id: "prompt-textarea", contenteditable: "true", role: "textbox" },
+          [],
+          "Diagnostic attachment send readiness repro. Reply exactly OK.",
+        ),
+        new FakeElement("button", {
+          "aria-label": "Send prompt",
+          "data-testid": "send-button",
+        }),
+      ]),
+    ]);
+
+    expect(evaluateAttachmentReadyExpression([fileName], document)).toBe(true);
+  });
+
+  test("attachment ready check still rejects prompt-only filename matches", () => {
+    const fileName = "oracle-diagnostic-unique-20260521.txt";
+    const document = new FakeDocument([
+      new FakeElement("form", {}, [
+        new FakeElement("button", { "data-testid": "composer-plus-btn" }),
+        new FakeElement(
+          "div",
+          { id: "prompt-textarea", contenteditable: "true", role: "textbox" },
+          [],
+          `Please mention ${fileName} without uploading it.`,
+        ),
+        new FakeElement("button", {
+          "aria-label": "Send prompt",
+          "data-testid": "send-button",
+        }),
+      ]),
+    ]);
+
+    expect(evaluateAttachmentReadyExpression([fileName], document)).toBe(false);
   });
 });

--- a/tests/browser/promptComposerExpressions.test.ts
+++ b/tests/browser/promptComposerExpressions.test.ts
@@ -183,6 +183,21 @@ describe("prompt composer attachment expressions", () => {
     expect(evaluateAttachmentReadyExpression([fileName], document)).toBe(true);
   });
 
+  test("attachment ready check prefers composer roots over unrelated forms", () => {
+    const fileName = "oracle-diagnostic-unique-20260521.txt";
+    const document = new FakeDocument([
+      new FakeElement("form", {}, [], "Search chats"),
+      new FakeElement("div", { "data-testid": "unified-composer" }, [
+        new FakeElement("div", { "data-testid": "attachment-chip" }, [
+          new FakeElement("span", {}, [], fileName),
+          new FakeElement("button", { "aria-label": `Remove file 1: ${fileName}` }),
+        ]),
+      ]),
+    ]);
+
+    expect(evaluateAttachmentReadyExpression([fileName], document)).toBe(true);
+  });
+
   test("attachment ready check still rejects prompt-only filename matches", () => {
     const fileName = "oracle-diagnostic-unique-20260521.txt";
     const document = new FakeDocument([


### PR DESCRIPTION
## Summary

Fix ChatGPT browser attachment sends false-failing with `attachment-send-not-ready` when the enabled Send button is present.

The attachment readiness check previously used `document.querySelector('[data-testid*="composer"]')` as its first root candidate. On the current ChatGPT DOM this can match `button[data-testid="composer-plus-btn"]`, so the readiness scan is scoped to the plus button instead of the form containing the attachment chip and Send button.

This patch anchors attachment readiness to the Send button's enclosing form before falling back to other composer roots.

Fixes #221.

## Verification

- `pnpm vitest run tests/browser/promptComposerExpressions.test.ts tests/browser/promptComposer.test.ts tests/browser/attachmentsCompletion.test.ts`
- `pnpm run check`
- Live browser smoke with `--browser-attachments always`: uploaded one synthetic attachment, logged `Clicked send button`, and received `OK`.
