### PR TITLE
fix(browser): wait for current Intelligence pill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Browser: wait for the current ChatGPT Intelligence pill before falling back to the default thinking level. This lets `--browser-model-strategy current --browser-thinking-time extra-high` select and verify Extra High before submitting.
+- Browser: wait for the current ChatGPT Intelligence pill before falling back to the default thinking level. This lets `--browser-model-strategy current --browser-thinking-time extra-high` select and verify Extra High before submitting (thanks @alex-on-java).
 
 ## 0.14.1 — 2026-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.14.2 — Unreleased
 
+### Fixed
+
+- Browser: wait for the current ChatGPT Intelligence pill before falling back to the default thinking level. This lets `--browser-model-strategy current --browser-thinking-time extra-high` select and verify Extra High before submitting.
+
 ## 0.14.1 — 2026-06-15
 
 ### Changed

--- a/src/browser/actions/thinkingTime.ts
+++ b/src/browser/actions/thinkingTime.ts
@@ -643,7 +643,12 @@ function buildThinkingTimeExpression(
       return null;
     };
 
-    const composerEffortPill = findComposerEffortPill();
+    let composerEffortPill = findComposerEffortPill();
+    const composerPillDeadline = performance.now() + MAX_WAIT_MS;
+    while (!composerEffortPill && performance.now() < composerPillDeadline) {
+      await sleep(100);
+      composerEffortPill = findComposerEffortPill();
+    }
     if (composerEffortPill) {
       const composerModelKind = TARGET_MODEL_KIND || modelKindFromNode(composerEffortPill);
       if (composerEffortPill.getAttribute?.('aria-expanded') !== 'true') {
@@ -762,7 +767,12 @@ function buildThinkingTimeExpression(
       return null;
     };
 
-    const modelBtn = findModelButton();
+    let modelBtn = findModelButton();
+    const modelButtonDeadline = performance.now() + MAX_WAIT_MS;
+    while (!modelBtn && performance.now() < modelButtonDeadline) {
+      await sleep(100);
+      modelBtn = findModelButton();
+    }
     if (!modelBtn) {
       return failure('chip-not-found');
     }

--- a/src/browser/actions/thinkingTime.ts
+++ b/src/browser/actions/thinkingTime.ts
@@ -642,14 +642,62 @@ function buildThinkingTimeExpression(
       }
       return null;
     };
-
     let composerEffortPill = findComposerEffortPill();
-    const composerPillDeadline = performance.now() + MAX_WAIT_MS;
-    while (!composerEffortPill && performance.now() < composerPillDeadline) {
+    let modelBtn = findModelButton();
+    const modelKindFromLegacyTrailing = (trailing) => {
+      const row = trailing.closest?.(
+        '[role="menuitem"], [role="menuitemradio"], [data-radix-collection-item]',
+      );
+      const idText = normalize(
+        (row?.getAttribute?.('data-testid') ?? '') + ' ' +
+        (trailing.getAttribute?.('data-testid') ?? '')
+      );
+      if (!idText.includes('model switcher')) return null;
+      const modelPart = normalize(idText.replace(/\\bthinking effort\\b.*$/, ''));
+      if (hasToken(modelPart, 'pro')) return 'pro';
+      if (hasToken(modelPart, 'thinking')) return 'thinking';
+      if (hasToken(modelPart, 'instant')) return 'instant';
+      return null;
+    };
+    const legacyEffortOwnerIsReady = () => {
+      if (
+        TARGET_MODEL_KIND === 'pro' &&
+        TARGET_LEVEL === 'extended' &&
+        isVisible(document.querySelector(INTELLIGENCE_MENU_SELECTOR))
+      ) {
+        return true;
+      }
+      const expectedKind = TARGET_MODEL_KIND || modelKindFromNode(modelBtn);
+      return Boolean(
+        expectedKind &&
+        findTrailingButtons().some(
+          (button) => isVisible(button) && modelKindFromLegacyTrailing(button) === expectedKind,
+        ),
+      );
+    };
+    let attemptedModelButton =
+      modelBtn?.getAttribute?.('aria-expanded') === 'true' ? modelBtn : null;
+    const effortOwnerDeadline = performance.now() + MAX_WAIT_MS;
+    while (!composerEffortPill && performance.now() < effortOwnerDeadline) {
+      if (
+        modelBtn &&
+        attemptedModelButton !== modelBtn &&
+        modelBtn.getAttribute?.('aria-expanded') !== 'true'
+      ) {
+        dispatchClickSequence(modelBtn);
+        attemptedModelButton = modelBtn;
+        await sleep(INITIAL_WAIT_MS);
+      }
+      if (modelBtn && legacyEffortOwnerIsReady()) break;
       await sleep(100);
       composerEffortPill = findComposerEffortPill();
+      modelBtn = findModelButton();
+      if (modelBtn?.getAttribute?.('aria-expanded') === 'true') {
+        attemptedModelButton = modelBtn;
+      }
     }
     if (composerEffortPill) {
+      if (attemptedModelButton && attemptedModelButton !== composerEffortPill) closeOpenMenus();
       const composerModelKind = TARGET_MODEL_KIND || modelKindFromNode(composerEffortPill);
       if (composerEffortPill.getAttribute?.('aria-expanded') !== 'true') {
         dispatchClickSequence(composerEffortPill);
@@ -715,22 +763,7 @@ function buildThinkingTimeExpression(
         (trailing.getAttribute?.('data-testid') ?? '')
       );
     };
-    const testIdTextForTrailing = (trailing) => {
-      const row = rowForTrailing(trailing) || findEffortRow(trailing);
-      return normalize(
-        (row?.getAttribute?.('data-testid') ?? '') + ' ' +
-        (trailing.getAttribute?.('data-testid') ?? '')
-      );
-    };
-    const modelKindFromTrailing = (trailing) => {
-      const idText = testIdTextForTrailing(trailing);
-      if (!idText.includes('model switcher')) return null;
-      const modelPart = normalize(idText.replace(/\\bthinking effort\\b.*$/, ''));
-      if (hasToken(modelPart, 'pro')) return 'pro';
-      if (hasToken(modelPart, 'thinking')) return 'thinking';
-      if (hasToken(modelPart, 'instant')) return 'instant';
-      return null;
-    };
+    const modelKindFromTrailing = modelKindFromLegacyTrailing;
     const trailingMatchesTargetModelKind = (trailing) => {
       if (!TARGET_MODEL_KIND) return false;
       const idKind = modelKindFromTrailing(trailing);
@@ -767,7 +800,6 @@ function buildThinkingTimeExpression(
       return null;
     };
 
-    let modelBtn = findModelButton();
     const modelButtonDeadline = performance.now() + MAX_WAIT_MS;
     while (!modelBtn && performance.now() < modelButtonDeadline) {
       await sleep(100);
@@ -777,7 +809,10 @@ function buildThinkingTimeExpression(
       return failure('chip-not-found');
     }
     // Open model menu (idempotent — leaves it open if already open).
-    if (modelBtn.getAttribute('aria-expanded') !== 'true') {
+    if (
+      modelBtn.getAttribute('aria-expanded') !== 'true' &&
+      !legacyEffortOwnerIsReady()
+    ) {
       dispatchClickSequence(modelBtn);
       await sleep(INITIAL_WAIT_MS);
     }

--- a/tests/browser/thinkingTime.test.ts
+++ b/tests/browser/thinkingTime.test.ts
@@ -81,7 +81,7 @@ describe("browser thinking-time selection expression", () => {
     expect(inferThinkingTargetModelKindForTest("project")).toBeNull();
   });
 
-  it("uses current ChatGPT data-testid shape to target the Pro effort row", async () => {
+  it("waits for the model button when current Pro effort rows render first", async () => {
     class FakeEventTarget {
       dispatchEvent(_event: unknown): boolean {
         return true;
@@ -148,10 +148,20 @@ describe("browser thinking-time selection expression", () => {
     let proClicks = 0;
     let thinkingClicks = 0;
     let now = 0;
-    const modelButton = new FakeElement("Extended", {
-      "data-testid": "model-switcher-dropdown-button",
-      "aria-expanded": "true",
-    });
+    let modelButtonClicks = 0;
+    let firstModelButtonClickAt: number | null = null;
+    const modelButton = new FakeElement(
+      "Extended",
+      {
+        "data-testid": "model-switcher-dropdown-button",
+        "aria-expanded": "false",
+      },
+      null,
+      () => {
+        modelButtonClicks += 1;
+        firstModelButtonClickAt ??= now;
+      },
+    );
     const unrelatedComposerPill = new FakeElement("Canvas", {
       class: "__composer-pill",
     });
@@ -188,7 +198,7 @@ describe("browser thinking-time selection expression", () => {
     const documentStub = {
       body: new FakeElement(""),
       querySelector: (selector: string) =>
-        selector.includes("model-switcher-dropdown-button") ? modelButton : null,
+        selector.includes("model-switcher-dropdown-button") && now >= 1_000 ? modelButton : null,
       querySelectorAll: (selector: string) => {
         if (selector.includes("__composer-pill")) return [unrelatedComposerPill];
         return selector.includes("data-model-picker-thinking-effort-action")
@@ -242,6 +252,9 @@ describe("browser thinking-time selection expression", () => {
         FakeElement,
       ),
     ).resolves.toMatchObject({ status: "menu-not-found" });
+    expect(modelButtonClicks).toBeGreaterThan(0);
+    expect(firstModelButtonClickAt).not.toBeNull();
+    expect(firstModelButtonClickAt ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(2_000);
     expect(proClicks).toBeGreaterThan(0);
     expect(thinkingClicks).toBe(0);
   });
@@ -610,7 +623,7 @@ describe("browser thinking-time selection expression", () => {
     expect(standard.getAttribute("aria-checked")).toBe("true");
   });
 
-  it("waits for the current Intelligence composer pill before selecting Extra High", async () => {
+  it("waits for a delayed Intelligence pill when its model button and menu appear first", async () => {
     class FakeEventTarget {
       dispatchEvent(_event: unknown): boolean {
         return true;
@@ -662,6 +675,19 @@ describe("browser thinking-time selection expression", () => {
     }
 
     let pillVisible = false;
+    let modelButtonClicks = 0;
+    const modelButton = new FakeElement(
+      "Thinking",
+      {
+        "data-testid": "model-switcher-dropdown-button",
+        "aria-expanded": "false",
+        "aria-haspopup": "menu",
+      },
+      [],
+      () => {
+        modelButtonClicks += 1;
+      },
+    );
     const intelligencePill = new FakeElement(
       "Medium",
       {
@@ -707,7 +733,11 @@ describe("browser thinking-time selection expression", () => {
     );
     const documentStub = {
       body: new FakeElement(""),
-      querySelector: (_selector: string) => null,
+      querySelector: (selector: string) => {
+        if (selector.includes("model-switcher-dropdown-button")) return modelButton;
+        if (selector === '[data-testid="composer-intelligence-picker-content"]') return effortMenu;
+        return null;
+      },
       querySelectorAll: (selector: string) => {
         if (
           selector.includes("form button.__composer-pill") ||
@@ -727,47 +757,58 @@ describe("browser thinking-time selection expression", () => {
           : null,
       dispatchEvent: () => true,
     };
-    let now = 0;
-    let timers = 0;
-    const expression = buildThinkingTimeExpressionForTest("heavy", null);
-    const evaluate = new Function(
-      "document",
-      "performance",
-      "setTimeout",
-      "window",
-      "EventTarget",
-      "PointerEvent",
-      "MouseEvent",
-      "HTMLElement",
-      `return ${expression};`,
-    ) as (
-      document: unknown,
-      performance: unknown,
-      setTimeout: unknown,
-      window: unknown,
-      EventTarget: unknown,
-      PointerEvent: unknown,
-      MouseEvent: unknown,
-      HTMLElement: unknown,
-    ) => Promise<unknown>;
+    for (const targetModel of [null, "gpt-5.5"] as const) {
+      pillVisible = false;
+      modelButtonClicks = 0;
+      intelligencePill.textContent = "Medium";
+      intelligencePill.setAttribute("aria-expanded", "false");
+      medium.setAttribute("aria-checked", "true");
+      medium.setAttribute("data-state", "checked");
+      extraHigh.setAttribute("aria-checked", "false");
+      extraHigh.setAttribute("data-state", "unchecked");
+      let now = 0;
+      let timers = 0;
+      const expression = buildThinkingTimeExpressionForTest("heavy", targetModel);
+      const evaluate = new Function(
+        "document",
+        "performance",
+        "setTimeout",
+        "window",
+        "EventTarget",
+        "PointerEvent",
+        "MouseEvent",
+        "HTMLElement",
+        `return ${expression};`,
+      ) as (
+        document: unknown,
+        performance: unknown,
+        setTimeout: unknown,
+        window: unknown,
+        EventTarget: unknown,
+        PointerEvent: unknown,
+        MouseEvent: unknown,
+        HTMLElement: unknown,
+      ) => Promise<unknown>;
 
-    await expect(
-      evaluate(
-        documentStub,
-        { now: () => (now += 100) },
-        (callback: () => void) => {
-          timers += 1;
-          if (timers >= 2) pillVisible = true;
-          callback();
-        },
-        { PointerEvent: FakeMouseEvent, MouseEvent: FakeMouseEvent, Event: FakeMouseEvent },
-        FakeEventTarget,
-        FakeMouseEvent,
-        FakeMouseEvent,
-        FakeElement,
-      ),
-    ).resolves.toEqual({ status: "switched", label: "Extra High" });
-    expect(intelligencePill.textContent).toBe("Extra High");
+      await expect(
+        evaluate(
+          documentStub,
+          { now: () => (now += 100) },
+          (callback: () => void) => {
+            timers += 1;
+            if (timers >= 40) pillVisible = true;
+            callback();
+          },
+          { PointerEvent: FakeMouseEvent, MouseEvent: FakeMouseEvent, Event: FakeMouseEvent },
+          FakeEventTarget,
+          FakeMouseEvent,
+          FakeMouseEvent,
+          FakeElement,
+        ),
+      ).resolves.toEqual({ status: "switched", label: "Extra High" });
+      expect(intelligencePill.textContent).toBe("Extra High");
+      expect(modelButtonClicks).toBeGreaterThan(0);
+    }
   });
 
   it("captures a model-picker diagnostic on failure outcomes", () => {

--- a/tests/browser/thinkingTime.test.ts
+++ b/tests/browser/thinkingTime.test.ts
@@ -610,6 +610,166 @@ describe("browser thinking-time selection expression", () => {
     expect(standard.getAttribute("aria-checked")).toBe("true");
   });
 
+  it("waits for the current Intelligence composer pill before selecting Extra High", async () => {
+    class FakeEventTarget {
+      dispatchEvent(_event: unknown): boolean {
+        return true;
+      }
+    }
+    class FakeElement extends FakeEventTarget {
+      constructor(
+        public textContent: string,
+        private readonly attributes: Record<string, string> = {},
+        private readonly children: FakeElement[] = [],
+        private readonly onDispatch?: () => void,
+      ) {
+        super();
+      }
+      getAttribute(name: string): string | null {
+        return this.attributes[name] ?? null;
+      }
+      setAttribute(name: string, value: string): void {
+        this.attributes[name] = value;
+      }
+      querySelector(_selector: string): FakeElement | null {
+        return null;
+      }
+      querySelectorAll(selector: string): FakeElement[] {
+        return selector.includes("menuitem") || selector === "button" ? this.children : [];
+      }
+      closest(_selector: string): FakeElement | null {
+        return null;
+      }
+      matches(selector: string): boolean {
+        return selector.includes("__composer-pill") && this.attributes.class === "__composer-pill";
+      }
+      contains(_node: unknown): boolean {
+        return false;
+      }
+      getBoundingClientRect(): { width: number; height: number } {
+        return { width: 144, height: 36 };
+      }
+      override dispatchEvent(event: unknown): boolean {
+        this.onDispatch?.();
+        return super.dispatchEvent(event);
+      }
+    }
+    class FakeMouseEvent {
+      constructor(
+        public readonly type: string,
+        public readonly init?: unknown,
+      ) {}
+    }
+
+    let pillVisible = false;
+    const intelligencePill = new FakeElement(
+      "Medium",
+      {
+        class: "__composer-pill",
+        "aria-controls": "intelligence-menu",
+        "aria-expanded": "false",
+        "aria-haspopup": "menu",
+      },
+      [],
+      () => intelligencePill.setAttribute("aria-expanded", "true"),
+    );
+    const medium = new FakeElement("Medium", {
+      role: "menuitemradio",
+      "aria-checked": "true",
+      "data-state": "checked",
+    });
+    const extraHigh = new FakeElement(
+      "Extra High",
+      {
+        role: "menuitemradio",
+        "aria-checked": "false",
+        "data-state": "unchecked",
+      },
+      [],
+      () => {
+        medium.setAttribute("aria-checked", "false");
+        medium.setAttribute("data-state", "unchecked");
+        extraHigh.setAttribute("aria-checked", "true");
+        extraHigh.setAttribute("data-state", "checked");
+        intelligencePill.textContent = "Extra High";
+        intelligencePill.setAttribute("aria-expanded", "false");
+      },
+    );
+    const effortMenu = new FakeElement(
+      "Intelligence Instant Medium High Extra High",
+      { role: "menu", "data-state": "open" },
+      [
+        new FakeElement("Instant", { role: "menuitemradio", "aria-checked": "false" }),
+        medium,
+        new FakeElement("High", { role: "menuitemradio", "aria-checked": "false" }),
+        extraHigh,
+      ],
+    );
+    const documentStub = {
+      body: new FakeElement(""),
+      querySelector: (_selector: string) => null,
+      querySelectorAll: (selector: string) => {
+        if (
+          selector.includes("form button.__composer-pill") ||
+          selector.includes("composer-footer-actions") ||
+          selector.includes("__composer-pill-composite")
+        ) {
+          return pillVisible ? [intelligencePill] : [];
+        }
+        if (selector.includes('[role="menu"]')) {
+          return intelligencePill.getAttribute("aria-expanded") === "true" ? [effortMenu] : [];
+        }
+        return [];
+      },
+      getElementById: (id: string) =>
+        id === "intelligence-menu" && intelligencePill.getAttribute("aria-expanded") === "true"
+          ? effortMenu
+          : null,
+      dispatchEvent: () => true,
+    };
+    let now = 0;
+    let timers = 0;
+    const expression = buildThinkingTimeExpressionForTest("heavy", null);
+    const evaluate = new Function(
+      "document",
+      "performance",
+      "setTimeout",
+      "window",
+      "EventTarget",
+      "PointerEvent",
+      "MouseEvent",
+      "HTMLElement",
+      `return ${expression};`,
+    ) as (
+      document: unknown,
+      performance: unknown,
+      setTimeout: unknown,
+      window: unknown,
+      EventTarget: unknown,
+      PointerEvent: unknown,
+      MouseEvent: unknown,
+      HTMLElement: unknown,
+    ) => Promise<unknown>;
+
+    await expect(
+      evaluate(
+        documentStub,
+        { now: () => (now += 100) },
+        (callback: () => void) => {
+          timers += 1;
+          if (timers >= 2) pillVisible = true;
+          callback();
+        },
+        { PointerEvent: FakeMouseEvent, MouseEvent: FakeMouseEvent, Event: FakeMouseEvent },
+        FakeEventTarget,
+        FakeMouseEvent,
+        FakeMouseEvent,
+        FakeElement,
+      ),
+    ).resolves.toEqual({ status: "switched", label: "Extra High" });
+    expect(intelligencePill.textContent).toBe("Extra High");
+  });
+
   it("captures a model-picker diagnostic on failure outcomes", () => {
     const expression = buildThinkingTimeExpressionForTest("extended", "gpt-5.5-pro");
     expect(expression).toContain("collectPickerDiagnostic");
@@ -702,9 +862,10 @@ describe("browser thinking-time selection expression", () => {
       HTMLElement: unknown,
     ) => Promise<unknown>;
 
+    let now = 0;
     const result = await evaluate(
       documentStub,
-      { now: () => 0 },
+      { now: () => (now += 500) },
       (callback: () => void) => callback(),
       { PointerEvent: FakeMouseEvent, MouseEvent: FakeMouseEvent, Event: FakeMouseEvent },
       FakeEventTarget,


### PR DESCRIPTION

Fixes #264

### Summary

- Wait for the current ChatGPT Intelligence pill before falling back to the default thinking level.
- Cover delayed current Intelligence controls in the browser thinking-time selector tests.
- Keep the fix scoped to current-model Intelligence selection.

### Why

Oracle `0.14.1` fixed the main updated-picker path, but the current-model path could still submit too early. A source browser run with `--browser-model-strategy current --browser-thinking-time extra-high` logged `thinking-chip-not-found`, continued with the ChatGPT default, and submitted without confirming Extra High.

### User Impact

Browser-mode runs that keep the current model can now apply the requested Intelligence level before prompt submission. This keeps `--browser-model-strategy current --browser-thinking-time extra-high` aligned with the user request.

### Testing

Validation used `mise exec -- pnpm vitest run tests/browser/thinkingTime.test.ts` for focused coverage.

Repository checks passed: `mise exec -- pnpm format:check`, `mise exec -- pnpm build`, `mise exec -- pnpm lint`, and `git diff --check`.

Failing source smoke before the fix:

```text
Model picker: current model (label unavailable)
Browser automation failure (thinking-chip-not-found); capturing DOM snapshot for debugging...
[browser] Thinking time: chip not found (requested Heavy); continuing with ChatGPT default.
```

Fixed local built CLI smoke:

```text
Model picker: current model (label unavailable)
[browser] Thinking time: Extra High (already selected)
Answer:
fixed-current-extra-high-smoke
```