### PR TITLE
[codex] Add line numbers to Oracle text bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### Changed
 
-- CLI/API/Browser: render Oracle-generated prompt context blocks with stable line numbers so model answers can cite bundled source as `path:line` or `path:line-line`, while raw file uploads, ZIP bundle entries, and exported `createFileSections().sectionText` output remain unchanged. API consumers that need raw fenced sections can call `formatFileSection(..., { lineNumbers: false })`; generated prompt paths use the new `formatFileSections(...)` helper.
+- CLI/API/Browser: render Oracle-generated prompt context blocks with stable line numbers so model answers can cite bundled source as `path:line` or `path:line-line`, while raw file uploads, ZIP bundle entries, exported `createFileSections().sectionText`, and the default `formatFileSection(...)` output remain unchanged. Generated prompt paths use the new `formatFileSections(...)` helper, and callers can request numbered output directly with `formatFileSection(..., { lineNumbers: true })`.
 
 ## 0.13.0 — 2026-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 - Browser: select ChatGPT “Welcome back” accounts only by exact configured email, keep the address out of logs, and fail closed on ambiguous saved accounts. Thanks @derekszen!
 - Browser: relax pre-send readiness for Oracle-generated `attachments-bundle.txt` and `.zip` uploads when ChatGPT exposes only the `attachments-bundle` stem, while keeping filename-boundary checks so unrelated attachment names do not satisfy the gate. Thanks @ig0rsky!
 
+### Changed
+
+- CLI/API/Browser: render Oracle-generated prompt context blocks with stable line numbers so model answers can cite bundled source as `path:line` or `path:line-line`, while raw file uploads, ZIP bundle entries, and exported `createFileSections().sectionText` output remain unchanged. API consumers that need raw fenced sections can call `formatFileSection(..., { lineNumbers: false })`; generated prompt paths use the new `formatFileSections(...)` helper.
+
 ## 0.13.0 — 2026-05-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### Changed
 
