### PR TITLE
[codex] Recover browser image artifact downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.14.1 — Unreleased
 
+### Fixed
+
+- Browser: retry manual-login DevTools tab creation on fresh Chrome launches, recover ChatGPT generated-image downloads through the authenticated browser context when Node-side fetch fails, and keep generated-image artifact waits fail-fast on visible ChatGPT warnings. Thanks @derekszen!
+
 ## 0.14.0 — 2026-06-12
 
 ### Added

--- a/src/browser/actions/assistantResponse.ts
+++ b/src/browser/actions/assistantResponse.ts
@@ -1037,7 +1037,8 @@ function buildAssistantExtractor(functionName: string): string {
         !normalizedText ||
         normalizedText === 'edit' ||
         normalizedText === 'stopped thinking' ||
-        normalizedText === 'stopped thinking edit';
+        normalizedText === 'stopped thinking edit' ||
+        /^thought for \\d+(?:\\.\\d+)?\\s*(?:s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours)\\s+edit$/.test(normalizedText);
       if (generatedImages.length > 0 && imageOnlyChrome) {
         const label = generatedImages.length === 1 ? 'Generated image.' : \`Generated \${generatedImages.length} images.\`;
         return { text: label, html: messageRoot?.innerHTML ?? html, messageId, turnId, turnIndex: index };

--- a/src/browser/chatgptImages.ts
+++ b/src/browser/chatgptImages.ts
@@ -250,8 +250,65 @@ async function buildCookieHeader(Network: ChromeClient["Network"]): Promise<stri
     .join("; ");
 }
 
+async function fetchGeneratedImageInBrowserContext(
+  Runtime: ChromeClient["Runtime"],
+  url: string,
+): Promise<{ buffer: Buffer; contentType: string | null; finalUrl: string }> {
+  const expression = `
+    (async () => {
+      const url = ${JSON.stringify(url)};
+      const response = await fetch(url, { credentials: 'include', redirect: 'follow' });
+      const contentType = response.headers.get('content-type') || '';
+      const buffer = await response.arrayBuffer();
+      const bytes = new Uint8Array(buffer);
+      let binary = '';
+      for (let index = 0; index < bytes.length; index += 0x8000) {
+        binary += String.fromCharCode(...bytes.slice(index, index + 0x8000));
+      }
+      return {
+        ok: response.ok,
+        status: response.status,
+        statusText: response.statusText,
+        contentType,
+        finalUrl: response.url,
+        b64: btoa(binary),
+      };
+    })()
+  `;
+  const { result, exceptionDetails } = await Runtime.evaluate({
+    expression,
+    awaitPromise: true,
+    returnByValue: true,
+    timeout: 120_000,
+  });
+  if (exceptionDetails) {
+    throw new Error("browser-context fetch threw an exception");
+  }
+  const value = result?.value as
+    | {
+        ok?: boolean;
+        status?: number;
+        statusText?: string;
+        contentType?: string;
+        finalUrl?: string;
+        b64?: string;
+      }
+    | undefined;
+  if (!value?.ok || typeof value.b64 !== "string") {
+    const status = typeof value?.status === "number" ? value.status : "unknown";
+    const statusText = typeof value?.statusText === "string" ? value.statusText : "";
+    throw new Error(`browser-context fetch failed: ${status} ${statusText}`.trim());
+  }
+  return {
+    buffer: Buffer.from(value.b64, "base64"),
+    contentType: typeof value.contentType === "string" ? value.contentType : null,
+    finalUrl: typeof value.finalUrl === "string" && value.finalUrl ? value.finalUrl : url,
+  };
+}
+
 export async function saveChatGptGeneratedImages(params: {
   Network: ChromeClient["Network"];
+  Runtime?: ChromeClient["Runtime"];
   images: BrowserGeneratedImage[];
   outputPath: string;
   logger?: BrowserLogger;
@@ -261,7 +318,7 @@ export async function saveChatGptGeneratedImages(params: {
   savedImages: SavedBrowserImage[];
   errors: string[];
 }> {
-  const { Network, images, outputPath, logger } = params;
+  const { Network, Runtime, images, outputPath, logger } = params;
   if (!images.length) return { saved: false, imageCount: 0, savedImages: [], errors: [] };
 
   const cookieHeader = await buildCookieHeader(Network);
@@ -281,20 +338,41 @@ export async function saveChatGptGeneratedImages(params: {
   for (let index = 0; index < images.length; index += 1) {
     const image = images[index];
     try {
-      const response = await fetch(image.url, {
-        headers: {
-          cookie: cookieHeader,
-          "user-agent": "Mozilla/5.0",
-        },
-        redirect: "follow",
-      });
-      if (!response.ok) {
-        throw new Error(`download failed: ${response.status} ${response.statusText}`);
+      let contentType: string | null = null;
+      let finalUrl = image.url;
+      let buffer: Buffer;
+
+      try {
+        const response = await fetch(image.url, {
+          headers: {
+            cookie: cookieHeader,
+            "user-agent": "Mozilla/5.0",
+          },
+          redirect: "follow",
+        });
+        if (!response.ok) {
+          throw new Error(`download failed: ${response.status} ${response.statusText}`);
+        }
+        contentType = response.headers.get("content-type");
+        finalUrl = response.url;
+        buffer = Buffer.from(await response.arrayBuffer());
+      } catch (downloadError) {
+        if (!Runtime) {
+          throw downloadError;
+        }
+        const message =
+          downloadError instanceof Error ? downloadError.message : String(downloadError);
+        logger?.(
+          `[browser] ChatGPT generated image download failed via Node fetch; retrying in browser context (${image.fileId ?? image.url}: ${message}).`,
+        );
+        const browserFetch = await fetchGeneratedImageInBrowserContext(Runtime, image.url);
+        contentType = browserFetch.contentType;
+        finalUrl = browserFetch.finalUrl;
+        buffer = browserFetch.buffer;
       }
-      const contentType = response.headers.get("content-type");
+
       const extension = contentTypeToExtension(contentType);
       const targetPath = resolveSiblingImagePath(path.resolve(outputPath), index, extension);
-      const buffer = Buffer.from(await response.arrayBuffer());
       await fs.writeFile(targetPath, buffer);
       savedImages.push({
         kind: "image",
@@ -304,7 +382,7 @@ export async function saveChatGptGeneratedImages(params: {
         sizeBytes: buffer.length,
         sourceUrl: image.url,
         url: image.url,
-        finalUrl: response.url,
+        finalUrl,
         alt: image.alt,
         width: image.width,
         height: image.height,
@@ -508,6 +586,7 @@ export async function collectGeneratedImageArtifacts(params: {
 
   const saved = await saveChatGptGeneratedImages({
     Network: params.Network,
+    Runtime: params.Runtime,
     images: generatedImages,
     outputPath: targetPath,
     logger: params.logger,

--- a/src/browser/chatgptImages.ts
+++ b/src/browser/chatgptImages.ts
@@ -16,6 +16,33 @@ import { saveAssistantDownloadButtonArtifacts } from "./chatgptFiles.js";
 
 const GENERATED_IMAGE_WAIT_MIN_MS = 15_000;
 const GENERATED_IMAGE_WAIT_MAX_MS = 15 * 60_000;
+const CHATGPT_GENERATED_IMAGE_BASE_URL = "https://chatgpt.com/";
+
+function isAllowedChatGptHost(hostname: string): boolean {
+  const value = hostname.toLowerCase();
+  return value === "chatgpt.com" || value === "chat.openai.com";
+}
+
+function normalizeGeneratedImageUrl(value?: string | null): string | undefined {
+  const raw = String(value ?? "").trim();
+  if (!raw) return undefined;
+  let url: URL;
+  try {
+    url = new URL(raw, CHATGPT_GENERATED_IMAGE_BASE_URL);
+  } catch {
+    return undefined;
+  }
+  if (url.protocol !== "https:" || url.port || !isAllowedChatGptHost(url.hostname)) {
+    return undefined;
+  }
+  if (url.pathname !== "/backend-api/estuary/content") {
+    return undefined;
+  }
+  if (!(url.searchParams.get("id") ?? "").startsWith("file_")) {
+    return undefined;
+  }
+  return url.href;
+}
 
 function extractFileId(url: string): string | undefined {
   try {
@@ -51,8 +78,12 @@ function buildAssistantImageExpression(minTurnIndex?: number): string {
     const CONVERSATION_SELECTOR = ${conversationLiteral};
     const ASSISTANT_SELECTOR = ${assistantLiteral};
     const isGeneratedImage = (img) => {
-      const url = img?.src || '';
-      if (!url.includes('/backend-api/estuary/content?id=file_')) return false;
+      const url = new URL(img?.src || '', location.origin || 'https://chatgpt.com');
+      const host = url.hostname.toLowerCase();
+      if (url.protocol !== 'https:' || url.port) return false;
+      if (host !== 'chatgpt.com' && host !== 'chat.openai.com') return false;
+      if (url.pathname !== '/backend-api/estuary/content') return false;
+      if (!String(url.searchParams.get('id') || '').startsWith('file_')) return false;
       const alt = String(img.alt || '').toLowerCase();
       if (alt.includes('generated image')) return true;
       let node = img;
@@ -118,13 +149,16 @@ export async function readAssistantGeneratedImages(
   });
   const raw = Array.isArray(result?.value) ? result.value : [];
   const normalized = raw
-    .map((item) => ({
-      url: typeof item?.url === "string" ? item.url : "",
-      alt: typeof item?.alt === "string" ? item.alt : undefined,
-      width: typeof item?.width === "number" ? item.width : undefined,
-      height: typeof item?.height === "number" ? item.height : undefined,
-      fileId: typeof item?.url === "string" ? extractFileId(item.url) : undefined,
-    }))
+    .map((item) => {
+      const url = normalizeGeneratedImageUrl(typeof item?.url === "string" ? item.url : "");
+      return {
+        url: url ?? "",
+        alt: typeof item?.alt === "string" ? item.alt : undefined,
+        width: typeof item?.width === "number" ? item.width : undefined,
+        height: typeof item?.height === "number" ? item.height : undefined,
+        fileId: url ? extractFileId(url) : undefined,
+      };
+    })
     .filter((item) => item.url.length > 0);
   return dedupeImages(normalized);
 }
@@ -338,12 +372,16 @@ export async function saveChatGptGeneratedImages(params: {
   for (let index = 0; index < images.length; index += 1) {
     const image = images[index];
     try {
+      const imageUrl = normalizeGeneratedImageUrl(image.url);
+      if (!imageUrl) {
+        throw new Error("rejected non-ChatGPT generated image URL");
+      }
       let contentType: string | null = null;
-      let finalUrl = image.url;
+      let finalUrl = imageUrl;
       let buffer: Buffer;
 
       try {
-        const response = await fetch(image.url, {
+        const response = await fetch(imageUrl, {
           headers: {
             cookie: cookieHeader,
             "user-agent": "Mozilla/5.0",
@@ -363,9 +401,9 @@ export async function saveChatGptGeneratedImages(params: {
         const message =
           downloadError instanceof Error ? downloadError.message : String(downloadError);
         logger?.(
-          `[browser] ChatGPT generated image download failed via Node fetch; retrying in browser context (${image.fileId ?? image.url}: ${message}).`,
+          `[browser] ChatGPT generated image download failed via Node fetch; retrying in browser context (${image.fileId ?? imageUrl}: ${message}).`,
         );
-        const browserFetch = await fetchGeneratedImageInBrowserContext(Runtime, image.url);
+        const browserFetch = await fetchGeneratedImageInBrowserContext(Runtime, imageUrl);
         contentType = browserFetch.contentType;
         finalUrl = browserFetch.finalUrl;
         buffer = browserFetch.buffer;
@@ -380,8 +418,8 @@ export async function saveChatGptGeneratedImages(params: {
         label: index === 0 ? "Generated image" : `Generated image ${index + 1}`,
         mimeType: contentType ?? undefined,
         sizeBytes: buffer.length,
-        sourceUrl: image.url,
-        url: image.url,
+        sourceUrl: imageUrl,
+        url: imageUrl,
         finalUrl,
         alt: image.alt,
         width: image.width,

--- a/src/browser/chatgptImages.ts
+++ b/src/browser/chatgptImages.ts
@@ -498,6 +498,7 @@ export async function collectGeneratedImageArtifacts(params: {
   outputPath?: string;
   answerText: string;
   waitTimeoutMs?: number;
+  checkBlockingUiWarning?: () => Promise<void>;
 }): Promise<{
   generatedImages: BrowserGeneratedImage[];
   savedImages: SavedBrowserImage[];
@@ -513,6 +514,7 @@ export async function collectGeneratedImageArtifacts(params: {
   let latestAnswerText = params.answerText;
 
   if (explicitTargetPath && generatedImages.length === 0) {
+    await params.checkBlockingUiWarning?.();
     const targetPath = path.resolve(explicitTargetPath);
     const buttonImages = await saveGeneratedImageButtonArtifacts({
       Browser: params.Browser,
@@ -529,6 +531,7 @@ export async function collectGeneratedImageArtifacts(params: {
     const deadline = Date.now() + resolveGeneratedImageWaitTimeoutMs(params.waitTimeoutMs);
     while (Date.now() < deadline) {
       await delay(1500);
+      await params.checkBlockingUiWarning?.();
       generatedImages = await readAssistantGeneratedImagesWithFallback(
         params.Runtime,
         params.minTurnIndex ?? undefined,
@@ -547,6 +550,7 @@ export async function collectGeneratedImageArtifacts(params: {
       }
     }
     if (generatedImages.length === 0) {
+      await params.checkBlockingUiWarning?.();
       const delayedButtonImages = await saveGeneratedImageButtonArtifacts({
         Browser: params.Browser,
         Client: params.Client,

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -369,27 +369,23 @@ function formatChatGptUiWarningType(type: ChatGptUiWarningType): string {
   }
 }
 
-async function createAssistantTimeoutError(params: {
+async function createChatGptUiWarningError(params: {
   Runtime: ChromeClient["Runtime"];
   logger: BrowserLogger;
   runtime: unknown;
+  stage: string;
+  waitTarget: string;
   diagnostics?: unknown;
-  cause: unknown;
-}): Promise<BrowserAutomationError> {
+  cause?: unknown;
+}): Promise<BrowserAutomationError | null> {
   const [uiWarning] = await collectChatGptUiWarnings(params.Runtime);
-  if (!uiWarning) {
-    return new BrowserAutomationError(
-      "Assistant response timed out before completion; reattach later to capture the answer.",
-      { stage: "assistant-timeout", runtime: params.runtime, diagnostics: params.diagnostics },
-      params.cause,
-    );
-  }
+  if (!uiWarning) return null;
 
   params.logger(`[browser] ChatGPT UI warning detected (${uiWarning.type}): ${uiWarning.message}`);
   return new BrowserAutomationError(
-    `ChatGPT displayed a ${formatChatGptUiWarningType(uiWarning.type)} warning while waiting for the assistant: ${uiWarning.message}`,
+    `ChatGPT displayed a ${formatChatGptUiWarningType(uiWarning.type)} warning while waiting for ${params.waitTarget}: ${uiWarning.message}`,
     {
-      stage: "assistant-timeout",
+      stage: params.stage,
       code: "chatgpt-ui-warning",
       uiWarning,
       runtime: params.runtime,
@@ -397,6 +393,44 @@ async function createAssistantTimeoutError(params: {
     },
     params.cause,
   );
+}
+
+async function throwChatGptUiWarningIfPresent(params: {
+  Runtime: ChromeClient["Runtime"];
+  logger: BrowserLogger;
+  runtime: unknown;
+  stage: string;
+  waitTarget: string;
+  diagnostics?: unknown;
+}): Promise<void> {
+  const error = await createChatGptUiWarningError(params);
+  if (error) throw error;
+}
+
+async function createAssistantTimeoutError(params: {
+  Runtime: ChromeClient["Runtime"];
+  logger: BrowserLogger;
+  runtime: unknown;
+  diagnostics?: unknown;
+  cause: unknown;
+}): Promise<BrowserAutomationError> {
+  const warningError = await createChatGptUiWarningError({
+    Runtime: params.Runtime,
+    logger: params.logger,
+    runtime: params.runtime,
+    stage: "assistant-timeout",
+    waitTarget: "the assistant",
+    diagnostics: params.diagnostics,
+    cause: params.cause,
+  });
+  if (!warningError) {
+    return new BrowserAutomationError(
+      "Assistant response timed out before completion; reattach later to capture the answer.",
+      { stage: "assistant-timeout", runtime: params.runtime, diagnostics: params.diagnostics },
+      params.cause,
+    );
+  }
+  return warningError;
 }
 
 function listIgnoredRemoteChromeFlags(config: {
@@ -1983,6 +2017,24 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
       outputPath: options.outputPath,
       answerText,
       waitTimeoutMs: options.config?.timeoutMs,
+      checkBlockingUiWarning: () =>
+        throwChatGptUiWarningIfPresent({
+          Runtime,
+          logger,
+          stage: "image-artifact-wait",
+          waitTarget: "generated image artifacts",
+          runtime: {
+            chromePid: chrome.pid,
+            chromePort: chrome.port,
+            chromeHost,
+            userDataDir,
+            chromeTargetId: lastTargetId,
+            tabUrl: lastUrl,
+            conversationId: lastUrl ? extractConversationIdFromUrl(lastUrl) : undefined,
+            promptSubmitted,
+            controllerPid: process.pid,
+          },
+        }),
     });
     answerText = imageArtifacts.answerText || answerText;
     if (imageArtifacts.markdownSuffix) {
@@ -3325,6 +3377,24 @@ async function runRemoteBrowserMode(
       outputPath: options.outputPath,
       answerText,
       waitTimeoutMs: options.config?.timeoutMs,
+      checkBlockingUiWarning: () =>
+        throwChatGptUiWarningIfPresent({
+          Runtime,
+          logger,
+          stage: "image-artifact-wait",
+          waitTarget: "generated image artifacts",
+          runtime: {
+            chromePort: port,
+            chromeHost: host,
+            chromeBrowserWSEndpoint: browserWSEndpoint,
+            chromeProfileRoot,
+            chromeTargetId: remoteTargetId ?? undefined,
+            tabUrl: lastUrl,
+            conversationId: lastUrl ? extractConversationIdFromUrl(lastUrl) : undefined,
+            promptSubmitted,
+            controllerPid: process.pid,
+          },
+        }),
     });
     answerText = imageArtifacts.answerText || answerText;
     if (imageArtifacts.markdownSuffix) {

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -563,7 +563,10 @@ function isImageOnlyUiChromeText(text: string): boolean {
     normalized.length === 0 ||
     normalized === "edit" ||
     normalized === "stopped thinking" ||
-    normalized === "stopped thinking edit"
+    normalized === "stopped thinking edit" ||
+    /^thought for \d+(?:\.\d+)?\s*(?:s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours)\s+edit$/.test(
+      normalized,
+    )
   );
 }
 

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1005,9 +1005,10 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
         );
       } else {
         const strictTabIsolation = Boolean(manualLogin && reusedChrome);
+        const devtoolsRetries = manualLogin ? 6 : 0;
         const connection = await connectWithNewTab(chrome.port, logger, config.url, chromeHost, {
           fallbackToDefault: !strictTabIsolation,
-          retries: strictTabIsolation ? 3 : 0,
+          retries: devtoolsRetries,
           retryDelayMs: 500,
         });
         client = connection.client;

--- a/src/browser/projectSourcesRunner.ts
+++ b/src/browser/projectSourcesRunner.ts
@@ -154,9 +154,10 @@ export async function runBrowserProjectSources(
     );
 
     const strictTabIsolation = Boolean(manualLogin && reusedChrome);
+    const devtoolsRetries = manualLogin ? 6 : 0;
     const connection = await connectWithNewTab(chrome.port, logger, "about:blank", chromeHost, {
       fallbackToDefault: !strictTabIsolation,
-      retries: strictTabIsolation ? 3 : 0,
+      retries: devtoolsRetries,
       retryDelayMs: 500,
     });
     client = connection.client;

--- a/tests/browser/chatgptImages.test.ts
+++ b/tests/browser/chatgptImages.test.ts
@@ -376,6 +376,28 @@ describe("collectGeneratedImageArtifacts", () => {
     }
   });
 
+  test("fails fast when a blocking UI warning appears before image artifacts", async () => {
+    const runtime = {
+      evaluate: vi.fn().mockResolvedValue({ result: { value: [] } }),
+    } as unknown as ChromeClient["Runtime"];
+    const warningError = new Error(
+      "ChatGPT displayed a rate-limit warning while waiting for generated image artifacts.",
+    );
+    const checkBlockingUiWarning = vi.fn().mockRejectedValue(warningError);
+
+    await expect(
+      collectGeneratedImageArtifacts({
+        Runtime: runtime,
+        Network: {} as ChromeClient["Network"],
+        generateImagePath: path.join(os.tmpdir(), "generated.png"),
+        answerText: "Working on it.",
+        waitTimeoutMs: 15_000,
+        checkBlockingUiWarning,
+      }),
+    ).rejects.toBe(warningError);
+    expect(checkBlockingUiWarning).toHaveBeenCalledTimes(1);
+  });
+
   test("retries behavior button downloads after waiting for delayed image generation", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-12T00:00:00Z"));

--- a/tests/browser/chatgptImages.test.ts
+++ b/tests/browser/chatgptImages.test.ts
@@ -248,6 +248,54 @@ describe("saveChatGptGeneratedImages", () => {
       Buffer.from([1, 2, 3, 4]),
     );
   });
+
+  test("falls back to browser-context fetch when Node fetch cannot download the image", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-chatgpt-images-"));
+    const network = {
+      getCookies: vi.fn().mockResolvedValue({
+        cookies: [{ name: "__Secure-next-auth.session-token", value: "abc" }],
+      }),
+    } as unknown as ChromeClient["Network"];
+    const runtime = {
+      evaluate: vi.fn().mockResolvedValue({
+        result: {
+          value: {
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            contentType: "image/png",
+            finalUrl: "https://chatgpt.com/backend-api/estuary/content?id=file_proxy",
+            b64: Buffer.from([9, 8, 7, 6]).toString("base64"),
+          },
+        },
+      }),
+    } as unknown as ChromeClient["Runtime"];
+
+    globalThis.fetch = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
+
+    const result = await saveChatGptGeneratedImages({
+      Network: network,
+      Runtime: runtime,
+      images: [
+        {
+          url: "https://chatgpt.com/backend-api/estuary/content?id=file_proxy",
+          fileId: "file_proxy",
+        },
+      ],
+      outputPath: path.join(tmpDir, "generated.png"),
+    });
+
+    expect(result.saved).toBe(true);
+    expect(runtime.evaluate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        awaitPromise: true,
+        returnByValue: true,
+      }),
+    );
+    await expect(fs.readFile(path.join(tmpDir, "generated.png"))).resolves.toEqual(
+      Buffer.from([9, 8, 7, 6]),
+    );
+  });
 });
 
 describe("resolveGeneratedImageWaitTimeoutMsForTest", () => {

--- a/tests/browser/chatgptImages.test.ts
+++ b/tests/browser/chatgptImages.test.ts
@@ -105,10 +105,18 @@ describe("readAssistantGeneratedImages", () => {
       "document",
       "HTMLElement",
       "Node",
+      "location",
       `return ${expression};`,
-    )(document, FakeElement, {
-      DOCUMENT_POSITION_FOLLOWING: 4,
-    });
+    )(
+      document,
+      FakeElement,
+      {
+        DOCUMENT_POSITION_FOLLOWING: 4,
+      },
+      {
+        origin: "https://chatgpt.com",
+      },
+    );
   }
 
   test("dedupes duplicate image urls by file id and keeps the largest candidate", async () => {
@@ -144,6 +152,34 @@ describe("readAssistantGeneratedImages", () => {
     expect(images[0]?.fileId).toBe("file_a");
     expect(images[0]?.width).toBe(1024);
     expect(images[1]?.fileId).toBe("file_b");
+  });
+
+  test("ignores generated-image lookalikes from non-ChatGPT hosts", async () => {
+    const runtime = {
+      evaluate: vi.fn().mockResolvedValue({
+        result: {
+          value: [
+            {
+              url: "https://example.com/backend-api/estuary/content?id=file_fake",
+              alt: "generated image",
+              width: 1024,
+              height: 1024,
+            },
+            {
+              url: "https://chatgpt.com/backend-api/estuary/content?id=file_real",
+              alt: "generated image",
+              width: 1024,
+              height: 1024,
+            },
+          ],
+        },
+      }),
+    } as unknown as ChromeClient["Runtime"];
+
+    const images = await readAssistantGeneratedImages(runtime);
+
+    expect(images).toHaveLength(1);
+    expect(images[0]?.fileId).toBe("file_real");
   });
 
   test("finds generated images rendered outside assistant turn wrappers", async () => {
@@ -295,6 +331,31 @@ describe("saveChatGptGeneratedImages", () => {
     await expect(fs.readFile(path.join(tmpDir, "generated.png"))).resolves.toEqual(
       Buffer.from([9, 8, 7, 6]),
     );
+  });
+
+  test("rejects non-ChatGPT image URLs before attaching cookies", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-chatgpt-images-"));
+    const network = {
+      getCookies: vi.fn().mockResolvedValue({
+        cookies: [{ name: "__Secure-next-auth.session-token", value: "abc" }],
+      }),
+    } as unknown as ChromeClient["Network"];
+    globalThis.fetch = vi.fn();
+
+    const result = await saveChatGptGeneratedImages({
+      Network: network,
+      images: [
+        {
+          url: "https://example.com/backend-api/estuary/content?id=file_fake",
+          fileId: "file_fake",
+        },
+      ],
+      outputPath: path.join(tmpDir, "generated.png"),
+    });
+
+    expect(result.saved).toBe(false);
+    expect(result.errors[0]).toContain("rejected non-ChatGPT generated image URL");
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 });
 
@@ -489,7 +550,7 @@ describe("collectGeneratedImageArtifacts", () => {
             },
           };
         }
-        if (expression.includes("/backend-api/estuary/content?id=file_")) {
+        if (expression.includes("/backend-api/estuary/content")) {
           return {
             result: {
               value: [
@@ -552,7 +613,7 @@ describe("collectGeneratedImageArtifacts", () => {
     setOracleHomeDirOverrideForTest(tmpHome);
     const runtime = {
       evaluate: vi.fn(async ({ expression }: { expression: string }) => {
-        if (expression.includes("/backend-api/estuary/content?id=file_")) {
+        if (expression.includes("/backend-api/estuary/content")) {
           return {
             result: {
               value: [
@@ -607,7 +668,7 @@ describe("collectGeneratedImageArtifacts", () => {
     setOracleHomeDirOverrideForTest(tmpHome);
     const runtime = {
       evaluate: vi.fn(async ({ expression }: { expression: string }) => {
-        if (expression.includes("/backend-api/estuary/content?id=file_")) {
+        if (expression.includes("/backend-api/estuary/content")) {
           return {
             result: {
               value: [

--- a/tests/browser/chromeLifecycle.test.ts
+++ b/tests/browser/chromeLifecycle.test.ts
@@ -132,6 +132,28 @@ describe("connectWithNewTab", () => {
     expect(cdpNewMock).toHaveBeenCalledTimes(1);
     expect(cdpMock).toHaveBeenCalledWith({ host: "127.0.0.1", port: 9222, target: "target-2" });
   });
+
+  test("retries transient DevTools connection failures before falling back", async () => {
+    vi.useFakeTimers();
+    cdpNewMock
+      .mockRejectedValueOnce(new Error("connect ECONNREFUSED 127.0.0.1:9222"))
+      .mockResolvedValueOnce({ id: "target-3" });
+    cdpMock.mockResolvedValue({});
+
+    const { connectWithNewTab } = await import("../../src/browser/chromeLifecycle.js");
+    const logger = vi.fn();
+
+    const resultPromise = connectWithNewTab(9222, logger, undefined, undefined, {
+      retries: 1,
+      retryDelayMs: 10,
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    const result = await resultPromise;
+
+    expect(result.targetId).toBe("target-3");
+    expect(cdpNewMock).toHaveBeenCalledTimes(2);
+    expect(cdpMock).toHaveBeenCalledWith({ host: "127.0.0.1", port: 9222, target: "target-3" });
+  });
 });
 
 describe("closeBlankChromeTabs", () => {

--- a/tests/browser/pageActionsExpressions.test.ts
+++ b/tests/browser/pageActionsExpressions.test.ts
@@ -24,6 +24,7 @@ describe("browser automation expressions", () => {
     expect(expression).toContain("/backend-api/estuary/content?id=file_");
     expect(expression).toContain("Generated image.");
     expect(expression).toContain("stopped thinking edit");
+    expect(expression).toContain("thought for");
   });
 
   test("conversation debug expression references conversation selector", () => {


### PR DESCRIPTION
## Summary

- retry manual-login DevTools tab creation on fresh browser launches, not only reused Chrome sessions
- fall back to authenticated browser-context fetch when Node fetch cannot download ChatGPT generated image artifacts
- reject non-ChatGPT generated-image lookalike URLs before attaching ChatGPT cookies
- add focused regression coverage and changelog entry

## Validation

- `pnpm exec vitest run tests/browser/chromeLifecycle.test.ts tests/browser/chatgptImages.test.ts tests/browser/pageActionsExpressions.test.ts`
- `pnpm run build`
- `pnpm test`
- `pnpm run check`
- `pnpm run test:packed-cli`
- `autoreview --mode local`

## Live proof

- Built `dist` CLI launched the default manual-login profile fresh; the run reached profile auth and failed because that private profile is not signed in.
- Built `dist` CLI with the real signed-in Chrome profile forced Node-side ChatGPT image fetch to fail, retried through the authenticated browser context, and saved a valid PNG.
- Artifact proof before local cleanup: PNG 1254 x 1254, 810027 bytes, SHA-256 `2b5fc33b822bdf6acd9b7dad6c60009846bf130fa8080eaef1c5ef7aed1f6abf`.

Supersedes #252 only because pushing the maintainer fixup to the contributor fork was rejected by GitHub.
