### PR TITLE
fix: chatgpt selector issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Browser: select explicit Thinking model versions through ChatGPT's current `Configure...` Intelligence dialog, retain support for the earlier direct-version submenu, and require observable version evidence before reporting success. Thanks @aaronflorey!
 - Browser: retry manual-login DevTools tab creation on fresh Chrome launches, recover ChatGPT generated-image downloads through the authenticated browser context when Node-side fetch fails, and keep generated-image artifact waits fail-fast on visible ChatGPT warnings. Thanks @derekszen!
 - Browser: support ChatGPT's updated Intelligence model picker and Pro effort submenu, and accept `instant`, `medium`, `high`, and `extra-high` as thinking-time aliases while preserving existing Oracle names. Thanks @orbitingflea!
 

--- a/src/browser/actions/modelSelection.ts
+++ b/src/browser/actions/modelSelection.ts
@@ -27,7 +27,6 @@ export async function ensureModelSelection(
   const result = outcome.result?.value as
     | { status: "already-selected"; label?: string | null }
     | { status: "switched"; label?: string | null }
-    | { status: "switched-best-effort"; label?: string | null }
     | {
         status: "option-not-found";
         hint?: { temporaryChat?: boolean; availableOptions?: string[] };
@@ -37,8 +36,7 @@ export async function ensureModelSelection(
 
   switch (result?.status) {
     case "already-selected":
-    case "switched":
-    case "switched-best-effort": {
+    case "switched": {
       const label = result.label?.trim() || (strategy === "current" ? null : desiredModel);
       if (strategy !== "current") {
         assertResolvedModelSelection(desiredModel, label ?? desiredModel);
@@ -144,8 +142,12 @@ function buildModelSelectionExpression(
   const composerIncludesLiteral = JSON.stringify(composerSignalMatchers.includesAny);
   const composerExcludesLiteral = JSON.stringify(composerSignalMatchers.excludesAny);
   const composerAllowBlankLiteral = JSON.stringify(composerSignalMatchers.allowBlank);
-  const menuContainerLiteral = JSON.stringify(MENU_CONTAINER_SELECTOR);
-  const menuItemLiteral = JSON.stringify(MENU_ITEM_SELECTOR);
+  const menuContainerLiteral = JSON.stringify(
+    `${MENU_CONTAINER_SELECTOR}, [role="listbox"], [role="dialog"]`,
+  );
+  const menuItemLiteral = JSON.stringify(
+    `${MENU_ITEM_SELECTOR}, [role="option"], [role="radio"], [role="combobox"]`,
+  );
   return `(() => {
     ${buildClickDispatcher()}
     // Capture the selectors and matcher literals up front so the browser expression stays pure.
@@ -183,6 +185,8 @@ function buildModelSelectionExpression(
       ? '5-4'
       : normalizedTarget.includes('5 5')
         ? '5-5'
+        : normalizedTarget.includes('5 3')
+          ? '5-3'
         : normalizedTarget.includes('5 2')
         ? '5-2'
         : normalizedTarget.includes('5 1')
@@ -267,6 +271,14 @@ function buildModelSelectionExpression(
     };
 
     const closeMenu = () => {
+      const dialogCloseButton = document.querySelector(
+        '[role="dialog"] [data-testid="close-button"]',
+      );
+      if (dialogCloseButton) {
+        try {
+          if (dispatchClickSequence(dialogCloseButton)) return;
+        } catch {}
+      }
       const button = findModelButton();
       if (!button) return;
       try {
@@ -305,6 +317,7 @@ function buildModelSelectionExpression(
       const normalized = normalizeText(label ?? '');
       if (normalized === '5 5' || normalized === 'gpt 5 5') return 'GPT-5.5';
       if (normalized === '5 4' || normalized === 'gpt 5 4') return 'GPT-5.4';
+      if (normalized === '5 3' || normalized === 'gpt 5 3') return 'GPT-5.3';
       if (normalized === '5 2' || normalized === 'gpt 5 2') return 'GPT-5.2';
       if (normalized === '5 1' || normalized === 'gpt 5 1') return 'GPT-5.1';
       if (normalized === '5 0' || normalized === 'gpt 5 0') return 'GPT-5.0';
@@ -318,17 +331,6 @@ function buildModelSelectionExpression(
       if (normalized.includes('thinking')) return 'Pro';
       if (normalized.includes('pro')) return resolved;
       return resolved + ' + Pro';
-    };
-    const getResolvedLabel = (fallback) => {
-      const composerLabel = getComposerModelLabel();
-      if (composerLabel) return withProPillSignal(composerLabel);
-      const buttonLabel = getButtonLabel();
-      const normalizedButton = normalizeText(buttonLabel);
-      const fallbackLabel = formatModelOptionLabel(fallback);
-      if (fallbackLabel && !wantsPro && isIntelligenceEffortLabel(normalizedButton)) {
-        return fallbackLabel;
-      }
-      return withProPillSignal(buttonLabel || fallbackLabel || fallback);
     };
     const isThinkingEffortLabel = (label) =>
       label === 'extended' ||
@@ -349,8 +351,64 @@ function buildModelSelectionExpression(
       if (label === '5 5' || label === 'gpt 5 5') return '5-5';
       if (label === '5 4' || label === 'gpt 5 4') return '5-4';
       if (label === '5 3' || label === 'gpt 5 3') return '5-3';
+      if (label === '5 2' || label === 'gpt 5 2') return '5-2';
+      if (label === '5 1' || label === 'gpt 5 1') return '5-1';
+      if (label === '5 0' || label === 'gpt 5 0') return '5-0';
       if (label === '4 5' || label === 'gpt 4 5') return '4-5';
       return null;
+    };
+    const versionFromTestId = (testid) => {
+      const normalized = normalizeText(testid);
+      if (normalized.includes('5 5') || normalized.includes('gpt55')) return '5-5';
+      if (normalized.includes('5 4') || normalized.includes('gpt54')) return '5-4';
+      if (normalized.includes('5 3') || normalized.includes('gpt53')) return '5-3';
+      if (normalized.includes('5 2') || normalized.includes('gpt52')) return '5-2';
+      if (normalized.includes('5 1') || normalized.includes('gpt51')) return '5-1';
+      if (normalized.includes('5 0') || normalized.includes('gpt50')) return '5-0';
+      return null;
+    };
+    const getConfigurationDialog = () => document.querySelector('[role="dialog"]');
+    const getConfiguredVersionLabel = () =>
+      (getConfigurationDialog()
+        ?.querySelector?.('[role="combobox"][aria-labelledby="model-selection-label"]')
+        ?.textContent ?? '').trim();
+    const getConfiguredVariantLabel = () => {
+      const label =
+        (getConfigurationDialog()
+          ?.querySelector?.('[aria-label="Model options"] [role="radio"][aria-checked="true"]')
+          ?.textContent ?? '').trim();
+      const normalized = normalizeText(label);
+      if (normalized.startsWith('instant')) return 'Instant';
+      if (normalized.startsWith('thinking')) return 'Thinking';
+      if (normalized.startsWith('pro')) return 'Pro';
+      return label;
+    };
+    const configuredSelectionMatchesTarget = () => {
+      const configuredVersion = versionFromLabel(normalizeText(getConfiguredVersionLabel()));
+      if (!configuredVersion || configuredVersion !== desiredVersion) return false;
+      const configuredVariant = normalizeText(getConfiguredVariantLabel());
+      if (wantsPro) return labelHasProWord(configuredVariant);
+      if (wantsInstant) return configuredVariant.includes('instant');
+      if (wantsThinking) {
+        return configuredVariant.includes('thinking') && !labelHasProWord(configuredVariant);
+      }
+      return true;
+    };
+    const getResolvedLabel = (fallback) => {
+      if (configuredSelectionMatchesTarget()) {
+        const variant = getConfiguredVariantLabel();
+        const version = formatModelOptionLabel(getConfiguredVersionLabel());
+        return [variant, version].filter(Boolean).join(' ');
+      }
+      const composerLabel = getComposerModelLabel();
+      if (composerLabel) return withProPillSignal(composerLabel);
+      const buttonLabel = getButtonLabel();
+      const normalizedButton = normalizeText(buttonLabel);
+      const fallbackLabel = formatModelOptionLabel(fallback);
+      if (fallbackLabel && !wantsPro && isIntelligenceEffortLabel(normalizedButton)) {
+        return fallbackLabel;
+      }
+      return withProPillSignal(buttonLabel || fallbackLabel || fallback);
     };
     if (MODEL_STRATEGY === 'current') {
       const currentLabel = getResolvedLabel('') || null;
@@ -365,6 +423,7 @@ function buildModelSelectionExpression(
       return { status: 'button-missing' };
     }
     const buttonMatchesTarget = () => {
+      if (configuredSelectionMatchesTarget()) return true;
       const normalizedLabel = normalizeText(getButtonLabel());
       if (!normalizedLabel) return false;
       if (wantsThinking && !wantsPro && hasProComposerPill()) return false;
@@ -393,6 +452,7 @@ function buildModelSelectionExpression(
       if (desiredVersion) {
         if (desiredVersion === '5-5' && !normalizedLabel.includes('5 5')) return false;
         if (desiredVersion === '5-4' && !normalizedLabel.includes('5 4')) return false;
+        if (desiredVersion === '5-3' && !normalizedLabel.includes('5 3')) return false;
         if (desiredVersion === '5-2' && !normalizedLabel.includes('5 2')) return false;
         if (desiredVersion === '5-1' && !normalizedLabel.includes('5 1')) return false;
         if (desiredVersion === '5-0' && !normalizedLabel.includes('5 0')) return false;
@@ -402,9 +462,9 @@ function buildModelSelectionExpression(
       if (wantsInstant && !normalizedLabel.includes('instant')) return false;
       if (
         wantsThinking &&
-        desiredVersion === '5-4' &&
-        !normalizedLabel.includes('pro') &&
-        !normalizedLabel.includes('instant')
+        desiredVersion &&
+        versionFromLabel(normalizedLabel) === desiredVersion &&
+        !labelHasProWord(normalizedLabel)
       ) {
         return true;
       }
@@ -503,13 +563,28 @@ function buildModelSelectionExpression(
       return false;
     };
 
-    const scoreOption = (normalizedText, testid) => {
+    const scoreOption = (normalizedText, testid, node) => {
       // Assign a score to every node so we can pick the most likely match without brittle equality checks.
       if (!normalizedText && !testid) {
         return 0;
       }
       let score = 0;
       const normalizedTestId = (testid ?? '').toLowerCase();
+      const candidateTextVersion = versionFromLabel(normalizedText);
+      const candidateIsVersionCombobox =
+        node?.getAttribute?.('role') === 'combobox' &&
+        node?.getAttribute?.('aria-labelledby') === 'model-selection-label';
+      if (candidateIsVersionCombobox && candidateTextVersion === desiredVersion) {
+        return 0;
+      }
+      const candidateOpensConfiguration =
+        Boolean(desiredVersion) &&
+        desiredVersion !== '5-5' &&
+        (normalizedTestId === 'model-configure-modal' ||
+          (candidateIsVersionCombobox && node?.getAttribute?.('aria-expanded') !== 'true'));
+      if (candidateOpensConfiguration) {
+        return 2000;
+      }
       let exactTestIdMatch = false;
       if (normalizedTestId) {
         if (desiredVersion) {
@@ -532,6 +607,12 @@ function buildModelSelectionExpression(
             normalizedTestId.includes('gpt-5-4') ||
             normalizedTestId.includes('gpt-5.4') ||
             normalizedTestId.includes('gpt54');
+          const has53 =
+            normalizedTestId.includes('5-3') ||
+            normalizedTestId.includes('5.3') ||
+            normalizedTestId.includes('gpt-5-3') ||
+            normalizedTestId.includes('gpt-5.3') ||
+            normalizedTestId.includes('gpt53');
           const has51 =
             normalizedTestId.includes('5-1') ||
             normalizedTestId.includes('5.1') ||
@@ -544,7 +625,19 @@ function buildModelSelectionExpression(
             normalizedTestId.includes('gpt-5-0') ||
             normalizedTestId.includes('gpt-5.0') ||
             normalizedTestId.includes('gpt50');
-          const candidateVersion = has55 ? '5-5' : has54 ? '5-4' : has52 ? '5-2' : has51 ? '5-1' : has50 ? '5-0' : null;
+          const candidateVersion = has55
+            ? '5-5'
+            : has54
+              ? '5-4'
+              : has53
+                ? '5-3'
+                : has52
+                  ? '5-2'
+                  : has51
+                    ? '5-1'
+                    : has50
+                      ? '5-0'
+                      : null;
           // If a candidate advertises a different version, ignore it entirely.
           if (candidateVersion && candidateVersion !== desiredVersion) {
             return 0;
@@ -585,7 +678,8 @@ function buildModelSelectionExpression(
         desiredVersion !== '5-5' &&
         normalizedText === 'gpt 5 5' &&
         !normalizedTestId.includes('pro');
-      const candidateTextVersion = versionFromLabel(normalizedText);
+      const candidateSelectsDesiredVersion =
+        Boolean(desiredVersion) && candidateTextVersion === desiredVersion;
       if (
         desiredVersion &&
         candidateTextVersion &&
@@ -609,9 +703,7 @@ function buildModelSelectionExpression(
         candidateClearsProForThinking ||
         candidateOpensVersionSubmenu ||
         candidateIsGpt55ThinkingFamily ||
-        (wantsThinking &&
-          desiredVersion === '5-4' &&
-          (exactTestIdMatch || candidateTextVersion === '5-4'));
+        (wantsThinking && desiredVersion && (exactTestIdMatch || candidateSelectsDesiredVersion));
       const candidateHasLegacyProVersion = labelHasLegacyProVersion(normalizedText);
       const candidateHasPro =
         labelHasProWord(normalizedText) ||
@@ -620,11 +712,11 @@ function buildModelSelectionExpression(
       const candidateHasInstant =
         normalizedText.includes('instant') || normalizedTestId.includes('instant');
       if (wantsPro && candidateHasThinking) return 0;
-      if (wantsPro && candidateHasLegacyProVersion) return 0;
-      if (wantsPro && !candidateHasPro) return 0;
-      if (wantsInstant && !candidateHasInstant) return 0;
+      if (wantsPro && candidateHasLegacyProVersion && !candidateSelectsDesiredVersion) return 0;
+      if (wantsPro && !candidateHasPro && !candidateSelectsDesiredVersion) return 0;
+      if (wantsInstant && !candidateHasInstant && !candidateSelectsDesiredVersion) return 0;
       if (wantsThinking && candidateHasPro) return 0;
-      if (wantsThinking && !candidateHasThinking) return 0;
+      if (wantsThinking && !candidateHasThinking && !candidateSelectsDesiredVersion) return 0;
       if (desiredVersion === '5-5' && normalizedText && !candidateGpt55VisibleAlias) {
         const candidateHasVersion =
           normalizedText.includes('5 5') ||
@@ -636,6 +728,20 @@ function buildModelSelectionExpression(
         }
       }
       if (candidateGpt55VisibleAlias) {
+        score += 900;
+      }
+      if (wantsPro && candidateHasPro && !candidateSelectsDesiredVersion) {
+        score += 900;
+      }
+      if (wantsInstant && candidateHasInstant && !candidateSelectsDesiredVersion) {
+        score += 900;
+      }
+      if (
+        wantsThinking &&
+        candidateHasThinking &&
+        !candidateSelectsDesiredVersion &&
+        !candidateOpensVersionSubmenu
+      ) {
         score += 900;
       }
       if (candidateIsNonProGpt55Thinking) {
@@ -742,12 +848,16 @@ function buildModelSelectionExpression(
     };
     const isSubmenuOption = (node, testid) =>
       (testid ?? '').toLowerCase().includes('submenu') ||
+      (testid ?? '').toLowerCase() === 'model-configure-modal' ||
+      (node?.getAttribute?.('role') === 'combobox' &&
+        node?.getAttribute?.('aria-labelledby') === 'model-selection-label') ||
       node?.getAttribute?.('aria-haspopup') === 'menu' ||
       node?.getAttribute?.('data-has-submenu') !== null;
-    const canTrustSelectedOption = (node, normalizedText) => {
+    const canTrustSelectedOption = (node, normalizedText, testid) => {
       if (!optionIsSelected(node)) return false;
-      const optionVersion = versionFromLabel(normalizedText);
-      if (desiredVersion && optionVersion && optionVersion !== desiredVersion) return false;
+      if (getConfigurationDialog() && !configuredSelectionMatchesTarget()) return false;
+      const optionVersion = versionFromLabel(normalizedText) ?? versionFromTestId(testid);
+      if (desiredVersion && optionVersion !== desiredVersion) return false;
       const currentButtonLabel = normalizeText(getButtonLabel());
       return !labelHasProWord(currentButtonLabel) && !hasProComposerPill();
     };
@@ -765,11 +875,11 @@ function buildModelSelectionExpression(
           const text = option.textContent ?? '';
           const normalizedText = normalizeText(text);
           const testid = option.getAttribute('data-testid') ?? '';
-          let score = scoreOption(normalizedText, testid);
+          let score = scoreOption(normalizedText, testid, option);
           if (score <= 0) {
             continue;
           }
-          if (canTrustSelectedOption(option, normalizedText)) {
+          if (canTrustSelectedOption(option, normalizedText, testid)) {
             score += 1000;
           }
           const label = getOptionLabel(option);
@@ -873,9 +983,13 @@ function buildModelSelectionExpression(
         ensureMenuOpen();
         const match = findBestOption();
         if (match) {
-          if (activeSelectionMatchesTarget() || canTrustSelectedOption(match.node, match.normalizedText)) {
+          if (
+            activeSelectionMatchesTarget() ||
+            canTrustSelectedOption(match.node, match.normalizedText, match.testid)
+          ) {
+            const resolvedLabel = getResolvedLabel(match.label);
             closeMenu();
-            resolve({ status: 'already-selected', label: getResolvedLabel(match.label) });
+            resolve({ status: 'already-selected', label: resolvedLabel });
             return;
           }
           const previousButtonLabel = normalizeText(getButtonLabel());
@@ -892,17 +1006,9 @@ function buildModelSelectionExpression(
           // Wait for the selected model signal to settle before reopening the picker.
           waitForTargetSelection(previousButtonLabel, previousComposerSignal).then((selectionSettled) => {
             if (selectionSettled === 'target') {
+              const resolvedLabel = getResolvedLabel(match.label);
               closeMenu();
-              resolve({ status: 'switched', label: getResolvedLabel(match.label) });
-              return;
-            }
-            if (
-              desiredVersion &&
-              versionFromLabel(match.normalizedText) === desiredVersion &&
-              !(wantsThinking && !wantsPro && hasProComposerPill())
-            ) {
-              closeMenu();
-              resolve({ status: 'switched-best-effort', label: getResolvedLabel(match.label) });
+              resolve({ status: 'switched', label: resolvedLabel });
               return;
             }
             attempt();
@@ -1027,6 +1133,34 @@ function buildModelMatchersLiteral(targetModel: string): {
     testIdTokens.add("gpt5-4");
     testIdTokens.add("gpt54");
   }
+  // Numeric variations (5.3 ↔ 53 ↔ gpt-5-3)
+  if (base.includes("5.3") || base.includes("5-3") || base.includes("53")) {
+    push("5.3", labelTokens);
+    push("gpt-5.3", labelTokens);
+    push("gpt5.3", labelTokens);
+    push("gpt-5-3", labelTokens);
+    push("gpt5-3", labelTokens);
+    push("gpt53", labelTokens);
+    push("chatgpt 5.3", labelTokens);
+    if (base.includes("thinking")) {
+      push("thinking", labelTokens);
+      testIdTokens.add("model-switcher-gpt-5-3-thinking");
+      testIdTokens.add("gpt-5-3-thinking");
+      testIdTokens.add("gpt-5.3-thinking");
+    }
+    if (base.includes("instant")) {
+      push("instant", labelTokens);
+      testIdTokens.add("model-switcher-gpt-5-3-instant");
+      testIdTokens.add("gpt-5-3-instant");
+      testIdTokens.add("gpt-5.3-instant");
+    }
+    if (!base.includes("pro") && !base.includes("thinking") && !base.includes("instant")) {
+      testIdTokens.add("model-switcher-gpt-5-3");
+    }
+    testIdTokens.add("gpt-5-3");
+    testIdTokens.add("gpt5-3");
+    testIdTokens.add("gpt53");
+  }
   // Numeric variations (5.1 ↔ 51 ↔ gpt-5-1)
   if (base.includes("5.1") || base.includes("5-1") || base.includes("51")) {
     push("5.1", labelTokens);
@@ -1100,6 +1234,11 @@ function buildModelMatchersLiteral(targetModel: string): {
       testIdTokens.add("gpt-5.4-pro");
       testIdTokens.add("gpt-5-4-pro");
       testIdTokens.add("gpt54pro");
+    }
+    if (base.includes("5.3") || base.includes("5-3") || base.includes("53")) {
+      testIdTokens.add("gpt-5.3-pro");
+      testIdTokens.add("gpt-5-3-pro");
+      testIdTokens.add("gpt53pro");
     }
     if (base.includes("5.1") || base.includes("5-1") || base.includes("51")) {
       testIdTokens.add("gpt-5.1-pro");

--- a/src/browser/actions/modelSelection.ts
+++ b/src/browser/actions/modelSelection.ts
@@ -338,6 +338,20 @@ function buildModelSelectionExpression(
       label === 'medium' ||
       label === 'high' ||
       label === 'extra high';
+    const isNonProIntelligenceThinkingLabel = (label) =>
+      label === 'medium' || label === 'high' || label === 'extra high';
+    const scoreNonProGpt55ThinkingLabel = (label) => {
+      if (label === 'extra high') return 1400;
+      if (label === 'high') return 1200;
+      return 1000;
+    };
+    const versionFromLabel = (label) => {
+      if (label === '5 5' || label === 'gpt 5 5') return '5-5';
+      if (label === '5 4' || label === 'gpt 5 4') return '5-4';
+      if (label === '5 3' || label === 'gpt 5 3') return '5-3';
+      if (label === '4 5' || label === 'gpt 4 5') return '4-5';
+      return null;
+    };
     if (MODEL_STRATEGY === 'current') {
       const currentLabel = getResolvedLabel('') || null;
       return {
@@ -353,13 +367,15 @@ function buildModelSelectionExpression(
     const buttonMatchesTarget = () => {
       const normalizedLabel = normalizeText(getButtonLabel());
       if (!normalizedLabel) return false;
+      if (wantsThinking && !wantsPro && hasProComposerPill()) return false;
       if (isTargetGpt55VisibleAlias(normalizedLabel)) return true;
       if (
         wantsThinking &&
         desiredVersion === '5-5' &&
         !hasProComposerPill() &&
         isThinkingEffortLabel(normalizedLabel) &&
-        isTargetGpt55VisibleAlias(readComposerModelSignal())
+        (isNonProIntelligenceThinkingLabel(normalizedLabel) ||
+          isTargetGpt55VisibleAlias(readComposerModelSignal()))
       ) {
         return true;
       }
@@ -453,10 +469,21 @@ function buildModelSelectionExpression(
     };
 
     const getOptionLabel = (node) => node?.textContent?.trim() ?? '';
-    const isThinkingEffortControl = (node) =>
+    const isDetachedProEffortMenu = (menu) => {
+      const text = normalizeText(menu?.textContent ?? '');
+      return (
+        menu?.getAttribute?.('data-testid') !== 'composer-intelligence-picker-content' &&
+        text.includes('pro standard') &&
+        text.includes('pro extended')
+      );
+    };
+    const isNestedEffortControl = (node, menu) =>
       node instanceof HTMLElement &&
       (node.getAttribute('data-model-picker-thinking-effort-action') === 'true' ||
-        Boolean(node.closest('[data-model-picker-thinking-effort-action="true"]')));
+        node.getAttribute('data-composer-intelligence-pro-effort-action') === 'true' ||
+        Boolean(node.closest('[data-model-picker-thinking-effort-action="true"]')) ||
+        Boolean(node.closest('[data-composer-intelligence-pro-effort-action="true"]')) ||
+        isDetachedProEffortMenu(menu));
     const optionIsSelected = (node) => {
       if (!(node instanceof HTMLElement)) {
         return false;
@@ -546,6 +573,27 @@ function buildModelSelectionExpression(
         }
       }
       const candidateGpt55VisibleAlias = isTargetGpt55VisibleAlias(normalizedText);
+      const candidateIsNonProThinkingEffort =
+        isNonProIntelligenceThinkingLabel(normalizedText) && !normalizedTestId.includes('pro');
+      const hasActiveProPill = hasProComposerPill();
+      const candidateIsNonProGpt55Thinking =
+        wantsThinking && desiredVersion === '5-5' && candidateIsNonProThinkingEffort;
+      const candidateClearsProForThinking =
+        wantsThinking && !wantsPro && hasActiveProPill && candidateIsNonProThinkingEffort;
+      const candidateOpensVersionSubmenu =
+        wantsThinking &&
+        desiredVersion !== '5-5' &&
+        normalizedText === 'gpt 5 5' &&
+        !normalizedTestId.includes('pro');
+      const candidateTextVersion = versionFromLabel(normalizedText);
+      if (
+        desiredVersion &&
+        candidateTextVersion &&
+        candidateTextVersion !== desiredVersion &&
+        !candidateOpensVersionSubmenu
+      ) {
+        return 0;
+      }
       const candidateIsGpt55ThinkingFamily =
         wantsThinking &&
         desiredVersion === '5-5' &&
@@ -557,8 +605,13 @@ function buildModelSelectionExpression(
       const candidateHasThinking =
         normalizedText.includes('thinking') ||
         normalizedTestId.includes('thinking') ||
+        candidateIsNonProGpt55Thinking ||
+        candidateClearsProForThinking ||
+        candidateOpensVersionSubmenu ||
         candidateIsGpt55ThinkingFamily ||
-        (wantsThinking && desiredVersion === '5-4' && exactTestIdMatch);
+        (wantsThinking &&
+          desiredVersion === '5-4' &&
+          (exactTestIdMatch || candidateTextVersion === '5-4'));
       const candidateHasLegacyProVersion = labelHasLegacyProVersion(normalizedText);
       const candidateHasPro =
         labelHasProWord(normalizedText) ||
@@ -584,6 +637,22 @@ function buildModelSelectionExpression(
       }
       if (candidateGpt55VisibleAlias) {
         score += 900;
+      }
+      if (candidateIsNonProGpt55Thinking) {
+        score += scoreNonProGpt55ThinkingLabel(normalizedText);
+      }
+      if (candidateClearsProForThinking) {
+        score += scoreNonProGpt55ThinkingLabel(normalizedText) + 600;
+      }
+      if (
+        desiredVersion &&
+        candidateTextVersion === desiredVersion &&
+        !(wantsThinking && desiredVersion === '5-5' && normalizedText === 'gpt 5 5')
+      ) {
+        score += 1200;
+      }
+      if (candidateOpensVersionSubmenu) {
+        score += 500;
       }
       if (candidateIsGpt55ThinkingFamily) {
         score += 260;
@@ -625,6 +694,9 @@ function buildModelSelectionExpression(
       if (wantsThinking) {
         if (
           !candidateIsGpt55ThinkingFamily &&
+          !candidateIsNonProGpt55Thinking &&
+          !candidateClearsProForThinking &&
+          !candidateOpensVersionSubmenu &&
           !normalizedText.includes('thinking') &&
           !normalizedTestId.includes('thinking')
         ) {
@@ -668,6 +740,17 @@ function buildModelSelectionExpression(
       );
       return pickerMenus.concat(textFallbackMenus);
     };
+    const isSubmenuOption = (node, testid) =>
+      (testid ?? '').toLowerCase().includes('submenu') ||
+      node?.getAttribute?.('aria-haspopup') === 'menu' ||
+      node?.getAttribute?.('data-has-submenu') !== null;
+    const canTrustSelectedOption = (node, normalizedText) => {
+      if (!optionIsSelected(node)) return false;
+      const optionVersion = versionFromLabel(normalizedText);
+      if (desiredVersion && optionVersion && optionVersion !== desiredVersion) return false;
+      const currentButtonLabel = normalizeText(getButtonLabel());
+      return !labelHasProWord(currentButtonLabel) && !hasProComposerPill();
+    };
 
     const findBestOption = () => {
       // Walk through every menu item and keep whichever earns the highest score.
@@ -676,7 +759,7 @@ function buildModelSelectionExpression(
       for (const menu of menus) {
         const buttons = Array.from(menu.querySelectorAll(${menuItemLiteral}));
         for (const option of buttons) {
-          if (isThinkingEffortControl(option)) {
+          if (isNestedEffortControl(option, menu)) {
             continue;
           }
           const text = option.textContent ?? '';
@@ -686,7 +769,7 @@ function buildModelSelectionExpression(
           if (score <= 0) {
             continue;
           }
-          if (optionIsSelected(option)) {
+          if (canTrustSelectedOption(option, normalizedText)) {
             score += 1000;
           }
           const label = getOptionLabel(option);
@@ -726,10 +809,6 @@ function buildModelSelectionExpression(
       };
       check();
     });
-    const isSubmenuOption = (node, testid) =>
-      (testid ?? '').toLowerCase().includes('submenu') ||
-      node?.getAttribute?.('aria-haspopup') === 'menu' ||
-      node?.getAttribute?.('data-has-submenu') !== null;
     const dispatchHoverSequence = (target) => {
       if (!target || !(target instanceof EventTarget)) return false;
       const types = ['pointerover', 'pointerenter', 'mouseover', 'mouseenter', 'pointermove', 'mousemove'];
@@ -794,14 +873,13 @@ function buildModelSelectionExpression(
         ensureMenuOpen();
         const match = findBestOption();
         if (match) {
-          if (optionIsSelected(match.node) || activeSelectionMatchesTarget()) {
+          if (activeSelectionMatchesTarget() || canTrustSelectedOption(match.node, match.normalizedText)) {
             closeMenu();
             resolve({ status: 'already-selected', label: getResolvedLabel(match.label) });
             return;
           }
           const previousButtonLabel = normalizeText(getButtonLabel());
           const previousComposerSignal = readComposerModelSignal();
-          dispatchClickSequence(match.node);
           // Submenus (e.g. "Legacy models") need a second pass to pick the actual model option.
           // Keep scanning once the submenu opens instead of treating the submenu click as a final switch.
           const isSubmenu = isSubmenuOption(match.node, match.testid);
@@ -810,11 +888,21 @@ function buildModelSelectionExpression(
             setTimeout(attempt, REOPEN_INTERVAL_MS / 2);
             return;
           }
+          dispatchClickSequence(match.node);
           // Wait for the selected model signal to settle before reopening the picker.
           waitForTargetSelection(previousButtonLabel, previousComposerSignal).then((selectionSettled) => {
             if (selectionSettled === 'target') {
               closeMenu();
               resolve({ status: 'switched', label: getResolvedLabel(match.label) });
+              return;
+            }
+            if (
+              desiredVersion &&
+              versionFromLabel(match.normalizedText) === desiredVersion &&
+              !(wantsThinking && !wantsPro && hasProComposerPill())
+            ) {
+              closeMenu();
+              resolve({ status: 'switched-best-effort', label: getResolvedLabel(match.label) });
               return;
             }
             attempt();

--- a/tests/browser/modelSelection.test.ts
+++ b/tests/browser/modelSelection.test.ts
@@ -445,6 +445,247 @@ const evaluateIntelligenceModelSelectionExpression = async (
   );
 };
 
+const evaluateConfiguredModelSelectionExpression = async (
+  targetModel: string,
+  initialVariant = "Thinking",
+): Promise<unknown> => {
+  class FakeEventTarget {
+    dispatchEvent(_event: unknown): boolean {
+      return true;
+    }
+  }
+
+  class FakeMouseEvent {
+    constructor(
+      readonly type: string,
+      readonly init?: unknown,
+    ) {}
+  }
+
+  let topMenuOpen = false;
+  let configurationOpen = false;
+  let versionListOpen = false;
+  let selectedVersion = "5.5";
+  let selectedVariant = initialVariant;
+
+  type AttributeValue = string | (() => string);
+  class FakeElement extends FakeEventTarget {
+    constructor(
+      public textContent: string,
+      private readonly attributes: Readonly<Record<string, AttributeValue>> = {},
+      private readonly children: readonly FakeElement[] = [],
+      private readonly onDispatch?: () => void,
+    ) {
+      super();
+    }
+
+    getAttribute(name: string): string | null {
+      const value = this.attributes[name];
+      return typeof value === "function" ? value() : (value ?? null);
+    }
+
+    querySelector(selector: string): FakeElement | null {
+      if (selector.includes("model-switcher-")) {
+        return (
+          this.children.find((child) =>
+            child.getAttribute("data-testid")?.startsWith("model-switcher-"),
+          ) ?? null
+        );
+      }
+      if (selector.includes("model-selection-label")) {
+        return (
+          this.children.find(
+            (child) => child.getAttribute("aria-labelledby") === "model-selection-label",
+          ) ?? null
+        );
+      }
+      if (selector.includes("Model options") && selector.includes('aria-checked="true"')) {
+        return (
+          this.children.find(
+            (child) =>
+              child.getAttribute("role") === "radio" &&
+              child.getAttribute("aria-checked") === "true",
+          ) ?? null
+        );
+      }
+      if (selector.includes("close-button")) {
+        return (
+          this.children.find((child) => child.getAttribute("data-testid") === "close-button") ??
+          null
+        );
+      }
+      return null;
+    }
+
+    querySelectorAll(_selector: string): FakeElement[] {
+      return [...this.children];
+    }
+
+    closest(_selector: string): FakeElement | null {
+      return null;
+    }
+
+    override dispatchEvent(event: unknown): boolean {
+      this.onDispatch?.();
+      return super.dispatchEvent(event);
+    }
+  }
+
+  const modelButton = new FakeElement(
+    "ChatGPT",
+    { "data-testid": "model-switcher-dropdown-button" },
+    [],
+    () => {
+      topMenuOpen = true;
+    },
+  );
+  const currentThinking = new FakeElement("ThinkingFor complex questions", {
+    role: "menuitemradio",
+    "data-testid": "model-switcher-gpt-5-5-thinking",
+    "aria-checked": "true",
+  });
+  const configure = new FakeElement(
+    "Configure...",
+    { role: "menuitem", "data-testid": "model-configure-modal" },
+    [],
+    () => {
+      topMenuOpen = false;
+      configurationOpen = true;
+    },
+  );
+  const topMenu = new FakeElement("Latest 5.5 Thinking Configure", { role: "menu" }, [
+    currentThinking,
+    configure,
+  ]);
+  const closeButton = new FakeElement("", { "data-testid": "close-button" }, [], () => {
+    configurationOpen = false;
+    versionListOpen = false;
+  });
+  const versionCombobox = new FakeElement(
+    selectedVersion,
+    {
+      role: "combobox",
+      "aria-labelledby": "model-selection-label",
+      "aria-expanded": () => String(versionListOpen),
+    },
+    [],
+    () => {
+      versionListOpen = true;
+    },
+  );
+  const variantRadio = (variant: string, description: string) =>
+    new FakeElement(
+      `${variant}${description}`,
+      {
+        role: "radio",
+        "aria-checked": () => String(selectedVariant === variant),
+      },
+      [],
+      () => {
+        selectedVariant = variant;
+      },
+    );
+  const instantRadio = variantRadio("Instant", "For everyday chats");
+  const thinkingRadio = variantRadio("Thinking", "For complex questions");
+  const proRadio = variantRadio("Pro", "Research-grade intelligence");
+  const configurationDialog = new FakeElement("Intelligence Model Thinking", { role: "dialog" }, [
+    closeButton,
+    versionCombobox,
+    instantRadio,
+    thinkingRadio,
+    proRadio,
+  ]);
+  const versionOption = (version: string) =>
+    new FakeElement(
+      version,
+      {
+        role: "option",
+        "aria-selected": () => String(selectedVersion === version),
+        "data-state": () => (selectedVersion === version ? "checked" : "unchecked"),
+      },
+      [],
+      () => {
+        selectedVersion = version;
+        versionCombobox.textContent = version;
+        versionListOpen = false;
+      },
+    );
+  const versionList = new FakeElement("5.5 5.4 5.3 5.2", { role: "listbox" }, [
+    versionOption("5.5"),
+    versionOption("5.4"),
+    versionOption("5.3"),
+    versionOption("5.2"),
+  ]);
+
+  const expression = buildModelSelectionExpressionForTest(targetModel);
+  const documentStub = {
+    querySelector: (selector: string) => {
+      if (selector.includes("close-button")) {
+        return configurationOpen ? closeButton : null;
+      }
+      if (selector === '[role="dialog"]') {
+        return configurationOpen ? configurationDialog : null;
+      }
+      if (selector.includes("model-switcher-dropdown-button")) {
+        return modelButton;
+      }
+      return null;
+    },
+    querySelectorAll: (selector: string) => {
+      if (selector.includes("button.__composer-pill")) {
+        return [];
+      }
+      if (selector.includes('role="menu"') || selector.includes("data-radix")) {
+        return [
+          ...(topMenuOpen ? [topMenu] : []),
+          ...(configurationOpen ? [configurationDialog] : []),
+          ...(versionListOpen ? [versionList] : []),
+        ];
+      }
+      return [];
+    },
+    title: "",
+    body: { innerText: "" },
+    dispatchEvent: () => true,
+  };
+  let now = 0;
+  const performanceStub = { now: () => (now += 100) };
+  const immediateSetTimeout = (handler: TimerHandler): number => {
+    if (typeof handler === "function") handler();
+    return 0;
+  };
+  const evaluate = new Function(
+    "document",
+    "performance",
+    "setTimeout",
+    "window",
+    "EventTarget",
+    "MouseEvent",
+    "HTMLElement",
+    `return ${expression};`,
+  ) as (
+    document: unknown,
+    performance: unknown,
+    setTimeout: unknown,
+    window: unknown,
+    EventTarget: unknown,
+    MouseEvent: unknown,
+    HTMLElement: unknown,
+  ) => unknown;
+
+  return await Promise.resolve(
+    evaluate(
+      documentStub,
+      performanceStub,
+      immediateSetTimeout,
+      { location: { href: "https://chatgpt.com/" } },
+      FakeEventTarget,
+      FakeMouseEvent,
+      FakeElement,
+    ),
+  );
+};
+
 const createNonPickerMenuForTest = (labels: string[]): unknown => {
   class FakeEventTarget {
     dispatchEvent(_event: unknown): boolean {
@@ -676,6 +917,12 @@ describe("browser model selection matchers", () => {
     );
   });
 
+  it("includes explicit 5.3 tokens for browser model overrides", () => {
+    const { labelTokens, testIdTokens } = buildModelMatchersLiteralForTest("Thinking 5.3");
+    expect(labelTokens).toContain("5.3");
+    expect(testIdTokens).toContain("model-switcher-gpt-5-3-thinking");
+  });
+
   it("includes rich tokens for gpt-5.1", () => {
     const { labelTokens, testIdTokens } = buildModelMatchersLiteralForTest("gpt-5.1");
     expectContains(labelTokens, "gpt-5.1");
@@ -738,7 +985,9 @@ describe("browser model selection matchers", () => {
   it("hard-rejects non-Instant candidates when targeting Instant", () => {
     const expression = buildModelSelectionExpressionForTest("GPT-5.5 Instant");
     expect(expression).toContain("const candidateHasInstant =");
-    expect(expression).toContain("if (wantsInstant && !candidateHasInstant) return 0;");
+    expect(expression).toContain(
+      "if (wantsInstant && !candidateHasInstant && !candidateSelectsDesiredVersion) return 0;",
+    );
   });
 
   it("selects the observed bare GPT-5.5 row when its label is Instant", async () => {
@@ -828,12 +1077,16 @@ describe("browser model selection matchers", () => {
     const expression = buildModelSelectionExpressionForTest("gpt-5.5-pro");
     expect(expression).toContain("const candidateHasThinking =");
     expect(expression).toContain("if (wantsPro && candidateHasThinking) return 0;");
-    expect(expression).toContain("if (wantsPro && !candidateHasPro) return 0;");
+    expect(expression).toContain(
+      "if (wantsPro && !candidateHasPro && !candidateSelectsDesiredVersion) return 0;",
+    );
   });
 
   it("hard-rejects non-Thinking candidates when targeting Thinking", () => {
     const expression = buildModelSelectionExpressionForTest("Thinking 5.5");
-    expect(expression).toContain("if (wantsThinking && !candidateHasThinking) return 0;");
+    expect(expression).toContain(
+      "if (wantsThinking && !candidateHasThinking && !candidateSelectsDesiredVersion) return 0;",
+    );
     expect(expression).not.toContain("candidateGpt55VisibleAlias ||\n        labelHasProWord");
   });
 
@@ -961,8 +1214,9 @@ describe("browser model selection matchers", () => {
     expect(expression).toContain("resolve('changed')");
     expect(expression).toContain("if (selectionSettled === 'target')");
     expect(expression).toContain(
-      "if (activeSelectionMatchesTarget() || canTrustSelectedOption(match.node, match.normalizedText))",
+      "canTrustSelectedOption(match.node, match.normalizedText, match.testid)",
     );
+    expect(expression).not.toContain("switched-best-effort");
   });
 
   it("fails loudly if post-selection state resolves to Thinking instead of Pro", () => {
@@ -1108,6 +1362,33 @@ describe("browser model selection matchers", () => {
     });
   });
 
+  it("uses Configure to select Thinking 5.4 in the current picker", async () => {
+    await expect(evaluateConfiguredModelSelectionExpression("Thinking 5.4")).resolves.toEqual({
+      status: "switched",
+      label: "Thinking GPT-5.4",
+    });
+  });
+
+  it("selects the requested variant after changing Configure versions", async () => {
+    await expect(evaluateConfiguredModelSelectionExpression("GPT-5.2 Instant")).resolves.toEqual({
+      status: "switched",
+      label: "Instant GPT-5.2",
+    });
+    await expect(evaluateConfiguredModelSelectionExpression("Pro 5.4")).resolves.toEqual({
+      status: "switched",
+      label: "Pro GPT-5.4",
+    });
+    await expect(evaluateConfiguredModelSelectionExpression("Thinking 5.3")).resolves.toEqual({
+      status: "switched",
+      label: "Thinking GPT-5.3",
+    });
+  });
+
+  it("does not accept a generic Thinking label for an explicit 5.4 request", () => {
+    const result = evaluateImmediateModelSelectionExpression("Thinking 5.4", "Thinking");
+    expect(result).toBeInstanceOf(Promise);
+  });
+
   it("clears Pro thinking before selecting hidden Thinking 5.4", async () => {
     await expect(
       evaluateIntelligenceModelSelectionExpression("Thinking 5.4", "Pro Extended"),
@@ -1121,6 +1402,6 @@ describe("browser model selection matchers", () => {
     const expression = buildModelSelectionExpressionForTest("Thinking 5.4");
     expect(expression).toContain("normalizedText === 'gpt 5 5'");
     expect(expression).toContain("candidateTextVersion !== desiredVersion");
-    expect(expression).toContain("canTrustSelectedOption(option, normalizedText)");
+    expect(expression).toContain("canTrustSelectedOption(option, normalizedText, testid)");
   });
 });

--- a/tests/browser/modelSelection.test.ts
+++ b/tests/browser/modelSelection.test.ts
@@ -214,6 +214,7 @@ const evaluateMenuModelSelectionExpression = async (
 
 const evaluateIntelligenceModelSelectionExpression = async (
   targetModel: string,
+  initialButtonLabel = "Extra High",
 ): Promise<unknown> => {
   class FakeEventTarget {
     dispatchEvent(_event: unknown): boolean {
@@ -233,6 +234,8 @@ const evaluateIntelligenceModelSelectionExpression = async (
 
   let intelligenceMenuOpen = false;
   let gpt55SubmenuOpen = false;
+  let modelButton: FakeElement;
+  let proPillActive = initialButtonLabel.toLowerCase().includes("pro");
 
   class FakeElement extends FakeEventTarget {
     constructor(
@@ -269,10 +272,13 @@ const evaluateIntelligenceModelSelectionExpression = async (
     }
 
     matches(selector: string): boolean {
-      return selector.includes("__composer-pill") &&
+      if (
+        selector.includes("__composer-pill") &&
         this.attributes.class?.includes("__composer-pill")
-        ? true
-        : selector.includes("aria-haspopup") && this.attributes["aria-haspopup"] === "menu";
+      ) {
+        return true;
+      }
+      return selector.includes("aria-haspopup") && this.attributes["aria-haspopup"] === "menu";
     }
 
     getBoundingClientRect(): { width: number; height: number } {
@@ -285,12 +291,31 @@ const evaluateIntelligenceModelSelectionExpression = async (
     }
   }
 
-  const fiveFive = new FakeElement("5.5", {
-    role: "menuitemradio",
-    "aria-checked": "true",
-    "data-state": "checked",
-  });
-  const gpt55Submenu = new FakeElement("5.55.45.34.5o3", { role: "menu" }, [fiveFive]);
+  const fiveFive = new FakeElement(
+    "5.5",
+    {
+      role: "menuitemradio",
+      "aria-checked": "true",
+      "data-state": "checked",
+    },
+    [],
+    () => {
+      modelButton.textContent = "GPT-5.5";
+    },
+  );
+  const fiveFour = new FakeElement(
+    "5.4",
+    {
+      role: "menuitemradio",
+      "aria-checked": "false",
+      "data-state": "unchecked",
+    },
+    [],
+    () => {
+      modelButton.textContent = "GPT-5.4";
+    },
+  );
+  const gpt55Submenu = new FakeElement("5.55.45.34.5o3", { role: "menu" }, [fiveFive, fiveFour]);
   const gpt55Trigger = new FakeElement(
     "GPT-5.5",
     {
@@ -304,6 +329,7 @@ const evaluateIntelligenceModelSelectionExpression = async (
       gpt55SubmenuOpen = true;
     },
   );
+  const initialIsPro = initialButtonLabel.toLowerCase().includes("pro");
   const intelligenceMenu = new FakeElement(
     "IntelligenceInstantMediumHighExtra HighPro ExtendedGPT-5.5",
     { role: "menu", "data-testid": "composer-intelligence-picker-content" },
@@ -311,19 +337,42 @@ const evaluateIntelligenceModelSelectionExpression = async (
       new FakeElement("Instant", { role: "menuitemradio", "aria-checked": "false" }),
       new FakeElement("Medium", { role: "menuitemradio", "aria-checked": "false" }),
       new FakeElement("High", { role: "menuitemradio", "aria-checked": "false" }),
-      new FakeElement("Extra High", { role: "menuitemradio", "aria-checked": "true" }),
-      new FakeElement("Pro Extended", { role: "menuitemradio", "aria-checked": "false" }),
+      new FakeElement(
+        "Extra High",
+        { role: "menuitemradio", "aria-checked": initialIsPro ? "false" : "true" },
+        [],
+        () => {
+          proPillActive = false;
+          modelButton.textContent = "Extra High";
+        },
+      ),
+      new FakeElement(
+        "Pro Extended",
+        {
+          role: "menuitemradio",
+          "aria-checked": initialIsPro ? "true" : "false",
+        },
+        [],
+        () => {
+          proPillActive = true;
+          modelButton.textContent = "Pro Extended";
+        },
+      ),
       gpt55Trigger,
     ],
   );
-  const modelButton = new FakeElement(
-    "Extra High",
+  modelButton = new FakeElement(
+    initialButtonLabel,
     { class: "__composer-pill", "aria-haspopup": "menu", "aria-expanded": "false" },
     [],
     () => {
       intelligenceMenuOpen = true;
     },
   );
+  const proPill = new FakeElement("Pro Extended", {
+    class: "__composer-pill",
+    "aria-label": "Pro Extended",
+  });
 
   const expression = buildModelSelectionExpressionForTest(targetModel);
   const documentStub = {
@@ -338,7 +387,7 @@ const evaluateIntelligenceModelSelectionExpression = async (
     },
     querySelectorAll: (selector: string) => {
       if (selector.includes("button.__composer-pill")) {
-        return [modelButton];
+        return proPillActive ? [modelButton, proPill] : [modelButton];
       }
       if (selector.includes('role="menu"') || selector.includes("data-radix")) {
         return [
@@ -441,6 +490,45 @@ const createNonPickerMenuForTest = (labels: string[]): unknown => {
     { "data-radix-collection-root": "" },
     labels.map((label) => new FakeElement(label)),
   );
+};
+
+const createDetachedProEffortMenuForTest = (): unknown => {
+  class FakeEventTarget {
+    dispatchEvent(_event: unknown): boolean {
+      return true;
+    }
+  }
+
+  class FakeElement extends FakeEventTarget {
+    constructor(
+      public textContent: string,
+      private readonly attributes: Readonly<Record<string, string>> = {},
+      private readonly children: readonly FakeElement[] = [],
+    ) {
+      super();
+    }
+
+    getAttribute(name: string): string | null {
+      return this.attributes[name] ?? null;
+    }
+
+    querySelector(_selector: string): FakeElement | null {
+      return null;
+    }
+
+    querySelectorAll(_selector: string): FakeElement[] {
+      return [...this.children];
+    }
+
+    closest(_selector: string): FakeElement | null {
+      return null;
+    }
+  }
+
+  return new FakeElement("Pro Standard Pro Extended", { role: "menu" }, [
+    new FakeElement("Pro Standard", { role: "menuitemradio", "aria-checked": "false" }),
+    new FakeElement("Pro Extended", { role: "menuitemradio", "aria-checked": "true" }),
+  ]);
 };
 
 const evaluateComposerPillFallbackExpression = (
@@ -805,9 +893,18 @@ describe("browser model selection matchers", () => {
 
   it("does not treat per-row thinking effort controls as model options", () => {
     const expression = buildModelSelectionExpressionForTest("gpt-5.5-pro");
-    expect(expression).toContain("const isThinkingEffortControl = (node) =>");
+    expect(expression).toContain("const isNestedEffortControl = (node, menu) =>");
     expect(expression).toContain("data-model-picker-thinking-effort-action");
-    expect(expression).toContain("if (isThinkingEffortControl(option))");
+    expect(expression).toContain("data-composer-intelligence-pro-effort-action");
+    expect(expression).toContain("if (isNestedEffortControl(option, menu))");
+  });
+
+  it("ignores detached Pro effort submenus when selecting the Pro model row", async () => {
+    await expect(
+      evaluateMenuModelSelectionExpression("Pro", { label: "Pro" }, [
+        createDetachedProEffortMenuForTest(),
+      ]),
+    ).resolves.toEqual({ status: "switched", label: "Pro" });
   });
 
   it("scopes model option scans to actual model picker menus", () => {
@@ -864,7 +961,7 @@ describe("browser model selection matchers", () => {
     expect(expression).toContain("resolve('changed')");
     expect(expression).toContain("if (selectionSettled === 'target')");
     expect(expression).toContain(
-      "if (optionIsSelected(match.node) || activeSelectionMatchesTarget())",
+      "if (activeSelectionMatchesTarget() || canTrustSelectedOption(match.node, match.normalizedText))",
     );
   });
 
@@ -989,7 +1086,41 @@ describe("browser model selection matchers", () => {
   it("recognizes GPT-5.5 from the new Intelligence submenu while the button shows effort", async () => {
     await expect(evaluateIntelligenceModelSelectionExpression("Thinking 5.5")).resolves.toEqual({
       status: "already-selected",
-      label: "GPT-5.5",
+      label: "Thinking 5.5",
     });
+  });
+
+  it("uses the non-Pro Intelligence effort row when switching from Pro to Thinking 5.5", async () => {
+    await expect(
+      evaluateIntelligenceModelSelectionExpression("Thinking 5.5", "Pro Extended"),
+    ).resolves.toEqual({
+      status: "switched",
+      label: "Extra High",
+    });
+  });
+
+  it("opens the GPT-5.5 submenu to select hidden Thinking 5.4", async () => {
+    await expect(
+      evaluateIntelligenceModelSelectionExpression("Thinking 5.4", "Extra High"),
+    ).resolves.toEqual({
+      status: "switched",
+      label: "GPT-5.4",
+    });
+  });
+
+  it("clears Pro thinking before selecting hidden Thinking 5.4", async () => {
+    await expect(
+      evaluateIntelligenceModelSelectionExpression("Thinking 5.4", "Pro Extended"),
+    ).resolves.toEqual({
+      status: "switched",
+      label: "GPT-5.4",
+    });
+  });
+
+  it("does not treat a checked GPT-5.5 submenu row as a match for Thinking 5.4", () => {
+    const expression = buildModelSelectionExpressionForTest("Thinking 5.4");
+    expect(expression).toContain("normalizedText === 'gpt 5 5'");
+    expect(expression).toContain("candidateTextVersion !== desiredVersion");
+    expect(expression).toContain("canTrustSelectedOption(option, normalizedText)");
   });
 });


### PR DESCRIPTION
## Summary

Fix ChatGPT model selection for the rewritten Intelligence picker.

- Selects non-Pro `Thinking 5.5` via the `Extra High` Intelligence effort row instead of repeatedly opening the `GPT-5.5` submenu
- Selects hidden versions like `Thinking 5.4` by opening the `GPT-5.5` submenu and choosing `5.4`
- Prevents checked wrong-version rows, like checked `5.5`, from satisfying a `5.4` request
- Clears active Pro thinking state before selecting non-Pro thinking versions, fixing `5.5 Pro Extended -> gpt-5.4`

## Testing

```bash
pnpm run format:check
pnpm run build
pnpm exec vitest run tests/browser/modelSelection.test.ts --pool=forks
```

Live smoke:

```bash
pnpm run oracle -- --engine browser \
  --browser-manual-login \
  --browser-keep-browser \
  --model gpt-5.4 \
  --prompt "Reply exactly CHECK_MODEL_PICKER_OK." \
  --verbose \
  --force
```

Result:

```text
Model selection evidence: requested=Thinking 5.4; resolved=5.4Extra High; status=switched; verified=yes.
Answer:
CHECK_MODEL_PICKER_OK
```