### PR TITLE
fix(browser): treat /api/auth/session as login authority over DOM login CTAs

### DIFF
--- a/src/browser/actions/navigation.ts
+++ b/src/browser/actions/navigation.ts
@@ -259,6 +259,9 @@ export async function ensureLoggedIn(
       probe.appAuthenticated,
     )}, cfBlocked=${Boolean(probe.cfBlocked)}, url=${probe.pageUrl ?? "n/a"}, error=${probe.error ?? "none"})`,
   );
+  if (probe.domLoginCtaDetail) {
+    logger(`Login CTA matched: ${probe.domLoginCtaDetail}`);
+  }
 
   const domLabel = probe.domLoginCta ? " Login button detected on page." : "";
   const cookieHint = options.remoteSession
@@ -638,6 +641,7 @@ type LoginProbeResult = {
   error?: string | null;
   pageUrl?: string | null;
   domLoginCta?: boolean;
+  domLoginCtaDetail?: string | null;
   onAuthPage?: boolean;
   appAuthenticated?: boolean;
   backendStatus?: number | null;
@@ -700,10 +704,22 @@ function buildLoginProbeExpression(timeoutMs: number): string {
           node.getAttribute('title') ||
           '';
         if (textMatches(label)) {
-          return true;
+          // Learned 2026-06-11: ChatGPT renders a visible "Log in" button pinned to the
+          // sidebar nav's sticky bottom even for authenticated sessions. Sidebar-nav CTAs
+          // are not logout proof; genuine logged-out pages place login CTAs in the main
+          // content, and an expired session already fails the session-endpoint check.
+          if (typeof node.closest === 'function' && node.closest('nav')) {
+            continue;
+          }
+          const testId = node.getAttribute('data-testid') || '';
+          return (
+            String(node.tagName || 'element').toLowerCase() +
+            (testId ? '[data-testid=' + testId + ']' : '') +
+            ' text=' + JSON.stringify(label.slice(0, 60))
+          );
         }
       }
-      return false;
+      return null;
     };
 
     // Learned 2026-05-16: ChatGPT's /backend-api/* endpoints now sit behind Cloudflare bot
@@ -868,7 +884,8 @@ function buildLoginProbeExpression(timeoutMs: number): string {
     };
 
     let auth = await readAuthDetail();
-    let domLoginCta = hasLoginCta();
+    let domLoginCtaDetail = hasLoginCta();
+    let domLoginCta = Boolean(domLoginCtaDetail);
     let appAuthenticated = hasAppAuthSignal();
     let classification = classifyAuth(auth, appAuthenticated);
     const settleDeadline = Date.now() + Math.min(${timeoutMs}, 2500);
@@ -879,7 +896,8 @@ function buildLoginProbeExpression(timeoutMs: number): string {
       Date.now() < settleDeadline
     ) {
       await new Promise((resolve) => setTimeout(resolve, 100));
-      domLoginCta = hasLoginCta();
+      domLoginCtaDetail = hasLoginCta();
+      domLoginCta = Boolean(domLoginCtaDetail);
       appAuthenticated = hasAppAuthSignal();
       auth = await readAuthDetail();
       classification = classifyAuth(auth, appAuthenticated);
@@ -889,7 +907,15 @@ function buildLoginProbeExpression(timeoutMs: number): string {
     const backendStatus = auth.backend ? auth.backend.status : null;
     const cfBlocked = auth.session.cfBlocked || Boolean(auth.backend?.cfBlocked);
     const error = auth.session.error || auth.backend?.error || null;
-    const ok = !loginSignals && classification.authenticated;
+    // /api/auth/session user presence is the primary authentication authority.
+    // ChatGPT can render visible login CTAs (e.g. data-testid="login-button")
+    // on fully authenticated, working pages, so a DOM CTA must not veto a
+    // resolved authenticated session backed by the authenticated app shell.
+    // CTAs remain authoritative for the weaker fallback classifications, and
+    // auth-page redirects always fail.
+    const sessionAuthoritative =
+      auth.session.authenticated && appAuthenticated && !onAuthPage;
+    const ok = sessionAuthoritative || (!loginSignals && classification.authenticated);
     return {
       ok,
       status: auth.session.status,
@@ -898,6 +924,7 @@ function buildLoginProbeExpression(timeoutMs: number): string {
       url: pageUrl,
       pageUrl,
       domLoginCta,
+      domLoginCtaDetail,
       onAuthPage,
       appAuthenticated,
       cfBlocked,
@@ -929,6 +956,7 @@ function normalizeLoginProbe(raw: unknown): LoginProbeResult {
     error: typeof value.error === "string" ? value.error : null,
     pageUrl: typeof value.pageUrl === "string" ? value.pageUrl : null,
     domLoginCta: Boolean(value.domLoginCta),
+    domLoginCtaDetail: typeof value.domLoginCtaDetail === "string" ? value.domLoginCtaDetail : null,
     onAuthPage: Boolean(value.onAuthPage),
     appAuthenticated: Boolean(value.appAuthenticated),
     backendStatus: typeof value.backendStatus === "number" ? value.backendStatus : null,

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -24,6 +24,17 @@ export const DEFAULT_CHATGPT_COOKIE_NAMES = [
   "_cfuvid",
   "CF_Authorization",
   "__cflb",
+  // ChatGPT binds sessions to a device identity; without these cookies the app
+  // renders a half-authenticated shell (valid session and composer, but visible
+  // login buttons) and /backend-api/* can return 401 for a valid session.
+  "oai-did",
+  "oai-sc",
+  "__Secure-oai-is",
+  "oai-allow-ne",
+  "oai-hlib",
+  "oai-client-auth-info",
+  "__Host-next-auth.csrf-token",
+  "__Secure-next-auth.callback-url",
 ];
 
 export const DEFAULT_BROWSER_CONFIG: ResolvedBrowserConfig = {

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -3706,7 +3706,9 @@ async function validateChatGPTSession(
       return { valid: false, reason: "Redirected to auth page" };
     }
 
-    if (result.hasLoginCta) {
+    if (result.hasLoginCta && !result.hasTextarea) {
+      // ChatGPT renders visible login CTAs on authenticated, working pages;
+      // only treat one as a logout signal when the composer is gone too.
       return { valid: false, reason: "Login button detected on page" };
     }
 
@@ -3757,6 +3759,9 @@ function buildSessionValidationExpression(): string {
       };
       for (const node of candidates) {
         if (!(node instanceof HTMLElement)) continue;
+        // Sidebar-nav login CTAs appear even for authenticated sessions (see
+        // hasLoginCta in actions/navigation.ts); they are not logout proof.
+        if (typeof node.closest === 'function' && node.closest('nav')) continue;
         const label =
           node.textContent?.trim() ||
           node.getAttribute('aria-label') ||
@@ -3782,7 +3787,7 @@ function buildSessionValidationExpression(): string {
     })();
 
     return {
-      valid: !onAuthPage && !hasLoginCta && hasTextarea,
+      valid: !onAuthPage && hasTextarea,
       hasLoginCta,
       hasTextarea,
       onAuthPage,

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -344,6 +344,7 @@ describe("ensureLoggedIn", () => {
       composerVisible?: boolean;
       appSignal?: "profile" | "history" | "model" | null;
       probeTimeoutMs?: number;
+      ctaInNav?: boolean;
     } = {},
   ) {
     const {
@@ -359,12 +360,18 @@ describe("ensureLoggedIn", () => {
       composerVisible = false,
       appSignal = null,
       probeTimeoutMs = 0,
+      ctaInNav = false,
     } = options;
     class FakeHTMLElement {
       constructor(
         public textContent: string,
         private readonly visible = true,
+        private readonly inNav = false,
       ) {}
+
+      closest(selector: string) {
+        return this.inNav && selector.includes("nav") ? this : null;
+      }
 
       getAttribute() {
         return "";
@@ -375,7 +382,7 @@ describe("ensureLoggedIn", () => {
       }
     }
 
-    const nodes = labels.map((label) => new FakeHTMLElement(label));
+    const nodes = labels.map((label) => new FakeHTMLElement(label, true, ctaInNav));
     const composer = composerVisible ? new FakeHTMLElement("") : null;
     const loggedInSignal = appSignal ? new FakeHTMLElement("") : null;
     const document = {
@@ -472,6 +479,21 @@ describe("ensureLoggedIn", () => {
       ok: true,
       domLoginCta: false,
       status: 200,
+    });
+  });
+
+  test("ignores sidebar-nav login CTAs for authenticated sessions", async () => {
+    // ChatGPT pins a visible "Log in" button to the sidebar nav's sticky bottom
+    // even when the session is authenticated; it must not veto the login check.
+    await expect(
+      runLoginProbeForLabels(["Log in"], {
+        ctaInNav: true,
+        composerVisible: true,
+        appSignal: "history",
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      domLoginCta: false,
     });
   });
 
@@ -606,7 +628,7 @@ describe("ensureLoggedIn", () => {
     }
   });
 
-  test("keeps auth pages and visible login CTAs authoritative", async () => {
+  test("keeps auth pages authoritative even with an authenticated session", async () => {
     await expect(
       runLoginProbeForLabels([], {
         pathname: "/auth/login",
@@ -618,16 +640,36 @@ describe("ensureLoggedIn", () => {
       onAuthPage: true,
       appAuthenticated: true,
     });
+  });
 
+  test("lets a resolved authenticated session with the app shell override a visible login CTA", async () => {
+    // ChatGPT renders visible login CTAs (e.g. data-testid="login-button") on
+    // fully authenticated, working pages. The session endpoint is the primary
+    // authentication authority, so it wins when the app shell confirms it.
     await expect(
       runLoginProbeForLabels(["Log in"], {
         composerVisible: true,
         appSignal: "history",
       }),
     ).resolves.toMatchObject({
-      ok: false,
+      ok: true,
       domLoginCta: true,
       appAuthenticated: true,
+      sessionAuthenticated: true,
+    });
+  });
+
+  test("keeps a visible login CTA authoritative when the session is resolved empty", async () => {
+    await expect(
+      runLoginProbeForLabels(["Log in"], {
+        sessionBody: {},
+        composerVisible: true,
+        appSignal: "history",
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      domLoginCta: true,
+      sessionAuthenticated: false,
     });
   });
 


### PR DESCRIPTION
## Problem

On current ChatGPT, browser-mode runs fail for **authenticated** sessions with:

```
ChatGPT session not detected. Login button detected on page.
```

Verbose probe output on a session that is genuinely logged in:

```
Login probe failed (sessionStatus=200, sessionAuthenticated=true,
sessionResolved=true, domLoginCta=true, appAuthenticated=true, onAuthPage=false)
```

Two ChatGPT-side changes cause this, neither fixed by re-login or cookie refresh:

1. **Login CTA on authenticated pages.** ChatGPT renders a visible "Log in" button (`data-testid="login-button"`) pinned to the sidebar nav's sticky bottom *even when fully authenticated*. `hasLoginCta()` matches it and vetoes the session, despite `/api/auth/session` returning an authenticated user and the app shell being authenticated.
2. **Device-bound sessions.** Sessions are now bound to a set of `oai-*` cookies. Without them, only ~4 cookies are copied, the app renders a half-authenticated shell, and `/backend-api/*` can return 401 for an otherwise valid session.

## Fix

- **Session-endpoint authority over DOM CTA.** A resolved authenticated `/api/auth/session` + authenticated app shell (and not on an auth page) is authoritative; a DOM login CTA no longer vetoes it. CTAs remain authoritative for the weaker fallback classifications, and auth-page redirects still fail closed.
- **Exclude sidebar-nav CTAs** (`node.closest('nav')`) from the login signal. Genuine logged-out pages place login CTAs in the main content.
- **Mid-run `validateChatGPTSession`** only treats a login CTA as a logout signal when the composer (textarea) is also gone.
- **Diagnostics:** the probe now reports `domLoginCtaDetail`, logged as `Login CTA matched: <element>`, so future drift is diagnosable from `--verbose`.
- **Device-binding cookies** added to `DEFAULT_CHATGPT_COOKIE_NAMES` (`oai-did`, `oai-sc`, `__Secure-oai-is`, …).

## Verification

Live against ChatGPT (browser serve mode, GPT-5.5 Pro):

- Before: stock 0.14.0 → `Login probe failed (... sessionAuthenticated=true ... domLoginCta=true)`, "Copied 4 cookies", run fails in ~32s.
- After: "Copied 13 cookies", no probe failure, run completes (`Answer: READY`, ~53s).
- `tests/browser/pageActions.test.ts` updated; 59 passing locally.

Happy to split the cookie-list change into its own commit or adjust the authority formula if you'd prefer a narrower fix.
