### PR TITLE
fix(browser): support updated ChatGPT model picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- Browser: support ChatGPT's updated Intelligence model picker and Pro effort submenu, and accept `instant`, `medium`, `high`, and `extra-high` as thinking-time aliases while preserving existing Oracle names. Thanks @orbitingflea!
 - Browser/MCP: save ChatGPT image-generation responses delivered as current-turn “Download…” behavior buttons, validating downloaded bytes as real images before returning typed artifacts instead of waiting for an inline image until timeout.
 - Gemini: refresh browser mappings for Gemini 3.1 Flash-Lite, Gemini 3.5 Flash, Gemini 3.1 Pro, and Pro Deep Think; add current Flash API model configs; keep legacy browser aliases working; and make the live text smoke fail on stale mappings instead of skipping. Fixes #242. Thanks @goldengrape!
 - Browser: restore Deep Research report capture from ChatGPT's out-of-process report iframe, prefer completed page-scoped reads with legacy frame fallback, and bind/filter CDP auto-attach by the active page session so other tabs or unrelated iframes cannot be harvested. Thanks @umutkeltek!

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -33,6 +33,7 @@ import {
   parseFloatOption,
   parseIntOption,
   parseSearchOption,
+  parseThinkingTimeOption,
   usesDefaultStatusFilters,
   resolvePreviewMode,
   normalizeModelOption,
@@ -771,9 +772,9 @@ program
   .addOption(
     new Option(
       "--browser-thinking-time <level>",
-      "Thinking time intensity for Thinking/Pro models: light, standard, extended, heavy.",
+      "Thinking time intensity for Thinking/Pro models: light, standard, extended, heavy, or ChatGPT UI aliases.",
     )
-      .choices(["light", "standard", "extended", "heavy"])
+      .argParser(parseThinkingTimeOption)
       .hideHelp(),
   )
   .addOption(

--- a/src/browser/actions/modelSelection.ts
+++ b/src/browser/actions/modelSelection.ts
@@ -245,7 +245,19 @@ function buildModelSelectionExpression(
       );
       if (!label) return false;
       if (label.includes('click to remove')) return false;
-      const modelTokens = ['chatgpt', 'gpt', 'instant', 'thinking', 'pro', 'extended', 'standard', 'heavy', 'light'];
+      const modelTokens = [
+        'chatgpt',
+        'gpt',
+        'instant',
+        'thinking',
+        'pro',
+        'extended',
+        'standard',
+        'medium',
+        'high',
+        'heavy',
+        'light',
+      ];
       return modelTokens.some((token) => hasToken(label, token));
     };
     const findModelButton = () => {
@@ -280,6 +292,24 @@ function buildModelSelectionExpression(
     const getComposerModelLabel = () =>
       (document.querySelector(COMPOSER_MODEL_SIGNAL_SELECTOR)?.textContent ?? '').trim();
     const readComposerModelSignal = () => normalizeText(getComposerModelLabel());
+    const isIntelligenceEffortLabel = (label) =>
+      label === 'instant' ||
+      label === 'medium' ||
+      label === 'high' ||
+      label === 'extra high' ||
+      label === 'extended' ||
+      label === 'standard' ||
+      label === 'heavy' ||
+      label === 'light';
+    const formatModelOptionLabel = (label) => {
+      const normalized = normalizeText(label ?? '');
+      if (normalized === '5 5' || normalized === 'gpt 5 5') return 'GPT-5.5';
+      if (normalized === '5 4' || normalized === 'gpt 5 4') return 'GPT-5.4';
+      if (normalized === '5 2' || normalized === 'gpt 5 2') return 'GPT-5.2';
+      if (normalized === '5 1' || normalized === 'gpt 5 1') return 'GPT-5.1';
+      if (normalized === '5 0' || normalized === 'gpt 5 0') return 'GPT-5.0';
+      return label || '';
+    };
     const withProPillSignal = (label) => {
       const resolved = label || '';
       if (!wantsPro || !hasProComposerPill()) return resolved;
@@ -289,10 +319,25 @@ function buildModelSelectionExpression(
       if (normalized.includes('pro')) return resolved;
       return resolved + ' + Pro';
     };
-    const getResolvedLabel = (fallback) =>
-      withProPillSignal(getComposerModelLabel() || getButtonLabel() || fallback);
+    const getResolvedLabel = (fallback) => {
+      const composerLabel = getComposerModelLabel();
+      if (composerLabel) return withProPillSignal(composerLabel);
+      const buttonLabel = getButtonLabel();
+      const normalizedButton = normalizeText(buttonLabel);
+      const fallbackLabel = formatModelOptionLabel(fallback);
+      if (fallbackLabel && !wantsPro && isIntelligenceEffortLabel(normalizedButton)) {
+        return fallbackLabel;
+      }
+      return withProPillSignal(buttonLabel || fallbackLabel || fallback);
+    };
     const isThinkingEffortLabel = (label) =>
-      label === 'extended' || label === 'standard' || label === 'heavy' || label === 'light';
+      label === 'extended' ||
+      label === 'standard' ||
+      label === 'heavy' ||
+      label === 'light' ||
+      label === 'medium' ||
+      label === 'high' ||
+      label === 'extra high';
     if (MODEL_STRATEGY === 'current') {
       const currentLabel = getResolvedLabel('') || null;
       return {
@@ -501,9 +546,18 @@ function buildModelSelectionExpression(
         }
       }
       const candidateGpt55VisibleAlias = isTargetGpt55VisibleAlias(normalizedText);
+      const candidateIsGpt55ThinkingFamily =
+        wantsThinking &&
+        desiredVersion === '5-5' &&
+        (normalizedText === 'gpt 5 5' ||
+          normalizedText === '5 5' ||
+          normalizedTestId.includes('gpt-5-5') ||
+          normalizedTestId.includes('gpt-5.5') ||
+          normalizedTestId.includes('gpt55'));
       const candidateHasThinking =
         normalizedText.includes('thinking') ||
         normalizedTestId.includes('thinking') ||
+        candidateIsGpt55ThinkingFamily ||
         (wantsThinking && desiredVersion === '5-4' && exactTestIdMatch);
       const candidateHasLegacyProVersion = labelHasLegacyProVersion(normalizedText);
       const candidateHasPro =
@@ -530,6 +584,9 @@ function buildModelSelectionExpression(
       }
       if (candidateGpt55VisibleAlias) {
         score += 900;
+      }
+      if (candidateIsGpt55ThinkingFamily) {
+        score += 260;
       }
       if (normalizedText && normalizedTarget) {
         if (normalizedText === normalizedTarget) {
@@ -566,7 +623,11 @@ function buildModelSelectionExpression(
       }
       // Similarly for Thinking variant
       if (wantsThinking) {
-        if (!normalizedText.includes('thinking') && !normalizedTestId.includes('thinking')) {
+        if (
+          !candidateIsGpt55ThinkingFamily &&
+          !normalizedText.includes('thinking') &&
+          !normalizedTestId.includes('thinking')
+        ) {
           score -= 80;
         }
       } else if (normalizedText.includes('thinking') || normalizedTestId.includes('thinking')) {
@@ -621,9 +682,12 @@ function buildModelSelectionExpression(
           const text = option.textContent ?? '';
           const normalizedText = normalizeText(text);
           const testid = option.getAttribute('data-testid') ?? '';
-          const score = scoreOption(normalizedText, testid);
+          let score = scoreOption(normalizedText, testid);
           if (score <= 0) {
             continue;
+          }
+          if (optionIsSelected(option)) {
+            score += 1000;
           }
           const label = getOptionLabel(option);
           if (!bestMatch || score > bestMatch.score) {
@@ -662,6 +726,32 @@ function buildModelSelectionExpression(
       };
       check();
     });
+    const isSubmenuOption = (node, testid) =>
+      (testid ?? '').toLowerCase().includes('submenu') ||
+      node?.getAttribute?.('aria-haspopup') === 'menu' ||
+      node?.getAttribute?.('data-has-submenu') !== null;
+    const dispatchHoverSequence = (target) => {
+      if (!target || !(target instanceof EventTarget)) return false;
+      const types = ['pointerover', 'pointerenter', 'mouseover', 'mouseenter', 'pointermove', 'mousemove'];
+      for (const type of types) {
+        try {
+          const common = { bubbles: true, cancelable: true, view: window };
+          const event =
+            type.startsWith('pointer') && 'PointerEvent' in window
+              ? new PointerEvent(type, { ...common, pointerId: 1, pointerType: 'mouse' })
+              : new MouseEvent(type, common);
+          target.dispatchEvent(event);
+        } catch {}
+      }
+      try {
+        target.focus?.();
+      } catch {}
+      return true;
+    };
+    const openSubmenuOption = (node) => {
+      dispatchHoverSequence(node);
+      dispatchClickSequence(node);
+    };
 
     return new Promise((resolve) => {
       const start = performance.now();
@@ -714,8 +804,9 @@ function buildModelSelectionExpression(
           dispatchClickSequence(match.node);
           // Submenus (e.g. "Legacy models") need a second pass to pick the actual model option.
           // Keep scanning once the submenu opens instead of treating the submenu click as a final switch.
-          const isSubmenu = (match.testid ?? '').toLowerCase().includes('submenu');
+          const isSubmenu = isSubmenuOption(match.node, match.testid);
           if (isSubmenu) {
+            openSubmenuOption(match.node);
             setTimeout(attempt, REOPEN_INTERVAL_MS / 2);
             return;
           }

--- a/src/browser/actions/thinkingTime.ts
+++ b/src/browser/actions/thinkingTime.ts
@@ -594,11 +594,6 @@ function buildThinkingTimeExpression(
           if (proEffortResult) {
             return proEffortResult;
           }
-          if (TARGET_MODEL_KIND === 'pro' && TARGET_LEVEL === 'standard') {
-            const result = failure('menu-not-found');
-            closeOpenMenus();
-            return result;
-          }
           return selectAndVerify(composerEffortPill, () => {
             const currentMenu = findVisibleEffortMenu(composerEffortPill);
             return currentMenu ? findOptionInMenu(currentMenu) : null;

--- a/src/browser/actions/thinkingTime.ts
+++ b/src/browser/actions/thinkingTime.ts
@@ -199,7 +199,7 @@ function buildThinkingTimeExpression(
     const LEVEL_TOKENS = {
       light: ['light', 'instant', '轻'],
       standard: ['standard', 'medium', '标准'],
-      extended: ['extended', '扩展', '深度', '加强'],
+      extended: ['extended', 'high', '扩展', '深度', '加强'],
       heavy: ['heavy', 'extra high', '重度', '加重', '高'],
     };
     const targetTokens = LEVEL_TOKENS[TARGET_LEVEL] || [TARGET_LEVEL];
@@ -219,11 +219,18 @@ function buildThinkingTimeExpression(
       .replace(/[^a-z0-9\\u4e00-\\u9fa5]+/g, ' ')
       .replace(/\\s+/g, ' ')
       .trim();
+    const hasToken = (text, token) => normalize(text).split(' ').includes(token);
     const matchesLevel = (text) => {
       const t = normalize(text);
-      return targetTokens.some((tok) => t.includes(String(tok).toLowerCase()));
+      if (!t) return false;
+      return targetTokens.some((tok) => {
+        const token = normalize(tok);
+        if (!token) return false;
+        if (token === 'high') return hasToken(t, 'high') && !hasToken(t, 'extra');
+        if (token === 'extra high') return hasToken(t, 'extra') && hasToken(t, 'high');
+        return t === token || hasToken(t, token) || t.includes(token);
+      });
     };
-    const hasToken = (text, token) => normalize(text).split(' ').includes(token);
     const optionIsSelected = (node) => {
       if (!(node instanceof HTMLElement)) return false;
       const ariaChecked = node.getAttribute('aria-checked');
@@ -460,6 +467,13 @@ function buildThinkingTimeExpression(
       }
       return false;
     };
+    const currentEffortPillMatchesTarget = () => {
+      if (currentProEffortPillMatchesTarget()) return true;
+      if (TARGET_MODEL_KIND === 'pro') return false;
+      const button = findModelButton();
+      const label = (button?.textContent ?? '') + ' ' + (button?.getAttribute?.('aria-label') ?? '');
+      return matchesLevel(label);
+    };
     const selectAndVerify = async (trigger, findOption) => {
       const option = findOption();
       if (!option) return failure('option-not-found');
@@ -476,7 +490,7 @@ function buildThinkingTimeExpression(
         closeOpenMenus();
         return { status: 'switched', label: refreshed.textContent?.trim?.() || label };
       }
-      if (currentProEffortPillMatchesTarget()) {
+      if (currentEffortPillMatchesTarget()) {
         closeOpenMenus();
         return { status: 'switched', label };
       }
@@ -492,7 +506,7 @@ function buildThinkingTimeExpression(
           closeOpenMenus();
           return { status: 'switched', label: selected.textContent?.trim?.() || label };
         }
-        if (currentProEffortPillMatchesTarget()) {
+        if (currentEffortPillMatchesTarget()) {
           closeOpenMenus();
           return { status: 'switched', label };
         }

--- a/src/browser/actions/thinkingTime.ts
+++ b/src/browser/actions/thinkingTime.ts
@@ -383,8 +383,7 @@ function buildThinkingTimeExpression(
         return { error: redactDiagnosticText(err && err.message ? err.message : err) };
       }
     };
-    const currentModelKind = () => {
-      const button = findModelButton();
+    const modelKindFromNode = (button) => {
       const label = normalize(
         (button?.textContent ?? '') + ' ' + (button?.getAttribute?.('aria-label') ?? ''),
       );
@@ -393,6 +392,7 @@ function buildThinkingTimeExpression(
       if (hasToken(label, 'instant')) return 'instant';
       return null;
     };
+    const currentModelKind = () => modelKindFromNode(findModelButton());
     const effectiveTargetModelKind = () => TARGET_MODEL_KIND || currentModelKind();
     const isIntelligenceEffortMenu = (menu) => {
       if (menu?.getAttribute?.('data-testid') === 'composer-intelligence-picker-content') {
@@ -407,9 +407,9 @@ function buildThinkingTimeExpression(
       ...extra,
       diagnostic: collectPickerDiagnostic(),
     });
-    const findOptionInMenu = (menu) => {
+    const findOptionInMenu = (menu, modelKindOverride = null) => {
       const items = Array.from(menu.querySelectorAll(MENU_ITEM_SELECTOR));
-      const modelKind = effectiveTargetModelKind();
+      const modelKind = modelKindOverride || effectiveTargetModelKind();
       if (modelKind === 'pro') {
         for (const item of items) {
           const itemText = normalize(
@@ -514,9 +514,12 @@ function buildThinkingTimeExpression(
       }
       return null;
     };
-    const currentProEffortPillMatchesTarget = () => {
-      if (TARGET_MODEL_KIND !== 'pro') return false;
-      const label = normalize(findModelButton()?.textContent ?? '');
+    const currentProEffortPillMatchesTarget = (trigger, modelKindOverride = null) => {
+      const button = trigger?.matches?.('button.__composer-pill') ? trigger : findModelButton();
+      if ((modelKindOverride || TARGET_MODEL_KIND || modelKindFromNode(button)) !== 'pro') {
+        return false;
+      }
+      const label = normalize(button?.textContent ?? '');
       if (TARGET_LEVEL === 'standard') {
         return hasToken(label, 'pro') && !hasToken(label, 'extended');
       }
@@ -525,16 +528,23 @@ function buildThinkingTimeExpression(
       }
       return false;
     };
-    const currentEffortPillMatchesTarget = () => {
-      if (currentProEffortPillMatchesTarget()) return true;
-      if (TARGET_MODEL_KIND === 'pro') return false;
-      const button = findModelButton();
+    const currentEffortPillMatchesTarget = (trigger, modelKindOverride = null) => {
+      if (currentProEffortPillMatchesTarget(trigger, modelKindOverride)) return true;
+      const button = trigger?.matches?.('button.__composer-pill') ? trigger : findModelButton();
+      if ((modelKindOverride || TARGET_MODEL_KIND || modelKindFromNode(button)) === 'pro') {
+        return false;
+      }
       const label = (button?.textContent ?? '') + ' ' + (button?.getAttribute?.('aria-label') ?? '');
       return matchesLevel(label);
     };
-    const selectAndVerify = async (trigger, findOption) => {
+    const selectAndVerify = async (trigger, findOption, modelKindOverride = null) => {
       const option = findOption();
-      if (!option) return failure('option-not-found');
+      const triggerModelKind =
+        modelKindOverride ||
+        TARGET_MODEL_KIND ||
+        modelKindFromNode(trigger) ||
+        effectiveTargetModelKind();
+      if (!option) return failure('option-not-found', { modelKind: triggerModelKind });
       const label = option.textContent?.trim?.() || null;
       if (optionIsSelected(option)) {
         closeOpenMenus();
@@ -548,7 +558,7 @@ function buildThinkingTimeExpression(
         closeOpenMenus();
         return { status: 'switched', label: refreshed.textContent?.trim?.() || label };
       }
-      if (currentEffortPillMatchesTarget()) {
+      if (currentEffortPillMatchesTarget(trigger, triggerModelKind)) {
         closeOpenMenus();
         return { status: 'switched', label };
       }
@@ -564,13 +574,13 @@ function buildThinkingTimeExpression(
           closeOpenMenus();
           return { status: 'switched', label: selected.textContent?.trim?.() || label };
         }
-        if (currentEffortPillMatchesTarget()) {
+        if (currentEffortPillMatchesTarget(trigger, triggerModelKind)) {
           closeOpenMenus();
           return { status: 'switched', label };
         }
         await sleep(100);
       }
-      const result = failure('selection-unverified');
+      const result = failure('selection-unverified', { modelKind: triggerModelKind });
       closeOpenMenus();
       return result;
     };
@@ -635,6 +645,7 @@ function buildThinkingTimeExpression(
 
     const composerEffortPill = findComposerEffortPill();
     if (composerEffortPill) {
+      const composerModelKind = TARGET_MODEL_KIND || modelKindFromNode(composerEffortPill);
       if (composerEffortPill.getAttribute?.('aria-expanded') !== 'true') {
         dispatchClickSequence(composerEffortPill);
         await sleep(INITIAL_WAIT_MS);
@@ -647,14 +658,20 @@ function buildThinkingTimeExpression(
           if (proEffortResult) {
             return proEffortResult;
           }
-          return selectAndVerify(composerEffortPill, () => {
-            const currentMenu = findVisibleEffortMenu(composerEffortPill);
-            return currentMenu ? findOptionInMenu(currentMenu) : null;
-          });
+          return selectAndVerify(
+            composerEffortPill,
+            () => {
+              const currentMenu = findVisibleEffortMenu(composerEffortPill);
+              return currentMenu ? findOptionInMenu(currentMenu, composerModelKind) : null;
+            },
+            composerModelKind,
+          );
         }
         await sleep(100);
       }
-      const result = failure('menu-not-found');
+      const result = failure('menu-not-found', {
+        modelKind: composerModelKind,
+      });
       closeOpenMenus();
       return result;
     }

--- a/src/browser/actions/thinkingTime.ts
+++ b/src/browser/actions/thinkingTime.ts
@@ -233,6 +233,24 @@ function buildThinkingTimeExpression(
         return t === token || hasToken(t, token) || t.includes(token);
       });
     };
+    const matchesAnyEffortLevel = (text) => {
+      const normalizedText = normalize(text);
+      if (!normalizedText) return false;
+      for (const tokens of Object.values(LEVEL_TOKENS)) {
+        for (const rawToken of tokens) {
+          const token = normalize(rawToken);
+          if (!token) continue;
+          if (token.includes(' ')) {
+            if (token.split(' ').every((part) => hasToken(normalizedText, part))) return true;
+          } else if (/^[a-z0-9]+$/.test(token)) {
+            if (hasToken(normalizedText, token)) return true;
+          } else if (normalizedText.includes(token)) {
+            return true;
+          }
+        }
+      }
+      return false;
+    };
     const optionIsSelected = (node) => {
       if (!(node instanceof HTMLElement)) return false;
       const ariaChecked = node.getAttribute('aria-checked');
@@ -586,18 +604,16 @@ function buildThinkingTimeExpression(
     // controlled menu contains the effort levels. Prefer this ownership boundary
     // before probing older model-picker layouts.
     const COMPOSER_EFFORT_PILL_SELECTORS = [
-      'form button.__composer-pill[aria-haspopup="menu"]',
-      '[data-testid="composer-footer-actions"] button[aria-haspopup="menu"]',
-      '.__composer-pill-composite button[aria-haspopup="menu"]',
+      'form button.__composer-pill',
+      '[data-testid="composer-footer-actions"] button.__composer-pill',
+      '.__composer-pill-composite button.__composer-pill',
     ];
     const findComposerEffortPill = () => {
-      const candidates = [];
       const seen = new Set();
       for (const selector of COMPOSER_EFFORT_PILL_SELECTORS) {
         for (const button of document.querySelectorAll(selector)) {
           if (seen.has(button) || !isVisible(button)) continue;
           seen.add(button);
-          if (button.getAttribute?.('aria-haspopup') !== 'menu') continue;
           if (button.getAttribute?.('data-testid') === 'model-switcher-dropdown-button') continue;
           const label = normalize(
             (button.getAttribute?.('aria-label') ?? '') + ' ' +
@@ -607,17 +623,14 @@ function buildThinkingTimeExpression(
           if (
             (TARGET_MODEL_KIND === 'pro' && hasToken(label, 'pro') && !hasToken(label, 'thinking')) ||
             (TARGET_MODEL_KIND === 'thinking' && hasToken(label, 'thinking') && !hasToken(label, 'pro')) ||
-            (!TARGET_MODEL_KIND && hasToken(label, 'thinking'))
+            (!TARGET_MODEL_KIND && hasToken(label, 'thinking')) ||
+            (button.matches?.('button.__composer-pill') && matchesAnyEffortLevel(label))
           ) {
             return button;
           }
-          candidates.push(button);
         }
       }
-      const composerPills = candidates.filter((button) =>
-        button.matches?.('button.__composer-pill'),
-      );
-      return composerPills.length === 1 ? composerPills[0] : null;
+      return null;
     };
 
     const composerEffortPill = findComposerEffortPill();

--- a/src/browser/actions/thinkingTime.ts
+++ b/src/browser/actions/thinkingTime.ts
@@ -13,7 +13,7 @@ import { buildClickDispatcher } from "./domEvents.js";
 // --verbose. Loosely typed: the shape is whatever the injected probe returns.
 type ThinkingTimePickerDiagnostic = Record<string, unknown>;
 
-type ThinkingTimeOutcome =
+type ThinkingTimeOutcome = (
   | { status: "already-selected"; label?: string | null }
   | { status: "switched"; label?: string | null }
   | { status: "chip-not-found"; diagnostic?: ThinkingTimePickerDiagnostic }
@@ -22,9 +22,9 @@ type ThinkingTimeOutcome =
   | { status: "selection-unverified"; diagnostic?: ThinkingTimePickerDiagnostic }
   | {
       status: "model-kind-not-found";
-      modelKind?: string | null;
       diagnostic?: ThinkingTimePickerDiagnostic;
-    };
+    }
+) & { modelKind?: string | null };
 
 const BROWSER_THINKING_LOG_PREFIX = "[browser] Thinking time:";
 
@@ -64,7 +64,9 @@ export async function ensureThinkingTime(
   const result = await evaluateThinkingTimeSelection(Runtime, level, desiredModel);
   const capitalizedLevel = level.charAt(0).toUpperCase() + level.slice(1);
   const targetModelKind = inferThinkingTargetModelKind(desiredModel);
-  const strictProEffort = targetModelKind === "pro" && level === "extended";
+  const observedModelKind = result && "modelKind" in result ? result.modelKind : null;
+  const strictProEffort =
+    (targetModelKind === "pro" || observedModelKind === "pro") && level === "extended";
 
   switch (result?.status) {
     case "already-selected":
@@ -363,17 +365,55 @@ function buildThinkingTimeExpression(
         return { error: redactDiagnosticText(err && err.message ? err.message : err) };
       }
     };
+    const currentModelKind = () => {
+      const button = findModelButton();
+      const label = normalize(
+        (button?.textContent ?? '') + ' ' + (button?.getAttribute?.('aria-label') ?? ''),
+      );
+      if (hasToken(label, 'pro')) return 'pro';
+      if (hasToken(label, 'thinking')) return 'thinking';
+      if (hasToken(label, 'instant')) return 'instant';
+      return null;
+    };
+    const effectiveTargetModelKind = () => TARGET_MODEL_KIND || currentModelKind();
+    const isIntelligenceEffortMenu = (menu) => {
+      if (menu?.getAttribute?.('data-testid') === 'composer-intelligence-picker-content') {
+        return true;
+      }
+      const label = menu?.querySelector?.('.__menu-label, [class*="menu-label"]');
+      return normalize(label?.textContent ?? '').includes('intelligence');
+    };
     const failure = (status, extra = {}) => ({
       status,
+      modelKind: effectiveTargetModelKind(),
       ...extra,
       diagnostic: collectPickerDiagnostic(),
     });
     const findOptionInMenu = (menu) => {
-      for (const item of menu.querySelectorAll(MENU_ITEM_SELECTOR)) {
+      const items = Array.from(menu.querySelectorAll(MENU_ITEM_SELECTOR));
+      const modelKind = effectiveTargetModelKind();
+      if (modelKind === 'pro') {
+        for (const item of items) {
+          const itemText = normalize(
+            (item.textContent ?? '') + ' ' + (item.getAttribute?.('aria-label') ?? ''),
+          );
+          if (
+            hasToken(itemText, 'pro') &&
+            (matchesLevel(item.textContent ?? '') ||
+              matchesLevel(item.getAttribute?.('aria-label') ?? ''))
+          ) {
+            return item;
+          }
+        }
+        if (isIntelligenceEffortMenu(menu)) {
+          return null;
+        }
+      }
+      for (const item of items) {
         const itemText = normalize(
           (item.textContent ?? '') + ' ' + (item.getAttribute?.('aria-label') ?? ''),
         );
-        if (TARGET_MODEL_KIND !== 'pro' && hasToken(itemText, 'pro')) {
+        if (modelKind && modelKind !== 'pro' && hasToken(itemText, 'pro')) {
           continue;
         }
         if (

--- a/src/browser/actions/thinkingTime.ts
+++ b/src/browser/actions/thinkingTime.ts
@@ -26,6 +26,12 @@ type ThinkingTimeOutcome =
       diagnostic?: ThinkingTimePickerDiagnostic;
     };
 
+const BROWSER_THINKING_LOG_PREFIX = "[browser] Thinking time:";
+
+function formatBrowserThinkingLog(message: string): string {
+  return `${BROWSER_THINKING_LOG_PREFIX} ${message.replace(/^Thinking time:\s*/, "")}`;
+}
+
 /**
  * Surfaces the model-picker snapshot captured alongside a failed detection.
  *
@@ -62,10 +68,10 @@ export async function ensureThinkingTime(
 
   switch (result?.status) {
     case "already-selected":
-      logger(`Thinking time: ${result.label ?? capitalizedLevel} (already selected)`);
+      logger(formatBrowserThinkingLog(`${result.label ?? capitalizedLevel} (already selected)`));
       return;
     case "switched":
-      logger(`Thinking time: ${result.label ?? capitalizedLevel}`);
+      logger(formatBrowserThinkingLog(result.label ?? capitalizedLevel));
       return;
     case "chip-not-found":
     case "menu-not-found":
@@ -84,7 +90,7 @@ export async function ensureThinkingTime(
       if (strictProEffort) {
         throw new Error(`${message}; refusing to submit without confirmed Pro Extended.`);
       }
-      logger(`${message}; continuing with ChatGPT default.`);
+      logger(formatBrowserThinkingLog(`${message}; continuing with ChatGPT default.`));
       return;
     }
     default: {
@@ -96,7 +102,9 @@ export async function ensureThinkingTime(
         );
       }
       logger(
-        `Thinking time: unknown outcome selecting ${capitalizedLevel}; continuing with ChatGPT default.`,
+        formatBrowserThinkingLog(
+          `unknown outcome selecting ${capitalizedLevel}; continuing with ChatGPT default.`,
+        ),
       );
       return;
     }
@@ -120,10 +128,10 @@ export async function ensureThinkingTimeIfAvailable(
 
     switch (result?.status) {
       case "already-selected":
-        logger(`Thinking time: ${result.label ?? capitalizedLevel} (already selected)`);
+        logger(formatBrowserThinkingLog(`${result.label ?? capitalizedLevel} (already selected)`));
         return true;
       case "switched":
-        logger(`Thinking time: ${result.label ?? capitalizedLevel}`);
+        logger(formatBrowserThinkingLog(result.label ?? capitalizedLevel));
         return true;
       case "chip-not-found":
       case "menu-not-found":
@@ -131,19 +139,23 @@ export async function ensureThinkingTimeIfAvailable(
       case "selection-unverified":
       case "model-kind-not-found":
         if (logger.verbose) {
-          logger(`Thinking time: ${result.status.replaceAll("-", " ")}; continuing with default.`);
+          logger(
+            formatBrowserThinkingLog(
+              `${result.status.replaceAll("-", " ")}; continuing with default.`,
+            ),
+          );
         }
         return false;
       default:
         if (logger.verbose) {
-          logger("Thinking time: unknown outcome; continuing with default.");
+          logger(formatBrowserThinkingLog("unknown outcome; continuing with default."));
         }
         return false;
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (logger.verbose) {
-      logger(`Thinking time selection failed (${message}); continuing with default.`);
+      logger(formatBrowserThinkingLog(`selection failed (${message}); continuing with default.`));
       await logDomFailure(Runtime, logger, "thinking-time");
     }
     return false;
@@ -185,10 +197,10 @@ function buildThinkingTimeExpression(
 
     // Bilingual matchers: English level token + observed Chinese variants.
     const LEVEL_TOKENS = {
-      light: ['light', '轻'],
-      standard: ['standard', '标准'],
+      light: ['light', 'instant', '轻'],
+      standard: ['standard', 'medium', '标准'],
       extended: ['extended', '扩展', '深度', '加强'],
-      heavy: ['heavy', '重度', '加重', '高'],
+      heavy: ['heavy', 'extra high', '重度', '加重', '高'],
     };
     const targetTokens = LEVEL_TOKENS[TARGET_LEVEL] || [TARGET_LEVEL];
 
@@ -235,9 +247,28 @@ function buildThinkingTimeExpression(
         );
       } catch {}
     };
+    const dispatchHoverSequence = (target) => {
+      if (!target || !(target instanceof EventTarget)) return false;
+      const types = ['pointerover', 'pointerenter', 'mouseover', 'mouseenter', 'pointermove', 'mousemove'];
+      for (const type of types) {
+        try {
+          const common = { bubbles: true, cancelable: true, view: window };
+          const event =
+            type.startsWith('pointer') && 'PointerEvent' in window
+              ? new PointerEvent(type, { ...common, pointerId: 1, pointerType: 'mouse' })
+              : new MouseEvent(type, common);
+          target.dispatchEvent(event);
+        } catch {}
+      }
+      try {
+        target.focus?.();
+      } catch {}
+      return true;
+    };
 
     const TRAILING_SELECTOR = '[data-model-picker-thinking-effort-action="true"]';
     const INTELLIGENCE_MENU_SELECTOR = '[data-testid="composer-intelligence-picker-content"]';
+    const PRO_EFFORT_TRIGGER_SELECTOR = '[data-testid="composer-intelligence-pro-thinking-effort-trigger"]';
 
     const findModelButton = () => document.querySelector(MODEL_BUTTON_SELECTOR);
     const findTrailingButtons = () => Array.from(document.querySelectorAll(TRAILING_SELECTOR));
@@ -332,6 +363,12 @@ function buildThinkingTimeExpression(
     });
     const findOptionInMenu = (menu) => {
       for (const item of menu.querySelectorAll(MENU_ITEM_SELECTOR)) {
+        const itemText = normalize(
+          (item.textContent ?? '') + ' ' + (item.getAttribute?.('aria-label') ?? ''),
+        );
+        if (TARGET_MODEL_KIND !== 'pro' && hasToken(itemText, 'pro')) {
+          continue;
+        }
         if (
           matchesLevel(item.textContent ?? '') ||
           matchesLevel(item.getAttribute?.('aria-label') ?? '')
@@ -351,13 +388,20 @@ function buildThinkingTimeExpression(
     };
     const isEffortMenu = (menu) => {
       if (!isVisible(menu)) return false;
+      if (menu.getAttribute?.('data-testid') === 'composer-intelligence-picker-content') return true;
       const label = menu.querySelector?.('.__menu-label, [class*="menu-label"]');
       const labelText = normalize(label?.textContent ?? '');
       return (
+        labelText.includes('intelligence') ||
         labelText.includes('thinking time') ||
         labelText.includes('thinking effort') ||
         countEffortLevels(menu) >= 2
       );
+    };
+    const isProEffortMenu = (menu) => {
+      if (!isVisible(menu)) return false;
+      const text = normalize(menu?.textContent ?? '');
+      return text.includes('pro standard') && text.includes('pro extended');
     };
     const controlledMenu = (trigger) => {
       const id = trigger?.getAttribute?.('aria-controls');
@@ -372,6 +416,49 @@ function buildThinkingTimeExpression(
         if (isEffortMenu(menu)) return menu;
       }
       return null;
+    };
+    const controlledProEffortMenu = (trigger) => {
+      const id = trigger?.getAttribute?.('aria-controls');
+      if (!id) return null;
+      const menu = document.getElementById?.(id);
+      return isProEffortMenu(menu) ? menu : null;
+    };
+    const findVisibleProEffortMenu = (trigger) => {
+      const controlled = controlledProEffortMenu(trigger);
+      if (controlled) return controlled;
+      for (const menu of document.querySelectorAll(MENU_CONTAINER_SELECTOR)) {
+        if (isProEffortMenu(menu)) return menu;
+      }
+      return null;
+    };
+    const matchesProEffortLevel = (node) => {
+      const text = normalize(
+        (node?.textContent ?? '') + ' ' + (node?.getAttribute?.('aria-label') ?? ''),
+      );
+      if (TARGET_LEVEL === 'standard') {
+        return text.includes('pro') && text.includes('standard');
+      }
+      if (TARGET_LEVEL === 'extended') {
+        return text.includes('pro') && text.includes('extended');
+      }
+      return false;
+    };
+    const findProEffortOptionInMenu = (menu) => {
+      for (const item of menu.querySelectorAll(MENU_ITEM_SELECTOR)) {
+        if (matchesProEffortLevel(item)) return item;
+      }
+      return null;
+    };
+    const currentProEffortPillMatchesTarget = () => {
+      if (TARGET_MODEL_KIND !== 'pro') return false;
+      const label = normalize(findModelButton()?.textContent ?? '');
+      if (TARGET_LEVEL === 'standard') {
+        return hasToken(label, 'pro') && !hasToken(label, 'extended');
+      }
+      if (TARGET_LEVEL === 'extended') {
+        return hasToken(label, 'pro') && hasToken(label, 'extended');
+      }
+      return false;
     };
     const selectAndVerify = async (trigger, findOption) => {
       const option = findOption();
@@ -389,6 +476,10 @@ function buildThinkingTimeExpression(
         closeOpenMenus();
         return { status: 'switched', label: refreshed.textContent?.trim?.() || label };
       }
+      if (currentProEffortPillMatchesTarget()) {
+        closeOpenMenus();
+        return { status: 'switched', label };
+      }
 
       if (!refreshed && trigger && trigger.getAttribute?.('aria-expanded') !== 'true') {
         dispatchClickSequence(trigger);
@@ -401,11 +492,40 @@ function buildThinkingTimeExpression(
           closeOpenMenus();
           return { status: 'switched', label: selected.textContent?.trim?.() || label };
         }
+        if (currentProEffortPillMatchesTarget()) {
+          closeOpenMenus();
+          return { status: 'switched', label };
+        }
         await sleep(100);
       }
       const result = failure('selection-unverified');
       closeOpenMenus();
       return result;
+    };
+    const selectProEffortFromSubmenu = async () => {
+      if (TARGET_MODEL_KIND !== 'pro' || (TARGET_LEVEL !== 'standard' && TARGET_LEVEL !== 'extended')) {
+        return null;
+      }
+      const trigger = document.querySelector(PRO_EFFORT_TRIGGER_SELECTOR);
+      if (!trigger) {
+        return null;
+      }
+      dispatchHoverSequence(trigger);
+      if (trigger.getAttribute?.('aria-expanded') !== 'true') {
+        dispatchClickSequence(trigger);
+      }
+      const deadline = performance.now() + MAX_WAIT_MS;
+      while (performance.now() < deadline) {
+        const menu = findVisibleProEffortMenu(trigger);
+        if (menu) {
+          return selectAndVerify(trigger, () => {
+            const currentMenu = findVisibleProEffortMenu(trigger);
+            return currentMenu ? findProEffortOptionInMenu(currentMenu) : null;
+          });
+        }
+        await sleep(100);
+      }
+      return null;
     };
 
     // Current ChatGPT exposes a standalone Pro or Thinking composer pill whose
@@ -456,6 +576,15 @@ function buildThinkingTimeExpression(
       while (performance.now() < deadline) {
         const menu = findVisibleEffortMenu(composerEffortPill);
         if (menu) {
+          const proEffortResult = await selectProEffortFromSubmenu();
+          if (proEffortResult) {
+            return proEffortResult;
+          }
+          if (TARGET_MODEL_KIND === 'pro' && TARGET_LEVEL === 'standard') {
+            const result = failure('menu-not-found');
+            closeOpenMenus();
+            return result;
+          }
           return selectAndVerify(composerEffortPill, () => {
             const currentMenu = findVisibleEffortMenu(composerEffortPill);
             return currentMenu ? findOptionInMenu(currentMenu) : null;
@@ -567,15 +696,9 @@ function buildThinkingTimeExpression(
     // ---------- COMPATIBILITY UI: unified "Intelligence" effort picker ----------
     // One observed ChatGPT layout replaced the per-model trailing buttons with a single
     // "Intelligence" menu ([data-testid="composer-intelligence-picker-content"]),
-    // whose role="menuitemradio" rows are the effort tiers. For the Pro model the
-    // combined "Pro Extended" row carries aria-checked when active, and Pro
-    // sub-options live behind
-    // [data-testid="composer-intelligence-pro-thinking-effort-trigger"]. We
-    // confirm Pro Extended by the radio's checked state (real proof), never by
-    // the composer-pill label. The new non-pro tiers (Instant/Medium/High/Extra
-    // High) don't map cleanly onto light/standard/extended/heavy, so we only
-    // drive this picker for the strict Pro Extended target and let other levels
-    // fall through to the legacy paths below.
+    // whose role="menuitemradio" rows are the effort tiers. We verify the checked
+    // radio instead of trusting the composer-pill label; non-Pro targets also
+    // explicitly skip Pro rows before matching effort labels.
     if (TARGET_MODEL_KIND === 'pro' && TARGET_LEVEL === 'extended') {
       const matchesProExtended = (node) => {
         const text = normalize(

--- a/src/cli/browserConfig.ts
+++ b/src/cli/browserConfig.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { BrowserSessionConfig } from "../sessionStore.js";
 import type { ModelName, ThinkingTimeLevel } from "../oracle/types.js";
+import { normalizeThinkingTimeLevel } from "../oracle/thinkingTime.js";
 import { CHATGPT_URL, DEFAULT_MODEL_STRATEGY, DEFAULT_MODEL_TARGET } from "../browser/constants.js";
 import { normalizeChatgptUrl } from "../browser/utils.js";
 import { parseDuration } from "../duration.js";
@@ -226,7 +227,7 @@ export async function buildBrowserConfig(
     allowCookieErrors: options.browserAllowCookieErrors ?? true,
     remoteChrome,
     browserTabRef: options.browserTab ?? undefined,
-    thinkingTime: options.browserThinkingTime,
+    thinkingTime: normalizeThinkingTimeLevel(options.browserThinkingTime) ?? undefined,
     researchMode: options.browserResearch === "deep" ? "deep" : "off",
     archiveConversations: options.browserArchive,
   };

--- a/src/cli/browserDefaults.ts
+++ b/src/cli/browserDefaults.ts
@@ -1,6 +1,7 @@
 import { CHATGPT_URL } from "../browser/constants.js";
 import { normalizeChatgptUrl } from "../browser/utils.js";
 import type { UserConfig } from "../config.js";
+import { normalizeThinkingTimeLevel } from "../oracle/thinkingTime.js";
 import type { ThinkingTimeLevel } from "../oracle/types.js";
 import type {
   BrowserArchiveMode,
@@ -145,7 +146,7 @@ export function applyBrowserDefaultsFromConfig(
     options.browserModelStrategy = browser.modelStrategy;
   }
   if (isUnset("browserThinkingTime") && browser.thinkingTime !== undefined) {
-    options.browserThinkingTime = browser.thinkingTime;
+    options.browserThinkingTime = normalizeThinkingTimeLevel(browser.thinkingTime) ?? undefined;
   }
   if (isUnset("browserResearch") && browser.researchMode !== undefined) {
     options.browserResearch = browser.researchMode;

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import fg from "fast-glob";
 import type { ModelName, PreviewMode } from "../oracle.js";
 import { DEFAULT_MODEL, MODEL_CONFIGS } from "../oracle/config.js";
+import { normalizeThinkingTimeLevel } from "../oracle/thinkingTime.js";
+import type { ThinkingTimeLevel } from "../oracle/types.js";
 
 export function collectPaths(
   value: string | string[] | undefined,
@@ -154,6 +156,16 @@ export function parseSearchOption(value: string): boolean {
     return false;
   }
   throw new InvalidArgumentError('Search mode must be "on" or "off".');
+}
+
+export function parseThinkingTimeOption(value: string): ThinkingTimeLevel {
+  const normalized = normalizeThinkingTimeLevel(value);
+  if (normalized) {
+    return normalized;
+  }
+  throw new InvalidArgumentError(
+    'Thinking time must be one of "light", "standard", "extended", "heavy", or a ChatGPT UI alias like "instant", "medium", "high", or "extra-high".',
+  );
 }
 
 export function normalizeModelOption(value: string | undefined): string {

--- a/src/mcp/tools/chatgptImage.ts
+++ b/src/mcp/tools/chatgptImage.ts
@@ -4,7 +4,11 @@ import path from "node:path";
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
 import { getOracleHomeDir } from "../../oracleHome.js";
-import { browserThinkingTimeInputSchema, type ConsultInput } from "../types.js";
+import {
+  browserThinkingTimeInputSchema,
+  browserThinkingTimeRawSchema,
+  type ConsultInput,
+} from "../types.js";
 import { consultOutputShape, runConsultTool } from "./consult.js";
 
 const chatGptImageInputShape = {
@@ -37,7 +41,7 @@ const chatGptImageInputShape = {
     .describe(
       'How to deliver files. Defaults to "always" when files are present so reference images are uploaded.',
     ),
-  browserThinkingTime: browserThinkingTimeInputSchema
+  browserThinkingTime: browserThinkingTimeRawSchema
     .optional()
     .describe("Set ChatGPT thinking time when supported by the chosen model."),
   browserModelStrategy: z
@@ -67,7 +71,12 @@ const chatGptImageOutputShape = {
   requestedOutputPath: z.string(),
 } satisfies z.ZodRawShape;
 
-const chatGptImageInputSchema = z.object(chatGptImageInputShape).strict();
+const chatGptImageInputSchema = z
+  .object({
+    ...chatGptImageInputShape,
+    browserThinkingTime: browserThinkingTimeInputSchema.optional(),
+  })
+  .strict();
 
 export type ChatGptImageInput = z.infer<typeof chatGptImageInputSchema>;
 

--- a/src/mcp/tools/chatgptImage.ts
+++ b/src/mcp/tools/chatgptImage.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
 import { getOracleHomeDir } from "../../oracleHome.js";
-import type { ConsultInput } from "../types.js";
+import { browserThinkingTimeInputSchema, type ConsultInput } from "../types.js";
 import { consultOutputShape, runConsultTool } from "./consult.js";
 
 const chatGptImageInputShape = {
@@ -37,8 +37,7 @@ const chatGptImageInputShape = {
     .describe(
       'How to deliver files. Defaults to "always" when files are present so reference images are uploaded.',
     ),
-  browserThinkingTime: z
-    .enum(["light", "standard", "extended", "heavy"])
+  browserThinkingTime: browserThinkingTimeInputSchema
     .optional()
     .describe("Set ChatGPT thinking time when supported by the chosen model."),
   browserModelStrategy: z

--- a/src/mcp/tools/consult.ts
+++ b/src/mcp/tools/consult.ts
@@ -34,6 +34,7 @@ import { loadUserConfig, type UserConfig } from "../../config.js";
 import { resolveNotificationSettings } from "../../cli/notifier.js";
 import { mapModelToBrowserLabel, resolveBrowserModelLabel } from "../../cli/browserConfig.js";
 import type { BrowserModelStrategy } from "../../browser/types.js";
+import { normalizeThinkingTimeLevel } from "../../oracle/thinkingTime.js";
 
 // Use raw shapes so the MCP SDK (with its bundled Zod) wraps them and emits valid JSON Schema.
 const consultInputShape = {
@@ -345,6 +346,7 @@ export function buildConsultBrowserConfig({
   const manualLogin = hasProfileDir
     ? true
     : (configuredBrowser.manualLogin ?? process.platform === "win32");
+  const configuredThinkingTime = normalizeThinkingTimeLevel(configuredBrowser.thinkingTime);
 
   return {
     ...configuredBrowser,
@@ -358,7 +360,7 @@ export function buildConsultBrowserConfig({
     manualLoginProfileDir: manualLogin
       ? ((envProfileDir || configuredBrowser.manualLoginProfileDir) ?? null)
       : null,
-    thinkingTime: browserThinkingTime ?? configuredBrowser.thinkingTime,
+    thinkingTime: browserThinkingTime ?? configuredThinkingTime ?? undefined,
     modelStrategy: browserModelStrategy ?? configuredBrowser.modelStrategy,
     researchMode: browserResearchMode ?? configuredBrowser.researchMode,
     archiveConversations: browserArchive ?? configuredBrowser.archiveConversations,

--- a/src/mcp/tools/consult.ts
+++ b/src/mcp/tools/consult.ts
@@ -28,7 +28,7 @@ async function readSessionLogTail(sessionId: string, maxBytes: number): Promise<
 import { performSessionRun } from "../../cli/sessionRunner.js";
 import { runDryRunSummary } from "../../cli/dryRun.js";
 import { CHATGPT_URL } from "../../browser/constants.js";
-import { CONSULT_PRESETS, browserThinkingTimeInputSchema, consultInputSchema } from "../types.js";
+import { CONSULT_PRESETS, browserThinkingTimeRawSchema, consultInputSchema } from "../types.js";
 import { applyConsultPreset } from "../consultPresets.js";
 import { loadUserConfig, type UserConfig } from "../../config.js";
 import { resolveNotificationSettings } from "../../cli/notifier.js";
@@ -88,7 +88,7 @@ const consultInputShape = {
     .describe(
       'Browser-only: bundle upload format when browserBundleFiles is true or auto-bundling is needed. Defaults to "text"; "zip" preserves individual file names in one uploaded archive.',
     ),
-  browserThinkingTime: browserThinkingTimeInputSchema
+  browserThinkingTime: browserThinkingTimeRawSchema
     .optional()
     .describe("Browser-only: set ChatGPT thinking time when supported by the chosen model."),
   browserModelStrategy: z

--- a/src/mcp/tools/consult.ts
+++ b/src/mcp/tools/consult.ts
@@ -28,7 +28,7 @@ async function readSessionLogTail(sessionId: string, maxBytes: number): Promise<
 import { performSessionRun } from "../../cli/sessionRunner.js";
 import { runDryRunSummary } from "../../cli/dryRun.js";
 import { CHATGPT_URL } from "../../browser/constants.js";
-import { CONSULT_PRESETS, consultInputSchema } from "../types.js";
+import { CONSULT_PRESETS, browserThinkingTimeInputSchema, consultInputSchema } from "../types.js";
 import { applyConsultPreset } from "../consultPresets.js";
 import { loadUserConfig, type UserConfig } from "../../config.js";
 import { resolveNotificationSettings } from "../../cli/notifier.js";
@@ -88,8 +88,7 @@ const consultInputShape = {
     .describe(
       'Browser-only: bundle upload format when browserBundleFiles is true or auto-bundling is needed. Defaults to "text"; "zip" preserves individual file names in one uploaded archive.',
     ),
-  browserThinkingTime: z
-    .enum(["light", "standard", "extended", "heavy"])
+  browserThinkingTime: browserThinkingTimeInputSchema
     .optional()
     .describe("Browser-only: set ChatGPT thinking time when supported by the chosen model."),
   browserModelStrategy: z

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,6 +1,18 @@
 import { z } from "zod";
+import { THINKING_TIME_INPUT_VALUES, normalizeThinkingTimeLevel } from "../oracle/thinkingTime.js";
+import type { ThinkingTimeLevel } from "../oracle/types.js";
 
 export const CONSULT_PRESETS = ["chatgpt-pro-heavy"] as const;
+
+export const browserThinkingTimeInputSchema = z
+  .enum(THINKING_TIME_INPUT_VALUES)
+  .transform((value): ThinkingTimeLevel => {
+    const normalized = normalizeThinkingTimeLevel(value);
+    if (!normalized) {
+      throw new Error(`Unknown browserThinkingTime value: ${value}`);
+    }
+    return normalized;
+  });
 
 export const consultInputSchema = z
   .object({
@@ -14,7 +26,7 @@ export const consultInputSchema = z
     browserAttachments: z.enum(["auto", "never", "always"]).optional(),
     browserBundleFiles: z.boolean().optional(),
     browserBundleFormat: z.enum(["text", "zip"]).optional(),
-    browserThinkingTime: z.enum(["light", "standard", "extended", "heavy"]).optional(),
+    browserThinkingTime: browserThinkingTimeInputSchema.optional(),
     browserModelStrategy: z.enum(["select", "current", "ignore"]).optional(),
     browserResearchMode: z.enum(["deep"]).optional(),
     browserArchive: z.enum(["auto", "always", "never"]).optional(),

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -4,15 +4,17 @@ import type { ThinkingTimeLevel } from "../oracle/types.js";
 
 export const CONSULT_PRESETS = ["chatgpt-pro-heavy"] as const;
 
-export const browserThinkingTimeInputSchema = z
-  .enum(THINKING_TIME_INPUT_VALUES)
-  .transform((value): ThinkingTimeLevel => {
+export const browserThinkingTimeRawSchema = z.enum(THINKING_TIME_INPUT_VALUES);
+
+export const browserThinkingTimeInputSchema = browserThinkingTimeRawSchema.transform(
+  (value): ThinkingTimeLevel => {
     const normalized = normalizeThinkingTimeLevel(value);
     if (!normalized) {
       throw new Error(`Unknown browserThinkingTime value: ${value}`);
     }
     return normalized;
-  });
+  },
+);
 
 export const consultInputSchema = z
   .object({

--- a/src/oracle/thinkingTime.ts
+++ b/src/oracle/thinkingTime.ts
@@ -1,0 +1,48 @@
+import type { ThinkingTimeLevel } from "./types.js";
+
+export const THINKING_TIME_LEVELS = ["light", "standard", "extended", "heavy"] as const;
+export const THINKING_TIME_ALIASES = [
+  "instant",
+  "low",
+  "medium",
+  "high",
+  "extra-high",
+  "extra high",
+  "extrahigh",
+  "xhigh",
+] as const;
+export const THINKING_TIME_INPUT_VALUES = [
+  ...THINKING_TIME_LEVELS,
+  ...THINKING_TIME_ALIASES,
+] as const;
+
+export type ThinkingTimeInput = (typeof THINKING_TIME_INPUT_VALUES)[number];
+
+export function normalizeThinkingTimeLevel(
+  value: string | null | undefined,
+): ThinkingTimeLevel | null {
+  const normalized = (value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[_\s]+/g, "-");
+
+  switch (normalized) {
+    case "light":
+    case "instant":
+    case "low":
+      return "light";
+    case "standard":
+    case "medium":
+      return "standard";
+    case "extended":
+    case "high":
+      return "extended";
+    case "heavy":
+    case "extra-high":
+    case "extrahigh":
+    case "xhigh":
+      return "heavy";
+    default:
+      return null;
+  }
+}

--- a/tests/browser/modelSelection.test.ts
+++ b/tests/browser/modelSelection.test.ts
@@ -212,6 +212,190 @@ const evaluateMenuModelSelectionExpression = async (
   );
 };
 
+const evaluateIntelligenceModelSelectionExpression = async (
+  targetModel: string,
+): Promise<unknown> => {
+  class FakeEventTarget {
+    dispatchEvent(_event: unknown): boolean {
+      return true;
+    }
+  }
+
+  class FakeMouseEvent {
+    readonly type: string;
+    readonly init?: unknown;
+
+    constructor(type: string, init?: unknown) {
+      this.type = type;
+      this.init = init;
+    }
+  }
+
+  let intelligenceMenuOpen = false;
+  let gpt55SubmenuOpen = false;
+
+  class FakeElement extends FakeEventTarget {
+    constructor(
+      public textContent: string,
+      private readonly attributes: Readonly<Record<string, string>> = {},
+      private readonly children: readonly FakeElement[] = [],
+      private readonly onDispatch?: (event: unknown) => void,
+    ) {
+      super();
+    }
+
+    getAttribute(name: string): string | null {
+      return this.attributes[name] ?? null;
+    }
+
+    querySelector(selector: string): FakeElement | null {
+      if (selector.includes("model-switcher-")) {
+        return (
+          this.children.find((child) =>
+            child.getAttribute("data-testid")?.startsWith("model-switcher-"),
+          ) ?? null
+        );
+      }
+      return null;
+    }
+
+    querySelectorAll(_selector: string): FakeElement[] {
+      return [...this.children];
+    }
+
+    closest(selector: string): FakeElement | null {
+      if (selector.includes("role")) return this;
+      return null;
+    }
+
+    matches(selector: string): boolean {
+      return selector.includes("__composer-pill") &&
+        this.attributes.class?.includes("__composer-pill")
+        ? true
+        : selector.includes("aria-haspopup") && this.attributes["aria-haspopup"] === "menu";
+    }
+
+    getBoundingClientRect(): { width: number; height: number } {
+      return { width: 120, height: 36 };
+    }
+
+    override dispatchEvent(event: unknown): boolean {
+      this.onDispatch?.(event);
+      return super.dispatchEvent(event);
+    }
+  }
+
+  const fiveFive = new FakeElement("5.5", {
+    role: "menuitemradio",
+    "aria-checked": "true",
+    "data-state": "checked",
+  });
+  const gpt55Submenu = new FakeElement("5.55.45.34.5o3", { role: "menu" }, [fiveFive]);
+  const gpt55Trigger = new FakeElement(
+    "GPT-5.5",
+    {
+      role: "menuitem",
+      "aria-haspopup": "menu",
+      "aria-expanded": "false",
+      "data-state": "closed",
+    },
+    [],
+    () => {
+      gpt55SubmenuOpen = true;
+    },
+  );
+  const intelligenceMenu = new FakeElement(
+    "IntelligenceInstantMediumHighExtra HighPro ExtendedGPT-5.5",
+    { role: "menu", "data-testid": "composer-intelligence-picker-content" },
+    [
+      new FakeElement("Instant", { role: "menuitemradio", "aria-checked": "false" }),
+      new FakeElement("Medium", { role: "menuitemradio", "aria-checked": "false" }),
+      new FakeElement("High", { role: "menuitemradio", "aria-checked": "false" }),
+      new FakeElement("Extra High", { role: "menuitemradio", "aria-checked": "true" }),
+      new FakeElement("Pro Extended", { role: "menuitemradio", "aria-checked": "false" }),
+      gpt55Trigger,
+    ],
+  );
+  const modelButton = new FakeElement(
+    "Extra High",
+    { class: "__composer-pill", "aria-haspopup": "menu", "aria-expanded": "false" },
+    [],
+    () => {
+      intelligenceMenuOpen = true;
+    },
+  );
+
+  const expression = buildModelSelectionExpressionForTest(targetModel);
+  const documentStub = {
+    querySelector: (selector: string) => {
+      if (selector.includes("__composer-pill")) {
+        return modelButton;
+      }
+      if (selector.includes("model-switcher-dropdown-button")) {
+        return null;
+      }
+      return null;
+    },
+    querySelectorAll: (selector: string) => {
+      if (selector.includes("button.__composer-pill")) {
+        return [modelButton];
+      }
+      if (selector.includes('role="menu"') || selector.includes("data-radix")) {
+        return [
+          ...(intelligenceMenuOpen ? [intelligenceMenu] : []),
+          ...(gpt55SubmenuOpen ? [gpt55Submenu] : []),
+        ];
+      }
+      return [];
+    },
+    title: "",
+    body: { innerText: "" },
+    dispatchEvent: () => true,
+  };
+  let now = 0;
+  const performanceStub = { now: () => (now += 250) };
+  const windowStub = {
+    location: { href: "https://chatgpt.com/" },
+    getComputedStyle: () => ({ display: "block", visibility: "visible" }),
+  };
+  const immediateSetTimeout = (handler: TimerHandler): number => {
+    if (typeof handler === "function") {
+      handler();
+    }
+    return 0;
+  };
+  const evaluate = new Function(
+    "document",
+    "performance",
+    "setTimeout",
+    "window",
+    "EventTarget",
+    "MouseEvent",
+    "HTMLElement",
+    `return ${expression};`,
+  ) as (
+    document: unknown,
+    performance: unknown,
+    setTimeout: unknown,
+    window: unknown,
+    EventTarget: unknown,
+    MouseEvent: unknown,
+    HTMLElement: unknown,
+  ) => unknown;
+
+  return await Promise.resolve(
+    evaluate(
+      documentStub,
+      performanceStub,
+      immediateSetTimeout,
+      windowStub,
+      FakeEventTarget,
+      FakeMouseEvent,
+      FakeElement,
+    ),
+  );
+};
+
 const createNonPickerMenuForTest = (labels: string[]): unknown => {
   class FakeEventTarget {
     dispatchEvent(_event: unknown): boolean {
@@ -262,6 +446,7 @@ const createNonPickerMenuForTest = (labels: string[]): unknown => {
 const evaluateComposerPillFallbackExpression = (
   targetModel: string,
   pillLabel: string,
+  strategy: "select" | "current" = "select",
 ): unknown => {
   class FakeElement {
     constructor(public textContent: string) {}
@@ -280,7 +465,7 @@ const evaluateComposerPillFallbackExpression = (
   }
 
   const pill = new FakeElement(pillLabel);
-  const expression = buildModelSelectionExpressionForTest(targetModel);
+  const expression = buildModelSelectionExpressionForTest(targetModel, strategy);
   const documentStub = {
     querySelector: (selector: string) => {
       if (selector.includes("model-switcher-dropdown-button")) {
@@ -598,6 +783,11 @@ describe("browser model selection matchers", () => {
     expect(result).toEqual({ status: "already-selected", label: "Thinking Heavy" });
   });
 
+  it("finds the new effort-only composer pill when ChatGPT omits aria-haspopup", () => {
+    const result = evaluateComposerPillFallbackExpression("Thinking 5.5", "Extra High", "current");
+    expect(result).toEqual({ status: "already-selected", label: "Extra High" });
+  });
+
   it("allows the explicit current strategy when ChatGPT hides the model picker", () => {
     const result = evaluateNoModelButtonExpression("Pro", "current");
     expect(result).toEqual({ status: "already-selected", label: null });
@@ -794,5 +984,12 @@ describe("browser model selection matchers", () => {
     expect(expression).toContain("button.__composer-pill[aria-haspopup=");
     expect(expression).toContain("const findModelButton = () =>");
     expect(expression).toContain("button.__composer-pill')).find(looksLikeModelPill)");
+  });
+
+  it("recognizes GPT-5.5 from the new Intelligence submenu while the button shows effort", async () => {
+    await expect(evaluateIntelligenceModelSelectionExpression("Thinking 5.5")).resolves.toEqual({
+      status: "already-selected",
+      label: "GPT-5.5",
+    });
   });
 });

--- a/tests/browser/thinkingTime.test.ts
+++ b/tests/browser/thinkingTime.test.ts
@@ -446,6 +446,150 @@ describe("browser thinking-time selection expression", () => {
     expect(extended.getAttribute("aria-checked")).toBe("true");
   });
 
+  it("selects Standard from the current standalone Pro composer pill", async () => {
+    class FakeEventTarget {
+      dispatchEvent(_event: unknown): boolean {
+        return true;
+      }
+    }
+    class FakeElement extends FakeEventTarget {
+      constructor(
+        public textContent: string,
+        private readonly attributes: Record<string, string> = {},
+        private readonly children: FakeElement[] = [],
+        private readonly onDispatch?: () => void,
+      ) {
+        super();
+      }
+      getAttribute(name: string): string | null {
+        return this.attributes[name] ?? null;
+      }
+      setAttribute(name: string, value: string): void {
+        this.attributes[name] = value;
+      }
+      querySelector(_selector: string): FakeElement | null {
+        return null;
+      }
+      querySelectorAll(selector: string): FakeElement[] {
+        return selector.includes("menuitem") || selector === "button" ? this.children : [];
+      }
+      closest(_selector: string): FakeElement | null {
+        return null;
+      }
+      matches(selector: string): boolean {
+        return selector === "button.__composer-pill" && this.attributes.class === "__composer-pill";
+      }
+      contains(_node: unknown): boolean {
+        return false;
+      }
+      getBoundingClientRect(): { width: number; height: number } {
+        return { width: 144, height: 36 };
+      }
+      override dispatchEvent(event: unknown): boolean {
+        this.onDispatch?.();
+        return super.dispatchEvent(event);
+      }
+    }
+    class FakeMouseEvent {
+      constructor(
+        public readonly type: string,
+        public readonly init?: unknown,
+      ) {}
+    }
+
+    const proPill = new FakeElement(
+      "Pro",
+      {
+        class: "__composer-pill",
+        "aria-controls": "pro-effort-menu",
+        "aria-expanded": "false",
+        "aria-haspopup": "menu",
+      },
+      [],
+      () => proPill.setAttribute("aria-expanded", "true"),
+    );
+    const standard = new FakeElement(
+      "Standard",
+      {
+        role: "menuitemradio",
+        "aria-checked": "false",
+        "data-state": "unchecked",
+      },
+      [],
+      () => {
+        standard.setAttribute("aria-checked", "true");
+        standard.setAttribute("data-state", "checked");
+        extended.setAttribute("aria-checked", "false");
+        extended.setAttribute("data-state", "unchecked");
+        proPill.setAttribute("aria-expanded", "false");
+      },
+    );
+    const extended = new FakeElement("Extended", {
+      role: "menuitemradio",
+      "aria-checked": "true",
+      "data-state": "checked",
+    });
+    const effortMenu = new FakeElement(
+      "Pro thinking effort Standard Extended",
+      { role: "menu", "data-state": "open" },
+      [standard, extended],
+    );
+    const documentStub = {
+      body: new FakeElement(""),
+      querySelector: (_selector: string) => null,
+      querySelectorAll: (selector: string) => {
+        if (selector.includes("form button.__composer-pill")) return [proPill];
+        if (selector.includes("composer-footer-actions")) return [proPill];
+        if (selector.includes("__composer-pill-composite")) return [proPill];
+        if (selector.includes('[role="menu"]')) {
+          return proPill.getAttribute("aria-expanded") === "true" ? [effortMenu] : [];
+        }
+        return [];
+      },
+      getElementById: (id: string) =>
+        id === "pro-effort-menu" && proPill.getAttribute("aria-expanded") === "true"
+          ? effortMenu
+          : null,
+      dispatchEvent: () => true,
+    };
+    let now = 0;
+    const expression = buildThinkingTimeExpressionForTest("standard", "gpt-5.5-pro");
+    const evaluate = new Function(
+      "document",
+      "performance",
+      "setTimeout",
+      "window",
+      "EventTarget",
+      "PointerEvent",
+      "MouseEvent",
+      "HTMLElement",
+      `return ${expression};`,
+    ) as (
+      document: unknown,
+      performance: unknown,
+      setTimeout: unknown,
+      window: unknown,
+      EventTarget: unknown,
+      PointerEvent: unknown,
+      MouseEvent: unknown,
+      HTMLElement: unknown,
+    ) => Promise<unknown>;
+
+    await expect(
+      evaluate(
+        documentStub,
+        { now: () => (now += 100) },
+        (callback: () => void) => callback(),
+        { PointerEvent: FakeMouseEvent, MouseEvent: FakeMouseEvent, Event: FakeMouseEvent },
+        FakeEventTarget,
+        FakeMouseEvent,
+        FakeMouseEvent,
+        FakeElement,
+      ),
+    ).resolves.toEqual({ status: "switched", label: "Standard" });
+    expect(standard.getAttribute("aria-checked")).toBe("true");
+  });
+
   it("captures a model-picker diagnostic on failure outcomes", () => {
     const expression = buildThinkingTimeExpressionForTest("extended", "gpt-5.5-pro");
     expect(expression).toContain("collectPickerDiagnostic");

--- a/tests/browser/thinkingTime.test.ts
+++ b/tests/browser/thinkingTime.test.ts
@@ -121,8 +121,11 @@ describe("browser thinking-time selection expression", () => {
         return this.parent;
       }
 
-      matches(_selector: string): boolean {
-        return false;
+      matches(selector: string): boolean {
+        return (
+          selector.includes("__composer-pill") &&
+          this.attributes.class?.includes("__composer-pill") === true
+        );
       }
 
       getBoundingClientRect(): { width: number; height: number } {
@@ -148,6 +151,9 @@ describe("browser thinking-time selection expression", () => {
     const modelButton = new FakeElement("Extended", {
       "data-testid": "model-switcher-dropdown-button",
       "aria-expanded": "true",
+    });
+    const unrelatedComposerPill = new FakeElement("Canvas", {
+      class: "__composer-pill",
     });
     const thinkingRow = new FakeElement("", {
       "data-model-picker-thinking-effort-row": "true",
@@ -183,10 +189,12 @@ describe("browser thinking-time selection expression", () => {
       body: new FakeElement(""),
       querySelector: (selector: string) =>
         selector.includes("model-switcher-dropdown-button") ? modelButton : null,
-      querySelectorAll: (selector: string) =>
-        selector.includes("data-model-picker-thinking-effort-action")
+      querySelectorAll: (selector: string) => {
+        if (selector.includes("__composer-pill")) return [unrelatedComposerPill];
+        return selector.includes("data-model-picker-thinking-effort-action")
           ? [thinkingTrailing, proTrailing]
-          : [],
+          : [];
+      },
       dispatchEvent: () => true,
     };
     const performanceStub = {
@@ -1229,7 +1237,7 @@ describe("browser thinking-time selection expression", () => {
     ).resolves.toEqual({ status: "switched", label: "Pro Extended" });
   });
 
-  it("confirms Extra High from the Intelligence menu for Thinking heavy", async () => {
+  it("confirms Extra High from an effort-only pill without aria-haspopup", async () => {
     class FakeEventTarget {
       dispatchEvent(_event: unknown): boolean {
         return true;
@@ -1293,22 +1301,21 @@ describe("browser thinking-time selection expression", () => {
     const modelButton = new FakeElement("Extra High", {
       class: "__composer-pill",
       "aria-expanded": "true",
-      "aria-haspopup": "menu",
     });
     const documentStub = {
       body: new FakeElement(""),
       querySelector: (selector: string) => {
         if (selector.includes("composer-intelligence-picker-content")) return intelligenceMenu;
-        if (
-          selector.includes("model-switcher-dropdown-button") ||
-          selector.includes("__composer-pill")
-        ) {
+        if (selector.includes("model-switcher-dropdown-button")) return null;
+        if (selector.includes("__composer-pill") && !selector.includes("aria-haspopup")) {
           return modelButton;
         }
         return null;
       },
       querySelectorAll: (selector: string) => {
-        if (selector.includes("__composer-pill")) return [modelButton];
+        if (selector.includes("__composer-pill")) {
+          return selector.includes("aria-haspopup") ? [] : [modelButton];
+        }
         if (selector.includes('role="menu"') || selector.includes("data-radix")) {
           return [intelligenceMenu];
         }

--- a/tests/browser/thinkingTime.test.ts
+++ b/tests/browser/thinkingTime.test.ts
@@ -649,4 +649,488 @@ describe("browser thinking-time selection expression", () => {
       ),
     ).resolves.toEqual({ status: "already-selected", label: "Pro Extended" });
   });
+
+  it("opens the Pro effort submenu before selecting Pro Standard", async () => {
+    class FakeEventTarget {
+      dispatchEvent(_event: unknown): boolean {
+        return true;
+      }
+    }
+    class FakeElement extends FakeEventTarget {
+      constructor(
+        public textContent: string,
+        private readonly attributes: Record<string, string> = {},
+        private readonly children: FakeElement[] = [],
+        private readonly onDispatch?: () => void,
+      ) {
+        super();
+      }
+      getAttribute(name: string): string | null {
+        return this.attributes[name] ?? null;
+      }
+      setAttribute(name: string, value: string): void {
+        this.attributes[name] = value;
+      }
+      querySelector(selector: string): FakeElement | null {
+        if (selector.includes("menu-label")) {
+          return new FakeElement("Intelligence");
+        }
+        return null;
+      }
+      querySelectorAll(_selector: string): FakeElement[] {
+        return this.children;
+      }
+      closest(_selector: string): FakeElement | null {
+        return null;
+      }
+      matches(selector: string): boolean {
+        return selector.includes("__composer-pill") &&
+          this.attributes.class?.includes("__composer-pill")
+          ? true
+          : false;
+      }
+      focus(): void {}
+      getBoundingClientRect(): { width: number; height: number } {
+        return { width: 144, height: 36 };
+      }
+      override dispatchEvent(event: unknown): boolean {
+        this.onDispatch?.();
+        return super.dispatchEvent(event);
+      }
+    }
+    class FakeMouseEvent {
+      constructor(
+        public readonly type: string,
+        public readonly init?: unknown,
+      ) {}
+    }
+
+    let proSubmenuOpen = false;
+    const mediumRadio = new FakeElement("Medium", {
+      role: "menuitemradio",
+      "aria-checked": "false",
+      "data-state": "unchecked",
+    });
+    const proTrigger = new FakeElement(
+      "",
+      {
+        role: "menuitem",
+        "aria-haspopup": "menu",
+        "aria-expanded": "false",
+        "data-state": "closed",
+        "data-testid": "composer-intelligence-pro-thinking-effort-trigger",
+      },
+      [],
+      () => {
+        proSubmenuOpen = true;
+        proTrigger.setAttribute("aria-expanded", "true");
+        proTrigger.setAttribute("data-state", "open");
+      },
+    );
+    const intelligenceMenu = new FakeElement(
+      "IntelligenceInstantMediumHighExtra HighPro ExtendedGPT-5.5",
+      { "data-testid": "composer-intelligence-picker-content", role: "menu" },
+      [
+        new FakeElement("Instant", { role: "menuitemradio", "aria-checked": "false" }),
+        mediumRadio,
+        new FakeElement("High", { role: "menuitemradio", "aria-checked": "false" }),
+        new FakeElement("Extra High", { role: "menuitemradio", "aria-checked": "false" }),
+        new FakeElement("Pro Extended", { role: "menuitemradio", "aria-checked": "true" }),
+        proTrigger,
+        new FakeElement("GPT-5.5", { role: "menuitem", "aria-haspopup": "menu" }),
+      ],
+    );
+    const proStandardRadio = new FakeElement(
+      "Pro Standard",
+      {
+        role: "menuitemradio",
+        "aria-checked": "false",
+        "data-state": "unchecked",
+      },
+      [],
+      () => {
+        proStandardRadio.setAttribute("aria-checked", "true");
+        proStandardRadio.setAttribute("data-state", "checked");
+        mediumRadio.setAttribute("aria-checked", "false");
+        mediumRadio.setAttribute("data-state", "unchecked");
+      },
+    );
+    const proSubmenu = new FakeElement("Pro StandardPro Extended", { role: "menu" }, [
+      proStandardRadio,
+      new FakeElement("Pro Extended", {
+        role: "menuitemradio",
+        "aria-checked": "false",
+        "data-state": "unchecked",
+      }),
+    ]);
+    const modelButton = new FakeElement("Pro Extended", {
+      class: "__composer-pill",
+      "aria-expanded": "true",
+      "aria-haspopup": "menu",
+    });
+    const documentStub = {
+      body: new FakeElement(""),
+      querySelector: (selector: string) => {
+        if (selector.includes("composer-intelligence-pro-thinking-effort-trigger")) {
+          return proTrigger;
+        }
+        if (selector.includes("composer-intelligence-picker-content")) return intelligenceMenu;
+        if (
+          selector.includes("model-switcher-dropdown-button") ||
+          selector.includes("__composer-pill")
+        ) {
+          return modelButton;
+        }
+        return null;
+      },
+      querySelectorAll: (selector: string) => {
+        if (selector.includes("__composer-pill")) return [modelButton];
+        if (selector.includes('role="menu"') || selector.includes("data-radix")) {
+          return proSubmenuOpen ? [intelligenceMenu, proSubmenu] : [intelligenceMenu];
+        }
+        return [];
+      },
+      dispatchEvent: () => true,
+    };
+    let now = 0;
+    const performanceStub = { now: () => (now += 100) };
+    const expression = buildThinkingTimeExpressionForTest("standard", "gpt-5.5-pro");
+    const evaluate = new Function(
+      "document",
+      "performance",
+      "setTimeout",
+      "window",
+      "EventTarget",
+      "PointerEvent",
+      "MouseEvent",
+      "HTMLElement",
+      `return ${expression};`,
+    ) as (
+      document: unknown,
+      performance: unknown,
+      setTimeout: unknown,
+      window: unknown,
+      EventTarget: unknown,
+      PointerEvent: unknown,
+      MouseEvent: unknown,
+      HTMLElement: unknown,
+    ) => Promise<unknown>;
+
+    await expect(
+      evaluate(
+        documentStub,
+        performanceStub,
+        (callback: () => void) => callback(),
+        { PointerEvent: FakeMouseEvent, MouseEvent: FakeMouseEvent, Event: FakeMouseEvent },
+        FakeEventTarget,
+        FakeMouseEvent,
+        FakeMouseEvent,
+        FakeElement,
+      ),
+    ).resolves.toEqual({ status: "switched", label: "Pro Standard" });
+  });
+
+  it("verifies Pro Extended when the submenu closes after selection", async () => {
+    class FakeEventTarget {
+      dispatchEvent(_event: unknown): boolean {
+        return true;
+      }
+    }
+    class FakeElement extends FakeEventTarget {
+      constructor(
+        public textContent: string,
+        private readonly attributes: Record<string, string> = {},
+        private readonly children: FakeElement[] = [],
+        private readonly onDispatch?: () => void,
+      ) {
+        super();
+      }
+      getAttribute(name: string): string | null {
+        return this.attributes[name] ?? null;
+      }
+      setAttribute(name: string, value: string): void {
+        this.attributes[name] = value;
+      }
+      querySelector(selector: string): FakeElement | null {
+        if (selector.includes("menu-label")) {
+          return new FakeElement("Intelligence");
+        }
+        return null;
+      }
+      querySelectorAll(_selector: string): FakeElement[] {
+        return this.children;
+      }
+      closest(_selector: string): FakeElement | null {
+        return null;
+      }
+      matches(selector: string): boolean {
+        return selector.includes("__composer-pill") &&
+          this.attributes.class?.includes("__composer-pill")
+          ? true
+          : false;
+      }
+      focus(): void {}
+      getBoundingClientRect(): { width: number; height: number } {
+        return { width: 144, height: 36 };
+      }
+      override dispatchEvent(event: unknown): boolean {
+        this.onDispatch?.();
+        return super.dispatchEvent(event);
+      }
+    }
+    class FakeMouseEvent {
+      constructor(
+        public readonly type: string,
+        public readonly init?: unknown,
+      ) {}
+    }
+
+    let intelligenceMenuOpen = true;
+    let proSubmenuOpen = false;
+    const proTrigger = new FakeElement(
+      "",
+      {
+        role: "menuitem",
+        "aria-haspopup": "menu",
+        "aria-expanded": "false",
+        "data-state": "closed",
+        "data-testid": "composer-intelligence-pro-thinking-effort-trigger",
+      },
+      [],
+      () => {
+        proSubmenuOpen = true;
+        proTrigger.setAttribute("aria-expanded", "true");
+        proTrigger.setAttribute("data-state", "open");
+      },
+    );
+    const intelligenceMenu = new FakeElement(
+      "IntelligenceInstantMediumHighExtra HighProGPT-5.5",
+      { "data-testid": "composer-intelligence-picker-content", role: "menu" },
+      [
+        new FakeElement("Instant", { role: "menuitemradio", "aria-checked": "false" }),
+        new FakeElement("Medium", { role: "menuitemradio", "aria-checked": "false" }),
+        new FakeElement("High", { role: "menuitemradio", "aria-checked": "false" }),
+        new FakeElement("Extra High", { role: "menuitemradio", "aria-checked": "false" }),
+        new FakeElement("Pro", { role: "menuitemradio", "aria-checked": "true" }),
+        proTrigger,
+        new FakeElement("GPT-5.5", { role: "menuitem", "aria-haspopup": "menu" }),
+      ],
+    );
+    const modelButton = new FakeElement("Pro", {
+      class: "__composer-pill",
+      "aria-expanded": "true",
+      "aria-haspopup": "menu",
+    });
+    const proExtendedRadio = new FakeElement(
+      "Pro Extended",
+      {
+        role: "menuitemradio",
+        "aria-checked": "false",
+        "data-state": "unchecked",
+      },
+      [],
+      () => {
+        modelButton.textContent = "Pro Extended";
+        modelButton.setAttribute("aria-expanded", "false");
+        intelligenceMenuOpen = false;
+        proSubmenuOpen = false;
+      },
+    );
+    const proSubmenu = new FakeElement("Pro StandardPro Extended", { role: "menu" }, [
+      new FakeElement("Pro Standard", {
+        role: "menuitemradio",
+        "aria-checked": "true",
+        "data-state": "checked",
+      }),
+      proExtendedRadio,
+    ]);
+    const documentStub = {
+      body: new FakeElement(""),
+      querySelector: (selector: string) => {
+        if (selector.includes("composer-intelligence-pro-thinking-effort-trigger")) {
+          return intelligenceMenuOpen ? proTrigger : null;
+        }
+        if (selector.includes("composer-intelligence-picker-content")) {
+          return intelligenceMenuOpen ? intelligenceMenu : null;
+        }
+        if (
+          selector.includes("model-switcher-dropdown-button") ||
+          selector.includes("__composer-pill")
+        ) {
+          return modelButton;
+        }
+        return null;
+      },
+      querySelectorAll: (selector: string) => {
+        if (selector.includes("__composer-pill")) return [modelButton];
+        if (selector.includes('role="menu"') || selector.includes("data-radix")) {
+          if (!intelligenceMenuOpen) return [];
+          return proSubmenuOpen ? [intelligenceMenu, proSubmenu] : [intelligenceMenu];
+        }
+        return [];
+      },
+      dispatchEvent: () => true,
+    };
+    let now = 0;
+    const performanceStub = { now: () => (now += 100) };
+    const expression = buildThinkingTimeExpressionForTest("extended", "gpt-5.5-pro");
+    const evaluate = new Function(
+      "document",
+      "performance",
+      "setTimeout",
+      "window",
+      "EventTarget",
+      "PointerEvent",
+      "MouseEvent",
+      "HTMLElement",
+      `return ${expression};`,
+    ) as (
+      document: unknown,
+      performance: unknown,
+      setTimeout: unknown,
+      window: unknown,
+      EventTarget: unknown,
+      PointerEvent: unknown,
+      MouseEvent: unknown,
+      HTMLElement: unknown,
+    ) => Promise<unknown>;
+
+    await expect(
+      evaluate(
+        documentStub,
+        performanceStub,
+        (callback: () => void) => callback(),
+        { PointerEvent: FakeMouseEvent, MouseEvent: FakeMouseEvent, Event: FakeMouseEvent },
+        FakeEventTarget,
+        FakeMouseEvent,
+        FakeMouseEvent,
+        FakeElement,
+      ),
+    ).resolves.toEqual({ status: "switched", label: "Pro Extended" });
+  });
+
+  it("confirms Extra High from the Intelligence menu for Thinking heavy", async () => {
+    class FakeEventTarget {
+      dispatchEvent(_event: unknown): boolean {
+        return true;
+      }
+    }
+    class FakeElement extends FakeEventTarget {
+      constructor(
+        public textContent: string,
+        private readonly attributes: Readonly<Record<string, string>> = {},
+        private readonly children: FakeElement[] = [],
+      ) {
+        super();
+      }
+      getAttribute(name: string): string | null {
+        return this.attributes[name] ?? null;
+      }
+      querySelector(selector: string): FakeElement | null {
+        if (selector.includes("menu-label")) {
+          return new FakeElement("Intelligence");
+        }
+        return null;
+      }
+      querySelectorAll(_selector: string): FakeElement[] {
+        return this.children;
+      }
+      closest(_selector: string): FakeElement | null {
+        return null;
+      }
+      matches(selector: string): boolean {
+        return selector.includes("__composer-pill") &&
+          this.attributes.class?.includes("__composer-pill")
+          ? true
+          : false;
+      }
+      getBoundingClientRect(): { width: number; height: number } {
+        return { width: 144, height: 36 };
+      }
+    }
+    class FakeMouseEvent {
+      constructor(
+        public readonly type: string,
+        public readonly init?: unknown,
+      ) {}
+    }
+
+    const extraHighRadio = new FakeElement("Extra High", {
+      role: "menuitemradio",
+      "aria-checked": "true",
+    });
+    const intelligenceMenu = new FakeElement(
+      "IntelligenceInstantMediumHighExtra HighPro ExtendedGPT-5.5",
+      { "data-testid": "composer-intelligence-picker-content", role: "menu" },
+      [
+        new FakeElement("Instant", { role: "menuitemradio", "aria-checked": "false" }),
+        new FakeElement("Medium", { role: "menuitemradio", "aria-checked": "false" }),
+        new FakeElement("High", { role: "menuitemradio", "aria-checked": "false" }),
+        extraHighRadio,
+        new FakeElement("Pro Extended", { role: "menuitemradio", "aria-checked": "false" }),
+      ],
+    );
+    const modelButton = new FakeElement("Extra High", {
+      class: "__composer-pill",
+      "aria-expanded": "true",
+      "aria-haspopup": "menu",
+    });
+    const documentStub = {
+      body: new FakeElement(""),
+      querySelector: (selector: string) => {
+        if (selector.includes("composer-intelligence-picker-content")) return intelligenceMenu;
+        if (
+          selector.includes("model-switcher-dropdown-button") ||
+          selector.includes("__composer-pill")
+        ) {
+          return modelButton;
+        }
+        return null;
+      },
+      querySelectorAll: (selector: string) => {
+        if (selector.includes("__composer-pill")) return [modelButton];
+        if (selector.includes('role="menu"') || selector.includes("data-radix")) {
+          return [intelligenceMenu];
+        }
+        return [];
+      },
+      dispatchEvent: () => true,
+    };
+    let now = 0;
+    const performanceStub = { now: () => (now += 100) };
+    const expression = buildThinkingTimeExpressionForTest("heavy", "Thinking 5.5");
+    const evaluate = new Function(
+      "document",
+      "performance",
+      "setTimeout",
+      "window",
+      "EventTarget",
+      "PointerEvent",
+      "MouseEvent",
+      "HTMLElement",
+      `return ${expression};`,
+    ) as (
+      document: unknown,
+      performance: unknown,
+      setTimeout: unknown,
+      window: unknown,
+      EventTarget: unknown,
+      PointerEvent: unknown,
+      MouseEvent: unknown,
+      HTMLElement: unknown,
+    ) => Promise<unknown>;
+
+    await expect(
+      evaluate(
+        documentStub,
+        performanceStub,
+        (callback: () => void) => callback(),
+        { PointerEvent: FakeMouseEvent, MouseEvent: FakeMouseEvent, Event: FakeMouseEvent },
+        FakeEventTarget,
+        FakeMouseEvent,
+        FakeMouseEvent,
+        FakeElement,
+      ),
+    ).resolves.toEqual({ status: "already-selected", label: "Extra High" });
+  });
 });

--- a/tests/browser/thinkingTime.test.ts
+++ b/tests/browser/thinkingTime.test.ts
@@ -695,10 +695,10 @@ describe("browser thinking-time selection expression", () => {
         return null;
       }
       matches(selector: string): boolean {
-        return selector.includes("__composer-pill") &&
-          this.attributes.class?.includes("__composer-pill")
-          ? true
-          : false;
+        return (
+          selector.includes("__composer-pill") &&
+          this.attributes.class?.includes("__composer-pill") === true
+        );
       }
       focus(): void {}
       getBoundingClientRect(): { width: number; height: number } {
@@ -875,10 +875,10 @@ describe("browser thinking-time selection expression", () => {
         return null;
       }
       matches(selector: string): boolean {
-        return selector.includes("__composer-pill") &&
-          this.attributes.class?.includes("__composer-pill")
-          ? true
-          : false;
+        return (
+          selector.includes("__composer-pill") &&
+          this.attributes.class?.includes("__composer-pill") === true
+        );
       }
       focus(): void {}
       getBoundingClientRect(): { width: number; height: number } {
@@ -1050,10 +1050,10 @@ describe("browser thinking-time selection expression", () => {
         return null;
       }
       matches(selector: string): boolean {
-        return selector.includes("__composer-pill") &&
-          this.attributes.class?.includes("__composer-pill")
-          ? true
-          : false;
+        return (
+          selector.includes("__composer-pill") &&
+          this.attributes.class?.includes("__composer-pill") === true
+        );
       }
       getBoundingClientRect(): { width: number; height: number } {
         return { width: 144, height: 36 };
@@ -1179,10 +1179,10 @@ describe("browser thinking-time selection expression", () => {
         return null;
       }
       matches(selector: string): boolean {
-        return selector.includes("__composer-pill") &&
-          this.attributes.class?.includes("__composer-pill")
-          ? true
-          : false;
+        return (
+          selector.includes("__composer-pill") &&
+          this.attributes.class?.includes("__composer-pill") === true
+        );
       }
       getBoundingClientRect(): { width: number; height: number } {
         return { width: 144, height: 36 };
@@ -1317,10 +1317,10 @@ describe("browser thinking-time selection expression", () => {
         return null;
       }
       matches(selector: string): boolean {
-        return selector.includes("__composer-pill") &&
-          this.attributes.class?.includes("__composer-pill")
-          ? true
-          : false;
+        return (
+          selector.includes("__composer-pill") &&
+          this.attributes.class?.includes("__composer-pill") === true
+        );
       }
       getBoundingClientRect(): { width: number; height: number } {
         return { width: 144, height: 36 };

--- a/tests/browser/thinkingTime.test.ts
+++ b/tests/browser/thinkingTime.test.ts
@@ -38,6 +38,17 @@ describe("browser thinking-time selection expression", () => {
     expect(expression).toContain("return selectAndVerify(trailing");
   });
 
+  it("maps ChatGPT's new Intelligence labels onto existing thinking levels", () => {
+    expect(buildThinkingTimeExpressionForTest("light")).toContain("light: ['light', 'instant'");
+    expect(buildThinkingTimeExpressionForTest("standard")).toContain(
+      "standard: ['standard', 'medium'",
+    );
+    expect(buildThinkingTimeExpressionForTest("extended")).toContain(
+      "extended: ['extended', 'high'",
+    );
+    expect(buildThinkingTimeExpressionForTest("heavy")).toContain("heavy: ['heavy', 'extra high'");
+  });
+
   it("accepts standard selected-state markers when verifying effort", () => {
     const expression = buildThinkingTimeExpressionForTest("extended");
     expect(expression).toContain("aria-selected");
@@ -1132,5 +1143,285 @@ describe("browser thinking-time selection expression", () => {
         FakeElement,
       ),
     ).resolves.toEqual({ status: "already-selected", label: "Extra High" });
+  });
+
+  it("selects High for Thinking extended without matching Extra High", async () => {
+    class FakeEventTarget {
+      dispatchEvent(_event: unknown): boolean {
+        return true;
+      }
+    }
+    class FakeElement extends FakeEventTarget {
+      constructor(
+        public textContent: string,
+        private readonly attributes: Record<string, string> = {},
+        private readonly children: FakeElement[] = [],
+        private readonly onDispatch?: () => void,
+      ) {
+        super();
+      }
+      getAttribute(name: string): string | null {
+        return this.attributes[name] ?? null;
+      }
+      setAttribute(name: string, value: string): void {
+        this.attributes[name] = value;
+      }
+      querySelector(selector: string): FakeElement | null {
+        if (selector.includes("menu-label")) {
+          return new FakeElement("Intelligence");
+        }
+        return null;
+      }
+      querySelectorAll(_selector: string): FakeElement[] {
+        return this.children;
+      }
+      closest(_selector: string): FakeElement | null {
+        return null;
+      }
+      matches(selector: string): boolean {
+        return selector.includes("__composer-pill") &&
+          this.attributes.class?.includes("__composer-pill")
+          ? true
+          : false;
+      }
+      getBoundingClientRect(): { width: number; height: number } {
+        return { width: 144, height: 36 };
+      }
+      override dispatchEvent(event: unknown): boolean {
+        this.onDispatch?.();
+        return super.dispatchEvent(event);
+      }
+    }
+    class FakeMouseEvent {
+      constructor(
+        public readonly type: string,
+        public readonly init?: unknown,
+      ) {}
+    }
+
+    const highRadio = new FakeElement(
+      "High",
+      { role: "menuitemradio", "aria-checked": "false", "data-state": "unchecked" },
+      [],
+      () => {
+        highRadio.setAttribute("aria-checked", "true");
+        highRadio.setAttribute("data-state", "checked");
+      },
+    );
+    const intelligenceMenu = new FakeElement(
+      "IntelligenceInstantMediumExtra HighHighPro ExtendedGPT-5.5",
+      { "data-testid": "composer-intelligence-picker-content", role: "menu" },
+      [
+        new FakeElement("Instant", { role: "menuitemradio", "aria-checked": "false" }),
+        new FakeElement("Medium", { role: "menuitemradio", "aria-checked": "false" }),
+        new FakeElement("Extra High", { role: "menuitemradio", "aria-checked": "false" }),
+        highRadio,
+        new FakeElement("Pro Extended", { role: "menuitemradio", "aria-checked": "false" }),
+      ],
+    );
+    const modelButton = new FakeElement("Extra High", {
+      class: "__composer-pill",
+      "aria-expanded": "true",
+      "aria-haspopup": "menu",
+    });
+    const documentStub = {
+      body: new FakeElement(""),
+      querySelector: (selector: string) => {
+        if (selector.includes("composer-intelligence-picker-content")) return intelligenceMenu;
+        if (
+          selector.includes("model-switcher-dropdown-button") ||
+          selector.includes("__composer-pill")
+        ) {
+          return modelButton;
+        }
+        return null;
+      },
+      querySelectorAll: (selector: string) => {
+        if (selector.includes("__composer-pill")) return [modelButton];
+        if (selector.includes('role="menu"') || selector.includes("data-radix")) {
+          return [intelligenceMenu];
+        }
+        return [];
+      },
+      dispatchEvent: () => true,
+    };
+    let now = 0;
+    const performanceStub = { now: () => (now += 100) };
+    const expression = buildThinkingTimeExpressionForTest("extended", "Thinking 5.5");
+    const evaluate = new Function(
+      "document",
+      "performance",
+      "setTimeout",
+      "window",
+      "EventTarget",
+      "PointerEvent",
+      "MouseEvent",
+      "HTMLElement",
+      `return ${expression};`,
+    ) as (
+      document: unknown,
+      performance: unknown,
+      setTimeout: unknown,
+      window: unknown,
+      EventTarget: unknown,
+      PointerEvent: unknown,
+      MouseEvent: unknown,
+      HTMLElement: unknown,
+    ) => Promise<unknown>;
+
+    await expect(
+      evaluate(
+        documentStub,
+        performanceStub,
+        (callback: () => void) => callback(),
+        { PointerEvent: FakeMouseEvent, MouseEvent: FakeMouseEvent, Event: FakeMouseEvent },
+        FakeEventTarget,
+        FakeMouseEvent,
+        FakeMouseEvent,
+        FakeElement,
+      ),
+    ).resolves.toEqual({ status: "switched", label: "High" });
+  });
+
+  it("verifies non-Pro Intelligence selection from the composer pill when the menu closes", async () => {
+    class FakeEventTarget {
+      dispatchEvent(_event: unknown): boolean {
+        return true;
+      }
+    }
+    class FakeElement extends FakeEventTarget {
+      constructor(
+        public textContent: string,
+        private readonly attributes: Record<string, string> = {},
+        private readonly children: FakeElement[] = [],
+        private readonly onDispatch?: () => void,
+      ) {
+        super();
+      }
+      getAttribute(name: string): string | null {
+        return this.attributes[name] ?? null;
+      }
+      setAttribute(name: string, value: string): void {
+        this.attributes[name] = value;
+      }
+      querySelector(selector: string): FakeElement | null {
+        if (selector.includes("menu-label")) {
+          return new FakeElement("Intelligence");
+        }
+        return null;
+      }
+      querySelectorAll(_selector: string): FakeElement[] {
+        return this.children;
+      }
+      closest(_selector: string): FakeElement | null {
+        return null;
+      }
+      matches(selector: string): boolean {
+        return selector.includes("__composer-pill") &&
+          this.attributes.class?.includes("__composer-pill")
+          ? true
+          : false;
+      }
+      getBoundingClientRect(): { width: number; height: number } {
+        return { width: 144, height: 36 };
+      }
+      override dispatchEvent(event: unknown): boolean {
+        this.onDispatch?.();
+        return super.dispatchEvent(event);
+      }
+    }
+    class FakeMouseEvent {
+      constructor(
+        public readonly type: string,
+        public readonly init?: unknown,
+      ) {}
+    }
+
+    let intelligenceMenuOpen = true;
+    const modelButton = new FakeElement("Extra High", {
+      class: "__composer-pill",
+      "aria-expanded": "true",
+      "aria-haspopup": "menu",
+    });
+    const instantRadio = new FakeElement(
+      "Instant",
+      { role: "menuitemradio", "aria-checked": "false", "data-state": "unchecked" },
+      [],
+      () => {
+        modelButton.textContent = "Instant";
+        modelButton.setAttribute("aria-expanded", "false");
+        intelligenceMenuOpen = false;
+      },
+    );
+    const intelligenceMenu = new FakeElement(
+      "IntelligenceInstantMediumHighExtra HighPro ExtendedGPT-5.5",
+      { "data-testid": "composer-intelligence-picker-content", role: "menu" },
+      [
+        instantRadio,
+        new FakeElement("Medium", { role: "menuitemradio", "aria-checked": "false" }),
+        new FakeElement("High", { role: "menuitemradio", "aria-checked": "false" }),
+        new FakeElement("Extra High", { role: "menuitemradio", "aria-checked": "true" }),
+        new FakeElement("Pro Extended", { role: "menuitemradio", "aria-checked": "false" }),
+      ],
+    );
+    const documentStub = {
+      body: new FakeElement(""),
+      querySelector: (selector: string) => {
+        if (selector.includes("composer-intelligence-picker-content")) {
+          return intelligenceMenuOpen ? intelligenceMenu : null;
+        }
+        if (
+          selector.includes("model-switcher-dropdown-button") ||
+          selector.includes("__composer-pill")
+        ) {
+          return modelButton;
+        }
+        return null;
+      },
+      querySelectorAll: (selector: string) => {
+        if (selector.includes("__composer-pill")) return [modelButton];
+        if (selector.includes('role="menu"') || selector.includes("data-radix")) {
+          return intelligenceMenuOpen ? [intelligenceMenu] : [];
+        }
+        return [];
+      },
+      dispatchEvent: () => true,
+    };
+    let now = 0;
+    const performanceStub = { now: () => (now += 100) };
+    const expression = buildThinkingTimeExpressionForTest("light", "Thinking 5.5");
+    const evaluate = new Function(
+      "document",
+      "performance",
+      "setTimeout",
+      "window",
+      "EventTarget",
+      "PointerEvent",
+      "MouseEvent",
+      "HTMLElement",
+      `return ${expression};`,
+    ) as (
+      document: unknown,
+      performance: unknown,
+      setTimeout: unknown,
+      window: unknown,
+      EventTarget: unknown,
+      PointerEvent: unknown,
+      MouseEvent: unknown,
+      HTMLElement: unknown,
+    ) => Promise<unknown>;
+
+    await expect(
+      evaluate(
+        documentStub,
+        performanceStub,
+        (callback: () => void) => callback(),
+        { PointerEvent: FakeMouseEvent, MouseEvent: FakeMouseEvent, Event: FakeMouseEvent },
+        FakeEventTarget,
+        FakeMouseEvent,
+        FakeMouseEvent,
+        FakeElement,
+      ),
+    ).resolves.toEqual({ status: "switched", label: "Instant" });
   });
 });

--- a/tests/browser/thinkingTime.test.ts
+++ b/tests/browser/thinkingTime.test.ts
@@ -778,22 +778,21 @@ describe("browser thinking-time selection expression", () => {
     const modelButton = new FakeElement("Pro Extended", {
       class: "__composer-pill",
       "aria-expanded": "true",
-      "aria-haspopup": "menu",
     });
     const documentStub = {
       body: new FakeElement(""),
       querySelector: (selector: string) => {
         if (selector.includes("composer-intelligence-picker-content")) return intelligenceMenu;
-        if (
-          selector.includes("model-switcher-dropdown-button") ||
-          selector.includes("__composer-pill")
-        ) {
+        if (selector.includes("model-switcher-dropdown-button")) return null;
+        if (selector.includes("__composer-pill") && !selector.includes("aria-haspopup")) {
           return modelButton;
         }
         return null;
       },
       querySelectorAll: (selector: string) => {
-        if (selector.includes("__composer-pill")) return [modelButton];
+        if (selector.includes("__composer-pill")) {
+          return selector.includes("aria-haspopup") ? [] : [modelButton];
+        }
         if (selector.includes('role="menu"') || selector.includes("data-radix")) {
           return [intelligenceMenu];
         }
@@ -1438,22 +1437,21 @@ describe("browser thinking-time selection expression", () => {
     const modelButton = new FakeElement("Extra High", {
       class: "__composer-pill",
       "aria-expanded": "true",
-      "aria-haspopup": "menu",
     });
     const documentStub = {
       body: new FakeElement(""),
       querySelector: (selector: string) => {
         if (selector.includes("composer-intelligence-picker-content")) return intelligenceMenu;
-        if (
-          selector.includes("model-switcher-dropdown-button") ||
-          selector.includes("__composer-pill")
-        ) {
+        if (selector.includes("model-switcher-dropdown-button")) return null;
+        if (selector.includes("__composer-pill") && !selector.includes("aria-haspopup")) {
           return modelButton;
         }
         return null;
       },
       querySelectorAll: (selector: string) => {
-        if (selector.includes("__composer-pill")) return [modelButton];
+        if (selector.includes("__composer-pill")) {
+          return selector.includes("aria-haspopup") ? [] : [modelButton];
+        }
         if (selector.includes('role="menu"') || selector.includes("data-radix")) {
           return [intelligenceMenu];
         }
@@ -1557,7 +1555,6 @@ describe("browser thinking-time selection expression", () => {
     const modelButton = new FakeElement("Extra High", {
       class: "__composer-pill",
       "aria-expanded": "true",
-      "aria-haspopup": "menu",
     });
     const instantRadio = new FakeElement(
       "Instant",
@@ -1586,16 +1583,16 @@ describe("browser thinking-time selection expression", () => {
         if (selector.includes("composer-intelligence-picker-content")) {
           return intelligenceMenuOpen ? intelligenceMenu : null;
         }
-        if (
-          selector.includes("model-switcher-dropdown-button") ||
-          selector.includes("__composer-pill")
-        ) {
+        if (selector.includes("model-switcher-dropdown-button")) return null;
+        if (selector.includes("__composer-pill") && !selector.includes("aria-haspopup")) {
           return modelButton;
         }
         return null;
       },
       querySelectorAll: (selector: string) => {
-        if (selector.includes("__composer-pill")) return [modelButton];
+        if (selector.includes("__composer-pill")) {
+          return selector.includes("aria-haspopup") ? [] : [modelButton];
+        }
         if (selector.includes('role="menu"') || selector.includes("data-radix")) {
           return intelligenceMenuOpen ? [intelligenceMenu] : [];
         }

--- a/tests/browser/thinkingTime.test.ts
+++ b/tests/browser/thinkingTime.test.ts
@@ -275,6 +275,18 @@ describe("browser thinking-time selection expression", () => {
     }
   });
 
+  it("fails closed when the current model is inferred as Pro", async () => {
+    const runtime = {
+      evaluate: async () => ({
+        result: { value: { status: "selection-unverified", modelKind: "pro" } },
+      }),
+    };
+
+    await expect(
+      ensureThinkingTime(runtime as never, "extended", (() => {}) as never, null),
+    ).rejects.toThrow(/refusing to submit without confirmed Pro Extended/);
+  });
+
   it("keeps thinking effort best-effort when no target model kind is provided", async () => {
     const runtime = {
       evaluate: async () => ({
@@ -699,7 +711,7 @@ describe("browser thinking-time selection expression", () => {
     expect(serialized).not.toContain(secret);
   });
 
-  it("confirms Pro Extended from the Intelligence menu's checked radio", async () => {
+  it("preserves current Pro Extended when no target model kind is supplied", async () => {
     class FakeEventTarget {
       dispatchEvent(_event: unknown): boolean {
         return true;
@@ -725,8 +737,11 @@ describe("browser thinking-time selection expression", () => {
       closest(_selector: string): FakeElement | null {
         return null;
       }
-      matches(_selector: string): boolean {
-        return false;
+      matches(selector: string): boolean {
+        return (
+          selector.includes("__composer-pill") &&
+          this.attributes.class?.includes("__composer-pill") === true
+        );
       }
       getBoundingClientRect(): { width: number; height: number } {
         return { width: 144, height: 36 };
@@ -739,6 +754,10 @@ describe("browser thinking-time selection expression", () => {
       ) {}
     }
 
+    const highRadio = new FakeElement("High", {
+      role: "menuitemradio",
+      "aria-checked": "false",
+    });
     const proExtendedRadio = new FakeElement("Pro Extended", {
       role: "menuitemradio",
       "aria-checked": "true",
@@ -746,9 +765,10 @@ describe("browser thinking-time selection expression", () => {
     const intelligenceMenu = new FakeElement(
       "InstantMediumHighExtra HighPro Extended",
       { "data-testid": "composer-intelligence-picker-content", role: "menu" },
-      [proExtendedRadio],
+      [highRadio, proExtendedRadio],
     );
     const modelButton = new FakeElement("Pro Extended", {
+      class: "__composer-pill",
       "aria-expanded": "true",
       "aria-haspopup": "menu",
     });
@@ -764,12 +784,18 @@ describe("browser thinking-time selection expression", () => {
         }
         return null;
       },
-      querySelectorAll: (_selector: string) => [],
+      querySelectorAll: (selector: string) => {
+        if (selector.includes("__composer-pill")) return [modelButton];
+        if (selector.includes('role="menu"') || selector.includes("data-radix")) {
+          return [intelligenceMenu];
+        }
+        return [];
+      },
       dispatchEvent: () => true,
     };
     let now = 0;
     const performanceStub = { now: () => (now += 100) };
-    const expression = buildThinkingTimeExpressionForTest("extended", "gpt-5.5-pro");
+    const expression = buildThinkingTimeExpressionForTest("extended", null);
     const evaluate = new Function(
       "document",
       "performance",
@@ -803,6 +829,45 @@ describe("browser thinking-time selection expression", () => {
         FakeElement,
       ),
     ).resolves.toEqual({ status: "already-selected", label: "Pro Extended" });
+
+    const genericOnlyMenu = new FakeElement(
+      "IntelligenceInstantMediumHighExtra High",
+      { "data-testid": "composer-intelligence-picker-content", role: "menu" },
+      [highRadio],
+    );
+    const genericOnlyDocument = {
+      ...documentStub,
+      querySelector: (selector: string) => {
+        if (selector.includes("composer-intelligence-picker-content")) return genericOnlyMenu;
+        if (
+          selector.includes("model-switcher-dropdown-button") ||
+          selector.includes("__composer-pill")
+        ) {
+          return modelButton;
+        }
+        return null;
+      },
+      querySelectorAll: (selector: string) => {
+        if (selector.includes("__composer-pill")) return [modelButton];
+        if (selector.includes('role="menu"') || selector.includes("data-radix")) {
+          return [genericOnlyMenu];
+        }
+        return [];
+      },
+    };
+
+    await expect(
+      evaluate(
+        genericOnlyDocument,
+        performanceStub,
+        (callback: () => void) => callback(),
+        { PointerEvent: FakeMouseEvent, MouseEvent: FakeMouseEvent, Event: FakeMouseEvent },
+        FakeEventTarget,
+        FakeMouseEvent,
+        FakeMouseEvent,
+        FakeElement,
+      ),
+    ).resolves.toMatchObject({ status: "option-not-found", modelKind: "pro" });
   });
 
   it("opens the Pro effort submenu before selecting Pro Standard", async () => {

--- a/tests/cli/options.test.ts
+++ b/tests/cli/options.test.ts
@@ -6,6 +6,7 @@ import {
   parseFloatOption,
   parseIntOption,
   parseSearchOption,
+  parseThinkingTimeOption,
   resolvePreviewMode,
   resolveApiModel,
   inferModelFromLabel,
@@ -179,6 +180,29 @@ describe("parseSearchOption", () => {
 
   test("throws on invalid input", () => {
     expect(() => parseSearchOption("maybe")).toThrow(InvalidArgumentError);
+  });
+});
+
+describe("parseThinkingTimeOption", () => {
+  test.each([
+    ["light", "light"],
+    ["instant", "light"],
+    ["low", "light"],
+    ["standard", "standard"],
+    ["medium", "standard"],
+    ["extended", "extended"],
+    ["high", "extended"],
+    ["heavy", "heavy"],
+    ["extra-high", "heavy"],
+    ["extra high", "heavy"],
+    ["extrahigh", "heavy"],
+    ["xhigh", "heavy"],
+  ] as const)("normalizes %s to %s", (input, expected) => {
+    expect(parseThinkingTimeOption(input)).toBe(expected);
+  });
+
+  test("throws for unknown thinking-time aliases", () => {
+    expect(() => parseThinkingTimeOption("maximum")).toThrow(InvalidArgumentError);
   });
 });
 

--- a/tests/mcp/chatgptImage.test.ts
+++ b/tests/mcp/chatgptImage.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
+import { z } from "zod";
 import {
   buildChatGptImageConsultInput,
   registerChatGptImageTool,
@@ -45,6 +46,35 @@ describe("chatgpt_image MCP tool", () => {
       browserThinkingTime: "extended",
     });
     expect(input.prompt).toContain("aspect ratio 9:16");
+  });
+
+  test("keeps the registered input schema discoverable and normalizes thinking aliases", async () => {
+    let inputSchema: z.ZodRawShape | undefined;
+    let handler: ((input: unknown) => Promise<unknown>) | undefined;
+    registerChatGptImageTool({
+      registerTool: (
+        _name: string,
+        def: unknown,
+        registeredHandler: (input: unknown) => Promise<unknown>,
+      ) => {
+        inputSchema = (def as { inputSchema: z.ZodRawShape }).inputSchema;
+        handler = registeredHandler;
+      },
+      server: {
+        sendLoggingMessage: async () => undefined,
+      },
+    } as unknown as Parameters<typeof registerChatGptImageTool>[0]);
+
+    expect(inputSchema).toBeDefined();
+    expect(() => z.toJSONSchema(z.object(inputSchema!))).not.toThrow();
+    const result = (await handler?.({
+      dryRun: true,
+      prompt: "Create a small product mockup.",
+      browserThinkingTime: "xhigh",
+    })) as {
+      structuredContent: { resolved: { browser?: { thinkingTime?: string } } };
+    };
+    expect(result.structuredContent.resolved.browser?.thinkingTime).toBe("heavy");
   });
 
   test("uses a unique default output path when agents only provide a prompt", () => {

--- a/tests/mcp/consult.test.ts
+++ b/tests/mcp/consult.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { describe, expect, test } from "vitest";
 import type { SessionModelRun } from "../../src/sessionStore.js";
 import { applyConsultPreset } from "../../src/mcp/consultPresets.ts";
+import { consultInputSchema } from "../../src/mcp/types.ts";
 import { setOracleHomeDirOverrideForTest } from "../../src/oracleHome.js";
 import {
   buildConsultBrowserConfig,
@@ -53,6 +54,18 @@ describe("summarizeModelRunsForConsult", () => {
         models: ["gpt-5.1", "gpt-5.2"],
       }),
     ).toThrow(/cannot be combined with models/i);
+  });
+
+  test("normalizes browser thinking-time aliases for MCP callers", () => {
+    expect(
+      consultInputSchema.parse({
+        prompt: "review this plan",
+        files: [],
+        browserThinkingTime: "xhigh",
+      }),
+    ).toMatchObject({
+      browserThinkingTime: "heavy",
+    });
   });
 
   test("maps per-model metadata into consult summaries", () => {

--- a/tests/mcp/consult.test.ts
+++ b/tests/mcp/consult.test.ts
@@ -174,7 +174,7 @@ describe("summarizeModelRunsForConsult", () => {
           keepBrowser: true,
           manualLogin: true,
           manualLoginProfileDir: "/tmp/oracle-profile",
-          thinkingTime: "extended",
+          thinkingTime: "high" as never,
           researchMode: "deep",
           archiveConversations: "never",
         },

--- a/tests/mcp/consult.test.ts
+++ b/tests/mcp/consult.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, test } from "vitest";
+import { z } from "zod";
 import type { SessionModelRun } from "../../src/sessionStore.js";
 import { applyConsultPreset } from "../../src/mcp/consultPresets.ts";
 import { consultInputSchema } from "../../src/mcp/types.ts";
@@ -66,6 +67,21 @@ describe("summarizeModelRunsForConsult", () => {
     ).toMatchObject({
       browserThinkingTime: "heavy",
     });
+  });
+
+  test("keeps the registered MCP input schema JSON-schema compatible", () => {
+    let inputSchema: z.ZodRawShape | undefined;
+    registerConsultTool({
+      registerTool: (_name: string, def: unknown) => {
+        inputSchema = (def as { inputSchema: z.ZodRawShape }).inputSchema;
+      },
+      server: {
+        sendLoggingMessage: async () => undefined,
+      },
+    } as unknown as Parameters<typeof registerConsultTool>[0]);
+
+    expect(inputSchema).toBeDefined();
+    expect(() => z.toJSONSchema(z.object(inputSchema!))).not.toThrow();
   });
 
   test("maps per-model metadata into consult summaries", () => {


### PR DESCRIPTION

## Summary

- Support ChatGPT's updated `Intelligence` picker while keeping the existing selector path.
- Select Pro thinking efforts through the new Pro submenu.
- Accept ChatGPT-style thinking aliases such as `instant`, `medium`, `high`, and `extra-high`.

## Why

ChatGPT changed the browser model picker UI. Oracle could no longer reliably find the selector, and Pro effort choices moved behind a secondary menu.

The new UI also labels the non-Pro thinking levels differently:

- `light` maps to `Instant`
- `standard` maps to `Medium`
- `extended` maps to `High`
- `heavy` maps to `Extra High`

## User Impact

Browser-mode runs can select the requested ChatGPT model and thinking effort again. Existing Oracle option names still work, and users can also pass the new ChatGPT-style aliases when preferred.