### PR TITLE
Fix: OpenRouter runs silently lose pricing and context length (per-token strings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- API/OpenRouter: parse catalog prompt/completion prices as USD-per-token strings, preserving model/context metadata and accurate cost estimates while malformed prices fall back cleanly. Thanks @devYRPauli!
 - Browser: honor `--browser-model-strategy current` when ChatGPT exposes a usable composer without a model-picker button, record unavailable current-model labels honestly, and keep strict selection failures actionable. Thanks @m-rousseau!
 - Browser: select and verify requested thinking effort from ChatGPT's standalone Pro/Thinking composer pills and earlier Intelligence/per-model picker layouts, keep Pro Extended fail-closed when the selected effort cannot be confirmed, and ignore status-only assistant turns such as `Pro thinking` only while generation is active; picker failures now emit a bounded, redacted diagnostic in normal session logs. Thanks @umutkeltek!
 - Browser: surface visible ChatGPT rate-limit, temporary-unavailable, and authentication/challenge warnings in assistant-timeout errors and session metadata instead of reporting only a generic timeout. Thanks @derekszen!

--- a/src/oracle/modelResolver.ts
+++ b/src/oracle/modelResolver.ts
@@ -1,7 +1,6 @@
 import { createRequire } from "node:module";
 import type { ModelConfig, ModelName, KnownModelName, TokenizerFn, ProModelName } from "./types.js";
 import { MODEL_CONFIGS, PRO_MODELS } from "./config.js";
-import { pricingFromUsdPerMillion } from "tokentally";
 
 const OPENROUTER_DEFAULT_BASE = "https://openrouter.ai/api/v1";
 const OPENROUTER_MODELS_ENDPOINT = "https://openrouter.ai/api/v1/models";
@@ -57,8 +56,9 @@ interface OpenRouterModelInfo {
   id: string;
   context_length?: number;
   pricing?: {
-    prompt?: number;
-    completion?: number;
+    // OpenRouter returns these as USD-per-token numeric strings (e.g. "0.000005").
+    prompt?: string | number;
+    completion?: string | number;
   };
 }
 
@@ -167,19 +167,22 @@ export async function resolveModelConfig(
           openRouterId: targetId,
           provider: known?.provider ?? "other",
           inputLimit: info.context_length ?? known?.inputLimit ?? 200_000,
-          pricing:
-            info.pricing && info.pricing.prompt != null && info.pricing.completion != null
-              ? (() => {
-                  const pricing = pricingFromUsdPerMillion({
-                    inputUsdPerMillion: info.pricing.prompt,
-                    outputUsdPerMillion: info.pricing.completion,
-                  });
-                  return {
-                    inputPerToken: pricing.inputUsdPerToken,
-                    outputPerToken: pricing.outputUsdPerToken,
-                  };
-                })()
-              : (known?.pricing ?? null),
+          pricing: (() => {
+            // OpenRouter publishes USD-per-token prices, often as strings (e.g. "0.000005").
+            // Treat null/undefined/blank/non-numeric values as malformed so they fall back.
+            const toPerToken = (v: string | number | undefined): number =>
+              typeof v === "number"
+                ? v
+                : typeof v === "string" && v.trim() !== ""
+                  ? Number(v)
+                  : NaN;
+            const input = toPerToken(info.pricing?.prompt);
+            const output = toPerToken(info.pricing?.completion);
+            if (Number.isFinite(input) && input >= 0 && Number.isFinite(output) && output >= 0) {
+              return { inputPerToken: input, outputPerToken: output };
+            }
+            return known?.pricing ?? null;
+          })(),
           supportsBackground: known?.supportsBackground ?? true,
           supportsSearch: known?.supportsSearch ?? true,
         };

--- a/src/oracle/modelResolver.ts
+++ b/src/oracle/modelResolver.ts
@@ -1,6 +1,7 @@
 import { createRequire } from "node:module";
 import type { ModelConfig, ModelName, KnownModelName, TokenizerFn, ProModelName } from "./types.js";
 import { MODEL_CONFIGS, PRO_MODELS } from "./config.js";
+import { pricingFromUsdPerToken } from "tokentally";
 
 const OPENROUTER_DEFAULT_BASE = "https://openrouter.ai/api/v1";
 const OPENROUTER_MODELS_ENDPOINT = "https://openrouter.ai/api/v1/models";
@@ -56,9 +57,30 @@ interface OpenRouterModelInfo {
   id: string;
   context_length?: number;
   pricing?: {
-    // OpenRouter returns these as USD-per-token numeric strings (e.g. "0.000005").
     prompt?: string | number;
     completion?: string | number;
+  };
+}
+
+function openRouterPricing(pricing: OpenRouterModelInfo["pricing"]): ModelConfig["pricing"] {
+  const parsePrice = (value: string | number | undefined): number | null => {
+    const parsed =
+      typeof value === "number"
+        ? value
+        : typeof value === "string" && value.trim() !== ""
+          ? Number(value)
+          : NaN;
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  };
+
+  const inputUsdPerToken = parsePrice(pricing?.prompt);
+  const outputUsdPerToken = parsePrice(pricing?.completion);
+  if (inputUsdPerToken === null || outputUsdPerToken === null) return null;
+
+  const normalized = pricingFromUsdPerToken({ inputUsdPerToken, outputUsdPerToken });
+  return {
+    inputPerToken: normalized.inputUsdPerToken,
+    outputPerToken: normalized.outputUsdPerToken,
   };
 }
 
@@ -167,22 +189,7 @@ export async function resolveModelConfig(
           openRouterId: targetId,
           provider: known?.provider ?? "other",
           inputLimit: info.context_length ?? known?.inputLimit ?? 200_000,
-          pricing: (() => {
-            // OpenRouter publishes USD-per-token prices, often as strings (e.g. "0.000005").
-            // Treat null/undefined/blank/non-numeric values as malformed so they fall back.
-            const toPerToken = (v: string | number | undefined): number =>
-              typeof v === "number"
-                ? v
-                : typeof v === "string" && v.trim() !== ""
-                  ? Number(v)
-                  : NaN;
-            const input = toPerToken(info.pricing?.prompt);
-            const output = toPerToken(info.pricing?.completion);
-            if (Number.isFinite(input) && input >= 0 && Number.isFinite(output) && output >= 0) {
-              return { inputPerToken: input, outputPerToken: output };
-            }
-            return known?.pricing ?? null;
-          })(),
+          pricing: openRouterPricing(info.pricing) ?? known?.pricing ?? null,
           supportsBackground: known?.supportsBackground ?? true,
           supportsSearch: known?.supportsSearch ?? true,
         };

--- a/tests/openrouter.test.ts
+++ b/tests/openrouter.test.ts
@@ -42,9 +42,6 @@ describe("OpenRouter helpers", () => {
   });
 
   it("hydrates pricing from OpenRouter string per-token values", async () => {
-    // OpenRouter's live /api/v1/models returns pricing as USD-per-token strings,
-    // e.g. "0.000005". Feeding them to a per-million converter previously threw,
-    // and the bare catch dropped the whole enrichment (pricing, context length).
     resetOpenRouterCatalogCacheForTest();
     const fetcher = vi.fn().mockResolvedValue({
       ok: true,
@@ -71,32 +68,31 @@ describe("OpenRouter helpers", () => {
     expect(config.pricing?.outputPerToken).toBeCloseTo(0.000025, 12);
   });
 
-  it("falls back when catalog pricing strings are blank", async () => {
-    // Blank/whitespace prices are malformed remote metadata; they must not be
-    // read as a free ($0) model. Enrichment still applies; pricing falls back.
+  it("preserves catalog metadata and known pricing when catalog pricing is invalid", async () => {
     resetOpenRouterCatalogCacheForTest();
+    const known = await resolveModelConfig("gpt-5.1");
     const fetcher = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
       json: async () => ({
         data: [
           {
-            id: "anthropic/claude-opus-4.8",
+            id: "openai/gpt-5.1",
             context_length: 123456,
-            pricing: { prompt: "", completion: "  " },
+            pricing: { prompt: "-1", completion: "-1" },
           },
         ],
       }),
     }) as unknown as typeof fetch;
 
-    const config = await resolveModelConfig("anthropic/claude-opus-4.8", {
+    const config = await resolveModelConfig("gpt-5.1", {
       openRouterApiKey: "dummy-blank",
       fetcher,
     });
 
-    expect(config.apiModel).toBe("anthropic/claude-opus-4.8");
+    expect(config.apiModel).toBe("openai/gpt-5.1");
     expect(config.inputLimit).toBe(123456);
-    expect(config.pricing ?? null).toBeNull();
+    expect(config.pricing).toEqual(known.pricing);
   });
 
   it("falls back to OpenRouter when provider key is missing but OPENROUTER_API_KEY is present", async () => {

--- a/tests/openrouter.test.ts
+++ b/tests/openrouter.test.ts
@@ -14,6 +14,7 @@ describe("OpenRouter helpers", () => {
   });
 
   it("hydrates config from OpenRouter catalog", async () => {
+    resetOpenRouterCatalogCacheForTest();
     const fetcher = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
@@ -22,7 +23,8 @@ describe("OpenRouter helpers", () => {
           {
             id: "minimax/minimax-m2",
             context_length: 100000,
-            pricing: { prompt: 2, completion: 3 },
+            // OpenRouter pricing is USD per token.
+            pricing: { prompt: 0.000002, completion: 0.000003 },
           },
         ],
       }),
@@ -35,8 +37,66 @@ describe("OpenRouter helpers", () => {
 
     expect(config.apiModel).toBe("minimax/minimax-m2");
     expect(config.inputLimit).toBe(100000);
-    expect(config.pricing?.inputPerToken).toBeCloseTo(2 / 1_000_000);
-    expect(config.pricing?.outputPerToken).toBeCloseTo(3 / 1_000_000);
+    expect(config.pricing?.inputPerToken).toBeCloseTo(0.000002, 12);
+    expect(config.pricing?.outputPerToken).toBeCloseTo(0.000003, 12);
+  });
+
+  it("hydrates pricing from OpenRouter string per-token values", async () => {
+    // OpenRouter's live /api/v1/models returns pricing as USD-per-token strings,
+    // e.g. "0.000005". Feeding them to a per-million converter previously threw,
+    // and the bare catch dropped the whole enrichment (pricing, context length).
+    resetOpenRouterCatalogCacheForTest();
+    const fetcher = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [
+          {
+            id: "anthropic/claude-opus-4.8",
+            context_length: 123456,
+            pricing: { prompt: "0.000005", completion: "0.000025" },
+          },
+        ],
+      }),
+    }) as unknown as typeof fetch;
+
+    const config = await resolveModelConfig("anthropic/claude-opus-4.8", {
+      openRouterApiKey: "dummy-opus48",
+      fetcher,
+    });
+
+    expect(config.apiModel).toBe("anthropic/claude-opus-4.8");
+    expect(config.inputLimit).toBe(123456);
+    expect(config.pricing?.inputPerToken).toBeCloseTo(0.000005, 12);
+    expect(config.pricing?.outputPerToken).toBeCloseTo(0.000025, 12);
+  });
+
+  it("falls back when catalog pricing strings are blank", async () => {
+    // Blank/whitespace prices are malformed remote metadata; they must not be
+    // read as a free ($0) model. Enrichment still applies; pricing falls back.
+    resetOpenRouterCatalogCacheForTest();
+    const fetcher = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [
+          {
+            id: "anthropic/claude-opus-4.8",
+            context_length: 123456,
+            pricing: { prompt: "", completion: "  " },
+          },
+        ],
+      }),
+    }) as unknown as typeof fetch;
+
+    const config = await resolveModelConfig("anthropic/claude-opus-4.8", {
+      openRouterApiKey: "dummy-blank",
+      fetcher,
+    });
+
+    expect(config.apiModel).toBe("anthropic/claude-opus-4.8");
+    expect(config.inputLimit).toBe(123456);
+    expect(config.pricing ?? null).toBeNull();
   });
 
   it("falls back to OpenRouter when provider key is missing but OPENROUTER_API_KEY is present", async () => {


### PR DESCRIPTION
## Problem

`resolveModelConfig` passed OpenRouter's `pricing.prompt` and `pricing.completion` fields to tokentally's per-million helper. OpenRouter's catalog publishes USD-per-token numeric strings, so string values threw inside the resolver's broad catalog fallback and discarded pricing, context length, `apiModel`, and `openRouterId`. Numeric values were divided by 1,000,000 again.

A live catalog check on June 11, 2026 found all 338 returned models using string prompt/completion prices. OpenRouter also uses negative sentinel prices for routing models.

## Fix

- Parse catalog string or numeric prices as USD per token.
- Validate them through tokentally's per-token helper.
- Fall back to known pricing for missing, malformed, or negative values without dropping catalog model/context metadata.
- Add focused numeric, string, and invalid-sentinel regression coverage.
- Add the maintainer changelog entry and contributor credit.

## Proof

Live catalog-only reproduction with a redacted placeholder key:

```text
main:   {"apiModel":null,"openRouterId":null,"inputLimit":200000,"pricing":null}
branch: {"apiModel":"anthropic/claude-opus-4.8","openRouterId":"anthropic/claude-opus-4.8","inputLimit":1000000,"pricing":{"inputPerToken":0.000005,"outputPerToken":0.000025}}
branch: {"apiModel":"openrouter/auto","openRouterId":"openrouter/auto","inputLimit":2000000,"pricing":null}
```

No provider inference request was submitted.

- Focused: `tests/openrouter.test.ts` - 8 passed.
- Full suite: 137 files and 1,171 tests passed; 18 files and 41 tests skipped.
- `pnpm run check`
- `pnpm run docs:check`
- `pnpm run build`
- `pnpm run docs:site`
- `pnpm run test:packed-cli`
- Structured autoreview: no accepted/actionable findings.

Contributor note: the original patch was prepared with the Claude CLI.
