### PR TITLE
fix(browser): validate Deep Research completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Browser: wait for the current ChatGPT Intelligence pill before falling back to the default thinking level, and make `--browser-model-strategy select` prefer concrete requested variants over version-only submenu wrappers with bounded retries. This lets current-model runs select and verify Extra High before submitting and prevents explicit Instant selection from hanging (thanks @alex-on-java and @servrox).
 - Browser: save ChatGPT generated-file button downloads sequentially, preserve browser-provided filenames for generic endpoints, and stop after a timed-out download so late completions cannot be attributed to the next file. Thanks @orbitingflea!
+- Browser: reject Deep Research planning/status captures and fail clearly when ChatGPT silently returns a normal response without observable research activity, instead of saving either as the final report. Fixes #261. Thanks @aaronflorey!
 
 ## 0.14.1 — 2026-06-15
 

--- a/src/browser/actions/deepResearch.ts
+++ b/src/browser/actions/deepResearch.ts
@@ -168,6 +168,7 @@ export async function waitForDeepResearchCompletion(
   options?: {
     ignoredTargetKeys?: readonly string[];
     requireScopedTargetOwner?: boolean;
+    targetBaselineCaptured?: boolean;
   },
 ): Promise<{
   text: string;
@@ -183,6 +184,9 @@ export async function waitForDeepResearchCompletion(
       : -1;
   const scopedToNewTurns = minTurnLiteral >= 0;
   const ignoredTargetKeys = new Set(options?.ignoredTargetKeys ?? []);
+  const requireScopedTargetOwner =
+    options?.requireScopedTargetOwner === true ||
+    (scopedToNewTurns && options?.targetBaselineCaptured !== true);
   let observedResearchEvidence = false;
   let loggedIncompleteResult = false;
 
@@ -223,9 +227,11 @@ export async function waitForDeepResearchCompletion(
     // and fall back to the in-page frame path for legacy/inline rendering.
     const rawTargetResult = client
       ? ((
-          await readDeepResearchTargetResult(client, ignoredTargetKeys, minTurnLiteral).catch(
-            () => null,
-          )
+          await readDeepResearchTargetResult(
+            client,
+            ignoredTargetKeys,
+            requireScopedTargetOwner ? minTurnLiteral : -1,
+          ).catch(() => null)
         )?.read ?? null)
       : null;
     const targetResult = filterIncompleteDeepResearchRead(rawTargetResult);
@@ -522,6 +528,9 @@ async function readDeepResearchTargetResult(
   if (typeof rawClient.send !== "function") {
     return null;
   }
+  if (typeof client.on !== "function") {
+    return null;
+  }
 
   // On the browser-WSEndpoint path, `client` is a session-bound wrapper whose
   // domain methods target the page session but whose raw `send` is the
@@ -553,7 +562,7 @@ async function readDeepResearchTargetResult(
     }
   };
 
-  client.on?.("Target.attachedToTarget", onAttached as never);
+  client.on("Target.attachedToTarget", onAttached as never);
   try {
     // Scope discovery to the current Oracle-controlled page. `client` is
     // connected to the conversation page target, so enabling auto-attach on this
@@ -565,7 +574,7 @@ async function readDeepResearchTargetResult(
     // would surface another tab's completed Deep Research report and let it be
     // saved into the current session (cross-tab leak). Only auto-attached,
     // page-scoped sessions are treated as belonging to this run.
-    await rawClient
+    const autoAttachEnabled = await rawClient
       .send(
         "Target.setAutoAttach",
         {
@@ -575,7 +584,13 @@ async function readDeepResearchTargetResult(
         },
         pageSessionId,
       )
-      .catch(() => undefined);
+      .then(
+        () => true,
+        () => false,
+      );
+    if (!autoAttachEnabled) {
+      return null;
+    }
     await delay(100);
 
     if (minTurnIndex >= 0) {
@@ -647,7 +662,11 @@ async function readDeepResearchTargetResult(
 }
 
 export async function captureDeepResearchTargetKeys(client: ChromeClient): Promise<string[]> {
-  return (await readDeepResearchTargetResult(client))?.targetKeys ?? [];
+  const scan = await readDeepResearchTargetResult(client);
+  if (!scan) {
+    throw new Error("Deep Research target baseline capture unavailable");
+  }
+  return scan.targetKeys;
 }
 
 async function readDeepResearchTargetOwnerTurnIndex(

--- a/src/browser/actions/deepResearch.ts
+++ b/src/browser/actions/deepResearch.ts
@@ -183,7 +183,6 @@ export async function waitForDeepResearchCompletion(
       : -1;
   const scopedToNewTurns = minTurnLiteral >= 0;
   const ignoredTargetKeys = new Set(options?.ignoredTargetKeys ?? []);
-  const requireScopedTargetOwner = options?.requireScopedTargetOwner === true;
   let observedResearchEvidence = false;
   let loggedIncompleteResult = false;
 
@@ -214,8 +213,6 @@ export async function waitForDeepResearchCompletion(
         { stage: "chatgpt-account-blocked", code: "chatgpt-account-blocked" },
       );
     }
-    const activeScopedResearch = Boolean(val?.hasActiveScopedResearch);
-
     // ChatGPT renders the Deep Research report inside an out-of-process,
     // sandboxed iframe (connector_openai_deep_research.*.oaiusercontent.com),
     // doubly nested and same-origin. That OOPIF does NOT appear in the main
@@ -226,39 +223,37 @@ export async function waitForDeepResearchCompletion(
     // and fall back to the in-page frame path for legacy/inline rendering.
     const rawTargetResult = client
       ? ((
-          await readDeepResearchTargetResult(
-            client,
-            ignoredTargetKeys,
-            requireScopedTargetOwner ? minTurnLiteral : -1,
-          ).catch(() => null)
+          await readDeepResearchTargetResult(client, ignoredTargetKeys, minTurnLiteral).catch(
+            () => null,
+          )
         )?.read ?? null)
       : null;
     const targetResult = filterIncompleteDeepResearchRead(rawTargetResult);
     // A completed target read is authoritative. If the target read is missing or
     // only in-progress, still try the in-page frame path so an incomplete target
     // read does not suppress a completed report there (legacy/inline rendering).
-    const rawInPageResult =
+    const inPageScan =
       !targetResult?.completed && Page
-        ? await readDeepResearchFrameResult(Runtime, Page).catch(() => null)
+        ? await readDeepResearchFrameResult(
+            Runtime,
+            Page,
+            client,
+            scopedToNewTurns ? minTurnLiteral : -1,
+          ).catch(() => null)
         : null;
+    const rawInPageResult = inPageScan?.read ?? null;
     const inPageResult = filterIncompleteDeepResearchRead(rawInPageResult);
     const read = pickPreferredDeepResearchRead(targetResult, inPageResult);
     // Target keys captured before submission are ignored, so a target result is
     // tied to this run. Main-page iframes are not: old reports can remain in the
     // conversation and must never authorize a new normal-response fallback.
     observedResearchEvidence ||= Boolean(
-      rawTargetResult || val?.researchActivity || val?.hasActiveScopedResearch,
+      rawTargetResult ||
+      (scopedToNewTurns && rawInPageResult) ||
+      val?.researchActivity ||
+      val?.hasActiveScopedResearch,
     );
-    // A target-confirmed completion read the live connector iframe directly, so
-    // it is authoritative even when the main DOM exposes no assistant turn (the
-    // report lives entirely in the OOPIF). The main-DOM hasActiveScopedResearch
-    // heuristic no longer holds in that case, so don't gate on it.
-    const completedFromTarget = Boolean(targetResult?.completed);
-    if (
-      read?.completed &&
-      read.text &&
-      (completedFromTarget || !scopedToNewTurns || activeScopedResearch)
-    ) {
+    if (read?.completed && read.text) {
       logger(`Deep Research completed (${Math.round((Date.now() - start) / 1000)}s elapsed)`);
       return {
         text: read.text,
@@ -385,6 +380,11 @@ interface DeepResearchTargetSessionResult {
   frameId?: string;
 }
 
+interface DeepResearchFrameReadResult {
+  read: DeepResearchFrameStatus;
+  ownerTurnIndex: number | null;
+}
+
 function filterIncompleteDeepResearchRead(
   result: DeepResearchFrameStatus | null,
 ): DeepResearchFrameStatus | null {
@@ -431,7 +431,9 @@ export function pickPreferredDeepResearchReadForTest(
 async function readDeepResearchFrameResult(
   Runtime: ChromeClient["Runtime"],
   Page: ChromeClient["Page"],
-): Promise<DeepResearchFrameStatus | null> {
+  client?: ChromeClient,
+  minTurnIndex = -1,
+): Promise<DeepResearchFrameReadResult | null> {
   const pageWithFrames = Page as ChromeClient["Page"] & {
     getFrameTree?: () => Promise<{ frameTree?: DeepResearchFrameTree }>;
     createIsolatedWorld?: (params: {
@@ -447,24 +449,61 @@ async function readDeepResearchFrameResult(
     return null;
   }
   const frameTree = (await pageWithFrames.getFrameTree())?.frameTree;
-  const frameId = findDeepResearchFrameId(frameTree);
-  if (!frameId) {
+  const frameIds = collectPageDeepResearchFrameIds(frameTree);
+  if (frameIds.length === 0) {
     return null;
   }
-  const world = await pageWithFrames.createIsolatedWorld({
-    frameId,
-    worldName: "oracle-deep-research",
-    grantUniveralAccess: true,
-  });
-  if (typeof world.executionContextId !== "number") {
-    return null;
+  const rawClient = client as
+    | (ChromeClient & {
+        send?: (
+          method: string,
+          params?: Record<string, unknown>,
+          sessionId?: string,
+        ) => Promise<unknown>;
+        oraclePageSessionId?: string;
+      })
+    | undefined;
+  if (minTurnIndex >= 0) {
+    if (typeof rawClient?.send !== "function") {
+      return null;
+    }
   }
-  const { result } = await Runtime.evaluate({
-    expression: buildDeepResearchFrameStatusExpression(),
-    contextId: world.executionContextId,
-    returnByValue: true,
-  });
-  return (result?.value as DeepResearchFrameStatus | undefined) ?? null;
+  let best: DeepResearchFrameReadResult | null = null;
+  for (const frameId of frameIds) {
+    let ownerTurnIndex: number | null = null;
+    if (minTurnIndex >= 0 && rawClient?.send) {
+      ownerTurnIndex = await readDeepResearchTargetOwnerTurnIndex(
+        rawClient as ChromeClient & { send: NonNullable<typeof rawClient.send> },
+        frameId,
+        rawClient.oraclePageSessionId,
+      );
+      if (ownerTurnIndex === null || ownerTurnIndex < minTurnIndex) {
+        continue;
+      }
+    }
+    const world = await pageWithFrames.createIsolatedWorld({
+      frameId,
+      worldName: "oracle-deep-research",
+      grantUniveralAccess: true,
+    });
+    if (typeof world.executionContextId !== "number") {
+      continue;
+    }
+    const { result } = await Runtime.evaluate({
+      expression: buildDeepResearchFrameStatusExpression(),
+      contextId: world.executionContextId,
+      returnByValue: true,
+    });
+    const read = (result?.value as DeepResearchFrameStatus | undefined) ?? null;
+    if (!read) {
+      continue;
+    }
+    best = { read, ownerTurnIndex };
+    if (read.completed) {
+      return best;
+    }
+  }
+  return best;
 }
 
 async function readDeepResearchTargetResult(
@@ -679,7 +718,7 @@ async function readDeepResearchTargetSession(
   const frameTree = (await rawClient
     .send("Page.getFrameTree", {}, sessionId)
     .catch(() => null)) as { frameTree?: DeepResearchFrameTree } | null;
-  const frameId = frameTree?.frameTree?.frame?.id;
+  const ownerFrameId = frameTree?.frameTree?.frame?.id;
   if (!isConfirmedDeepResearchTarget(targetUrl, frameTree?.frameTree)) {
     return { confirmed: false, read: null };
   }
@@ -707,7 +746,7 @@ async function readDeepResearchTargetSession(
       world.executionContextId,
     );
     if (value?.completed) {
-      return { confirmed: true, read: value, frameId };
+      return { confirmed: true, read: value, frameId: ownerFrameId };
     }
     if ((value?.textLength ?? 0) > (best?.textLength ?? 0) || value?.inProgress) {
       best = value;
@@ -716,13 +755,13 @@ async function readDeepResearchTargetSession(
 
   const topFrameValue = await evaluateDeepResearchFrameStatus(rawClient, sessionId);
   if (topFrameValue?.completed) {
-    return { confirmed: true, read: topFrameValue, frameId };
+    return { confirmed: true, read: topFrameValue, frameId: ownerFrameId };
   }
   if ((topFrameValue?.textLength ?? 0) > (best?.textLength ?? 0) || topFrameValue?.inProgress) {
     best = topFrameValue;
   }
 
-  return { confirmed: true, read: best, frameId };
+  return { confirmed: true, read: best, frameId: ownerFrameId };
 }
 
 async function evaluateDeepResearchFrameStatus(
@@ -769,21 +808,21 @@ function isDeepResearchFrameDescriptor(url: string, name = ""): boolean {
 }
 
 function findDeepResearchFrameId(tree: DeepResearchFrameTree | undefined): string | null {
+  return collectPageDeepResearchFrameIds(tree)[0] ?? null;
+}
+
+function collectPageDeepResearchFrameIds(tree: DeepResearchFrameTree | undefined): string[] {
   if (!tree?.frame) {
-    return null;
+    return [];
   }
-  const url = tree.frame.url ?? "";
-  const name = tree.frame.name ?? "";
-  if (isDeepResearchFrameDescriptor(url, name)) {
-    return tree.frame.id ?? null;
+  const ids: string[] = [];
+  if (tree.frame.id && isDeepResearchFrameDescriptor(tree.frame.url ?? "", tree.frame.name ?? "")) {
+    ids.push(tree.frame.id);
   }
   for (const child of tree.childFrames ?? []) {
-    const match = findDeepResearchFrameId(child);
-    if (match) {
-      return match;
-    }
+    ids.push(...collectPageDeepResearchFrameIds(child));
   }
-  return null;
+  return ids;
 }
 
 function collectDeepResearchFrameIds(tree: DeepResearchFrameTree | undefined): string[] {
@@ -1000,9 +1039,16 @@ function buildDeepResearchCompletionPollExpression(minTurnIndex: number): string
       const rect = f.getBoundingClientRect();
       return rect.width > 200 && rect.height > 200;
     });
-    const hasActiveScopedResearch = scopedToNewTurns && Boolean(lastTurn) && hasIframe &&
-      (isToolStub || tailIsPlanningPanel);
-    return { finished, stopVisible, textLength, hasIframe, isToolStub, incompleteResult, researchActivity: tailIsPlanningPanel, hasActiveScopedResearch, accountBlocked };
+    const hasScopedDeepResearchIframe = Array.from(lastTurn?.querySelectorAll?.('iframe') || []).some(f => {
+      const rect = f.getBoundingClientRect();
+      const descriptor = String(f.getAttribute('src') || '') + ' ' + String(f.getAttribute('name') || '');
+      return rect.width > 200 && rect.height > 200 &&
+        /connector_openai_deep_research|deep-research/i.test(descriptor);
+    });
+    const hasActiveScopedResearch = scopedToNewTurns && Boolean(lastTurn) &&
+      hasScopedDeepResearchIframe &&
+      (textLength < 40 || isToolStub || tailIsPlanningPanel || /chatgpt\\s+said:?$/i.test(text));
+    return { finished, stopVisible, textLength, hasIframe, isToolStub, incompleteResult, researchActivity: tailIsPlanningPanel || (isToolStub && hasScopedDeepResearchIframe), hasActiveScopedResearch, accountBlocked };
   })()`;
 }
 

--- a/src/browser/actions/deepResearch.ts
+++ b/src/browser/actions/deepResearch.ts
@@ -11,6 +11,7 @@ import {
   CONVERSATION_TURN_SELECTOR,
 } from "../constants.js";
 import { delay } from "../utils.js";
+import { isDeepResearchIncompleteText } from "../deepResearchResult.js";
 import { buildClickDispatcher } from "./domEvents.js";
 import { captureAssistantMarkdown, readAssistantSnapshot } from "./assistantResponse.js";
 import { BrowserAutomationError } from "../../oracle/errors.js";
@@ -183,6 +184,8 @@ export async function waitForDeepResearchCompletion(
   const scopedToNewTurns = minTurnLiteral >= 0;
   const ignoredTargetKeys = new Set(options?.ignoredTargetKeys ?? []);
   const requireScopedTargetOwner = options?.requireScopedTargetOwner === true;
+  let observedResearchEvidence = false;
+  let loggedIncompleteResult = false;
 
   logger(`Monitoring Deep Research (timeout: ${Math.round(timeoutMs / 60_000)}min)...`);
 
@@ -199,6 +202,8 @@ export async function waitForDeepResearchCompletion(
           textLength?: number;
           hasIframe?: boolean;
           hasActiveScopedResearch?: boolean;
+          incompleteResult?: boolean;
+          researchActivity?: boolean;
           accountBlocked?: boolean;
         }
       | undefined;
@@ -219,7 +224,7 @@ export async function waitForDeepResearchCompletion(
     // (readDeepResearchTargetResult) attaches to the iframe's own CDP target and
     // walks its nested frames, so it CAN read the report. Prefer the target path
     // and fall back to the in-page frame path for legacy/inline rendering.
-    const targetResult = client
+    const rawTargetResult = client
       ? ((
           await readDeepResearchTargetResult(
             client,
@@ -228,14 +233,22 @@ export async function waitForDeepResearchCompletion(
           ).catch(() => null)
         )?.read ?? null)
       : null;
+    const targetResult = filterIncompleteDeepResearchRead(rawTargetResult);
     // A completed target read is authoritative. If the target read is missing or
     // only in-progress, still try the in-page frame path so an incomplete target
     // read does not suppress a completed report there (legacy/inline rendering).
-    const inPageResult =
+    const rawInPageResult =
       !targetResult?.completed && Page
         ? await readDeepResearchFrameResult(Runtime, Page).catch(() => null)
         : null;
+    const inPageResult = filterIncompleteDeepResearchRead(rawInPageResult);
     const read = pickPreferredDeepResearchRead(targetResult, inPageResult);
+    // Target keys captured before submission are ignored, so a target result is
+    // tied to this run. Main-page iframes are not: old reports can remain in the
+    // conversation and must never authorize a new normal-response fallback.
+    observedResearchEvidence ||= Boolean(
+      rawTargetResult || val?.researchActivity || val?.hasActiveScopedResearch,
+    );
     // A target-confirmed completion read the live connector iframe directly, so
     // it is authoritative even when the main DOM exposes no assistant turn (the
     // report lives entirely in the OOPIF). The main-DOM hasActiveScopedResearch
@@ -256,8 +269,23 @@ export async function waitForDeepResearchCompletion(
 
     // Completion detected
     if (val?.finished) {
+      if (!observedResearchEvidence) {
+        throw new BrowserAutomationError(
+          "ChatGPT returned a completed response without starting Deep Research. The Deep Research selection may have silently fallen back to a normal response.",
+          { stage: "deep-research-not-started", code: "deep-research-not-started" },
+        );
+      }
       logger(`Deep Research completed (${Math.round((Date.now() - start) / 1000)}s elapsed)`);
       return await extractDeepResearchResult(Runtime, logger, minTurnIndex ?? undefined);
+    }
+
+    const incompleteFrameResult = Boolean(
+      (rawTargetResult?.completed && !targetResult?.completed) ||
+      (rawInPageResult?.completed && !inPageResult?.completed),
+    );
+    if ((val?.incompleteResult || incompleteFrameResult) && !loggedIncompleteResult) {
+      logger("Deep Research interim status detected; waiting for the final report");
+      loggedIncompleteResult = true;
     }
 
     // Progress logging every 60 seconds
@@ -314,12 +342,12 @@ export async function extractDeepResearchResult(
 
   // Try the copy-button approach first for clean markdown
   const markdown = await captureAssistantMarkdown(Runtime, meta, logger);
-  if (markdown && !isDeepResearchPlaceholderText(markdown)) {
+  if (markdown && !isDeepResearchIncompleteText(markdown)) {
     return { text: markdown, html: snapshot?.html ?? undefined, meta };
   }
 
   // Fall back to snapshot text
-  if (snapshot?.text && !isDeepResearchPlaceholderText(snapshot.text)) {
+  if (snapshot?.text && !isDeepResearchIncompleteText(snapshot.text)) {
     return { text: snapshot.text, html: snapshot.html ?? undefined, meta };
   }
 
@@ -329,18 +357,8 @@ export async function extractDeepResearchResult(
   );
 }
 
-function isDeepResearchPlaceholderText(text: string): boolean {
-  const normalized = text.toLowerCase().replace(/\s+/g, " ").trim();
-  return (
-    normalized === "called tool" ||
-    normalized === "used tool" ||
-    normalized === "użyto narzędzia" ||
-    normalized === "narzędzie wywołane"
-  );
-}
-
 export function isDeepResearchPlaceholderTextForTest(text: string): boolean {
-  return isDeepResearchPlaceholderText(text);
+  return isDeepResearchIncompleteText(text);
 }
 
 interface DeepResearchFrameTree {
@@ -365,6 +383,21 @@ interface DeepResearchTargetSessionResult {
   confirmed: boolean;
   read: DeepResearchFrameStatus | null;
   frameId?: string;
+}
+
+function filterIncompleteDeepResearchRead(
+  result: DeepResearchFrameStatus | null,
+): DeepResearchFrameStatus | null {
+  if (!result?.completed || !result.text || !isDeepResearchIncompleteText(result.text)) {
+    return result;
+  }
+  return { ...result, completed: false, inProgress: true };
+}
+
+export function filterIncompleteDeepResearchReadForTest(
+  result: DeepResearchFrameStatus | null,
+): DeepResearchFrameStatus | null {
+  return filterIncompleteDeepResearchRead(result);
 }
 
 /**
@@ -942,20 +975,34 @@ function buildDeepResearchCompletionPollExpression(minTurnIndex: number): string
     const text = (lastTurn?.textContent || '').trim();
     const normalized = text.toLowerCase().replace(/\\s+/g, ' ').trim();
     const textLength = text.length;
+    const lines = text.split(/\\n+/).map(line => line.trim()).filter(Boolean);
+    const tailIsPlanningPanel = text.length <= 1500 &&
+      lines.length >= 4 &&
+      lines.length <= 20 &&
+      /^update$/i.test(lines[1] || '') &&
+      /^stop research$/i.test(lines[lines.length - 1] || '') &&
+      /^determining steps for creating a report(?:\\.\\.\\.)?$/i.test(lines[lines.length - 2] || '');
     const isToolStub = normalized === 'called tool' ||
       normalized === 'used tool' ||
       normalized === 'użyto narzędzia' ||
       normalized === 'narzędzie wywołane';
+    const incompleteResult = isToolStub ||
+      normalized === 'planning' ||
+      normalized === 'researching' ||
+      normalized === 'searching the web' ||
+      (text.trimStart().startsWith('<system-reminder>') &&
+        /<system-reminder>[\\s\\S]*#\\s*plan mode\\b/i.test(text)) ||
+      tailIsPlanningPanel;
     const finished = Boolean(lastTurn?.querySelector(${finishedSelector})) &&
       textLength >= 40 &&
-      !isToolStub;
+      !incompleteResult;
     const hasIframe = Array.from(document.querySelectorAll('iframe')).some(f => {
       const rect = f.getBoundingClientRect();
       return rect.width > 200 && rect.height > 200;
     });
     const hasActiveScopedResearch = scopedToNewTurns && Boolean(lastTurn) && hasIframe &&
-      (textLength < 40 || isToolStub || /chatgpt\\s+said:?$/i.test(text));
-    return { finished, stopVisible, textLength, hasIframe, isToolStub, hasActiveScopedResearch, accountBlocked };
+      (isToolStub || tailIsPlanningPanel);
+    return { finished, stopVisible, textLength, hasIframe, isToolStub, incompleteResult, researchActivity: tailIsPlanningPanel, hasActiveScopedResearch, accountBlocked };
   })()`;
 }
 

--- a/src/browser/artifacts.ts
+++ b/src/browser/artifacts.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { getOracleHomeDir } from "../oracleHome.js";
 import type { SessionArtifact } from "../sessionStore.js";
+import { isDeepResearchIncompleteText } from "./deepResearchResult.js";
 import type { BrowserLogger } from "./types.js";
 
 const ARTIFACTS_DIRNAME = "artifacts";
@@ -118,16 +119,6 @@ export async function writeBinaryBrowserArtifact(params: {
   };
 }
 
-function isToolOnlyPlaceholder(text: string): boolean {
-  const normalized = text.toLowerCase().replace(/\s+/g, " ").trim();
-  return (
-    normalized === "called tool" ||
-    normalized === "used tool" ||
-    normalized === "użyto narzędzia" ||
-    normalized === "narzędzie wywołane"
-  );
-}
-
 export async function saveDeepResearchReportArtifact(params: {
   sessionId?: string;
   reportMarkdown: string;
@@ -135,7 +126,7 @@ export async function saveDeepResearchReportArtifact(params: {
   logger?: BrowserLogger;
 }): Promise<SessionArtifact | null> {
   const report = params.reportMarkdown.trim();
-  if (report.length < 40 || isToolOnlyPlaceholder(report)) {
+  if (report.length < 40 || isDeepResearchIncompleteText(report)) {
     return null;
   }
   return writeTextBrowserArtifact({

--- a/src/browser/chromeLifecycle.ts
+++ b/src/browser/chromeLifecycle.ts
@@ -474,6 +474,9 @@ function createSessionBoundChromeClient(browser: ChromeClient, sessionId: string
     // Raw `send` here is the browser-level send (not session-bound), so callers
     // that issue Target.* via `send` must pass this page session id explicitly to
     // stay scoped to this tab (e.g. Deep Research OOPIF auto-attach).
+    // chrome-remote-interface defines `send` on the client prototype, so object
+    // spread does not preserve it. Bind it explicitly for raw session commands.
+    send: typeof browser.send === "function" ? browser.send.bind(browser) : undefined,
     oraclePageSessionId: sessionId,
     Network: bindDomain("Network"),
     Page: bindDomain("Page"),

--- a/src/browser/deepResearchResult.ts
+++ b/src/browser/deepResearchResult.ts
@@ -1,0 +1,26 @@
+export function isDeepResearchIncompleteText(text: string): boolean {
+  const normalized = text.toLowerCase().replace(/\s+/g, " ").trim();
+  const lines = text
+    .split(/\n+/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const tailIsPlanningPanel =
+    text.length <= 1_500 &&
+    lines.length >= 4 &&
+    lines.length <= 20 &&
+    /^update$/i.test(lines[1] ?? "") &&
+    /^stop research$/i.test(lines.at(-1) ?? "") &&
+    /^determining steps for creating a report(?:\.\.\.)?$/i.test(lines.at(-2) ?? "");
+  return (
+    normalized === "called tool" ||
+    normalized === "used tool" ||
+    normalized === "użyto narzędzia" ||
+    normalized === "narzędzie wywołane" ||
+    normalized === "planning" ||
+    normalized === "researching" ||
+    normalized === "searching the web" ||
+    (text.trimStart().startsWith("<system-reminder>") &&
+      /<system-reminder>[\s\S]*#\s*plan mode\b/i.test(text)) ||
+    tailIsPlanningPanel
+  );
+}

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -679,7 +679,22 @@ type BrowserSubmissionResult = {
   baselineTurns: number | null;
   baselineAssistantText: string | null;
   deepResearchTargetKeys?: string[];
+  deepResearchTargetBaselineCaptured?: boolean;
 };
+
+async function captureDeepResearchTargetBaseline(
+  client: ChromeClient,
+  logger: BrowserLogger,
+): Promise<{ targetKeys: string[]; captured: boolean }> {
+  try {
+    return { targetKeys: await captureDeepResearchTargetKeys(client), captured: true };
+  } catch {
+    logger(
+      "[browser] Deep Research target baseline unavailable; retaining conversation-turn owner scoping.",
+    );
+    return { targetKeys: [], captured: false };
+  }
+}
 
 type BrowserSubmissionFallback = {
   prompt: string;
@@ -1453,9 +1468,9 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
         attachmentNames: attachmentExpectations,
         onPromptSubmitted: markPromptSubmitted,
       };
-      const deepResearchTargetKeys =
+      const deepResearchTargetBaseline =
         deepResearch && client
-          ? await captureDeepResearchTargetKeys(client).catch(() => [])
+          ? await captureDeepResearchTargetBaseline(client, logger)
           : undefined;
       await runProviderSubmissionFlow(chatgptDomProvider, {
         prompt,
@@ -1497,7 +1512,12 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
       }
       // Reattach needs a /c/ URL; ChatGPT can update it late, so poll in the background.
       scheduleConversationHint("post-submit", config.timeoutMs ?? 120_000);
-      return { baselineTurns, baselineAssistantText, deepResearchTargetKeys };
+      return {
+        baselineTurns,
+        baselineAssistantText,
+        deepResearchTargetKeys: deepResearchTargetBaseline?.targetKeys,
+        deepResearchTargetBaselineCaptured: deepResearchTargetBaseline?.captured,
+      };
     };
     const reloadPromptComposer = async () => {
       logger("[browser] Composer became unresponsive; reloading page and retrying once.");
@@ -1508,6 +1528,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
     let baselineTurns: number | null = null;
     let baselineAssistantText: string | null = null;
     let deepResearchTargetKeys: string[] = [];
+    let deepResearchTargetBaselineCaptured = false;
     await acquireProfileLockIfNeeded();
     try {
       const submission = await runSubmissionWithRecovery({
@@ -1526,6 +1547,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
       baselineTurns = submission.baselineTurns;
       baselineAssistantText = submission.baselineAssistantText;
       deepResearchTargetKeys = submission.deepResearchTargetKeys ?? [];
+      deepResearchTargetBaselineCaptured = submission.deepResearchTargetBaselineCaptured ?? false;
     } finally {
       await releaseProfileLockIfHeld();
     }
@@ -1540,7 +1562,10 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
           baselineTurns,
           Page,
           client,
-          { ignoredTargetKeys: deepResearchTargetKeys },
+          {
+            ignoredTargetKeys: deepResearchTargetKeys,
+            targetBaselineCaptured: deepResearchTargetBaselineCaptured,
+          },
         ),
       );
       await updateConversationHint("post-deep-research", 15_000).catch(() => false);
@@ -2889,9 +2914,9 @@ async function runRemoteBrowserMode(
         attachmentNames: attachmentExpectations,
         onPromptSubmitted: markPromptSubmitted,
       };
-      const deepResearchTargetKeys =
+      const deepResearchTargetBaseline =
         deepResearch && client
-          ? await captureDeepResearchTargetKeys(client).catch(() => [])
+          ? await captureDeepResearchTargetBaseline(client, logger)
           : undefined;
       await runProviderSubmissionFlow(chatgptDomProvider, {
         prompt,
@@ -2905,7 +2930,12 @@ async function runRemoteBrowserMode(
       if (typeof providerBaselineTurns === "number" && Number.isFinite(providerBaselineTurns)) {
         baselineTurns = providerBaselineTurns;
       }
-      return { baselineTurns, baselineAssistantText, deepResearchTargetKeys };
+      return {
+        baselineTurns,
+        baselineAssistantText,
+        deepResearchTargetKeys: deepResearchTargetBaseline?.targetKeys,
+        deepResearchTargetBaselineCaptured: deepResearchTargetBaseline?.captured,
+      };
     };
     const reloadPromptComposer = async () => {
       logger("[browser] Composer became unresponsive; reloading page and retrying once.");
@@ -2916,6 +2946,7 @@ async function runRemoteBrowserMode(
     let baselineTurns: number | null = null;
     let baselineAssistantText: string | null = null;
     let deepResearchTargetKeys: string[] = [];
+    let deepResearchTargetBaselineCaptured = false;
     const submission = await runSubmissionWithRecovery({
       prompt: promptText,
       attachments,
@@ -2931,6 +2962,7 @@ async function runRemoteBrowserMode(
     baselineTurns = submission.baselineTurns;
     baselineAssistantText = submission.baselineAssistantText;
     deepResearchTargetKeys = submission.deepResearchTargetKeys ?? [];
+    deepResearchTargetBaselineCaptured = submission.deepResearchTargetBaselineCaptured ?? false;
     const imageArtifactMinTurnIndex = baselineTurns;
     if (deepResearch) {
       await waitForResearchPlanAutoConfirm(Runtime, logger);
@@ -2941,7 +2973,10 @@ async function runRemoteBrowserMode(
         baselineTurns,
         Page,
         client,
-        { ignoredTargetKeys: deepResearchTargetKeys },
+        {
+          ignoredTargetKeys: deepResearchTargetKeys,
+          targetBaselineCaptured: deepResearchTargetBaselineCaptured,
+        },
       );
       await emitRuntimeHint();
       const durationMs = Date.now() - startedAt;

--- a/tests/browser/artifacts.test.ts
+++ b/tests/browser/artifacts.test.ts
@@ -52,6 +52,19 @@ describe("browser session artifacts", () => {
     ).resolves.toBeNull();
   });
 
+  test("does not save Deep Research planning panels as reports", async () => {
+    const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-artifacts-"));
+    setOracleHomeDirOverrideForTest(tmpHome);
+
+    await expect(
+      saveDeepResearchReportArtifact({
+        sessionId: "planning-placeholder",
+        reportMarkdown:
+          "project root-cause analysis\nUpdate\nInspect the adapter.\nDetermining steps for creating a report...\nStop research",
+      }),
+    ).resolves.toBeNull();
+  });
+
   test("writes a transcript with prompt, answer, conversation URL, and artifact references", async () => {
     const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-transcript-"));
     setOracleHomeDirOverrideForTest(tmpHome);

--- a/tests/browser/chromeLifecycle.test.ts
+++ b/tests/browser/chromeLifecycle.test.ts
@@ -201,6 +201,7 @@ describe("closeBlankChromeTabs", () => {
   });
 
   test("opens a dedicated tab through a browser websocket endpoint", async () => {
+    const send = vi.fn(async () => ({}));
     const browserClient = {
       Target: {
         createTarget: vi.fn(async () => ({ targetId: "target-9" })),
@@ -218,6 +219,7 @@ describe("closeBlankChromeTabs", () => {
       removeListener: vi.fn(),
       close: vi.fn(async () => {}),
     };
+    Object.defineProperty(browserClient, "send", { value: send });
     cdpMock.mockResolvedValue(browserClient);
 
     const { connectToRemoteChrome } = await import("../../src/browser/chromeLifecycle.js");
@@ -241,6 +243,16 @@ describe("closeBlankChromeTabs", () => {
       flatten: true,
     });
     expect(connection.targetId).toBe("target-9");
+    await (
+      connection.client as typeof connection.client & {
+        send: (method: string, params: unknown, sessionId: string) => Promise<unknown>;
+      }
+    ).send("Target.setAutoAttach", { autoAttach: true }, "session-9");
+    expect(send).toHaveBeenCalledWith(
+      "Target.setAutoAttach",
+      { autoAttach: true },
+      "session-9",
+    );
   });
 
   test("waits on a single websocket connection attempt for Chrome approval", async () => {

--- a/tests/browser/deepResearch.test.ts
+++ b/tests/browser/deepResearch.test.ts
@@ -469,6 +469,23 @@ describe("waitForDeepResearchCompletion", () => {
     ]);
   });
 
+  it("rejects an unavailable target baseline instead of trusting an empty scan", async () => {
+    const mockClient = {
+      on: vi.fn(),
+      removeListener: vi.fn(),
+      send: vi.fn(async (method: string) => {
+        if (method === "Target.setAutoAttach") {
+          throw new Error("auto-attach unavailable");
+        }
+        return {};
+      }),
+    };
+
+    await expect(captureDeepResearchTargetKeys(mockClient as never)).rejects.toThrow(
+      "baseline capture unavailable",
+    );
+  });
+
   it("detects completion via finished actions", async () => {
     // First poll: still in progress
     mockRuntime.evaluate.mockResolvedValueOnce({
@@ -1059,32 +1076,19 @@ describe("waitForDeepResearchCompletion", () => {
     }
   });
 
-  it("ignores pre-submit targets while accepting an OOPIF-only current report", async () => {
-    mockRuntime.evaluate
-      .mockResolvedValueOnce({
-        result: {
-          value: {
-            finished: false,
-            stopVisible: true,
-            textLength: 11,
-            hasIframe: true,
-            hasActiveScopedResearch: false,
-          },
+  it("accepts a fresh OOPIF report when its frame owner is unavailable", async () => {
+    mockRuntime.evaluate.mockResolvedValue({
+      result: {
+        value: {
+          finished: false,
+          stopVisible: true,
+          textLength: 11,
+          hasIframe: true,
+          hasActiveScopedResearch: false,
         },
-      })
-      .mockResolvedValueOnce({
-        result: {
-          value: {
-            finished: false,
-            stopVisible: false,
-            textLength: 0,
-            hasIframe: true,
-            hasActiveScopedResearch: false,
-          },
-        },
-      });
+      },
+    });
 
-    let attachPoll = 0;
     const evaluatedSessions: string[] = [];
     const listeners = new Map<string, (params: unknown, sessionId?: string) => void>();
     const deepResearchUrl =
@@ -1097,7 +1101,6 @@ describe("waitForDeepResearchCompletion", () => {
       removeListener: vi.fn(),
       send: vi.fn(async (method: string, params?: unknown, sessionId?: string) => {
         if (method === "Target.setAutoAttach" && (params as { autoAttach?: boolean })?.autoAttach) {
-          attachPoll += 1;
           listeners.get("Target.attachedToTarget")?.(
             {
               sessionId: "old-session",
@@ -1125,16 +1128,7 @@ describe("waitForDeepResearchCompletion", () => {
           return { executionContextId: sessionId === "old-session" ? 10 : 20 };
         }
         if (method === "DOM.getFrameOwner") {
-          const frameId = (params as { frameId?: string }).frameId;
-          return { backendNodeId: frameId === "current-session-frame" ? 20 : 10 };
-        }
-        if (method === "DOM.resolveNode") {
-          const backendNodeId = (params as { backendNodeId?: number }).backendNodeId;
-          return { object: { objectId: backendNodeId === 20 ? "current-owner" : "old-owner" } };
-        }
-        if (method === "Runtime.callFunctionOn" && sessionId === "page-session") {
-          const objectId = (params as { objectId?: string }).objectId;
-          return { result: { value: objectId === "current-owner" ? 1 : 0 } };
+          return {};
         }
         if (method === "Runtime.evaluate" && sessionId) {
           evaluatedSessions.push(sessionId);
@@ -1152,19 +1146,12 @@ describe("waitForDeepResearchCompletion", () => {
           }
           return {
             result: {
-              value:
-                attachPoll >= 2
-                  ? {
-                      completed: true,
-                      inProgress: false,
-                      textLength: 90,
-                      text: "CURRENT_REPORT https://example.com/current",
-                    }
-                  : {
-                      completed: false,
-                      inProgress: true,
-                      textLength: 12,
-                    },
+              value: {
+                completed: true,
+                inProgress: false,
+                textLength: 90,
+                text: "CURRENT_REPORT https://example.com/current",
+              },
             },
           };
         }
@@ -1179,12 +1166,17 @@ describe("waitForDeepResearchCompletion", () => {
       1,
       undefined,
       mockClient as never,
-      { ignoredTargetKeys: ["old-target"] },
+      { ignoredTargetKeys: ["old-target"], targetBaselineCaptured: true },
     );
 
     expect(result.text).toBe("CURRENT_REPORT https://example.com/current");
     expect(evaluatedSessions).toContain("old-session");
     expect(evaluatedSessions).toContain("current-session");
+    expect(mockClient.send).not.toHaveBeenCalledWith(
+      "DOM.getFrameOwner",
+      expect.anything(),
+      "page-session",
+    );
   });
 
   it("scopes reattached OOPIF reports to their owning conversation turn", async () => {
@@ -1548,14 +1540,15 @@ describe("waitForDeepResearchCompletion", () => {
     }
   });
 
-  it("returns an OOPIF report via the target path during a scoped run when the main DOM has no assistant turn", async () => {
+  it("returns a fresh OOPIF report when the main DOM has no assistant turn", async () => {
     // Regression: ChatGPT renders the Deep Research report inside an
     // out-of-process iframe that is invisible to the main page's frame tree.
     // The main-DOM poll therefore shows no assistant turn and
     // hasActiveScopedResearch=false, while the target-attach path reads the
     // completed report directly. Both Page and client are passed (production
-    // shape) and the run is scoped (minTurnIndex>=0). The target-confirmed
-    // completion must be returned instead of hanging until timeout.
+    // shape), the run is scoped (minTurnIndex>=0), and the pre-submit target
+    // baseline is present. The target-confirmed completion must be returned
+    // without requiring frame-owner resolution, which OOPIFs may not support.
     mockRuntime.evaluate.mockResolvedValue({
       result: {
         value: {
@@ -1654,10 +1647,11 @@ describe("waitForDeepResearchCompletion", () => {
       1,
       mockPage as never,
       mockClient as never,
+      { ignoredTargetKeys: [], targetBaselineCaptured: true },
     );
 
     expect(result.text).toBe("OOPIF_REPORT https://example.com/report");
-    expect(mockClient.send).toHaveBeenCalledWith(
+    expect(mockClient.send).not.toHaveBeenCalledWith(
       "DOM.getFrameOwner",
       { frameId: "sandbox" },
       undefined,

--- a/tests/browser/deepResearch.test.ts
+++ b/tests/browser/deepResearch.test.ts
@@ -41,6 +41,34 @@ function createMockLogger(): BrowserLogger {
   return fn;
 }
 
+function createFrameOwnerClient(
+  ownerTurnIndex: number | null | ((frameId: string) => number | null),
+) {
+  let currentFrameId = "";
+  return {
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    send: vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === "DOM.getFrameOwner") {
+        currentFrameId = String(params?.frameId ?? "");
+        return { backendNodeId: 7 };
+      }
+      if (method === "DOM.resolveNode") return { object: { objectId: "frame-owner" } };
+      if (method === "Runtime.callFunctionOn") {
+        return {
+          result: {
+            value:
+              typeof ownerTurnIndex === "function"
+                ? ownerTurnIndex(currentFrameId)
+                : ownerTurnIndex,
+          },
+        };
+      }
+      return {};
+    }),
+  };
+}
+
 describe("activateDeepResearch", () => {
   let mockRuntime: ReturnType<typeof createMockRuntime>;
   let mockInput: Record<string, unknown>;
@@ -577,8 +605,9 @@ describe("waitForDeepResearchCompletion", () => {
           textLength: 11,
           hasIframe: true,
           incompleteResult: true,
-          researchActivity: false,
+          researchActivity: true,
           hasActiveScopedResearch: true,
+          hasVerifiedScopedResearchActivity: true,
         },
       },
     });
@@ -1095,6 +1124,18 @@ describe("waitForDeepResearchCompletion", () => {
         if (method === "Page.createIsolatedWorld") {
           return { executionContextId: sessionId === "old-session" ? 10 : 20 };
         }
+        if (method === "DOM.getFrameOwner") {
+          const frameId = (params as { frameId?: string }).frameId;
+          return { backendNodeId: frameId === "current-session-frame" ? 20 : 10 };
+        }
+        if (method === "DOM.resolveNode") {
+          const backendNodeId = (params as { backendNodeId?: number }).backendNodeId;
+          return { object: { objectId: backendNodeId === 20 ? "current-owner" : "old-owner" } };
+        }
+        if (method === "Runtime.callFunctionOn" && sessionId === "page-session") {
+          const objectId = (params as { objectId?: string }).objectId;
+          return { result: { value: objectId === "current-owner" ? 1 : 0 } };
+        }
         if (method === "Runtime.evaluate" && sessionId) {
           evaluatedSessions.push(sessionId);
           if (sessionId === "old-session") {
@@ -1288,6 +1329,9 @@ describe("waitForDeepResearchCompletion", () => {
         if (method === "Page.createIsolatedWorld") {
           return { executionContextId: sessionId === "complete-session" ? 22 : 11 };
         }
+        if (method === "DOM.getFrameOwner") return { backendNodeId: 7 };
+        if (method === "DOM.resolveNode") return { object: { objectId: "current-owner" } };
+        if (method === "Runtime.callFunctionOn") return { result: { value: 1 } };
         if (method === "Runtime.evaluate" && sessionId === "complete-session") {
           return {
             result: {
@@ -1374,6 +1418,9 @@ describe("waitForDeepResearchCompletion", () => {
             frameTree: { frame: { id: `${sessionId}-frame`, name: "root", url: deepResearchUrl } },
           };
         }
+        if (method === "DOM.getFrameOwner") return { backendNodeId: 7 };
+        if (method === "DOM.resolveNode") return { object: { objectId: "current-owner" } };
+        if (method === "Runtime.callFunctionOn") return { result: { value: 1 } };
         if (method === "Runtime.evaluate" && sessionId === "complete-session") {
           return {
             result: {
@@ -1565,6 +1612,9 @@ describe("waitForDeepResearchCompletion", () => {
             executionContextId: (params as { frameId?: string }).frameId === "root-frame" ? 12 : 11,
           };
         }
+        if (method === "DOM.getFrameOwner") return { backendNodeId: 7 };
+        if (method === "DOM.resolveNode") return { object: { objectId: "current-owner" } };
+        if (method === "Runtime.callFunctionOn") return { result: { value: 1 } };
         if (
           method === "Runtime.evaluate" &&
           sessionId === "deep-session" &&
@@ -1607,6 +1657,11 @@ describe("waitForDeepResearchCompletion", () => {
     );
 
     expect(result.text).toBe("OOPIF_REPORT https://example.com/report");
+    expect(mockClient.send).toHaveBeenCalledWith(
+      "DOM.getFrameOwner",
+      { frameId: "sandbox" },
+      undefined,
+    );
   });
 
   it("does not complete from an unscoped frame result during a scoped run", async () => {
@@ -1645,6 +1700,7 @@ describe("waitForDeepResearchCompletion", () => {
       }),
       createIsolatedWorld: vi.fn().mockResolvedValue({ executionContextId: 42 }),
     };
+    const mockClient = createFrameOwnerClient(0);
     let nowCalls = 0;
     const dateNowSpy = vi.spyOn(Date, "now").mockImplementation(() => {
       nowCalls += 1;
@@ -1653,11 +1709,16 @@ describe("waitForDeepResearchCompletion", () => {
 
     try {
       await expect(
-        waitForDeepResearchCompletion(mockRuntime as never, mockLogger, 100, 1, mockPage as never),
+        waitForDeepResearchCompletion(
+          mockRuntime as never,
+          mockLogger,
+          100,
+          1,
+          mockPage as never,
+          mockClient as never,
+        ),
       ).rejects.toThrow(/did not complete/);
-      expect(mockPage.createIsolatedWorld).toHaveBeenCalledWith(
-        expect.objectContaining({ frameId: "old-deep-frame" }),
-      );
+      expect(mockPage.createIsolatedWorld).not.toHaveBeenCalled();
     } finally {
       dateNowSpy.mockRestore();
     }
@@ -1696,6 +1757,12 @@ describe("waitForDeepResearchCompletion", () => {
           childFrames: [
             {
               frame: {
+                id: "old-deep-frame",
+                url: "https://connector_openai_deep_research.web-sandbox.oaiusercontent.com/old",
+              },
+            },
+            {
+              frame: {
                 id: "fresh-deep-frame",
                 url: "https://connector_openai_deep_research.web-sandbox.oaiusercontent.com/",
               },
@@ -1705,6 +1772,9 @@ describe("waitForDeepResearchCompletion", () => {
       }),
       createIsolatedWorld: vi.fn().mockResolvedValue({ executionContextId: 42 }),
     };
+    const mockClient = createFrameOwnerClient((frameId) =>
+      frameId === "fresh-deep-frame" ? 1 : 0,
+    );
 
     const result = await waitForDeepResearchCompletion(
       mockRuntime as never,
@@ -1712,9 +1782,14 @@ describe("waitForDeepResearchCompletion", () => {
       60_000,
       1,
       mockPage as never,
+      mockClient as never,
     );
 
     expect(result.text).toBe("FRESH_REPORT https://example.com/report");
+    expect(mockPage.createIsolatedWorld).toHaveBeenCalledTimes(1);
+    expect(mockPage.createIsolatedWorld).toHaveBeenCalledWith(
+      expect.objectContaining({ frameId: "fresh-deep-frame" }),
+    );
   });
 
   it("does not fall back to an older completed turn when scoped to new turns", () => {
@@ -1850,6 +1925,107 @@ describe("checkDeepResearchStatus", () => {
 
     expect(result.finished).toBe(false);
     expect(result.incompleteResult).toBe(true);
+  });
+
+  it("keeps short scoped iframe turns active", () => {
+    const expression = buildDeepResearchCompletionPollExpressionForTest(0);
+    const iframe = {
+      getBoundingClientRect: () => ({ width: 800, height: 600 }),
+      getAttribute: (name: string) =>
+        name === "src"
+          ? "https://connector_openai_deep_research.web-sandbox.oaiusercontent.com/"
+          : null,
+    };
+    const assistantTurn = {
+      textContent: "ChatGPT said:",
+      innerText: "ChatGPT said:",
+      dataset: {},
+      getAttribute: (name: string) => (name === "data-message-author-role" ? "assistant" : null),
+      querySelector: () => null,
+      querySelectorAll: (selector: string) => (selector === "iframe" ? [iframe] : []),
+    };
+    const result = new vm.Script(expression).runInNewContext({
+      document: {
+        body: { innerText: assistantTurn.textContent },
+        querySelector: () => null,
+        querySelectorAll: (selector: string) => {
+          if (selector === "iframe") {
+            return [iframe];
+          }
+          if (selector.includes("conversation-turn")) return [assistantTurn];
+          if (selector.includes("data-message-author-role")) return [assistantTurn];
+          return [];
+        },
+      },
+    }) as { hasActiveScopedResearch?: boolean };
+
+    expect(result.hasActiveScopedResearch).toBe(true);
+  });
+
+  it("does not treat a page-global stale iframe as scoped activity", () => {
+    const expression = buildDeepResearchCompletionPollExpressionForTest(0);
+    const iframe = {
+      getBoundingClientRect: () => ({ width: 800, height: 600 }),
+      getAttribute: (name: string) =>
+        name === "src"
+          ? "https://connector_openai_deep_research.web-sandbox.oaiusercontent.com/old"
+          : null,
+    };
+    const assistantTurn = {
+      textContent: "ChatGPT said:",
+      innerText: "ChatGPT said:",
+      dataset: {},
+      getAttribute: (name: string) => (name === "data-message-author-role" ? "assistant" : null),
+      querySelector: () => null,
+      querySelectorAll: () => [],
+    };
+    const result = new vm.Script(expression).runInNewContext({
+      document: {
+        body: { innerText: assistantTurn.textContent },
+        querySelector: () => null,
+        querySelectorAll: (selector: string) => {
+          if (selector === "iframe") return [iframe];
+          if (selector.includes("conversation-turn")) return [assistantTurn];
+          if (selector.includes("data-message-author-role")) return [assistantTurn];
+          return [];
+        },
+      },
+    }) as { hasActiveScopedResearch?: boolean };
+
+    expect(result.hasActiveScopedResearch).toBe(false);
+  });
+
+  it("does not treat a bare tool stub as Deep Research evidence", () => {
+    const expression = buildDeepResearchCompletionPollExpressionForTest(0);
+    const staleIframe = {
+      getBoundingClientRect: () => ({ width: 800, height: 600 }),
+      getAttribute: (name: string) =>
+        name === "src"
+          ? "https://connector_openai_deep_research.web-sandbox.oaiusercontent.com/old"
+          : null,
+    };
+    const assistantTurn = {
+      textContent: "Called tool",
+      innerText: "Called tool",
+      dataset: {},
+      getAttribute: (name: string) => (name === "data-message-author-role" ? "assistant" : null),
+      querySelector: () => null,
+    };
+    const result = new vm.Script(expression).runInNewContext({
+      document: {
+        body: { innerText: assistantTurn.textContent },
+        querySelector: () => null,
+        querySelectorAll: (selector: string) => {
+          if (selector === "iframe") return [staleIframe];
+          if (selector.includes("conversation-turn")) return [assistantTurn];
+          if (selector.includes("data-message-author-role")) return [assistantTurn];
+          return [];
+        },
+      },
+    }) as { researchActivity?: boolean; hasActiveScopedResearch?: boolean };
+
+    expect(result.researchActivity).toBe(false);
+    expect(result.hasActiveScopedResearch).toBe(false);
   });
 
   it("detects ChatGPT account security blocks during completion polling", () => {

--- a/tests/browser/deepResearch.test.ts
+++ b/tests/browser/deepResearch.test.ts
@@ -17,6 +17,7 @@ import {
   buildDeepResearchFrameStatusExpressionForTest,
   buildDeepResearchStatusExpressionForTest,
   captureDeepResearchTargetKeys,
+  filterIncompleteDeepResearchReadForTest,
   findDeepResearchFrameIdForTest,
   isConfirmedDeepResearchTargetForTest,
   isDeepResearchPlaceholderTextForTest,
@@ -133,9 +134,53 @@ describe("isDeepResearchPlaceholderTextForTest", () => {
     expect(isDeepResearchPlaceholderTextForTest("Użyto narzędzia")).toBe(true);
     expect(isDeepResearchPlaceholderTextForTest("CHECK_DEEP_OK https://example.com")).toBe(false);
   });
+
+  it("rejects Deep Research planning and status captures", () => {
+    expect(
+      isDeepResearchPlaceholderTextForTest(
+        "project root-cause analysis\nUpdate\nInspect the adapter.\nDetermining steps for creating a report...\nStop research",
+      ),
+    ).toBe(true);
+    expect(
+      isDeepResearchPlaceholderTextForTest(
+        "<system-reminder>\n# Plan Mode - System Reminder\nDo not make edits.\n</system-reminder>",
+      ),
+    ).toBe(true);
+    expect(
+      isDeepResearchPlaceholderTextForTest(
+        "The final report explains why the Stop research control can remain visible.",
+      ),
+    ).toBe(false);
+    expect(
+      isDeepResearchPlaceholderTextForTest(
+        "# UI findings\n\nThe control can remain visible after completion:\n\nStop research\n\nThis is the defect.",
+      ),
+    ).toBe(false);
+    expect(
+      isDeepResearchPlaceholderTextForTest(
+        "# Evidence\n\nThe captured panel ended with:\n\nDetermining steps for creating a report...\nStop research\n\nThat was not a final report.",
+      ),
+    ).toBe(false);
+    expect(
+      isDeepResearchPlaceholderTextForTest(
+        "# Evidence\n\nThis completed report quotes the two final UI lines.\n\nDetermining steps for creating a report...\nStop research",
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("Deep Research iframe helpers", () => {
+  it("downgrades incomplete iframe content from completed to in-progress", () => {
+    expect(
+      filterIncompleteDeepResearchReadForTest({
+        completed: true,
+        inProgress: false,
+        textLength: 120,
+        text: "project root-cause analysis\nUpdate\nInspect the adapter.\nDetermining steps for creating a report...\nStop research",
+      }),
+    ).toMatchObject({ completed: false, inProgress: true });
+  });
+
   it("finds nested Deep Research frames", () => {
     expect(
       findDeepResearchFrameIdForTest({
@@ -400,7 +445,14 @@ describe("waitForDeepResearchCompletion", () => {
     // First poll: still in progress
     mockRuntime.evaluate.mockResolvedValueOnce({
       result: {
-        value: { finished: false, stopVisible: true, textLength: 100, hasIframe: true },
+        value: {
+          finished: false,
+          stopVisible: true,
+          textLength: 100,
+          hasIframe: true,
+          incompleteResult: true,
+          researchActivity: true,
+        },
       },
     });
     // Second poll: completed
@@ -424,6 +476,128 @@ describe("waitForDeepResearchCompletion", () => {
     mockRuntime.evaluate.mockResolvedValueOnce({
       result: { value: null },
     });
+
+    const result = await waitForDeepResearchCompletion(mockRuntime as never, mockLogger, 60_000);
+    expect(result.text).toBe("Research report content");
+  });
+
+  it("fails clearly when ChatGPT silently returns a normal response", async () => {
+    mockRuntime.evaluate.mockResolvedValueOnce({
+      result: {
+        value: { finished: true, stopVisible: false, textLength: 100, hasIframe: false },
+      },
+    });
+
+    await expect(
+      waitForDeepResearchCompletion(mockRuntime as never, mockLogger, 60_000),
+    ).rejects.toThrow(/without starting Deep Research/);
+  });
+
+  it("does not treat an unscoped page iframe as evidence for a normal response", async () => {
+    mockRuntime.evaluate.mockResolvedValueOnce({
+      result: {
+        value: { finished: false, stopVisible: true, textLength: 10, hasIframe: true },
+      },
+    });
+    mockRuntime.evaluate.mockResolvedValueOnce({
+      result: {
+        value: { finished: true, stopVisible: false, textLength: 100, hasIframe: true },
+      },
+    });
+
+    await expect(
+      waitForDeepResearchCompletion(mockRuntime as never, mockLogger, 60_000),
+    ).rejects.toThrow(/without starting Deep Research/);
+  });
+
+  it("does not treat a system reminder as evidence for a normal response", async () => {
+    mockRuntime.evaluate.mockResolvedValueOnce({
+      result: {
+        value: {
+          finished: false,
+          stopVisible: true,
+          textLength: 100,
+          hasIframe: false,
+          incompleteResult: true,
+          researchActivity: false,
+        },
+      },
+    });
+    mockRuntime.evaluate.mockResolvedValueOnce({
+      result: {
+        value: { finished: true, stopVisible: false, textLength: 100, hasIframe: false },
+      },
+    });
+
+    await expect(
+      waitForDeepResearchCompletion(mockRuntime as never, mockLogger, 60_000),
+    ).rejects.toThrow(/without starting Deep Research/);
+  });
+
+  it("accepts a finished DOM report after observing a planning panel", async () => {
+    mockRuntime.evaluate.mockResolvedValueOnce({
+      result: {
+        value: {
+          finished: false,
+          stopVisible: true,
+          textLength: 100,
+          hasIframe: false,
+          incompleteResult: true,
+          researchActivity: true,
+        },
+      },
+    });
+    mockRuntime.evaluate.mockResolvedValueOnce({
+      result: {
+        value: { finished: true, stopVisible: false, textLength: 5000, hasIframe: false },
+      },
+    });
+    mockRuntime.evaluate.mockResolvedValueOnce({
+      result: {
+        value: {
+          text: "Research report content",
+          html: "<p>Research report content</p>",
+          turnId: "t1",
+          messageId: "m1",
+        },
+      },
+    });
+    mockRuntime.evaluate.mockResolvedValueOnce({ result: { value: null } });
+
+    const result = await waitForDeepResearchCompletion(mockRuntime as never, mockLogger, 60_000);
+    expect(result.text).toBe("Research report content");
+  });
+
+  it("accepts a finished DOM report after scoped tool activity", async () => {
+    mockRuntime.evaluate.mockResolvedValueOnce({
+      result: {
+        value: {
+          finished: false,
+          stopVisible: true,
+          textLength: 11,
+          hasIframe: true,
+          incompleteResult: true,
+          researchActivity: false,
+          hasActiveScopedResearch: true,
+        },
+      },
+    });
+    mockRuntime.evaluate.mockResolvedValueOnce({
+      result: {
+        value: { finished: true, stopVisible: false, textLength: 5000, hasIframe: false },
+      },
+    });
+    mockRuntime.evaluate.mockResolvedValueOnce({
+      result: {
+        value: {
+          text: "Research report content",
+          html: "<p>Research report content</p>",
+          turnId: "t1",
+          messageId: "m1",
+        },
+      },
+    });
+    mockRuntime.evaluate.mockResolvedValueOnce({ result: { value: null } });
 
     const result = await waitForDeepResearchCompletion(mockRuntime as never, mockLogger, 60_000);
     expect(result.text).toBe("Research report content");
@@ -1653,6 +1827,29 @@ describe("checkDeepResearchStatus", () => {
     expect(result.completed).toBe(false);
     expect(result.placeholderOnly).toBe(true);
     expect(result.textLength).toBe("Called tool".length);
+  });
+
+  it("does not report completed for a Deep Research planning panel", () => {
+    const expression = buildDeepResearchCompletionPollExpressionForTest();
+    const assistantTurn = {
+      textContent:
+        "project root-cause analysis\nUpdate\nInspect the adapter.\nDetermining steps for creating a report...\nStop research",
+      querySelector: () => ({}),
+    };
+    const result = new vm.Script(expression).runInNewContext({
+      document: {
+        body: { innerText: assistantTurn.textContent },
+        querySelector: () => null,
+        querySelectorAll: (selector: string) => {
+          if (selector === "iframe") return [];
+          if (selector.includes("data-message-author-role")) return [assistantTurn];
+          return [];
+        },
+      },
+    }) as { finished?: boolean; incompleteResult?: boolean };
+
+    expect(result.finished).toBe(false);
+    expect(result.incompleteResult).toBe(true);
   });
 
   it("detects ChatGPT account security blocks during completion polling", () => {


### PR DESCRIPTION
## Summary

- reject Deep Research planning panels, system reminders, and tool placeholders before treating them as final reports
- require current-run research evidence before accepting a finished main-DOM response, so silent normal-response fallback fails clearly
- apply the same incomplete-result classifier to iframe reads, extraction, and report artifact saving
- scope target and in-page research frames to their owning post-submission conversation turn, skipping retained stale frames

Fixes #261.

## Verification

- affected Deep Research, reattach, and artifact suites — 83 passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — 1,309 passed, 43 skipped
- Auto Review (`gpt-5.5`, high) — clean; no accepted/actionable findings

## Caveat

No live Deep Research credit was consumed. The regression uses the reporter's captured planning/status and system-reminder shapes; a real browser Deep Research run remains the final merge gate.