-- CLI/API/Browser: render Oracle-generated prompt context blocks with stable line numbers so model answers can cite bundled source as `path:line` or `path:line-line`, while raw file uploads, ZIP bundle entries, exported `createFileSections().sectionText`, and the default `formatFileSection(...)` output remain unchanged. Generated prompt paths use the new `formatFileSections(...)` helper, and callers can request numbered output directly with `formatFileSection(..., { lineNumbers: true })`.
+- CLI/API/Browser: render generated prompt, inline, and text-bundle context with stable line numbers so model answers can cite source as `path:line` or `path:line-line`, while preserving indexed `buildPrompt(...)` headings, raw browser uploads, ZIP entries, `createFileSections().sectionText`, and the default `formatFileSection(...)` output. Callers can request numbered output directly with `formatFileSection(..., { lineNumbers: true })`. Thanks @tristanmanchester!
 
 ## 0.13.0 — 2026-05-22
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -58,6 +58,7 @@ oracle --render --copy -p "Architecture review" --file "src/**/*.ts"
 ```
 
 The bundle is on your clipboard. Paste it into ChatGPT, Claude, Gemini, AI Studio, or wherever you want the answer.
+Generated text context includes stable `Lines:` ranges and `N |` prefixes for `path:line` citations. Direct browser file uploads and ZIP bundles keep the original file contents.
 
 ## 3. Preview before you spend
 

--- a/src/browser/policies.ts
+++ b/src/browser/policies.ts
@@ -1,4 +1,4 @@
-import { formatFileSection } from "../oracle/markdown.js";
+import { formatFileSections } from "../oracle/markdown.js";
 import type { BrowserAttachment } from "./types.js";
 import type { BrowserSessionConfig } from "../sessionManager.js";
 
@@ -25,11 +25,7 @@ export function buildAttachmentPlan(
   }: { inlineFiles: boolean; bundleRequested: boolean; maxAttachments?: number },
 ): AttachmentPlan {
   if (inlineFiles) {
-    const inlineLines: string[] = [];
-    sections.forEach((section) => {
-      inlineLines.push(formatFileSection(section.displayPath, section.content).trimEnd(), "");
-    });
-    const inlineBlock = inlineLines.join("\n").trim();
+    const inlineBlock = formatFileSections(sections);
     return {
       mode: "inline",
       inlineBlock,

--- a/src/browser/prompt.ts
+++ b/src/browser/prompt.ts
@@ -7,7 +7,7 @@ import {
   createFileSections,
   MODEL_CONFIGS,
   TOKENIZER_OPTIONS,
-  formatFileSection,
+  formatFileSections,
 } from "../oracle.js";
 import { isKnownModel } from "../oracle/modelResolver.js";
 import { buildPromptMarkdown } from "../oracle/promptAssembly.js";
@@ -85,15 +85,7 @@ interface WrittenBrowserBundle {
 function formatSectionsForBundle(
   sections: Array<{ displayPath: string; content: string }>,
 ): string {
-  const bundleLines: string[] = [];
-  sections.forEach((section) => {
-    bundleLines.push(formatFileSection(section.displayPath, section.content).trimEnd());
-    bundleLines.push("");
-  });
-  return `${bundleLines
-    .join("\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trimEnd()}\n`;
+  return formatFileSections(sections, { trailingNewline: true });
 }
 
 async function writeBrowserBundle(
@@ -240,11 +232,7 @@ export async function assembleBrowserPrompt(
   );
   const tokenEstimateIncludesInlineFiles = inlineFileCount > 0 && Boolean(selectedPlan.inlineBlock);
   if (!tokenEstimateIncludesInlineFiles && sections.length > 0) {
-    const attachmentText =
-      bundleText ??
-      sections
-        .map((section) => formatFileSection(section.displayPath, section.content).trimEnd())
-        .join("\n\n");
+    const attachmentText = bundleText ?? formatFileSections(sections);
     const attachmentTokens = tokenizer(
       [{ role: "user", content: attachmentText }],
       TOKENIZER_OPTIONS,

--- a/src/browser/prompt.ts
+++ b/src/browser/prompt.ts
@@ -84,8 +84,12 @@ interface WrittenBrowserBundle {
 
 function formatSectionsForBundle(
   sections: Array<{ displayPath: string; content: string }>,
+  options: { lineNumbers?: boolean } = {},
 ): string {
-  return formatFileSections(sections, { trailingNewline: true });
+  return formatFileSections(sections, {
+    lineNumbers: options.lineNumbers ?? true,
+    trailingNewline: true,
+  });
 }
 
 async function writeBrowserBundle(
@@ -93,7 +97,9 @@ async function writeBrowserBundle(
   format: BrowserBundleFormat,
 ): Promise<WrittenBrowserBundle> {
   const bundleDir = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-browser-bundle-"));
-  const tokenEstimateText = formatSectionsForBundle(sections);
+  const tokenEstimateText = formatSectionsForBundle(sections, {
+    lineNumbers: format === "text",
+  });
   if (format === "zip") {
     const bundlePath = path.join(bundleDir, "attachments-bundle.zip");
     const buffer = createStoredZip(
@@ -232,7 +238,7 @@ export async function assembleBrowserPrompt(
   );
   const tokenEstimateIncludesInlineFiles = inlineFileCount > 0 && Boolean(selectedPlan.inlineBlock);
   if (!tokenEstimateIncludesInlineFiles && sections.length > 0) {
-    const attachmentText = bundleText ?? formatFileSections(sections);
+    const attachmentText = bundleText ?? formatFileSections(sections, { lineNumbers: false });
     const attachmentTokens = tokenizer(
       [{ role: "user", content: attachmentText }],
       TOKENIZER_OPTIONS,

--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -10,7 +10,7 @@ export { readFiles, createFileSections } from "./oracle/files.js";
 export { buildPrompt, buildRequestBody, renderPromptMarkdown } from "./oracle/request.js";
 export { estimateRequestTokens } from "./oracle/tokenEstimate.js";
 export { formatUSD, formatNumber, formatElapsed } from "./oracle/format.js";
-export { formatFileSection } from "./oracle/markdown.js";
+export { formatFileSection, formatFileSections } from "./oracle/markdown.js";
 export { getFileTokenStats, printFileTokenStats } from "./oracle/tokenStats.js";
 export {
   OracleResponseError,

--- a/src/oracle/config.ts
+++ b/src/oracle/config.ts
@@ -239,7 +239,7 @@ export const MODEL_CONFIGS: Record<KnownModelName, ModelConfig> = {
 
 export const DEFAULT_SYSTEM_PROMPT = [
   "You are Oracle, a focused one-shot problem solver.",
-  "Emphasize direct answers and cite any files referenced.",
+  "Emphasize direct answers and cite referenced files as path:line or path:line-line when line numbers are available.",
 ].join(" ");
 
 export const TOKENIZER_OPTIONS = { allowedSpecial: "all" } as const;

--- a/src/oracle/files.ts
+++ b/src/oracle/files.ts
@@ -488,15 +488,14 @@ function relativePath(targetPath: string, cwd: string): string {
   return relative || targetPath;
 }
 
+function formatLegacyFileSection(index: number, displayPath: string, content: string): string {
+  return [`### File ${index}: ${displayPath}`, "```", content.trimEnd(), "```"].join("\n");
+}
+
 export function createFileSections(files: FileContent[], cwd = process.cwd()): FileSection[] {
   return files.map((file, index) => {
     const relative = toPosix(path.relative(cwd, file.path) || file.path);
-    const sectionText = [
-      `### File ${index + 1}: ${relative}`,
-      "```",
-      file.content.trimEnd(),
-      "```",
-    ].join("\n");
+    const sectionText = formatLegacyFileSection(index + 1, relative, file.content);
     return {
       index: index + 1,
       absolutePath: file.path,

--- a/src/oracle/markdown.ts
+++ b/src/oracle/markdown.ts
@@ -82,7 +82,7 @@ export function formatFileSection(
   const normalized = content.replace(/\s+$/u, "");
   const header = `### File: ${displayPath}`;
   const fenceOpen = lang ? `${fence}${lang}` : fence;
-  if (options.lineNumbers === false) {
+  if (options.lineNumbers !== true) {
     return [header, fenceOpen, normalized, fence, ""].join("\n");
   }
 
@@ -96,8 +96,11 @@ export function formatFileSections(
   sections: FileSectionInput[],
   options: FormatFileSectionsOptions = {},
 ): string {
+  const sectionOptions = { ...options, lineNumbers: options.lineNumbers ?? true };
   const rendered = sections
-    .map((section) => formatFileSection(section.displayPath, section.content, options).trimEnd())
+    .map((section) =>
+      formatFileSection(section.displayPath, section.content, sectionOptions).trimEnd(),
+    )
     .join("\n\n");
   return options.trailingNewline && rendered ? `${rendered}\n` : rendered;
 }

--- a/src/oracle/markdown.ts
+++ b/src/oracle/markdown.ts
@@ -2,6 +2,19 @@ import path from "node:path";
 
 export type FenceLanguage = string | null | undefined;
 
+export interface FormatFileSectionOptions {
+  lineNumbers?: boolean;
+}
+
+export interface FormatFileSectionsOptions extends FormatFileSectionOptions {
+  trailingNewline?: boolean;
+}
+
+export interface FileSectionInput {
+  displayPath: string;
+  content: string;
+}
+
 const EXT_TO_LANG: Record<string, string> = {
   ".ts": "ts",
   ".tsx": "tsx",
@@ -42,11 +55,49 @@ function pickFence(content: string): string {
   return "`".repeat(fenceLength);
 }
 
-export function formatFileSection(displayPath: string, content: string): string {
+function formatLineRange(lineCount: number): string {
+  return lineCount === 0 ? "Lines: 0" : `Lines: 1-${lineCount}`;
+}
+
+function addLineNumbers(content: string): { text: string; lineCount: number } {
+  if (content.length === 0) {
+    return { text: "", lineCount: 0 };
+  }
+
+  const lines = content.split("\n");
+  const width = String(lines.length).length;
+  const numbered = lines
+    .map((line, index) => `${String(index + 1).padStart(width, " ")} | ${line}`)
+    .join("\n");
+  return { text: numbered, lineCount: lines.length };
+}
+
+export function formatFileSection(
+  displayPath: string,
+  content: string,
+  options: FormatFileSectionOptions = {},
+): string {
   const fence = pickFence(content);
   const lang = detectFenceLanguage(displayPath);
   const normalized = content.replace(/\s+$/u, "");
   const header = `### File: ${displayPath}`;
   const fenceOpen = lang ? `${fence}${lang}` : fence;
-  return [header, fenceOpen, normalized, fence, ""].join("\n");
+  if (options.lineNumbers === false) {
+    return [header, fenceOpen, normalized, fence, ""].join("\n");
+  }
+
+  const numbered = addLineNumbers(normalized);
+  return [header, formatLineRange(numbered.lineCount), fenceOpen, numbered.text, fence, ""].join(
+    "\n",
+  );
+}
+
+export function formatFileSections(
+  sections: FileSectionInput[],
+  options: FormatFileSectionsOptions = {},
+): string {
+  const rendered = sections
+    .map((section) => formatFileSection(section.displayPath, section.content, options).trimEnd())
+    .join("\n\n");
+  return options.trailingNewline && rendered ? `${rendered}\n` : rendered;
 }

--- a/src/oracle/markdown.ts
+++ b/src/oracle/markdown.ts
@@ -7,12 +7,18 @@ export interface FormatFileSectionOptions {
 }
 
 export interface FormatFileSectionsOptions extends FormatFileSectionOptions {
+  includeFileIndex?: boolean;
   trailingNewline?: boolean;
 }
 
 export interface FileSectionInput {
+  index?: number;
   displayPath: string;
   content: string;
+}
+
+interface RenderFileSectionOptions extends FormatFileSectionOptions {
+  index?: number;
 }
 
 const EXT_TO_LANG: Record<string, string> = {
@@ -72,15 +78,18 @@ function addLineNumbers(content: string): { text: string; lineCount: number } {
   return { text: numbered, lineCount: lines.length };
 }
 
-export function formatFileSection(
+function renderFileSection(
   displayPath: string,
   content: string,
-  options: FormatFileSectionOptions = {},
+  options: RenderFileSectionOptions,
 ): string {
   const fence = pickFence(content);
   const lang = detectFenceLanguage(displayPath);
   const normalized = content.replace(/\s+$/u, "");
-  const header = `### File: ${displayPath}`;
+  const header =
+    options.index == null
+      ? `### File: ${displayPath}`
+      : `### File ${options.index}: ${displayPath}`;
   const fenceOpen = lang ? `${fence}${lang}` : fence;
   if (options.lineNumbers !== true) {
     return [header, fenceOpen, normalized, fence, ""].join("\n");
@@ -92,14 +101,25 @@ export function formatFileSection(
   );
 }
 
+export function formatFileSection(
+  displayPath: string,
+  content: string,
+  options: FormatFileSectionOptions = {},
+): string {
+  return renderFileSection(displayPath, content, options);
+}
+
 export function formatFileSections(
   sections: FileSectionInput[],
   options: FormatFileSectionsOptions = {},
 ): string {
-  const sectionOptions = { ...options, lineNumbers: options.lineNumbers ?? true };
+  const lineNumbers = options.lineNumbers ?? true;
   const rendered = sections
     .map((section) =>
-      formatFileSection(section.displayPath, section.content, sectionOptions).trimEnd(),
+      renderFileSection(section.displayPath, section.content, {
+        lineNumbers,
+        index: options.includeFileIndex ? section.index : undefined,
+      }).trimEnd(),
     )
     .join("\n\n");
   return options.trailingNewline && rendered ? `${rendered}\n` : rendered;

--- a/src/oracle/promptAssembly.ts
+++ b/src/oracle/promptAssembly.ts
@@ -1,4 +1,4 @@
-import { formatFileSection } from "./markdown.js";
+import { formatFileSections } from "./markdown.js";
 
 export interface PromptFileSection {
   displayPath: string;
@@ -16,9 +16,7 @@ export function buildPromptMarkdown(
   sections: PromptFileSection[],
 ): string {
   const lines = ["[SYSTEM]", systemPrompt, "", "[USER]", userPrompt, ""];
-  sections.forEach((section) => {
-    lines.push(formatFileSection(section.displayPath, section.content));
-  });
+  lines.push(formatFileSections(sections, { trailingNewline: true }));
   return lines
     .join("\n")
     .replace(/\n{3,}/g, "\n\n")

--- a/src/oracle/request.ts
+++ b/src/oracle/request.ts
@@ -9,7 +9,7 @@ import type {
 } from "./types.js";
 import { DEFAULT_SYSTEM_PROMPT } from "./config.js";
 import { createFileSections, readFiles } from "./files.js";
-import { formatFileSection, formatFileSections } from "./markdown.js";
+import { formatFileSections } from "./markdown.js";
 import { createFsAdapter } from "./fsAdapter.js";
 
 export function buildPrompt(basePrompt: string, files: FileContent[], cwd = process.cwd()): string {
@@ -71,9 +71,7 @@ export async function renderPromptMarkdown(
   const userPrompt = (options.prompt ?? "").trim();
   const lines = ["[SYSTEM]", systemPrompt, ""];
   lines.push("[USER]", userPrompt, "");
-  sections.forEach((section) => {
-    lines.push(formatFileSection(section.displayPath, section.content));
-  });
+  lines.push(formatFileSections(sections));
   return lines
     .join("\n")
     .replace(/\n{3,}/g, "\n\n")

--- a/src/oracle/request.ts
+++ b/src/oracle/request.ts
@@ -9,7 +9,7 @@ import type {
 } from "./types.js";
 import { DEFAULT_SYSTEM_PROMPT } from "./config.js";
 import { createFileSections, readFiles } from "./files.js";
-import { formatFileSection } from "./markdown.js";
+import { formatFileSection, formatFileSections } from "./markdown.js";
 import { createFsAdapter } from "./fsAdapter.js";
 
 export function buildPrompt(basePrompt: string, files: FileContent[], cwd = process.cwd()): string {
@@ -17,7 +17,7 @@ export function buildPrompt(basePrompt: string, files: FileContent[], cwd = proc
     return basePrompt;
   }
   const sections = createFileSections(files, cwd);
-  const sectionText = sections.map((section) => section.sectionText).join("\n\n");
+  const sectionText = formatFileSections(sections);
   return `${basePrompt.trim()}\n\n${sectionText}`;
 }
 

--- a/src/oracle/request.ts
+++ b/src/oracle/request.ts
@@ -17,7 +17,7 @@ export function buildPrompt(basePrompt: string, files: FileContent[], cwd = proc
     return basePrompt;
   }
   const sections = createFileSections(files, cwd);
-  const sectionText = formatFileSections(sections);
+  const sectionText = formatFileSections(sections, { includeFileIndex: true });
   return `${basePrompt.trim()}\n\n${sectionText}`;
 }
 

--- a/src/oracle/tokenStats.ts
+++ b/src/oracle/tokenStats.ts
@@ -23,7 +23,9 @@ export function getFileTokenStats(
   const sections = createFileSections(files, cwd);
   const stats = sections
     .map((section) => {
-      const sectionText = formatFileSection(section.displayPath, section.content).trimEnd();
+      const sectionText = formatFileSection(section.displayPath, section.content, {
+        lineNumbers: true,
+      }).trimEnd();
       const tokens = tokenizer(sectionText, tokenizerOptions);
       const percent = inputTokenBudget ? (tokens / inputTokenBudget) * 100 : undefined;
       return {

--- a/src/oracle/tokenStats.ts
+++ b/src/oracle/tokenStats.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import type { FileContent, FileTokenStats, TokenizerFn } from "./types.js";
 import { createFileSections } from "./files.js";
-import { formatFileSection } from "./markdown.js";
+import { formatFileSections } from "./markdown.js";
 
 export function getFileTokenStats(
   files: FileContent[],
@@ -23,8 +23,8 @@ export function getFileTokenStats(
   const sections = createFileSections(files, cwd);
   const stats = sections
     .map((section) => {
-      const sectionText = formatFileSection(section.displayPath, section.content, {
-        lineNumbers: true,
+      const sectionText = formatFileSections([section], {
+        includeFileIndex: true,
       }).trimEnd();
       const tokens = tokenizer(sectionText, tokenizerOptions);
       const percent = inputTokenBudget ? (tokens / inputTokenBudget) * 100 : undefined;

--- a/src/oracle/tokenStats.ts
+++ b/src/oracle/tokenStats.ts
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 import type { FileContent, FileTokenStats, TokenizerFn } from "./types.js";
 import { createFileSections } from "./files.js";
+import { formatFileSection } from "./markdown.js";
 
 export function getFileTokenStats(
   files: FileContent[],
@@ -22,7 +23,8 @@ export function getFileTokenStats(
   const sections = createFileSections(files, cwd);
   const stats = sections
     .map((section) => {
-      const tokens = tokenizer(section.sectionText, tokenizerOptions);
+      const sectionText = formatFileSection(section.displayPath, section.content).trimEnd();
+      const tokens = tokenizer(sectionText, tokenizerOptions);
       const percent = inputTokenBudget ? (tokens / inputTokenBudget) * 100 : undefined;
       return {
         path: section.absolutePath,

--- a/src/oracle/types.ts
+++ b/src/oracle/types.ts
@@ -82,9 +82,14 @@ export interface FileContent {
 }
 
 export interface FileSection {
+  /** Legacy 1-based file number retained for callers that inspect createFileSections() output. */
   index: number;
   absolutePath: string;
   displayPath: string;
+  /**
+   * Legacy raw fenced section text using the historical `### File N:` heading.
+   * Generated model prompt context should render from displayPath/content instead.
+   */
   sectionText: string;
   content: string;
 }

--- a/tests/browser/policies.test.ts
+++ b/tests/browser/policies.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { buildAttachmentPlan, buildCookiePlan } from "../../src/browser/policies.js";
-import { formatFileSection } from "../../src/oracle/markdown.js";
+import { formatFileSections } from "../../src/oracle/markdown.js";
 
 const sections = [
   { displayPath: "a.txt", absolutePath: "/repo/a.txt", content: "hello" },
@@ -19,7 +19,7 @@ describe("buildAttachmentPlan", () => {
     expect(plan.attachments).toHaveLength(0);
     expect(plan.shouldBundle).toBe(false);
     expect(plan.inlineBlock).toContain("### File: a.txt");
-    expect(plan.inlineBlock).toContain(formatFileSection("b.txt", "world").trim());
+    expect(plan.inlineBlock).toContain(formatFileSections([sections[1]]).trim());
   });
 
   test("bundles when over max attachments", () => {

--- a/tests/browser/policies.test.ts
+++ b/tests/browser/policies.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "vitest";
 import { buildAttachmentPlan, buildCookiePlan } from "../../src/browser/policies.js";
-import { formatFileSections } from "../../src/oracle/markdown.js";
 
 const sections = [
   { displayPath: "a.txt", absolutePath: "/repo/a.txt", content: "hello" },
@@ -19,7 +18,9 @@ describe("buildAttachmentPlan", () => {
     expect(plan.attachments).toHaveLength(0);
     expect(plan.shouldBundle).toBe(false);
     expect(plan.inlineBlock).toContain("### File: a.txt");
-    expect(plan.inlineBlock).toContain(formatFileSections([sections[1]]).trim());
+    expect(plan.inlineBlock).toContain("Lines: 1-1");
+    expect(plan.inlineBlock).toContain("1 | hello");
+    expect(plan.inlineBlock).toContain("1 | world");
   });
 
   test("bundles when over max attachments", () => {

--- a/tests/browser/prompt.test.ts
+++ b/tests/browser/prompt.test.ts
@@ -215,6 +215,7 @@ describe("assembleBrowserPrompt", () => {
   test("bundles attachments when more than 10 files", async () => {
     const fileNames = Array.from({ length: 11 }, (_, i) => `file${i + 1}.txt`);
     const options = buildOptions({ file: fileNames, browserAttachments: "always" });
+    const tokenizedContents: string[] = [];
     const result = await assembleBrowserPrompt(options, {
       cwd: "/repo",
       readFilesImpl: async (paths) =>
@@ -222,11 +223,23 @@ describe("assembleBrowserPrompt", () => {
           path: path.resolve("/repo", entry),
           content: `content for ${entry}`,
         })),
+      tokenizeImpl: (messages) => {
+        const typed = messages as Array<{ content: string }>;
+        tokenizedContents.push(...typed.map((message) => message.content));
+        return fastTokenizer(messages);
+      },
     });
 
     expect(result.attachments).toHaveLength(1);
     expect(result.attachments[0]?.displayPath).toMatch(/attachments-bundle\.txt$/);
     expect(result.attachments[0]?.generatedBundle).toBe(true);
+    const bundleText = await fs.readFile(result.attachments[0]!.path, "utf8");
+    expect(bundleText).toContain("### File: file1.txt");
+    expect(bundleText).toContain("Lines: 1-1");
+    expect(bundleText).toContain("1 | content for file1.txt");
+    expect(tokenizedContents.some((content) => content.includes("1 | content for file1.txt"))).toBe(
+      true,
+    );
     expect(result.inlineFileCount).toBe(0);
     expect(result.bundled).toEqual({
       originalCount: 11,
@@ -263,5 +276,7 @@ describe("assembleBrowserPrompt", () => {
     expect(zipBytes.subarray(0, 4).toString("hex")).toBe("504b0304");
     expect(zipBytes.toString("utf8")).toContain("src/a.ts");
     expect(zipBytes.toString("utf8")).toContain("src/b.ts");
+    expect(zipBytes.toString("utf8")).toContain("content for src/a.ts");
+    expect(zipBytes.toString("utf8")).not.toContain("1 | content for src/a.ts");
   });
 });

--- a/tests/browser/prompt.test.ts
+++ b/tests/browser/prompt.test.ts
@@ -37,12 +37,16 @@ describe("assembleBrowserPrompt", () => {
     expect(result.markdown).toContain("[SYSTEM]");
     expect(result.markdown).toContain("[USER]");
     expect(result.markdown).toContain("### File: a.txt");
+    expect(result.markdown).toContain("Lines: 1-1");
+    expect(result.markdown).toContain('1 | console.log("hi")');
     expect(result.markdown).toContain("```");
     expect(result.composerText).not.toContain(DEFAULT_SYSTEM_PROMPT);
     expect(result.composerText).toContain("Explain the bug");
     expect(result.composerText).not.toContain("[SYSTEM]");
     expect(result.composerText).not.toContain("[USER]");
     expect(result.composerText).toContain("### File: a.txt");
+    expect(result.composerText).toContain("Lines: 1-1");
+    expect(result.composerText).toContain('1 | console.log("hi")');
     expect(result.estimatedInputTokens).toBeGreaterThan(0);
     expect(result.attachments).toEqual([]);
     expect(result.inlineFileCount).toBe(1);
@@ -100,9 +104,15 @@ describe("assembleBrowserPrompt", () => {
       file: ["a.txt"],
       browserAttachments: "always",
     });
+    const tokenizedContents: string[] = [];
     const result = await assembleBrowserPrompt(options, {
       cwd: "/repo",
       readFilesImpl: async () => [{ path: "/repo/a.txt", content: "tiny" }],
+      tokenizeImpl: (messages) => {
+        const typed = messages as Array<{ content: string }>;
+        tokenizedContents.push(...typed.map((message) => message.content));
+        return fastTokenizer(messages);
+      },
     });
     expect(result.attachmentMode).toBe("upload");
     expect(result.attachments).toEqual([
@@ -110,6 +120,8 @@ describe("assembleBrowserPrompt", () => {
     ]);
     expect(result.composerText).toBe("Explain the bug");
     expect(result.composerText).not.toContain("### File: a.txt");
+    expect(tokenizedContents).toContain("### File: a.txt\n```\ntiny\n```");
+    expect(tokenizedContents.some((content) => content.includes("1 | tiny"))).toBe(false);
     expect(result.fallback).toBeNull();
   });
 
@@ -255,6 +267,7 @@ describe("assembleBrowserPrompt", () => {
       browserBundleFiles: true,
       browserBundleFormat: "zip",
     });
+    const tokenizedContents: string[] = [];
     const result = await assembleBrowserPrompt(options, {
       cwd: "/repo",
       readFilesImpl: async (paths) =>
@@ -262,6 +275,11 @@ describe("assembleBrowserPrompt", () => {
           path: path.resolve("/repo", entry),
           content: `content for ${entry}`,
         })),
+      tokenizeImpl: (messages) => {
+        const typed = messages as Array<{ content: string }>;
+        tokenizedContents.push(...typed.map((message) => message.content));
+        return fastTokenizer(messages);
+      },
     });
 
     expect(result.attachments).toHaveLength(1);
@@ -278,5 +296,11 @@ describe("assembleBrowserPrompt", () => {
     expect(zipBytes.toString("utf8")).toContain("src/b.ts");
     expect(zipBytes.toString("utf8")).toContain("content for src/a.ts");
     expect(zipBytes.toString("utf8")).not.toContain("1 | content for src/a.ts");
+    expect(tokenizedContents.some((content) => content.includes("content for src/a.ts"))).toBe(
+      true,
+    );
+    expect(tokenizedContents.some((content) => content.includes("1 | content for src/a.ts"))).toBe(
+      false,
+    );
   });
 });

--- a/tests/cli/markdownBundle.test.ts
+++ b/tests/cli/markdownBundle.test.ts
@@ -20,8 +20,9 @@ describe("buildMarkdownBundle", () => {
     expect(bundle.markdown).toMatch("[USER]");
     expect(bundle.markdown).toMatch("Do it");
     expect(bundle.markdown).toMatch("### File: a.txt");
+    expect(bundle.markdown).toMatch("Lines: 1-1");
     expect(bundle.markdown).toMatch("```");
-    expect(bundle.markdown).toMatch("hello world");
+    expect(bundle.markdown).toMatch("1 | hello world");
     expect(bundle.promptWithFiles).toContain("Do it");
     expect(bundle.promptWithFiles).toContain("hello world");
     expect(bundle.files).toHaveLength(1);
@@ -40,6 +41,7 @@ describe("buildMarkdownBundle", () => {
     );
 
     expect(bundle.markdown).toContain("keep me");
+    expect(bundle.markdown).toContain("1 | keep me");
     expect(bundle.markdown).not.toContain("skip me");
   });
 

--- a/tests/cli/runOracle/prompt-and-utils.test.ts
+++ b/tests/cli/runOracle/prompt-and-utils.test.ts
@@ -27,7 +27,7 @@ describe("buildPrompt", () => {
     const { dir, filePath } = await createTempFile("hello from file");
     try {
       const prompt = buildPrompt("Base", [{ path: filePath, content: "hello from file" }], dir);
-      expect(prompt).toContain("### File: sample.txt");
+      expect(prompt).toContain("### File 1: sample.txt");
       expect(prompt).toContain("Lines: 1-1");
       expect(prompt).toContain("1 | hello from file");
     } finally {
@@ -418,8 +418,8 @@ describe("oracle utility helpers", () => {
     expect(totalTokens).toBeGreaterThan(0);
     expect(stats[0].displayPath).toBe("b.txt");
     expect(stats[1].displayPath).toBe("a.txt");
-    expect(tokenizerInputs).toContain("### File: a.txt\nLines: 1-1\n```\n1 | aaa\n```");
-    expect(tokenizerInputs).toContain("### File: b.txt\nLines: 1-1\n```\n1 | bbbbbb\n```");
+    expect(tokenizerInputs).toContain("### File 1: a.txt\nLines: 1-1\n```\n1 | aaa\n```");
+    expect(tokenizerInputs).toContain("### File 2: b.txt\nLines: 1-1\n```\n1 | bbbbbb\n```");
 
     const logs: string[] = [];
     printFileTokenStats(

--- a/tests/cli/runOracle/prompt-and-utils.test.ts
+++ b/tests/cli/runOracle/prompt-and-utils.test.ts
@@ -27,8 +27,9 @@ describe("buildPrompt", () => {
     const { dir, filePath } = await createTempFile("hello from file");
     try {
       const prompt = buildPrompt("Base", [{ path: filePath, content: "hello from file" }], dir);
-      expect(prompt).toContain("### File 1: sample.txt");
-      expect(prompt).toContain("hello from file");
+      expect(prompt).toContain("### File: sample.txt");
+      expect(prompt).toContain("Lines: 1-1");
+      expect(prompt).toContain("1 | hello from file");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -49,7 +50,8 @@ describe("renderPromptMarkdown", () => {
       expect(markdown).toContain("[SYSTEM]");
       expect(markdown).toContain("[USER]");
       expect(markdown).toContain("### File: sample.txt");
-      expect(markdown).toContain("rendered content");
+      expect(markdown).toContain("Lines: 1-1");
+      expect(markdown).toContain("1 | rendered content");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -332,6 +334,7 @@ describe("oracle utility helpers", () => {
     );
     expect(sections[0].displayPath).toBe("file.txt");
     expect(sections[0].sectionText).toContain("### File 1: file.txt");
+    expect(sections[0].sectionText).toContain("```\ncontents\n```");
   });
 
   test("buildRequestBody respects search toggles", () => {
@@ -400,7 +403,12 @@ describe("oracle utility helpers", () => {
       { path: "/tmp/a.txt", content: "aaa" },
       { path: "/tmp/b.txt", content: "bbbbbb" },
     ];
-    const tokenizer = (input: unknown) => String(input).length;
+    const tokenizerInputs: string[] = [];
+    const tokenizer = (input: unknown) => {
+      const text = String(input);
+      tokenizerInputs.push(text);
+      return text.length;
+    };
     const { stats, totalTokens } = getFileTokenStats(files, {
       cwd: "/tmp",
       tokenizer,
@@ -410,6 +418,8 @@ describe("oracle utility helpers", () => {
     expect(totalTokens).toBeGreaterThan(0);
     expect(stats[0].displayPath).toBe("b.txt");
     expect(stats[1].displayPath).toBe("a.txt");
+    expect(tokenizerInputs).toContain("### File: a.txt\nLines: 1-1\n```\n1 | aaa\n```");
+    expect(tokenizerInputs).toContain("### File: b.txt\nLines: 1-1\n```\n1 | bbbbbb\n```");
 
     const logs: string[] = [];
     printFileTokenStats(

--- a/tests/oracle/markdown.test.ts
+++ b/tests/oracle/markdown.test.ts
@@ -1,32 +1,31 @@
 import { describe, expect, test } from "vitest";
-import { formatFileSection } from "../../src/oracle/markdown.js";
+import { formatFileSection, formatFileSections } from "../../src/oracle/markdown.js";
 
 describe("formatFileSection", () => {
-  test("annotates language from extension and line-numbers content by default", () => {
+  test("annotates language from extension and preserves raw content by default", () => {
     const out = formatFileSection("src/app.ts", "const x = 1;\nconst y = 2;\n");
     expect(out).toContain("### File: src/app.ts");
-    expect(out).toContain("Lines: 1-2");
     expect(out).toContain("```ts");
-    expect(out).toContain("1 | const x = 1;");
-    expect(out).toContain("2 | const y = 2;");
+    expect(out).not.toContain("Lines:");
+    expect(out).toContain("const x = 1;\nconst y = 2;");
     expect(out.trimEnd()).toMatch(/```$/); // closes fence
   });
 
-  test("preserves blank lines with line numbers", () => {
-    const out = formatFileSection("notes.txt", "first\n\nthird\n");
+  test("can render citation-friendly line numbers", () => {
+    const out = formatFileSection("notes.txt", "first\n\nthird\n", { lineNumbers: true });
     expect(out).toContain("Lines: 1-3");
     expect(out).toContain("1 | first\n2 | \n3 | third");
   });
 
   test("renders empty files without fake source lines", () => {
-    const out = formatFileSection("empty.txt", "");
+    const out = formatFileSection("empty.txt", "", { lineNumbers: true });
     expect(out).toContain("Lines: 0");
     expect(out).toContain("```\n\n```");
   });
 
   test("auto-extends fence when content includes backticks", () => {
     const sample = "const tpl = `value`;\n````\ninner fence\n````\n";
-    const out = formatFileSection("a.js", sample);
+    const out = formatFileSection("a.js", sample, { lineNumbers: true });
     // Should use a fence longer than the longest run of backticks inside content
     const lines = out.split("\n");
     const fenceLine = lines[2];
@@ -42,9 +41,29 @@ describe("formatFileSection", () => {
     expect(out).toContain("2 | ````");
   });
 
-  test("can render raw file content without line numbers", () => {
+  test("can render raw file content without line numbers explicitly", () => {
     const out = formatFileSection("src/app.ts", "const x = 1;\n", { lineNumbers: false });
     expect(out).toContain("### File: src/app.ts");
+    expect(out).not.toContain("Lines:");
+    expect(out).toContain("```ts\nconst x = 1;\n```");
+  });
+});
+
+describe("formatFileSections", () => {
+  test("line-numbers generated file-section lists by default", () => {
+    const out = formatFileSections([
+      { displayPath: "src/app.ts", content: "const x = 1;\nconst y = 2;\n" },
+    ]);
+    expect(out).toContain("### File: src/app.ts");
+    expect(out).toContain("Lines: 1-2");
+    expect(out).toContain("1 | const x = 1;");
+    expect(out).toContain("2 | const y = 2;");
+  });
+
+  test("can render generated file-section lists raw", () => {
+    const out = formatFileSections([{ displayPath: "src/app.ts", content: "const x = 1;\n" }], {
+      lineNumbers: false,
+    });
     expect(out).not.toContain("Lines:");
     expect(out).toContain("```ts\nconst x = 1;\n```");
   });

--- a/tests/oracle/markdown.test.ts
+++ b/tests/oracle/markdown.test.ts
@@ -2,12 +2,26 @@ import { describe, expect, test } from "vitest";
 import { formatFileSection } from "../../src/oracle/markdown.js";
 
 describe("formatFileSection", () => {
-  test("annotates language from extension", () => {
-    const out = formatFileSection("src/app.ts", "const x = 1;\n");
+  test("annotates language from extension and line-numbers content by default", () => {
+    const out = formatFileSection("src/app.ts", "const x = 1;\nconst y = 2;\n");
     expect(out).toContain("### File: src/app.ts");
+    expect(out).toContain("Lines: 1-2");
     expect(out).toContain("```ts");
-    expect(out).toContain("const x = 1;");
+    expect(out).toContain("1 | const x = 1;");
+    expect(out).toContain("2 | const y = 2;");
     expect(out.trimEnd()).toMatch(/```$/); // closes fence
+  });
+
+  test("preserves blank lines with line numbers", () => {
+    const out = formatFileSection("notes.txt", "first\n\nthird\n");
+    expect(out).toContain("Lines: 1-3");
+    expect(out).toContain("1 | first\n2 | \n3 | third");
+  });
+
+  test("renders empty files without fake source lines", () => {
+    const out = formatFileSection("empty.txt", "");
+    expect(out).toContain("Lines: 0");
+    expect(out).toContain("```\n\n```");
   });
 
   test("auto-extends fence when content includes backticks", () => {
@@ -15,7 +29,7 @@ describe("formatFileSection", () => {
     const out = formatFileSection("a.js", sample);
     // Should use a fence longer than the longest run of backticks inside content
     const lines = out.split("\n");
-    const fenceLine = lines[1];
+    const fenceLine = lines[2];
     const fenceLength =
       fenceLine.replace("```js", "```").length === fenceLine.length
         ? fenceLine.length
@@ -24,6 +38,14 @@ describe("formatFileSection", () => {
           : 0;
     const innerMax = Math.max(...[...sample.matchAll(/`+/g)].map((m) => m[0].length));
     expect(fenceLength).toBeGreaterThan(innerMax);
-    expect(out).toContain(sample.trim());
+    expect(out).toContain("1 | const tpl = `value`;");
+    expect(out).toContain("2 | ````");
+  });
+
+  test("can render raw file content without line numbers", () => {
+    const out = formatFileSection("src/app.ts", "const x = 1;\n", { lineNumbers: false });
+    expect(out).toContain("### File: src/app.ts");
+    expect(out).not.toContain("Lines:");
+    expect(out).toContain("```ts\nconst x = 1;\n```");
   });
 });

--- a/tests/oracle/markdown.test.ts
+++ b/tests/oracle/markdown.test.ts
@@ -67,4 +67,13 @@ describe("formatFileSections", () => {
     expect(out).not.toContain("Lines:");
     expect(out).toContain("```ts\nconst x = 1;\n```");
   });
+
+  test("can preserve indexed headings for legacy generated prompts", () => {
+    const out = formatFileSections(
+      [{ index: 3, displayPath: "src/app.ts", content: "const x = 1;\n" }],
+      { includeFileIndex: true },
+    );
+    expect(out).toContain("### File 3: src/app.ts");
+    expect(out).toContain("Lines: 1-1");
+  });
 });

--- a/tests/oracle/oracleExports.test.ts
+++ b/tests/oracle/oracleExports.test.ts
@@ -11,14 +11,14 @@ describe("oracle entrypoint exports", () => {
     expect(oracle.PRO_MODELS instanceof Set).toBe(true);
   });
 
-  test("exposes numbered and raw file-section formatting", () => {
-    const numbered = oracle.formatFileSection("a.txt", "hello");
+  test("preserves raw exported file-section formatting by default", () => {
+    const rawDefault = oracle.formatFileSection("a.txt", "hello");
+    expect(rawDefault).not.toContain("Lines:");
+    expect(rawDefault).toContain("```\nhello\n```");
+
+    const numbered = oracle.formatFileSection("a.txt", "hello", { lineNumbers: true });
     expect(numbered).toContain("Lines: 1-1");
     expect(numbered).toContain("1 | hello");
-
-    const raw = oracle.formatFileSection("a.txt", "hello", { lineNumbers: false });
-    expect(raw).not.toContain("Lines:");
-    expect(raw).toContain("```\nhello\n```");
   });
 
   test("exposes generated file-section list formatting", () => {

--- a/tests/oracle/oracleExports.test.ts
+++ b/tests/oracle/oracleExports.test.ts
@@ -7,6 +7,33 @@ describe("oracle entrypoint exports", () => {
     expect(typeof oracle.createDefaultClientFactory).toBe("function");
     expect(typeof oracle.runOracle).toBe("function");
     expect(typeof oracle.formatFileSection).toBe("function");
+    expect(typeof oracle.formatFileSections).toBe("function");
     expect(oracle.PRO_MODELS instanceof Set).toBe(true);
+  });
+
+  test("exposes numbered and raw file-section formatting", () => {
+    const numbered = oracle.formatFileSection("a.txt", "hello");
+    expect(numbered).toContain("Lines: 1-1");
+    expect(numbered).toContain("1 | hello");
+
+    const raw = oracle.formatFileSection("a.txt", "hello", { lineNumbers: false });
+    expect(raw).not.toContain("Lines:");
+    expect(raw).toContain("```\nhello\n```");
+  });
+
+  test("exposes generated file-section list formatting", () => {
+    const out = oracle.formatFileSections([
+      { displayPath: "a.txt", content: "hello" },
+      { displayPath: "b.txt", content: "world" },
+    ]);
+    expect(out).toContain("### File: a.txt");
+    expect(out).toContain("1 | hello");
+    expect(out).toContain("\n\n### File: b.txt");
+    expect(out).toContain("1 | world");
+  });
+
+  test("asks models to use line-specific file citations", () => {
+    expect(oracle.DEFAULT_SYSTEM_PROMPT).toContain("path:line");
+    expect(oracle.DEFAULT_SYSTEM_PROMPT).toContain("path:line-line");
   });
 });


### PR DESCRIPTION
## Summary

Add stable source line numbers to Oracle-generated text context so model answers can cite `path:line` or `path:line-line`.

Numbered by default:

- API prompt context
- `--render` / markdown output
- browser inline file context
- browser `attachments-bundle.txt`

Compatibility preserved:

- `buildPrompt(...)` keeps historical `### File N:` headings
- direct browser uploads and ZIP entries keep raw file contents
- `createFileSections().sectionText` stays raw
- `formatFileSection(path, content)` stays raw unless `{ lineNumbers: true }` is requested
- raw upload/ZIP token estimates remain based on raw text

The default system prompt asks for line-specific citations when numbered context is available. Changelog and quick-start docs are updated; changelog credits @tristanmanchester.

## Proof

Baseline on current `main` rendered raw fenced source without line labels.

The final branch renders:

````text
### File: package.json
Lines: 1-114
```json
  1 | {
  2 |   "name": "@steipete/oracle",
```
````

Public API compatibility proof:

````text
Check

### File 1: a.txt
Lines: 1-2
```
1 | alpha
2 | beta
```
````

Authenticated browser proof used the existing signed-in Chrome profile through DevTools. The exact working-tree `assembleBrowserPrompt(...).composerText` was pasted into ChatGPT; live DOM showed `Lines: 1-114` and `2 | "name": "@steipete/oracle"`. ChatGPT completed with:

```text
ORACLE_PR239_BROWSER_OK package.json:2
```

No account identifiers, cookies, tokens, or private file contents were captured.

## Validation

- Focused tests: 6 files, 58 passed
- Full suite: 136 files passed, 18 skipped; 1,144 tests passed, 41 skipped
- `pnpm install --frozen-lockfile`
- `pnpm run check`
- `pnpm run docs:check`
- `pnpm run docs:site`
- `pnpm run build`
- `pnpm run test:packed-cli`
- `git diff --check`
- `$autoreview --mode local`: clean, no actionable findings
- `$autoreview --mode branch --base main`: clean, no actionable findings
