### PR TITLE
fix(mcp): ignore blank stdio input

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -12,40 +12,87 @@ import { registerProjectSourcesTool } from "./tools/projectSources.js";
 import { registerSessionsTool } from "./tools/sessions.js";
 import { registerSessionResources } from "./tools/sessionResources.js";
 
-function createBlankLineFilteredStdin(stdin: Readable): Transform {
+const MAX_STDIN_LINE_BYTES = 16 * 1024 * 1024;
+const EOF_RESPONSE_IDLE_MS = 50;
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function createBlankLineFilteredStdin(stdin: Readable, onForwardedLine: () => void): Transform {
   let pending = Buffer.alloc(0);
   const filtered = new Transform({
     transform(chunk, _encoding, callback) {
-      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-      pending = pending.length > 0 ? Buffer.concat([pending, buffer]) : buffer;
+      try {
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        pending = pending.length > 0 ? Buffer.concat([pending, buffer]) : buffer;
 
-      while (true) {
-        const lineEnd = pending.indexOf(0x0a);
-        if (lineEnd === -1) break;
+        while (true) {
+          const lineEnd = pending.indexOf(0x0a);
+          if (lineEnd === -1) break;
 
-        const line = pending.subarray(0, lineEnd);
-        const lineWithNewline = pending.subarray(0, lineEnd + 1);
-        pending = pending.subarray(lineEnd + 1);
+          const line = pending.subarray(0, lineEnd);
+          if (line.length > MAX_STDIN_LINE_BYTES) {
+            throw new Error(`MCP stdio line exceeded ${MAX_STDIN_LINE_BYTES} bytes`);
+          }
 
-        // MCP stdio is JSON-per-line; blank terminal input should not be parsed as JSON.
-        if (line.toString("utf8").replace(/\r$/, "").trim().length > 0) {
-          this.push(lineWithNewline);
+          const lineWithNewline = pending.subarray(0, lineEnd + 1);
+          pending = pending.subarray(lineEnd + 1);
+
+          // MCP stdio is JSON-per-line; blank terminal input should not be parsed as JSON.
+          if (line.toString("utf8").replace(/\r$/, "").trim().length > 0) {
+            onForwardedLine();
+            this.push(lineWithNewline);
+          }
         }
-      }
 
-      callback();
+        if (pending.length > MAX_STDIN_LINE_BYTES) {
+          throw new Error(`MCP stdio line exceeded ${MAX_STDIN_LINE_BYTES} bytes`);
+        }
+
+        callback();
+      } catch (error) {
+        callback(toError(error));
+      }
     },
     flush(callback) {
-      if (pending.toString("utf8").trim().length > 0) {
-        this.push(pending);
+      try {
+        if (pending.length > MAX_STDIN_LINE_BYTES) {
+          throw new Error(`MCP stdio line exceeded ${MAX_STDIN_LINE_BYTES} bytes`);
+        }
+        if (pending.toString("utf8").trim().length > 0) {
+          onForwardedLine();
+          this.push(pending);
+        }
+        pending = Buffer.alloc(0);
+        callback();
+      } catch (error) {
+        callback(toError(error));
       }
-      pending = Buffer.alloc(0);
-      callback();
     },
   });
 
   stdin.pipe(filtered);
   return filtered;
+}
+
+function isJsonRpcRequest(message: unknown): message is { id: string | number } {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    "id" in message &&
+    "method" in message &&
+    typeof (message as { method: unknown }).method === "string"
+  );
+}
+
+function isJsonRpcResponse(message: unknown): message is { id: string | number } {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    "id" in message &&
+    ("result" in message || "error" in message)
+  );
 }
 
 export async function startMcpServer(): Promise<void> {
@@ -66,23 +113,72 @@ export async function startMcpServer(): Promise<void> {
   registerSessionsTool(server);
   registerSessionResources(server);
 
-  const stdin = createBlankLineFilteredStdin(process.stdin);
-  const transport = new StdioServerTransport(stdin, process.stdout);
+  let forwardedLineCount = 0;
+  const activeRequestIds = new Set<string | number>();
+  const filteredStdin = createBlankLineFilteredStdin(process.stdin, () => {
+    forwardedLineCount += 1;
+  });
+  const transport = new StdioServerTransport(filteredStdin, process.stdout);
+  let inFlightSends = 0;
+  let filteredInputEnded = false;
+  let closeTimer: ReturnType<typeof setTimeout> | undefined;
+
+  transport.onmessage = (message) => {
+    if (isJsonRpcRequest(message)) {
+      activeRequestIds.add(message.id);
+    }
+  };
+  const send = transport.send.bind(transport);
+  transport.send = async (message) => {
+    inFlightSends += 1;
+    if (closeTimer) {
+      clearTimeout(closeTimer);
+      closeTimer = undefined;
+    }
+    try {
+      await send(message);
+    } finally {
+      inFlightSends -= 1;
+      if (isJsonRpcResponse(message)) {
+        activeRequestIds.delete(message.id);
+      }
+      scheduleCloseAfterInputEnd();
+    }
+  };
+
+  const scheduleCloseAfterInputEnd = () => {
+    if (!filteredInputEnded || closeTimer) return;
+    if (forwardedLineCount > 0 && (activeRequestIds.size > 0 || inFlightSends > 0)) return;
+
+    closeTimer = setTimeout(resolveClosed, forwardedLineCount === 0 ? 0 : EOF_RESPONSE_IDLE_MS);
+  };
   transport.onerror = (error) => {
     console.error("MCP transport error:", error);
   };
+  let didClose = false;
+  let resolveClosedPromise = () => {};
+  const resolveClosed = () => {
+    if (didClose) return;
+    didClose = true;
+    if (closeTimer) {
+      clearTimeout(closeTimer);
+      closeTimer = undefined;
+    }
+    process.stdin.unpipe(filteredStdin);
+    filteredStdin.destroy();
+    resolveClosedPromise();
+  };
   const closed = new Promise<void>((resolve) => {
-    let didClose = false;
-    const resolveClosed = () => {
-      if (didClose) return;
-      didClose = true;
-      process.stdin.unpipe(stdin);
-      stdin.destroy();
-      resolve();
-    };
+    resolveClosedPromise = resolve;
     transport.onclose = resolveClosed;
-    stdin.once("end", resolveClosed);
-    stdin.once("close", resolveClosed);
+    filteredStdin.once("end", () => {
+      filteredInputEnded = true;
+      scheduleCloseAfterInputEnd();
+    });
+    filteredStdin.once("close", () => {
+      filteredInputEnded = true;
+      scheduleCloseAfterInputEnd();
+    });
   });
 
   // Keep the process alive until the client closes the transport.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
+import { Buffer } from "node:buffer";
 import "dotenv/config";
 import process from "node:process";
+import { Transform, type Readable } from "node:stream";
 import { pathToFileURL } from "node:url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
@@ -9,6 +11,42 @@ import { registerConsultTool } from "./tools/consult.js";
 import { registerProjectSourcesTool } from "./tools/projectSources.js";
 import { registerSessionsTool } from "./tools/sessions.js";
 import { registerSessionResources } from "./tools/sessionResources.js";
+
+function createBlankLineFilteredStdin(stdin: Readable): Transform {
+  let pending = Buffer.alloc(0);
+  const filtered = new Transform({
+    transform(chunk, _encoding, callback) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      pending = pending.length > 0 ? Buffer.concat([pending, buffer]) : buffer;
+
+      while (true) {
+        const lineEnd = pending.indexOf(0x0a);
+        if (lineEnd === -1) break;
+
+        const line = pending.subarray(0, lineEnd);
+        const lineWithNewline = pending.subarray(0, lineEnd + 1);
+        pending = pending.subarray(lineEnd + 1);
+
+        // MCP stdio is JSON-per-line; blank terminal input should not be parsed as JSON.
+        if (line.toString("utf8").replace(/\r$/, "").trim().length > 0) {
+          this.push(lineWithNewline);
+        }
+      }
+
+      callback();
+    },
+    flush(callback) {
+      if (pending.toString("utf8").trim().length > 0) {
+        this.push(pending);
+      }
+      pending = Buffer.alloc(0);
+      callback();
+    },
+  });
+
+  stdin.pipe(filtered);
+  return filtered;
+}
 
 export async function startMcpServer(): Promise<void> {
   const server = new McpServer(
@@ -28,14 +66,23 @@ export async function startMcpServer(): Promise<void> {
   registerSessionsTool(server);
   registerSessionResources(server);
 
-  const transport = new StdioServerTransport();
+  const stdin = createBlankLineFilteredStdin(process.stdin);
+  const transport = new StdioServerTransport(stdin, process.stdout);
   transport.onerror = (error) => {
     console.error("MCP transport error:", error);
   };
   const closed = new Promise<void>((resolve) => {
-    transport.onclose = () => {
+    let didClose = false;
+    const resolveClosed = () => {
+      if (didClose) return;
+      didClose = true;
+      process.stdin.unpipe(stdin);
+      stdin.destroy();
       resolve();
     };
+    transport.onclose = resolveClosed;
+    stdin.once("end", resolveClosed);
+    stdin.once("close", resolveClosed);
   });
 
   // Keep the process alive until the client closes the transport.


### PR DESCRIPTION
Fixes oracle-mcp stdio handling when blank lines reach stdin.

Changes:
- Filters blank/whitespace-only stdio lines before the MCP SDK parses JSON-RPC.
- Adds a 16 MiB maximum JSON-RPC line guard so pending stdio input cannot grow without bound.
- Routes transform errors through `callback(error)` instead of throwing out of the stream implementation.
- Tracks active JSON-RPC request ids and in-flight sends so EOF after a real request waits for the response write to drain before `startMcpServer()` returns.

Verification:
- `pnpm run build`
- `pnpm vitest run tests/mcp.integration.test.ts tests/mcp.stdout.test.ts tests/mcp.schema.test.ts`
- `pnpm exec oxfmt --check src/mcp/server.ts`

Behavior proof:

Blank stdin smoke:

```text
$ printf '\n\n' | timeout 5 node dist/bin/oracle-cli.js oracle-mcp 2>&1; printf 'blank_exit=%s\n' $?
blank_exit=0
```

Valid initialize smoke:

```text
$ printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}\n' | timeout 8 node dist/bin/oracle-cli.js oracle-mcp 2>&1; printf 'init_exit=%s\n' $?
{"result":{"protocolVersion":"2024-11-05","capabilities":{"logging":{},"tools":{"listChanged":true},"resources":{"listChanged":true}},"serverInfo":{"name":"oracle-mcp","version":"0.13.0"}},"jsonrpc":"2.0","id":1}
init_exit=0
```

EOF after multiple JSON-RPC requests waits for both responses:

```text
{
  "code": 0,
  "signal": null,
  "stdoutLineCount": 2,
  "ids": [
    1,
    2
  ],
  "stderr": ""
}
```

Focused MCP tests:

```text
Test Files  3 passed (3)
Tests  4 passed (4)
```
