### PR TITLE
feat(session): recover --harvest/--live by reopening saved tab URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Browser: `oracle session <id> --harvest` and `--live` now auto-recover when the original Chrome has been closed by relaunching the manual-login profile and reopening the saved conversation URL, then retrying the harvest against the recovered tab. Resolves the failure mode where a long GPT-5 Pro Extended response completed in the background after the CLI's 20-minute wall expired and the conversation was archived. Opt out with `--no-recover` on the `session` subcommand.
+- Browser: `oracle session <id> --harvest` and `--live` now auto-recover when the original Chrome has been closed by relaunching the manual-login profile and reopening the saved conversation URL, then retrying the harvest against the recovered tab. Resolves the failure mode where a long GPT-5 Pro Extended response completed in the background after the CLI's 20-minute wall expired and the conversation was archived. Recovery URL selection prefers `browser.harvest.url` over `browser.runtime.tabUrl` and is gated by a shared ChatGPT-conversation-URL check (rejects home, project shell, and external URLs so the persistent profile can't be navigated to the wrong page from stale metadata). Opt out with `--no-recover` on the `session` subcommand.
 
 ## 0.13.0 — 2026-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.13.1 — Unreleased
 
+### Added
+
+- Browser: `oracle session <id> --harvest` and `--live` now auto-recover when the original Chrome has been closed by relaunching the manual-login profile and reopening the saved conversation URL, then retrying the harvest against the recovered tab. Resolves the failure mode where a long GPT-5 Pro Extended response completed in the background after the CLI's 20-minute wall expired and the conversation was archived. Opt out with `--no-recover` on the `session` subcommand.
+
 ## 0.13.0 — 2026-05-22
 
 ### Added

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -1182,6 +1182,10 @@ program
     "--browser-tab <ref>",
     "Override the browser tab ref used for harvesting/live tail (current, target id, URL, or title substring).",
   )
