### PR TITLE
fix(browser): allow current model without picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- Browser: honor `--browser-model-strategy current` when ChatGPT exposes a usable composer without a model-picker button, record unavailable current-model labels honestly, and keep strict selection failures actionable. Thanks @m-rousseau!
 - Browser: select and verify requested thinking effort from ChatGPT's standalone Pro/Thinking composer pills and earlier Intelligence/per-model picker layouts, keep Pro Extended fail-closed when the selected effort cannot be confirmed, and ignore status-only assistant turns such as `Pro thinking` only while generation is active; picker failures now emit a bounded, redacted diagnostic in normal session logs. Thanks @umutkeltek!
 - Browser: surface visible ChatGPT rate-limit, temporary-unavailable, and authentication/challenge warnings in assistant-timeout errors and session metadata instead of reporting only a generic timeout. Thanks @derekszen!
 - Browser: verify ChatGPT login through the cookie-authenticated `/api/auth/session` endpoint before falling back to the legacy `/backend-api/me` probe and strong app-shell signals, avoiding false “session not detected” failures when the legacy endpoint requires bearer auth. Fixes #241. Thanks @hexsprite and @orbitingflea!

--- a/src/browser/actions/modelSelection.ts
+++ b/src/browser/actions/modelSelection.ts
@@ -32,18 +32,18 @@ export async function ensureModelSelection(
         status: "option-not-found";
         hint?: { temporaryChat?: boolean; availableOptions?: string[] };
       }