+  .option(
+    "--no-recover",
+    "Do not relaunch Chrome to reopen the saved conversation URL when --harvest/--live finds no live tab.",
+  )
   .addOption(new Option("--clean", "Deprecated alias for --clear.").default(false).hideHelp())
   .action(async (sessionId, _options: StatusOptions, cmd: Command) => {
     const { handleSessionCommand } = await import("../src/cli/sessionCommand.js");

--- a/src/browser/reattachability.ts
+++ b/src/browser/reattachability.ts
@@ -1,5 +1,27 @@
 import type { BrowserRuntimeMetadata } from "../sessionStore.js";
 
+/**
+ * True when the URL points at a specific ChatGPT conversation (`/c/<id>`) on
+ * chatgpt.com or chat.openai.com. Rejects home, project shell, and external
+ * URLs — anything else would be unsafe to auto-reopen in a persistent
+ * signed-in browser profile.
+ */
+export function isRecoverableChatGptConversationUrl(candidate: string | null | undefined): boolean {
+  const trimmed = candidate?.trim();
+  if (!trimmed) {
+    return false;
+  }
+  try {
+    const url = new URL(trimmed);
+    if (url.hostname !== "chatgpt.com" && url.hostname !== "chat.openai.com") {
+      return false;
+    }
+    return /(?:^|\/)c\/[^/]+/.test(url.pathname);
+  } catch {
+    return false;
+  }
+}
+
 export function hasRecoverableChatGptConversation(
   runtime: BrowserRuntimeMetadata | null | undefined,
 ): boolean {
@@ -9,17 +31,5 @@ export function hasRecoverableChatGptConversation(
   if (runtime.conversationId?.trim()) {
     return true;
   }
-  const tabUrl = runtime.tabUrl?.trim();
-  if (!tabUrl) {
-    return false;
-  }
-  try {
-    const url = new URL(tabUrl);
-    if (url.hostname !== "chatgpt.com" && url.hostname !== "chat.openai.com") {
-      return false;
-    }
-    return /(?:^|\/)c\/[^/]+/.test(url.pathname);
-  } catch {
-    return false;
-  }
+  return isRecoverableChatGptConversationUrl(runtime.tabUrl);
 }

--- a/src/browser/recoverConversation.ts
+++ b/src/browser/recoverConversation.ts
@@ -2,6 +2,7 @@ import { launch, type LaunchedChrome } from "chrome-launcher";
 import type { SessionMetadata } from "../sessionStore.js";
 import type { BrowserLogger } from "./types.js";
 import { defaultManualLoginProfileDir } from "./manualLoginProfile.js";
+import { isRecoverableChatGptConversationUrl } from "./reattachability.js";
 
 const DEFAULT_HYDRATION_DELAY_MS = 3_000;
 
@@ -12,13 +13,23 @@ export interface RecoveredConversation {
   chrome: LaunchedChrome;
 }
 
-function resolveRecoveryUrl(meta: SessionMetadata): string | null {
-  const runtime = meta?.browser?.runtime ?? {};
+/**
+ * Picks the URL to navigate the recovered Chrome tab to.
+ *
+ * Preference order matches `resolveSessionTabRef`: `harvest.url` (post-harvest,
+ * always a ChatGPT conversation URL when present) wins over `runtime.tabUrl`
+ * (the URL the original run last navigated to, which can be stale).
+ *
+ * Both candidates are gated by `isRecoverableChatGptConversationUrl` so a stale
+ * home / project shell URL or an unrelated external URL stored in metadata
+ * cannot navigate the persistent signed-in profile to the wrong page.
+ */
+export function resolveRecoveryUrl(meta: SessionMetadata): string | null {
   const harvest = meta?.browser?.harvest ?? {};
-  const candidates = [runtime.tabUrl, harvest.url];
-  for (const candidate of candidates) {
-    if (typeof candidate === "string" && candidate.startsWith("http")) {
-      return candidate;
+  const runtime = meta?.browser?.runtime ?? {};
+  for (const candidate of [harvest.url, runtime.tabUrl]) {
+    if (isRecoverableChatGptConversationUrl(candidate)) {
+      return candidate as string;
     }
   }
   return null;
@@ -50,7 +61,8 @@ export async function recoverConversationTab(
   const url = resolveRecoveryUrl(meta);
   if (!url) {
     throw new Error(
-      "Cannot recover conversation: no saved tab URL in session metadata (browser.runtime.tabUrl).",
+      "Cannot recover conversation: session metadata has no recoverable ChatGPT conversation URL " +
+        "(expected browser.harvest.url or browser.runtime.tabUrl to be a chatgpt.com/c/<id> URL).",
     );
   }
   const userDataDir = resolveProfileDir(meta);

--- a/src/browser/recoverConversation.ts
+++ b/src/browser/recoverConversation.ts
@@ -1,0 +1,88 @@
+import { launch, type LaunchedChrome } from "chrome-launcher";
+import type { SessionMetadata } from "../sessionStore.js";
+import type { BrowserLogger } from "./types.js";
+import { defaultManualLoginProfileDir } from "./manualLoginProfile.js";
+
+const DEFAULT_HYDRATION_DELAY_MS = 3_000;
+
+export interface RecoveredConversation {
+  host: string;
+  port: number;
+  url: string;
+  chrome: LaunchedChrome;
+}
+
+function resolveRecoveryUrl(meta: SessionMetadata): string | null {
+  const runtime = meta?.browser?.runtime ?? {};
+  const harvest = meta?.browser?.harvest ?? {};
+  const candidates = [runtime.tabUrl, harvest.url];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.startsWith("http")) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function resolveProfileDir(meta: SessionMetadata): string {
+  const fromMeta = meta?.browser?.config?.manualLoginProfileDir;
+  if (typeof fromMeta === "string" && fromMeta.length > 0) {
+    return fromMeta;
+  }
+  return defaultManualLoginProfileDir();
+}
+
+/**
+ * Re-open a previously-harvested ChatGPT conversation by relaunching Chrome
+ * with the session's persistent profile and navigating to the saved tab URL.
+ *
+ * Used as a fallback when `harvestChatGptTab` can find no live tab matching the
+ * stored target (common after the original CLI run exits and closes its
+ * browser). ChatGPT preserves attachments + history at the conversation URL,
+ * so harvesting against the relaunched tab returns the original message + any
+ * assistant response that completed after the original run gave up.
+ */
+export async function recoverConversationTab(
+  meta: SessionMetadata,
+  logger: BrowserLogger,
+  options: { hydrationDelayMs?: number } = {},
+): Promise<RecoveredConversation> {
+  const url = resolveRecoveryUrl(meta);
+  if (!url) {
+    throw new Error(
+      "Cannot recover conversation: no saved tab URL in session metadata (browser.runtime.tabUrl).",
+    );
+  }
+  const userDataDir = resolveProfileDir(meta);
+
+  logger(
+    `[browser] Recovery: relaunching Chrome with profile ${userDataDir} and navigating to ${url}`,
+  );
+
+  const chrome = await launch({
+    chromeFlags: [
+      "--no-first-run",
+      "--no-default-browser-check",
+      "--disable-features=AutomationControlled,TranslateUI",
+      "--disable-sync",
+      "--password-store=basic",
+      "--use-mock-keychain",
+      "--lang=en-US",
+      url,
+    ],
+    userDataDir,
+    handleSIGINT: false,
+  });
+
+  const host = "127.0.0.1";
+  const port = chrome.port;
+
+  const hydrationDelayMs = options.hydrationDelayMs ?? DEFAULT_HYDRATION_DELAY_MS;
+  if (hydrationDelayMs > 0) {
+    await new Promise((resolve) => setTimeout(resolve, hydrationDelayMs));
+  }
+
+  logger(`[browser] Recovery: Chrome listening on ${host}:${port}; tab loaded.`);
+
+  return { host, port, url, chrome };
+}

--- a/src/cli/browserTabs.ts
+++ b/src/cli/browserTabs.ts
@@ -241,40 +241,40 @@ export async function harvestSessionBrowserOutput(
   const ref = options.browserTabRef ?? resolveSessionTabRef(meta);
   const recoverIfMissing = options.recoverIfMissing !== false;
 
-  let harvested: ChatGptTabSummary;
   let recoveredChrome: { kill: () => void } | null = null;
   try {
-    harvested = await harvestChatGptTab({
-      host: initialEndpoint.host,
-      port: initialEndpoint.port,
-      ref,
-      stallWindowMs: options.stallWindowMs,
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    const isMissingTabError =
-      message.includes("No ChatGPT tab matched") ||
-      message.includes("ECONNREFUSED") ||
-      message.includes("Could not connect");
-    if (!isMissingTabError || !recoverIfMissing) {
-      throw error;
+    let harvested: ChatGptTabSummary;
+    try {
+      harvested = await harvestChatGptTab({
+        host: initialEndpoint.host,
+        port: initialEndpoint.port,
+        ref,
+        stallWindowMs: options.stallWindowMs,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const isMissingTabError =
+        message.includes("No ChatGPT tab matched") ||
+        message.includes("ECONNREFUSED") ||
+        message.includes("Could not connect");
+      if (!isMissingTabError || !recoverIfMissing) {
+        throw error;
+      }
+      console.log(
+        chalk.yellow(
+          `No live ChatGPT tab matched session "${sessionId}". Attempting recovery by reopening the saved conversation URL.`,
+        ),
+      );
+      const recovered = await recoverConversationTab(meta, (line) => console.log(line));
+      recoveredChrome = recovered.chrome;
+      harvested = await harvestChatGptTab({
+        host: recovered.host,
+        port: recovered.port,
+        ref: recovered.url,
+        stallWindowMs: options.stallWindowMs,
+      });
     }
-    console.log(
-      chalk.yellow(
-        `No live ChatGPT tab matched session "${sessionId}". Attempting recovery by reopening the saved conversation URL.`,
-      ),
-    );
-    const recovered = await recoverConversationTab(meta, (line) => console.log(line));
-    recoveredChrome = recovered.chrome;
-    harvested = await harvestChatGptTab({
-      host: recovered.host,
-      port: recovered.port,
-      ref: recovered.url,
-      stallWindowMs: options.stallWindowMs,
-    });
-  }
 
-  try {
     await persistHarvest(sessionId, meta, harvested);
     printHarvestSummary(sessionId, harvested);
     const output = harvested.lastAssistantMarkdown ?? harvested.lastAssistantText ?? "";
@@ -311,38 +311,38 @@ export async function liveTailSessionBrowserOutput(
   let browserTabRef = options.browserTabRef ?? resolveSessionTabRef(meta);
   const recoverIfMissing = options.recoverIfMissing !== false;
   let recoveredChrome: { kill: () => void } | null = null;
-
-  // Probe once to see if the live tab is still alive; recover if not.
-  try {
-    await harvestChatGptTab({
-      host: endpoint.host,
-      port: endpoint.port,
-      ref: browserTabRef,
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    const isMissingTabError =
-      message.includes("No ChatGPT tab matched") ||
-      message.includes("ECONNREFUSED") ||
-      message.includes("Could not connect");
-    if (!isMissingTabError || !recoverIfMissing) {
-      throw error;
-    }
-    console.log(
-      chalk.yellow(
-        `No live ChatGPT tab matched session "${sessionId}". Attempting recovery by reopening the saved conversation URL.`,
-      ),
-    );
-    const recovered = await recoverConversationTab(meta, (line) => console.log(line));
-    recoveredChrome = recovered.chrome;
-    endpoint = { host: recovered.host, port: recovered.port };
-    browserTabRef = recovered.url;
-  }
   const stallThresholdMs = options.stallThresholdMs ?? DEFAULT_STALL_THRESHOLD_MS;
   let lastHash: string | null = null;
   let unchangedSince = Date.now();
 
   try {
+    // Probe once to see if the live tab is still alive; recover if not.
+    try {
+      await harvestChatGptTab({
+        host: endpoint.host,
+        port: endpoint.port,
+        ref: browserTabRef,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const isMissingTabError =
+        message.includes("No ChatGPT tab matched") ||
+        message.includes("ECONNREFUSED") ||
+        message.includes("Could not connect");
+      if (!isMissingTabError || !recoverIfMissing) {
+        throw error;
+      }
+      console.log(
+        chalk.yellow(
+          `No live ChatGPT tab matched session "${sessionId}". Attempting recovery by reopening the saved conversation URL.`,
+        ),
+      );
+      const recovered = await recoverConversationTab(meta, (line) => console.log(line));
+      recoveredChrome = recovered.chrome;
+      endpoint = { host: recovered.host, port: recovered.port };
+      browserTabRef = recovered.url;
+    }
+
     while (true) {
       const harvested = await harvestChatGptTab({
         host: endpoint.host,

--- a/src/cli/browserTabs.ts
+++ b/src/cli/browserTabs.ts
@@ -13,6 +13,7 @@ import {
   sessionMatchesTab,
   type ChatGptTabSummary,
 } from "../browser/liveTabs.js";
+import { recoverConversationTab } from "../browser/recoverConversation.js";
 import { resolveOutputPath } from "./writeOutputPath.js";
 
 const LIVE_POLL_MS = 2000;
@@ -23,12 +24,34 @@ export interface BrowserHarvestOptions {
   browserTabRef?: string;
   stallWindowMs?: number;
   quietOutput?: boolean;
+  /**
+   * When the live tab cannot be found, relaunch Chrome with the session's
+   * persistent profile and navigate to the saved tab URL, then retry harvest.
+   * Default: true.
+   */
+  recoverIfMissing?: boolean;
+  /**
+   * After a successful recovery harvest, close the relaunched Chrome.
+   * Default: false (leave the recovered tab visible for the user).
+   */
+  closeAfterRecover?: boolean;
 }
 
 export interface BrowserLiveTailOptions {
   writeOutputPath?: string;
   browserTabRef?: string;
   stallThresholdMs?: number;
+  /**
+   * When no live tab matches the session's stored target, relaunch Chrome with
+   * the persistent profile and navigate to the saved tab URL before tailing.
+   * Default: true.
+   */
+  recoverIfMissing?: boolean;
+  /**
+   * After completion, close the relaunched Chrome.
+   * Default: false (leave the recovered tab visible).
+   */
+  closeAfterRecover?: boolean;
 }
 
 function sessionBrowserEndpoint(
@@ -211,26 +234,66 @@ export async function harvestSessionBrowserOutput(
   if (!meta) {
     throw new Error(`No session found with ID ${sessionId}.`);
   }
-  const endpoint = sessionBrowserEndpoint(meta) ?? {
+  const initialEndpoint = sessionBrowserEndpoint(meta) ?? {
     host: DEFAULT_REMOTE_CHROME_HOST,
     port: DEFAULT_REMOTE_CHROME_PORT,
   };
-  const harvested = await harvestChatGptTab({
-    host: endpoint.host,
-    port: endpoint.port,
-    ref: options.browserTabRef ?? resolveSessionTabRef(meta),
-    stallWindowMs: options.stallWindowMs,
-  });
-  await persistHarvest(sessionId, meta, harvested);
-  printHarvestSummary(sessionId, harvested);
-  const output = harvested.lastAssistantMarkdown ?? harvested.lastAssistantText ?? "";
-  if (options.writeOutputPath) {
-    await maybeWriteHarvestOutput(options.writeOutputPath, meta.cwd ?? process.cwd(), output);
+  const ref = options.browserTabRef ?? resolveSessionTabRef(meta);
+  const recoverIfMissing = options.recoverIfMissing !== false;
+
+  let harvested: ChatGptTabSummary;
+  let recoveredChrome: { kill: () => void } | null = null;
+  try {
+    harvested = await harvestChatGptTab({
+      host: initialEndpoint.host,
+      port: initialEndpoint.port,
+      ref,
+      stallWindowMs: options.stallWindowMs,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const isMissingTabError =
+      message.includes("No ChatGPT tab matched") ||
+      message.includes("ECONNREFUSED") ||
+      message.includes("Could not connect");
+    if (!isMissingTabError || !recoverIfMissing) {
+      throw error;
+    }
+    console.log(
+      chalk.yellow(
+        `No live ChatGPT tab matched session "${sessionId}". Attempting recovery by reopening the saved conversation URL.`,
+      ),
+    );
+    const recovered = await recoverConversationTab(meta, (line) => console.log(line));
+    recoveredChrome = recovered.chrome;
+    harvested = await harvestChatGptTab({
+      host: recovered.host,
+      port: recovered.port,
+      ref: recovered.url,
+      stallWindowMs: options.stallWindowMs,
+    });
   }
-  if (!options.quietOutput && output) {
-    process.stdout.write(`${output}${output.endsWith("\n") ? "" : "\n"}`);
+
+  try {
+    await persistHarvest(sessionId, meta, harvested);
+    printHarvestSummary(sessionId, harvested);
+    const output = harvested.lastAssistantMarkdown ?? harvested.lastAssistantText ?? "";
+    if (options.writeOutputPath) {
+      await maybeWriteHarvestOutput(options.writeOutputPath, meta.cwd ?? process.cwd(), output);
+    }
+    if (!options.quietOutput && output) {
+      process.stdout.write(`${output}${output.endsWith("\n") ? "" : "\n"}`);
+    }
+    return harvested;
+  } finally {
+    if (recoveredChrome && options.closeAfterRecover) {
+      try {
+        recoveredChrome.kill();
+      } catch {
+        // best-effort cleanup
+      }
+    }
   }
-  return harvested;
 }
 
 export async function liveTailSessionBrowserOutput(
@@ -241,59 +304,102 @@ export async function liveTailSessionBrowserOutput(
   if (!meta) {
     throw new Error(`No session found with ID ${sessionId}.`);
   }
-  const endpoint = sessionBrowserEndpoint(meta) ?? {
+  let endpoint = sessionBrowserEndpoint(meta) ?? {
     host: DEFAULT_REMOTE_CHROME_HOST,
     port: DEFAULT_REMOTE_CHROME_PORT,
   };
-  const browserTabRef = options.browserTabRef ?? resolveSessionTabRef(meta);
-  const stallThresholdMs = options.stallThresholdMs ?? DEFAULT_STALL_THRESHOLD_MS;
-  let lastHash: string | null = null;
-  let unchangedSince = Date.now();
+  let browserTabRef = options.browserTabRef ?? resolveSessionTabRef(meta);
+  const recoverIfMissing = options.recoverIfMissing !== false;
+  let recoveredChrome: { kill: () => void } | null = null;
 
-  while (true) {
-    const harvested = await harvestChatGptTab({
+  // Probe once to see if the live tab is still alive; recover if not.
+  try {
+    await harvestChatGptTab({
       host: endpoint.host,
       port: endpoint.port,
       ref: browserTabRef,
     });
-    const fullText = harvested.lastAssistantMarkdown ?? harvested.lastAssistantText ?? "";
-    const hash = createHash("sha1").update(fullText).digest("hex");
-    if (hash !== lastHash) {
-      lastHash = hash;
-      unchangedSince = Date.now();
-      const statusLine =
-        `[${new Date().toISOString()}] state=${harvested.state} stop=${harvested.stopExists ? "yes" : "no"} ` +
-        `send=${harvested.sendExists ? "yes" : "no"} model=${harvested.currentModelLabel || "(unknown)"} ` +
-        `snippet=${snippet(harvested.lastAssistantSnippet || fullText, 160)}`;
-      console.log(statusLine);
-      await persistHarvest(sessionId, meta, harvested);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const isMissingTabError =
+      message.includes("No ChatGPT tab matched") ||
+      message.includes("ECONNREFUSED") ||
+      message.includes("Could not connect");
+    if (!isMissingTabError || !recoverIfMissing) {
+      throw error;
     }
+    console.log(
+      chalk.yellow(
+        `No live ChatGPT tab matched session "${sessionId}". Attempting recovery by reopening the saved conversation URL.`,
+      ),
+    );
+    const recovered = await recoverConversationTab(meta, (line) => console.log(line));
+    recoveredChrome = recovered.chrome;
+    endpoint = { host: recovered.host, port: recovered.port };
+    browserTabRef = recovered.url;
+  }
+  const stallThresholdMs = options.stallThresholdMs ?? DEFAULT_STALL_THRESHOLD_MS;
+  let lastHash: string | null = null;
+  let unchangedSince = Date.now();
 
-    const derivedState = harvested.stopExists
-      ? Date.now() - unchangedSince >= stallThresholdMs
-        ? "stalled"
-        : "running"
-      : harvested.authenticated
-        ? "completed"
-        : "detached";
+  try {
+    while (true) {
+      const harvested = await harvestChatGptTab({
+        host: endpoint.host,
+        port: endpoint.port,
+        ref: browserTabRef,
+      });
+      const fullText = harvested.lastAssistantMarkdown ?? harvested.lastAssistantText ?? "";
+      const hash = createHash("sha1").update(fullText).digest("hex");
+      if (hash !== lastHash) {
+        lastHash = hash;
+        unchangedSince = Date.now();
+        const statusLine =
+          `[${new Date().toISOString()}] state=${harvested.state} stop=${harvested.stopExists ? "yes" : "no"} ` +
+          `send=${harvested.sendExists ? "yes" : "no"} model=${harvested.currentModelLabel || "(unknown)"} ` +
+          `snippet=${snippet(harvested.lastAssistantSnippet || fullText, 160)}`;
+        console.log(statusLine);
+        await persistHarvest(sessionId, meta, harvested);
+      }
 
-    if (derivedState === "completed" || derivedState === "stalled" || derivedState === "detached") {
-      const finalHarvest: ChatGptTabSummary = {
-        ...harvested,
-        state: derivedState,
-      };
-      await persistHarvest(sessionId, meta, finalHarvest);
-      printHarvestSummary(sessionId, finalHarvest);
-      const output = finalHarvest.lastAssistantMarkdown ?? finalHarvest.lastAssistantText ?? "";
-      if (options.writeOutputPath) {
-        await maybeWriteHarvestOutput(options.writeOutputPath, meta.cwd ?? process.cwd(), output);
+      const derivedState = harvested.stopExists
+        ? Date.now() - unchangedSince >= stallThresholdMs
+          ? "stalled"
+          : "running"
+        : harvested.authenticated
+          ? "completed"
+          : "detached";
+
+      if (
+        derivedState === "completed" ||
+        derivedState === "stalled" ||
+        derivedState === "detached"
+      ) {
+        const finalHarvest: ChatGptTabSummary = {
+          ...harvested,
+          state: derivedState,
+        };
+        await persistHarvest(sessionId, meta, finalHarvest);
+        printHarvestSummary(sessionId, finalHarvest);
+        const output = finalHarvest.lastAssistantMarkdown ?? finalHarvest.lastAssistantText ?? "";
+        if (options.writeOutputPath) {
+          await maybeWriteHarvestOutput(options.writeOutputPath, meta.cwd ?? process.cwd(), output);
+        }
+        if (output) {
+          process.stdout.write(`${output}${output.endsWith("\n") ? "" : "\n"}`);
+        }
+        return finalHarvest;
       }
-      if (output) {
-        process.stdout.write(`${output}${output.endsWith("\n") ? "" : "\n"}`);
-      }
-      return finalHarvest;
+
+      await new Promise((resolve) => setTimeout(resolve, LIVE_POLL_MS));
     }
-
-    await new Promise((resolve) => setTimeout(resolve, LIVE_POLL_MS));
+  } finally {
+    if (recoveredChrome && options.closeAfterRecover) {
+      try {
+        recoveredChrome.kill();
+      } catch {
+        // best-effort cleanup
+      }
+    }
   }
 }

--- a/src/cli/sessionCommand.ts
+++ b/src/cli/sessionCommand.ts
@@ -174,16 +174,20 @@ export async function handleSessionCommand(
       process.exitCode = 1;
       return;
     }
+    // Commander sets `recover: false` when --no-recover is passed; default is `true`.
+    const recoverIfMissing = sessionOptions.recover !== false;
     if (harvestRequested) {
       await deps.harvestSessionBrowserOutput(sessionId, {
         writeOutputPath,
         browserTabRef,
+        recoverIfMissing,
       });
       return;
     }
     await deps.liveTailSessionBrowserOutput(sessionId, {
       writeOutputPath,
       browserTabRef,
+      recoverIfMissing,
     });
     return;
   }

--- a/tests/browser/recoverConversation.test.ts
+++ b/tests/browser/recoverConversation.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "vitest";
+import { resolveRecoveryUrl } from "../../src/browser/recoverConversation.js";
+import type { SessionMetadata } from "../../src/sessionStore.js";
+
+function metaWith(
+  runtime: Record<string, unknown> | undefined,
+  harvest: Record<string, unknown> | undefined,
+): SessionMetadata {
+  return {
+    id: "x",
+    createdAt: "2026-05-26T00:00:00.000Z",
+    status: "completed",
+    options: {},
+    mode: "browser",
+    browser: {
+      runtime: runtime ?? {},
+      harvest: harvest ?? {},
+    },
+  } as unknown as SessionMetadata;
+}
+
+describe("resolveRecoveryUrl", () => {
+  test("accepts a chatgpt.com/c/<id> conversation URL", () => {
+    expect(
+      resolveRecoveryUrl(metaWith({ tabUrl: "https://chatgpt.com/c/abc-123" }, undefined)),
+    ).toBe("https://chatgpt.com/c/abc-123");
+  });
+
+  test("accepts a legacy chat.openai.com/c/<id> URL", () => {
+    expect(
+      resolveRecoveryUrl(metaWith({ tabUrl: "https://chat.openai.com/c/legacy-id" }, undefined)),
+    ).toBe("https://chat.openai.com/c/legacy-id");
+  });
+
+  test("rejects the ChatGPT home shell URL", () => {
+    expect(resolveRecoveryUrl(metaWith({ tabUrl: "https://chatgpt.com/" }, undefined))).toBeNull();
+  });
+
+  test("rejects a project shell URL with no conversation segment", () => {
+    expect(
+      resolveRecoveryUrl(
+        metaWith({ tabUrl: "https://chatgpt.com/g/g-12345-some-project" }, undefined),
+      ),
+    ).toBeNull();
+  });
+
+  test("rejects an unrelated external URL stored in metadata", () => {
+    expect(
+      resolveRecoveryUrl(metaWith({ tabUrl: "https://example.com/some/path" }, undefined)),
+    ).toBeNull();
+  });
+
+  test("rejects malformed URL strings", () => {
+    expect(resolveRecoveryUrl(metaWith({ tabUrl: "not a url" }, undefined))).toBeNull();
+    expect(resolveRecoveryUrl(metaWith({ tabUrl: "" }, undefined))).toBeNull();
+  });
+
+  test("prefers harvest.url when runtime.tabUrl is a stale shell URL", () => {
+    expect(
+      resolveRecoveryUrl(
+        metaWith({ tabUrl: "https://chatgpt.com/" }, { url: "https://chatgpt.com/c/from-harvest" }),
+      ),
+    ).toBe("https://chatgpt.com/c/from-harvest");
+  });
+
+  test("falls back to runtime.tabUrl when harvest.url is missing", () => {
+    expect(
+      resolveRecoveryUrl(metaWith({ tabUrl: "https://chatgpt.com/c/runtime-only" }, undefined)),
+    ).toBe("https://chatgpt.com/c/runtime-only");
+  });
+
+  test("returns null when neither candidate is a valid conversation URL", () => {
+    expect(
+      resolveRecoveryUrl(
+        metaWith({ tabUrl: "https://chatgpt.com/" }, { url: "https://example.com/foo" }),
+      ),
+    ).toBeNull();
+  });
+
+  test("ignores empty browser metadata", () => {
+    expect(resolveRecoveryUrl({ id: "x" } as unknown as SessionMetadata)).toBeNull();
+  });
+});

--- a/tests/cli/browserTabsRecover.test.ts
+++ b/tests/cli/browserTabsRecover.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { SessionMetadata } from "../../src/sessionStore.js";
+
+const baseMeta = {
+  id: "sess-recover",
+  createdAt: "2026-05-26T00:00:00.000Z",
+  status: "completed",
+  options: {},
+  mode: "browser",
+  cwd: "/tmp/recover-cwd",
+  browser: {
+    config: {
+      manualLogin: true,
+      manualLoginProfileDir: "/tmp/recover-profile",
+    },
+    runtime: {
+      tabUrl: "https://chatgpt.com/c/saved-conversation",
+      conversationId: "saved-conversation",
+    },
+  },
+} as unknown as SessionMetadata;
+
+const completedHarvest = {
+  targetId: "target-x",
+  url: "https://chatgpt.com/c/saved-conversation",
+  conversationId: "saved-conversation",
+  state: "completed",
+  authenticated: true,
+  stopExists: false,
+  sendExists: true,
+  assistantCount: 1,
+  currentModelLabel: "GPT-5.5 Pro",
+  lastAssistantMarkdown: "## Recovered answer\n\nFull response captured.",
+  lastAssistantText: "Recovered answer. Full response captured.",
+  lastAssistantSnippet: "Recovered answer.",
+  lastUserSnippet: "original prompt",
+} as const;
+
+describe("harvestSessionBrowserOutput recovery fallback", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  test("retries via recoverConversationTab when initial harvest finds no live tab", async () => {
+    const harvestChatGptTab = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error('No ChatGPT tab matched "https://chatgpt.com/c/saved-conversation".'),
+      )
+      .mockResolvedValueOnce(completedHarvest);
+
+    const fakeChrome = { kill: vi.fn() };
+    const recoverConversationTab = vi.fn(async (meta: SessionMetadata) => ({
+      host: "127.0.0.1",
+      port: 53999,
+      url: meta.browser?.runtime?.tabUrl ?? "",
+      chrome: fakeChrome,
+    }));
+
+    const updateSession = vi.fn(async () => {});
+    const readSession = vi.fn(async () => baseMeta);
+
+    vi.doMock("../../src/browser/liveTabs.js", () => ({
+      collectChatGptTabs: vi.fn(),
+      DEFAULT_REMOTE_CHROME_HOST: "127.0.0.1",
+      DEFAULT_REMOTE_CHROME_PORT: 9222,
+      extractConversationIdFromUrl: (url: string) =>
+        url.includes("/c/") ? url.split("/c/")[1] : null,
+      formatBrowserTabState: () => "completed",
+      harvestChatGptTab,
+      sessionMatchesTab: () => false,
+    }));
+    vi.doMock("../../src/browser/recoverConversation.js", () => ({
+      recoverConversationTab,
+    }));
+    vi.doMock("../../src/sessionStore.js", () => ({
+      sessionStore: { readSession, updateSession },
+    }));
+
+    const { harvestSessionBrowserOutput } = await import("../../src/cli/browserTabs.js");
+    const result = await harvestSessionBrowserOutput("sess-recover", { quietOutput: true });
+
+    expect(harvestChatGptTab).toHaveBeenCalledTimes(2);
+    expect(recoverConversationTab).toHaveBeenCalledTimes(1);
+    expect(recoverConversationTab).toHaveBeenCalledWith(baseMeta, expect.any(Function));
+    // After recovery, harvest is retried against the recovered endpoint/url.
+    expect(harvestChatGptTab).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        host: "127.0.0.1",
+        port: 53999,
+        ref: "https://chatgpt.com/c/saved-conversation",
+      }),
+    );
+    expect(result.lastAssistantMarkdown).toBe(completedHarvest.lastAssistantMarkdown);
+    expect(updateSession).toHaveBeenCalled();
+    // Default closeAfterRecover is false — Chrome stays alive for the user.
+    expect(fakeChrome.kill).not.toHaveBeenCalled();
+  });
+
+  test("does not recover when recoverIfMissing is false; surfaces the original error", async () => {
+    const harvestChatGptTab = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("No ChatGPT tab matched stuff"));
+    const recoverConversationTab = vi.fn();
+
+    vi.doMock("../../src/browser/liveTabs.js", () => ({
+      collectChatGptTabs: vi.fn(),
+      DEFAULT_REMOTE_CHROME_HOST: "127.0.0.1",
+      DEFAULT_REMOTE_CHROME_PORT: 9222,
+      extractConversationIdFromUrl: () => null,
+      formatBrowserTabState: () => "completed",
+      harvestChatGptTab,
+      sessionMatchesTab: () => false,
+    }));
+    vi.doMock("../../src/browser/recoverConversation.js", () => ({
+      recoverConversationTab,
+    }));
+    vi.doMock("../../src/sessionStore.js", () => ({
+      sessionStore: { readSession: async () => baseMeta, updateSession: async () => {} },
+    }));
+
+    const { harvestSessionBrowserOutput } = await import("../../src/cli/browserTabs.js");
+    await expect(
+      harvestSessionBrowserOutput("sess-recover", { recoverIfMissing: false, quietOutput: true }),
+    ).rejects.toThrow(/No ChatGPT tab matched/);
+    expect(recoverConversationTab).not.toHaveBeenCalled();
+  });
+
+  test("closes the recovered Chrome when closeAfterRecover is true", async () => {
+    const harvestChatGptTab = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("No ChatGPT tab matched"))
+      .mockResolvedValueOnce(completedHarvest);
+    const fakeChrome = { kill: vi.fn() };
+    vi.doMock("../../src/browser/liveTabs.js", () => ({
+      collectChatGptTabs: vi.fn(),
+      DEFAULT_REMOTE_CHROME_HOST: "127.0.0.1",
+      DEFAULT_REMOTE_CHROME_PORT: 9222,
+      extractConversationIdFromUrl: () => null,
+      formatBrowserTabState: () => "completed",
+      harvestChatGptTab,
+      sessionMatchesTab: () => false,
+    }));
+    vi.doMock("../../src/browser/recoverConversation.js", () => ({
+      recoverConversationTab: vi.fn(async () => ({
+        host: "127.0.0.1",
+        port: 53777,
+        url: "https://chatgpt.com/c/saved-conversation",
+        chrome: fakeChrome,
+      })),
+    }));
+    vi.doMock("../../src/sessionStore.js", () => ({
+      sessionStore: { readSession: async () => baseMeta, updateSession: async () => {} },
+    }));
+
+    const { harvestSessionBrowserOutput } = await import("../../src/cli/browserTabs.js");
+    await harvestSessionBrowserOutput("sess-recover", {
+      closeAfterRecover: true,
+      quietOutput: true,
+    });
+    expect(fakeChrome.kill).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/cli/sessionCommand.test.ts
+++ b/tests/cli/sessionCommand.test.ts
@@ -212,6 +212,7 @@ describe("handleSessionCommand", () => {
     expect(deps.harvestSessionBrowserOutput).toHaveBeenCalledWith("abc", {
       writeOutputPath: "/tmp/out.md",
       browserTabRef: "current",
+      recoverIfMissing: true,
     });
     expect(deps.liveTailSessionBrowserOutput).not.toHaveBeenCalled();
   });
@@ -231,6 +232,7 @@ describe("handleSessionCommand", () => {
     expect(deps.liveTailSessionBrowserOutput).toHaveBeenCalledWith("abc", {
       writeOutputPath: undefined,
       browserTabRef: "tab-123",
+      recoverIfMissing: true,
     });
     expect(deps.harvestSessionBrowserOutput).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

- When `oracle session <id> --harvest` or `--live` fails to find a live ChatGPT tab, automatically relaunch Chrome with the session's manual-login profile, navigate to the conversation URL stored in session metadata, and retry the harvest against the recovered tab.
- Default on; opt out with `--no-recover` on the `session` subcommand.
- New module `src/browser/recoverConversation.ts`. Recovery URL is gated by `isRecoverableChatGptConversationUrl` (extracted from `hasRecoverableChatGptConversation`) so home, project shell, and external URLs in stale metadata can never navigate the persistent profile to the wrong page. Preference order: `meta.browser.harvest.url` then `meta.browser.runtime.tabUrl` (matches `resolveSessionTabRef`).
- Profile dir prefers `meta.browser.config.manualLoginProfileDir`, falling back to `defaultManualLoginProfileDir()`.
- The recovered Chrome is owned by a single try/finally that wraps both the recovery retry and (for `--live`) the main poll loop, so `closeAfterRecover` is honored even if the post-recovery harvest itself throws.
- Tests in `tests/browser/recoverConversation.test.ts` (10 cases on URL validation/preference) and `tests/cli/browserTabsRecover.test.ts` (3 cases on fallback path, opt-out, cleanup).

## Why

Long GPT-5.x Pro Extended runs frequently complete in the background after the CLI's 20-minute wall expires. The original session has the full conversation URL persisted in `~/.oracle/sessions/<id>/meta.json` (`browser.runtime.tabUrl`), and ChatGPT preserves attachments and the assistant response at that URL, but `--harvest` and `--live` only look at *live* tabs in a running Chrome — when the original CLI exits, the browser closes and the response becomes unrecoverable through `oracle`.

The motivating concrete case: a 191k-token GPT-5.5 Pro Extended code review timed out at the 20-minute wall. The original CLI saved `meta.browser.runtime.tabUrl` but exited with only `"I"` captured. The actual 17.5KB review had completed in ChatGPT's background. With this patch, `oracle session <slug> --live --write-output ...` relaunches the profile, reopens the URL, harvests the now-complete response, and writes it to disk in ~10 seconds.

## Real behavior proof

End-to-end recovery against the timed-out session described above. Paths, conversation IDs, and the dynamic CDP port redacted; all other output is verbatim from the patched build.

```
$ node ./dist/bin/oracle-cli.js session <session-slug> --harvest --write-output /tmp/recovered.md

🧿 oracle 0.13.0 — From shruggy agents to shippable PRs.
No live ChatGPT tab matched session "<session-slug>". Attempting recovery by reopening the saved conversation URL.
[browser] Recovery: relaunching Chrome with profile /Users/redacted/.oracle/browser-profile and navigating to https://chatgpt.com/c/<conversation-id>
[browser] Recovery: Chrome listening on 127.0.0.1:<port>; tab loaded.
Session: <session-slug>
Target: C11E88428F3D01E0CDD12E13312AB7D6
State: completed
Model: (unknown)
URL: https://chatgpt.com/c/<conversation-id>
Assistant turns: 4
Signals: stop=no send=no
Last user: hermor-tab-codebase(1).zip ZipArchive ...
---
1. **End-state alignment — usable substrate, not end-state…**

   The code has the core pieces: `hermor_tab/mcp_server.py` exposes lifecycle tools and auto-registers `SUPPORTED_TOOL_NAMES` as MCP tools (`mcp_server.py:257–309`); `api.py` has the external enqueue endpoint (`api.py:151–165`); the extension executor polls and executes server commands…
```

`--live` (full streaming variant) recovered the complete 17.5KB markdown of the original review (all 5 requested sections + 7 follow-up recommendations) in ~10 seconds total — the same conversation the original 20-min CLI run had given up on with only `"I"` captured. The harvested output was written to disk via `--write-output`; the live tail terminated cleanly when ChatGPT's `stopExists: false` was detected on the first poll (= response was already complete in background).

## Verification

- `pnpm run check` — clean (typecheck + format + lint)
- `pnpm docs:check` — ok (85 flags, 6 files)
- `pnpm vitest run` — **1076/1076 pass** (10 new tests added in the second commit)
- Manual end-to-end against the timed-out session described above: see proof block.

## Changes between the first push and now (review pass)

The second commit `fix(session): gate recovery URL + tighten cleanup` addresses ClawSweeper's findings:

1. **Recovery URL is now validated.** Extracted `isRecoverableChatGptConversationUrl(candidate)` from `hasRecoverableChatGptConversation` in [`src/browser/reattachability.ts`](https://github.com/steipete/oracle/blob/feat/harvest-recover-via-saved-url/src/browser/reattachability.ts) and reuse it in `resolveRecoveryUrl`. Stale home URLs (`https://chatgpt.com/`), project shells (`/g/g-…`), and unrelated external URLs are now rejected — recovery falls through to the original missing-tab error rather than navigating the persistent profile to the wrong page.
2. **Preference order flipped.** `harvest.url` is checked before `runtime.tabUrl`, matching `resolveSessionTabRef`. This way a stale `runtime.tabUrl = https://chatgpt.com/` (shell) can no longer beat a valid `harvest.url = https://chatgpt.com/c/<id>` from a prior harvest.
3. **Cleanup gap closed.** Both `harvestSessionBrowserOutput` and `liveTailSessionBrowserOutput` now wrap the recovery retry (and, for `--live`, the main poll loop) inside the same try/finally as the `recoveredChrome` declaration. `closeAfterRecover: true` is now honored even if the post-recovery harvest itself throws.
4. **New test file** `tests/browser/recoverConversation.test.ts`: 10 cases covering accepted URLs, rejected shell/project/external URLs, malformed input, the harvest-vs-runtime preference order, and empty browser metadata.

## Notes

- The recovery launch still uses a minimal flag set (anti-detection + lang + no-first-run + use-mock-keychain). Kept narrow on purpose to avoid drifting from `launchChrome`'s production flag set in `chromeLifecycle.ts`. Happy to refactor to share a helper if you'd prefer one source of truth.
- No CLI flag was added for `closeAfterRecover` (kept it as an internal option); could expose `--close-after-recover` if useful.