-    | { status: "button-missing"; hint?: { accountPlan?: string; composerSignal?: string } }
+    | { status: "button-missing" }
     | undefined;
 
   switch (result?.status) {
     case "already-selected":
     case "switched":
     case "switched-best-effort": {
-      const label = result.label ?? desiredModel;
+      const label = result.label?.trim() || (strategy === "current" ? null : desiredModel);
       if (strategy !== "current") {
-        assertResolvedModelSelection(desiredModel, label);
+        assertResolvedModelSelection(desiredModel, label ?? desiredModel);
       }
-      logger(`Model picker: ${label}`);
+      logger(`Model picker: ${label ?? "current model (label unavailable)"}`);
       return {
         requestedModel: desiredModel,
         resolvedLabel: label,
@@ -69,18 +69,8 @@ export async function ensureModelSelection(
     }
     default: {
       await logDomFailure(Runtime, logger, "model-switcher-button");
-      const accountPlan = result?.status === "button-missing" ? result.hint?.accountPlan : null;
-      const composerSignal =
-        result?.status === "button-missing" ? result.hint?.composerSignal : null;
-      const visibleState = [
-        accountPlan ? `account=${accountPlan}` : null,
-        composerSignal ? `composer=${composerSignal}` : null,
-      ]
-        .filter(Boolean)
-        .join("; ");
-      const stateHint = visibleState ? ` Visible state: ${visibleState}.` : "";
       throw new Error(
-        `Unable to locate the ChatGPT model selector button.${stateHint} If the desired model is already selected in the browser, retry with --browser-model-strategy current; otherwise retry with --browser-model-strategy ignore to skip model selection.`,
+        "Unable to locate the ChatGPT model selector button. If the desired model is already selected in the browser, retry with --browser-model-strategy current; otherwise retry with --browser-model-strategy ignore to skip model selection.",
       );
     }
   }
@@ -289,12 +279,6 @@ function buildModelSelectionExpression(
     const getButtonLabel = () => (findModelButton()?.textContent ?? '').trim();
     const getComposerModelLabel = () =>
       (document.querySelector(COMPOSER_MODEL_SIGNAL_SELECTOR)?.textContent ?? '').trim();
-    const getAccountPlanLabel = () => {
-      const labels = Array.from(document.querySelectorAll('[data-testid="accounts-profile-button"]'))
-        .map((node) => (node.getAttribute('aria-label') ?? node.textContent ?? '').trim())
-        .filter(Boolean);
-      return labels.find((label) => hasToken(label, 'pro')) ?? labels[0] ?? '';
-    };
     const readComposerModelSignal = () => normalizeText(getComposerModelLabel());
     const withProPillSignal = (label) => {
       const resolved = label || '';
@@ -310,7 +294,7 @@ function buildModelSelectionExpression(
     const isThinkingEffortLabel = (label) =>
       label === 'extended' || label === 'standard' || label === 'heavy' || label === 'light';
     if (MODEL_STRATEGY === 'current') {
-      const currentLabel = getResolvedLabel(PRIMARY_LABEL);
+      const currentLabel = getResolvedLabel('') || null;
       return {
         status: 'already-selected',
         label: currentLabel,
@@ -319,13 +303,7 @@ function buildModelSelectionExpression(
 
     const button = findModelButton();
     if (!button) {
-      return {
-        status: 'button-missing',
-        hint: {
-          accountPlan: getAccountPlanLabel(),
-          composerSignal: getComposerModelLabel(),
-        },
-      };
+      return { status: 'button-missing' };
     }
     const buttonMatchesTarget = () => {
       const normalizedLabel = normalizeText(getButtonLabel());

--- a/src/browser/actions/modelSelection.ts
+++ b/src/browser/actions/modelSelection.ts
@@ -32,7 +32,7 @@ export async function ensureModelSelection(
         status: "option-not-found";
         hint?: { temporaryChat?: boolean; availableOptions?: string[] };
       }
-    | { status: "button-missing" }
+    | { status: "button-missing"; hint?: { accountPlan?: string; composerSignal?: string } }
     | undefined;
 
   switch (result?.status) {
@@ -69,7 +69,19 @@ export async function ensureModelSelection(
     }
     default: {
       await logDomFailure(Runtime, logger, "model-switcher-button");
-      throw new Error("Unable to locate the ChatGPT model selector button.");
+      const accountPlan = result?.status === "button-missing" ? result.hint?.accountPlan : null;
+      const composerSignal =
+        result?.status === "button-missing" ? result.hint?.composerSignal : null;
+      const visibleState = [
+        accountPlan ? `account=${accountPlan}` : null,
+        composerSignal ? `composer=${composerSignal}` : null,
+      ]
+        .filter(Boolean)
+        .join("; ");
+      const stateHint = visibleState ? ` Visible state: ${visibleState}.` : "";
+      throw new Error(
+        `Unable to locate the ChatGPT model selector button.${stateHint} If the desired model is already selected in the browser, retry with --browser-model-strategy current; otherwise retry with --browser-model-strategy ignore to skip model selection.`,
+      );
     }
   }
 }
@@ -252,12 +264,9 @@ function buildModelSelectionExpression(
       return Array.from(document.querySelectorAll('button.__composer-pill')).find(looksLikeModelPill) ?? null;
     };
 
-    const button = findModelButton();
-    if (!button) {
-      return { status: 'button-missing' };
-    }
-
     const closeMenu = () => {
+      const button = findModelButton();
+      if (!button) return;
       try {
         if (dispatchClickSequence(button)) {
           lastPointerClick = performance.now();
@@ -277,9 +286,15 @@ function buildModelSelectionExpression(
       } catch {}
     };
 
-    const getButtonLabel = () => (button.textContent ?? '').trim();
+    const getButtonLabel = () => (findModelButton()?.textContent ?? '').trim();
     const getComposerModelLabel = () =>
       (document.querySelector(COMPOSER_MODEL_SIGNAL_SELECTOR)?.textContent ?? '').trim();
+    const getAccountPlanLabel = () => {
+      const labels = Array.from(document.querySelectorAll('[data-testid="accounts-profile-button"]'))
+        .map((node) => (node.getAttribute('aria-label') ?? node.textContent ?? '').trim())
+        .filter(Boolean);
+      return labels.find((label) => hasToken(label, 'pro')) ?? labels[0] ?? '';
+    };
     const readComposerModelSignal = () => normalizeText(getComposerModelLabel());
     const withProPillSignal = (label) => {
       const resolved = label || '';
@@ -299,6 +314,17 @@ function buildModelSelectionExpression(
       return {
         status: 'already-selected',
         label: currentLabel,
+      };
+    }
+
+    const button = findModelButton();
+    if (!button) {
+      return {
+        status: 'button-missing',
+        hint: {
+          accountPlan: getAccountPlanLabel(),
+          composerSignal: getComposerModelLabel(),
+        },
       };
     }
     const buttonMatchesTarget = () => {

--- a/tests/browser/modelSelection.test.ts
+++ b/tests/browser/modelSelection.test.ts
@@ -334,6 +334,64 @@ const evaluateComposerPillFallbackExpression = (
   );
 };
 
+const evaluateNoModelButtonExpression = (
+  targetModel: string,
+  strategy: "select" | "current" = "select",
+): unknown => {
+  const expression = buildModelSelectionExpressionForTest(targetModel, strategy);
+  const accountNodes = [
+    {
+      textContent: "",
+      getAttribute: (name: string) => (name === "aria-label" ? "Open profile menu" : null),
+    },
+    {
+      textContent: "marc rousseau Pro",
+      getAttribute: (name: string) =>
+        name === "aria-label" ? "marc rousseau Pro, open profile menu" : null,
+    },
+  ];
+  const documentStub = {
+    querySelector: () => null,
+    querySelectorAll: (selector: string) =>
+      selector.includes("accounts-profile-button") ? accountNodes : [],
+    title: "",
+    body: { innerText: "marc rousseau Pro Ready when you are." },
+    dispatchEvent: () => true,
+  };
+  const performanceStub = { now: () => 0 };
+  const windowStub = { location: { href: "https://chatgpt.com/" } };
+  const EventTargetStub = class {};
+  const MouseEventStub = class {};
+  const evaluate = new Function(
+    "document",
+    "performance",
+    "setTimeout",
+    "window",
+    "EventTarget",
+    "MouseEvent",
+    "HTMLElement",
+    `return ${expression};`,
+  ) as (
+    document: unknown,
+    performance: unknown,
+    setTimeout: unknown,
+    window: unknown,
+    EventTarget: unknown,
+    MouseEvent: unknown,
+    HTMLElement: unknown,
+  ) => unknown;
+
+  return evaluate(
+    documentStub,
+    performanceStub,
+    () => 0,
+    windowStub,
+    EventTargetStub,
+    MouseEventStub,
+    class {},
+  );
+};
+
 describe("browser model selection matchers", () => {
   it("includes pro + 5.5 tokens for gpt-5.5-pro", () => {
     const { labelTokens, testIdTokens } = buildModelMatchersLiteralForTest("gpt-5.5-pro");
@@ -546,6 +604,22 @@ describe("browser model selection matchers", () => {
   it("finds the current model pill when ChatGPT omits aria-haspopup", () => {
     const result = evaluateComposerPillFallbackExpression("Thinking 5.5", "Thinking Heavy");
     expect(result).toEqual({ status: "already-selected", label: "Thinking Heavy" });
+  });
+
+  it("allows the explicit current strategy when ChatGPT hides the model picker", () => {
+    const result = evaluateNoModelButtonExpression("Pro", "current");
+    expect(result).toEqual({ status: "already-selected", label: "Pro" });
+  });
+
+  it("reports visible account state when strict selection cannot find a picker", () => {
+    const result = evaluateNoModelButtonExpression("Pro", "select");
+    expect(result).toEqual({
+      status: "button-missing",
+      hint: {
+        accountPlan: "marc rousseau Pro, open profile menu",
+        composerSignal: "",
+      },
+    });
   });
 
   it("does not treat per-row thinking effort controls as model options", () => {

--- a/tests/browser/modelSelection.test.ts
+++ b/tests/browser/modelSelection.test.ts
@@ -337,25 +337,17 @@ const evaluateComposerPillFallbackExpression = (
 const evaluateNoModelButtonExpression = (
   targetModel: string,
   strategy: "select" | "current" = "select",
+  composerLabel = "",
 ): unknown => {
   const expression = buildModelSelectionExpressionForTest(targetModel, strategy);
-  const accountNodes = [
-    {
-      textContent: "",
-      getAttribute: (name: string) => (name === "aria-label" ? "Open profile menu" : null),
-    },
-    {
-      textContent: "marc rousseau Pro",
-      getAttribute: (name: string) =>
-        name === "aria-label" ? "marc rousseau Pro, open profile menu" : null,
-    },
-  ];
   const documentStub = {
-    querySelector: () => null,
-    querySelectorAll: (selector: string) =>
-      selector.includes("accounts-profile-button") ? accountNodes : [],
+    querySelector: (selector: string) =>
+      selector.includes("composer-footer-actions") && composerLabel
+        ? { textContent: composerLabel }
+        : null,
+    querySelectorAll: () => [],
     title: "",
-    body: { innerText: "marc rousseau Pro Ready when you are." },
+    body: { innerText: "Ready when you are." },
     dispatchEvent: () => true,
   };
   const performanceStub = { now: () => 0 };
@@ -608,18 +600,17 @@ describe("browser model selection matchers", () => {
 
   it("allows the explicit current strategy when ChatGPT hides the model picker", () => {
     const result = evaluateNoModelButtonExpression("Pro", "current");
-    expect(result).toEqual({ status: "already-selected", label: "Pro" });
+    expect(result).toEqual({ status: "already-selected", label: null });
   });
 
-  it("reports visible account state when strict selection cannot find a picker", () => {
+  it("records a visible composer model label without requiring the picker", () => {
+    const result = evaluateNoModelButtonExpression("Pro", "current", "Thinking");
+    expect(result).toEqual({ status: "already-selected", label: "Thinking" });
+  });
+
+  it("keeps strict selection failed when ChatGPT hides the model picker", () => {
     const result = evaluateNoModelButtonExpression("Pro", "select");
-    expect(result).toEqual({
-      status: "button-missing",
-      hint: {
-        accountPlan: "marc rousseau Pro, open profile menu",
-        composerSignal: "",
-      },
-    });
+    expect(result).toEqual({ status: "button-missing" });
   });
 
   it("does not treat per-row thinking effort controls as model options", () => {
@@ -737,6 +728,26 @@ describe("browser model selection matchers", () => {
       verified: false,
     });
     expect(logger).toHaveBeenCalledWith("Model picker: Thinking 5.5 Heavy");
+  });
+
+  it("does not substitute the requested model when the current label is unavailable", async () => {
+    const runtime = {
+      evaluate: vi.fn().mockResolvedValue({
+        result: { value: { status: "already-selected", label: null } },
+      }),
+    };
+    const logger = vi.fn();
+
+    await expect(
+      ensureModelSelection(runtime as never, "gpt-5.5-pro", logger as never, "current"),
+    ).resolves.toMatchObject({
+      requestedModel: "gpt-5.5-pro",
+      resolvedLabel: null,
+      status: "already-selected",
+      strategy: "current",
+      verified: false,
+    });
+    expect(logger).toHaveBeenCalledWith("Model picker: current model (label unavailable)");
   });
 
   it("builds composer footer matchers for generic ChatGPT header states", () => {

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -74,10 +74,17 @@ describe("ensureModelSelection", () => {
 
   test("throws when button missing", async () => {
     const runtime = {
-      evaluate: vi.fn().mockResolvedValue({ result: { value: { status: "button-missing" } } }),
+      evaluate: vi.fn().mockResolvedValue({
+        result: {
+          value: {
+            status: "button-missing",
+            hint: { accountPlan: "marc rousseau Pro, open profile menu" },
+          },
+        },
+      }),
     } as unknown as ChromeClient["Runtime"];
     await expect(ensureModelSelection(runtime, "Instant", logger)).rejects.toThrow(
-      /Unable to locate the ChatGPT model selector button/,
+      /Unable to locate the ChatGPT model selector button.*account=marc rousseau Pro.*--browser-model-strategy current/s,
     );
   });
 });

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -74,17 +74,10 @@ describe("ensureModelSelection", () => {
 
   test("throws when button missing", async () => {
     const runtime = {
-      evaluate: vi.fn().mockResolvedValue({
-        result: {
-          value: {
-            status: "button-missing",
-            hint: { accountPlan: "marc rousseau Pro, open profile menu" },
-          },
-        },
-      }),
+      evaluate: vi.fn().mockResolvedValue({ result: { value: { status: "button-missing" } } }),
     } as unknown as ChromeClient["Runtime"];
     await expect(ensureModelSelection(runtime, "Instant", logger)).rejects.toThrow(
-      /Unable to locate the ChatGPT model selector button.*account=marc rousseau Pro.*--browser-model-strategy current/s,
+      /Unable to locate the ChatGPT model selector button.*--browser-model-strategy current.*--browser-model-strategy ignore/s,
     );
   });
 });


### PR DESCRIPTION
## Problem

Some authenticated ChatGPT profiles expose a usable composer without a model-picker button. `--browser-model-strategy current` promises to keep the active model, but current `main` checks for a picker before honoring that strategy and aborts with `button-missing`.

Independent evaluation of the exact current-main browser expression with no model button returned:

```json
{"status":"button-missing"}
```

## Root cause

The picker requirement predates `--browser-model-strategy current`; the strategy branch was added later but remained below the early missing-button return. Provenance is clear: the early guard was carried forward from the original picker flow, while model strategy was introduced in `50b32920` on December 27, 2025.

## Fix

- Honor explicit `current` before requiring a picker button.
- Record a visible composer/model label when one exists.
- Record `resolvedLabel: null` when no current-model label is observable instead of substituting the requested model and presenting it as evidence.
- Keep `select` strict when the picker is absent, with actionable `current`/`ignore` guidance.
- Keep account/profile labels out of diagnostics and errors.

## Authenticated live proof

Using the existing signed-in Chrome profile, with model-picker selectors temporarily masked and restored immediately:

- patched `current`: `{"status":"already-selected","label":"Extended Pro"}`
- patched strict `select`: `{"status":"button-missing","hasHint":false}`

No prompt was submitted and no account/session data was captured.

## Validation

- `pnpm run check`
- focused browser tests: 118 passed, 1 skipped
- `pnpm test`: 137 files passed, 18 skipped; 1,169 tests passed, 41 skipped
- `pnpm run docs:check` (85 flags, 6 files)
- `pnpm run build`
- `pnpm run docs:site`
- `pnpm run test:packed-cli`
- structured Codex autoreview: clean, no accepted/actionable findings

Contributor credit is preserved in Marc's authored commit and the changelog entry thanks `@m-rousseau`.
