### PR TITLE
fix(browser): save generated files sequentially

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Browser: wait for the current ChatGPT Intelligence pill before falling back to the default thinking level, and make `--browser-model-strategy select` prefer concrete requested variants over version-only submenu wrappers with bounded retries. This lets current-model runs select and verify Extra High before submitting and prevents explicit Instant selection from hanging (thanks @alex-on-java and @servrox).
+- Browser: save ChatGPT generated-file button downloads sequentially, preserve browser-provided filenames for generic endpoints, and stop after a timed-out download so late completions cannot be attributed to the next file. Thanks @orbitingflea!
 
 ## 0.14.1 — 2026-06-15
 

--- a/src/browser/chatgptFiles.ts
+++ b/src/browser/chatgptFiles.ts
@@ -507,6 +507,7 @@ function buildClickAssistantDownloadButtonsExpression(
   minTurnIndex?: number | null,
   expectedLabels: string[] = [],
   allowGenericDownloadLabels = true,
+  options: { markClicked?: boolean; maxClicks?: number } = {},
 ): string {
   const minTurnLiteral =
     typeof minTurnIndex === "number" && Number.isFinite(minTurnIndex) && minTurnIndex >= 0
@@ -516,12 +517,23 @@ function buildClickAssistantDownloadButtonsExpression(
   const assistantLiteral = JSON.stringify(ASSISTANT_ROLE_SELECTOR);
   const expectedLabelsLiteral = JSON.stringify(expectedLabels);
   const allowGenericDownloadLabelsLiteral = JSON.stringify(allowGenericDownloadLabels);
+  const markClickedLiteral = JSON.stringify(options.markClicked === true);
+  const maxClicksLiteral =
+    typeof options.maxClicks === "number" &&
+    Number.isFinite(options.maxClicks) &&
+    options.maxClicks > 0
+      ? Math.floor(options.maxClicks)
+      : 0;
   return `(() => {
     const MIN_TURN_INDEX = ${minTurnLiteral};
     const CONVERSATION_SELECTOR = ${conversationLiteral};
     const ASSISTANT_SELECTOR = ${assistantLiteral};
     const EXPECTED_LABELS = ${expectedLabelsLiteral};
     const ALLOW_GENERIC_DOWNLOAD_LABELS = ${allowGenericDownloadLabelsLiteral};
+    const MARK_CLICKED = ${markClickedLiteral};
+    const MAX_CLICKS = ${maxClicksLiteral};
+    const HAS_EXPECTED_LABELS = EXPECTED_LABELS.length > 0;
+    const CLICKED_ATTRIBUTE = 'data-oracle-download-clicked';
     const isAssistantTurn = (node) => {
       if (!(node instanceof HTMLElement)) return false;
       const turnAttr = (node.getAttribute('data-turn') || node.dataset?.turn || '').toLowerCase();
@@ -532,39 +544,165 @@ function buildClickAssistantDownloadButtonsExpression(
       if (testId.includes('assistant')) return true;
       return Boolean(node.querySelector(ASSISTANT_SELECTOR) || node.querySelector('[data-testid*="assistant"]'));
     };
+    const expectedFileButton = (button) => {
+      const text = (button.textContent || '').trim().toLowerCase();
+      return EXPECTED_LABELS.some((label) => {
+        const downloadLabel = 'download ' + label;
+        return text === label ||
+          text.startsWith(label + ' ') ||
+          text === downloadLabel ||
+          text.startsWith(downloadLabel + ' ');
+      });
+    };
+    const genericBehaviorButton = (button) => {
+      const text = (button.textContent || '').trim().toLowerCase();
+      return ALLOW_GENERIC_DOWNLOAD_LABELS && /^download\\b/.test(text);
+    };
+    const genericFallbackButton = (button) => {
+      if (!ALLOW_GENERIC_DOWNLOAD_LABELS) return false;
+      const text = (button.textContent || '').trim().toLowerCase();
+      const aria = (button.getAttribute('aria-label') || '').trim().toLowerCase();
+      const testId = (button.getAttribute('data-testid') || '').trim().toLowerCase();
+      return text === 'download' || aria === 'download' || testId === 'download-files-turn-action-button';
+    };
     const turns = Array.from(document.querySelectorAll(CONVERSATION_SELECTOR));
-    const selected = new Set();
+    const expectedMatches = new Set();
+    const genericBehaviorMatches = new Set();
+    const genericFallbackMatches = new Set();
+    const genericAllMatches = new Set();
     for (let index = turns.length - 1; index >= 0; index -= 1) {
       const turn = turns[index];
       if (!isAssistantTurn(turn)) continue;
       if (MIN_TURN_INDEX >= 0 && index < MIN_TURN_INDEX) continue;
       const messageRoot = turn.querySelector(ASSISTANT_SELECTOR) || turn;
-      const buttons = Array.from(messageRoot.querySelectorAll('button'));
-      const primary = buttons.filter((button) => {
-        const text = (button.textContent || '').trim().toLowerCase();
-        const expectedFile = EXPECTED_LABELS.some(
-          (label) => text === label || text.startsWith(label + ' ')
-        );
-        return String(button.className || '').includes('behavior-btn') &&
-          (expectedFile || (ALLOW_GENERIC_DOWNLOAD_LABELS && /^download\\b/.test(text)));
+      const buttons = Array.from(messageRoot.querySelectorAll('button'))
+        .filter((button) => !(MARK_CLICKED && button.getAttribute(CLICKED_ATTRIBUTE) === 'true'));
+      const behaviorButtons = buttons.filter((button) =>
+        String(button.className || '').includes('behavior-btn')
+      );
+      behaviorButtons.filter(expectedFileButton).forEach((button) => expectedMatches.add(button));
+      const genericBehavior = behaviorButtons.filter(genericBehaviorButton);
+      genericBehavior.forEach((button) => {
+        genericBehaviorMatches.add(button);
+        genericAllMatches.add(button);
       });
-      const fallback = primary.length > 0 ? [] : buttons.filter((button) => {
-        if (!ALLOW_GENERIC_DOWNLOAD_LABELS) return false;
-        const text = (button.textContent || '').trim().toLowerCase();
-        const aria = (button.getAttribute('aria-label') || '').trim().toLowerCase();
-        const testId = (button.getAttribute('data-testid') || '').trim().toLowerCase();
-        return text === 'download' || aria === 'download' || testId === 'download-files-turn-action-button';
-      });
-      [...primary, ...fallback].forEach((button) => selected.add(button));
+      if (genericBehavior.length === 0) {
+        buttons.filter(genericFallbackButton).forEach((button) => {
+          genericFallbackMatches.add(button);
+          genericAllMatches.add(button);
+        });
+      }
     }
-    const selectedButtons = Array.from(selected);
-    selectedButtons.forEach((button) => button.click());
+    const selected = expectedMatches.size > 0
+      ? expectedMatches
+      : HAS_EXPECTED_LABELS
+        ? genericBehaviorMatches.size > 0
+          ? genericBehaviorMatches
+          : genericFallbackMatches
+        : genericAllMatches;
+    const selectedButtons = Array.from(selected).slice(0, MAX_CLICKS > 0 ? MAX_CLICKS : undefined);
+    selectedButtons.forEach((button) => {
+      if (MARK_CLICKED) button.setAttribute(CLICKED_ATTRIBUTE, 'true');
+      button.click();
+    });
     return selectedButtons.map((button) => ({
       text: (button.textContent || '').trim(),
       ariaLabel: button.getAttribute('aria-label') || '',
       testId: button.getAttribute('data-testid') || '',
     }));
   })()`;
+}
+
+function describeDownloadableFile(file: BrowserDownloadableFile): string {
+  return (
+    file.filename ??
+    file.label ??
+    filenameFromUrl(file.sandboxUrl) ??
+    filenameFromUrl(file.downloadUrl) ??
+    filenameFromUrl(file.url) ??
+    file.sandboxUrl ??
+    file.downloadUrl ??
+    file.url
+  );
+}
+
+function expectedDownloadedFilename(file: BrowserDownloadableFile): string | undefined {
+  const filename =
+    file.filename ??
+    filenameFromUrl(file.sandboxUrl) ??
+    filenameFromUrl(file.downloadUrl) ??
+    filenameFromUrl(file.url);
+  const basename = path.basename(String(filename ?? "").trim());
+  return basename && basename !== "." ? basename : undefined;
+}
+
+async function moveDownloadedFileToExpectedName(
+  filePath: string,
+  file: BrowserDownloadableFile,
+): Promise<string> {
+  const filename = expectedDownloadedFilename(file);
+  if (!filename) {
+    return filePath;
+  }
+  const targetPath = path.join(path.dirname(filePath), filename);
+  if (path.resolve(targetPath) === path.resolve(filePath)) {
+    return filePath;
+  }
+  const targetExists = await fs
+    .stat(targetPath)
+    .then((stat) => stat.isFile())
+    .catch(() => false);
+  if (targetExists) {
+    return filePath;
+  }
+  await fs.rename(filePath, targetPath);
+  return targetPath;
+}
+
+async function clickAssistantDownloadButtons(params: {
+  Runtime: ChromeClient["Runtime"];
+  minTurnIndex?: number | null;
+  expectedLabels?: string[];
+  allowGenericDownloadLabels?: boolean;
+  markClicked?: boolean;
+  maxClicks?: number;
+  timeoutMs?: number;
+}): Promise<unknown[]> {
+  const expression = buildClickAssistantDownloadButtonsExpression(
+    params.minTurnIndex,
+    params.expectedLabels ?? [],
+    params.allowGenericDownloadLabels,
+    { markClicked: params.markClicked, maxClicks: params.maxClicks },
+  );
+  const deadline = Date.now() + (params.timeoutMs ?? DOWNLOAD_BUTTON_WAIT_MS);
+  while (Date.now() < deadline) {
+    const { result } = await params.Runtime.evaluate({
+      expression,
+      returnByValue: true,
+    });
+    const clicked = Array.isArray(result?.value) ? result.value : [];
+    if (clicked.length > 0) {
+      return clicked;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  return [];
+}
+
+async function savedBrowserFileFromPath(filePath: string): Promise<SavedBrowserFile> {
+  const filename = path.basename(filePath);
+  const stat = await fs.stat(filePath);
+  return {
+    kind: "file",
+    path: filePath,
+    label: filename,
+    mimeType: mimeTypeFromFilename(filename),
+    sizeBytes: stat.size,
+    sourceUrl: "browser-download",
+    url: "browser-download",
+    finalUrl: "browser-download",
+    filename,
+  };
 }
 
 export async function saveAssistantDownloadButtonArtifacts(params: {
@@ -575,7 +713,9 @@ export async function saveAssistantDownloadButtonArtifacts(params: {
   logger?: BrowserLogger;
   files?: BrowserDownloadableFile[];
   allowGenericDownloadLabels?: boolean;
+  buttonWaitMs?: number;
   downloadPath?: string;
+  downloadWaitMs?: number;
   minTurnIndex?: number | null;
   sessionId?: string;
 }): Promise<SavedBrowserFile[]> {
@@ -607,47 +747,89 @@ export async function saveAssistantDownloadButtonArtifacts(params: {
     return [];
   }
 
-  let clicked: unknown[] = [];
-  const expression = buildClickAssistantDownloadButtonsExpression(
-    params.minTurnIndex,
-    resolveDownloadButtonLabels(params.files ?? []),
-    params.allowGenericDownloadLabels,
-  );
-  const deadline = Date.now() + DOWNLOAD_BUTTON_WAIT_MS;
-  while (Date.now() < deadline) {
-    const { result } = await params.Runtime.evaluate({
-      expression,
-      returnByValue: true,
+  const buttonWaitMs = params.buttonWaitMs ?? DOWNLOAD_BUTTON_WAIT_MS;
+  const downloadWaitMs = params.downloadWaitMs ?? DOWNLOAD_BUTTON_WAIT_MS;
+  const expectedFiles = params.files ?? [];
+
+  if (expectedFiles.length === 0) {
+    const clicked = await clickAssistantDownloadButtons({
+      Runtime: params.Runtime,
+      minTurnIndex: params.minTurnIndex,
+      expectedLabels: [],
+      allowGenericDownloadLabels: params.allowGenericDownloadLabels,
+      timeoutMs: buttonWaitMs,
     });
-    clicked = Array.isArray(result?.value) ? result.value : [];
-    if (clicked.length > 0) {
-      break;
+    if (clicked.length === 0) {
+      params.logger?.("[browser] No assistant download buttons found for button fallback.");
+      return [];
     }
-    await new Promise((resolve) => setTimeout(resolve, 250));
+    params.logger?.(`[browser] Clicked ${clicked.length} assistant download button(s).`);
+    const downloaded = await waitForCompletedDownloadFiles(
+      artifactsDir,
+      before,
+      clicked.length,
+      downloadWaitMs,
+    );
+    return Promise.all(downloaded.map(savedBrowserFileFromPath));
   }
-  if (clicked.length === 0) {
+
+  let clickedCount = 0;
+  let knownEntries = before;
+  const downloadedPaths: string[] = [];
+  const missingFiles: string[] = [];
+
+  for (const file of expectedFiles) {
+    const expectedLabels = resolveDownloadButtonLabels([file]);
+    const clicked = await clickAssistantDownloadButtons({
+      Runtime: params.Runtime,
+      minTurnIndex: params.minTurnIndex,
+      expectedLabels,
+      allowGenericDownloadLabels: params.allowGenericDownloadLabels === true,
+      markClicked: true,
+      maxClicks: 1,
+      timeoutMs: buttonWaitMs,
+    });
+    const displayName = describeDownloadableFile(file);
+    if (clicked.length === 0) {
+      missingFiles.push(displayName);
+      knownEntries = new Set(await fs.readdir(artifactsDir).catch(() => []));
+      continue;
+    }
+
+    clickedCount += clicked.length;
+    const downloaded = await waitForCompletedDownloadFiles(
+      artifactsDir,
+      knownEntries,
+      1,
+      downloadWaitMs,
+    );
+    if (downloaded.length === 0) {
+      missingFiles.push(displayName);
+      knownEntries = new Set(await fs.readdir(artifactsDir).catch(() => []));
+      continue;
+    }
+
+    const normalizedDownloads = await Promise.all(
+      downloaded.map((filePath, index) =>
+        index === 0 ? moveDownloadedFileToExpectedName(filePath, file) : filePath,
+      ),
+    );
+    downloadedPaths.push(...normalizedDownloads);
+    knownEntries = new Set(await fs.readdir(artifactsDir).catch(() => []));
+  }
+
+  if (clickedCount === 0) {
     params.logger?.("[browser] No assistant download buttons found for button fallback.");
-    return [];
+  } else {
+    params.logger?.(`[browser] Clicked ${clickedCount} assistant download button(s).`);
   }
-  params.logger?.(`[browser] Clicked ${clicked.length} assistant download button(s).`);
-  const downloaded = await waitForCompletedDownloadFiles(artifactsDir, before, clicked.length);
-  return Promise.all(
-    downloaded.map(async (filePath): Promise<SavedBrowserFile> => {
-      const filename = path.basename(filePath);
-      const stat = await fs.stat(filePath);
-      return {
-        kind: "file",
-        path: filePath,
-        label: filename,
-        mimeType: mimeTypeFromFilename(filename),
-        sizeBytes: stat.size,
-        sourceUrl: "browser-download",
-        url: "browser-download",
-        finalUrl: "browser-download",
-        filename,
-      };
-    }),
-  );
+  if (missingFiles.length > 0) {
+    params.logger?.(
+      `[browser] Download button fallback did not save expected file(s): ${missingFiles.join(", ")}`,
+    );
+  }
+
+  return Promise.all([...new Set(downloadedPaths)].map(savedBrowserFileFromPath));
 }
 
 interface DownloadedFilePayload {

--- a/src/browser/chatgptFiles.ts
+++ b/src/browser/chatgptFiles.ts
@@ -648,6 +648,14 @@ async function moveDownloadedFileToExpectedName(
   if (path.resolve(targetPath) === path.resolve(filePath)) {
     return filePath;
   }
+  const expected = path.parse(filename);
+  const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const duplicatePattern = new RegExp(
+    `^${escapeRegExp(expected.name)} ?\\(\\d+\\)${escapeRegExp(expected.ext)}$`,
+  );
+  if (!duplicatePattern.test(path.basename(filePath))) {
+    return filePath;
+  }
   const targetExists = await fs
     .stat(targetPath)
     .then((stat) => stat.isFile())
@@ -778,7 +786,8 @@ export async function saveAssistantDownloadButtonArtifacts(params: {
   const downloadedPaths: string[] = [];
   const missingFiles: string[] = [];
 
-  for (const file of expectedFiles) {
+  const unattemptedFiles: string[] = [];
+  for (const [fileIndex, file] of expectedFiles.entries()) {
     const expectedLabels = resolveDownloadButtonLabels([file]);
     const clicked = await clickAssistantDownloadButtons({
       Runtime: params.Runtime,
@@ -805,8 +814,16 @@ export async function saveAssistantDownloadButtonArtifacts(params: {
     );
     if (downloaded.length === 0) {
       missingFiles.push(displayName);
-      knownEntries = new Set(await fs.readdir(artifactsDir).catch(() => []));
-      continue;
+      unattemptedFiles.push(...expectedFiles.slice(fileIndex + 1).map(describeDownloadableFile));
+      missingFiles.push(...unattemptedFiles);
+      params.logger?.(
+        `[browser] Download timed out for ${displayName}${
+          unattemptedFiles.length > 0
+            ? `; skipped remaining expected file(s) to avoid misassigning a late completion: ${unattemptedFiles.join(", ")}`
+            : ""
+        }`,
+      );
+      break;
     }
 
     const normalizedDownloads = await Promise.all(

--- a/tests/browser/chatgptFiles.test.ts
+++ b/tests/browser/chatgptFiles.test.ts
@@ -612,12 +612,54 @@ describe("collectChatGptFileArtifacts", () => {
     }
   });
 
-  test("reports missing expected files after partial button fallback", async () => {
+  test("preserves a browser-provided filename for a generic download endpoint", async () => {
+    const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-chatgpt-file-filename-"));
+    setOracleHomeDirOverrideForTest(tmpHome);
+    const sessionId = "collect-session";
+    const artifactsDir = path.join(tmpHome, "sessions", sessionId, "artifacts");
+    const runtime = {
+      evaluate: vi.fn().mockImplementation(async () => {
+        await fs.mkdir(artifactsDir, { recursive: true });
+        await fs.writeFile(path.join(artifactsDir, "report.csv"), "a,b\n1,2\n", "utf8");
+        return { result: { value: [{ text: "Download", ariaLabel: "", testId: "" }] } };
+      }),
+    } as unknown as ChromeClient["Runtime"];
+    const page = {
+      setDownloadBehavior: vi.fn().mockResolvedValue({}),
+    } as unknown as ChromeClient["Page"];
+
+    const savedFiles = await saveAssistantDownloadButtonArtifacts({
+      Page: page,
+      Runtime: runtime,
+      sessionId,
+      downloadWaitMs: 25,
+      files: [
+        {
+          url: "https://chatgpt.com/backend-api/files/file_csv/download",
+          downloadUrl: "https://chatgpt.com/backend-api/files/file_csv/download",
+        },
+      ],
+    });
+
+    expect(savedFiles).toHaveLength(1);
+    expect(savedFiles[0]).toMatchObject({
+      filename: "report.csv",
+      label: "report.csv",
+      mimeType: "text/csv",
+    });
+    await expect(fs.readFile(path.join(artifactsDir, "report.csv"), "utf8")).resolves.toBe(
+      "a,b\n1,2\n",
+    );
+    await expect(fs.stat(path.join(artifactsDir, "download"))).rejects.toThrow();
+  });
+
+  test("stops after a timed-out download so a late completion cannot become the next file", async () => {
     const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-chatgpt-file-missing-"));
     setOracleHomeDirOverrideForTest(tmpHome);
     const sessionId = "collect-session";
     const artifactsDir = path.join(tmpHome, "sessions", sessionId, "artifacts");
     const logger = vi.fn();
+    let lateCompletion: Promise<void> | undefined;
     const runtime = {
       evaluate: vi.fn().mockImplementation(async ({ expression }: { expression?: string }) => {
         const text = String(expression ?? "");
@@ -627,10 +669,16 @@ describe("collectChatGptFileArtifacts", () => {
           return { result: { value: [{ text: "Download A.txt", ariaLabel: "", testId: "" }] } };
         }
         if (text.includes('"b.md"')) {
+          const partialPath = path.join(artifactsDir, "B.md.crdownload");
+          await fs.writeFile(partialPath, "B");
+          lateCompletion = new Promise<void>((resolve, reject) => {
+            setTimeout(() => {
+              void fs.rename(partialPath, path.join(artifactsDir, "B.md")).then(resolve, reject);
+            }, 275);
+          });
           return { result: { value: [{ text: "Download B.md", ariaLabel: "", testId: "" }] } };
         }
         if (text.includes('"c.zip"')) {
-          await fs.writeFile(path.join(artifactsDir, "C(1).zip"), "C");
           return { result: { value: [{ text: "Download C.zip", ariaLabel: "", testId: "" }] } };
         }
         return { result: { value: [] } };
@@ -661,9 +709,24 @@ describe("collectChatGptFileArtifacts", () => {
       ],
     });
 
-    expect(savedFiles.map((file) => file.filename).sort()).toEqual(["A.txt", "C.zip"]);
+    await lateCompletion;
+    expect(savedFiles.map((file) => file.filename)).toEqual(["A.txt"]);
+    expect(
+      vi
+        .mocked(runtime.evaluate)
+        .mock.calls.some(([options]) => String(options?.expression ?? "").includes('"c.zip"')),
+    ).toBe(false);
+    await expect(fs.readFile(path.join(artifactsDir, "B.md"), "utf8")).resolves.toBe("B");
+    await expect(fs.stat(path.join(artifactsDir, "C.zip"))).rejects.toThrow();
     expect(logger).toHaveBeenCalledWith(
-      expect.stringContaining("Download button fallback did not save expected file(s): B.md"),
+      expect.stringContaining(
+        "Download timed out for B.md; skipped remaining expected file(s) to avoid misassigning a late completion: C.zip",
+      ),
+    );
+    expect(logger).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Download button fallback did not save expected file(s): B.md, C.zip",
+      ),
     );
   });
 

--- a/tests/browser/chatgptFiles.test.ts
+++ b/tests/browser/chatgptFiles.test.ts
@@ -5,11 +5,60 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   collectChatGptFileArtifacts,
   readAssistantDownloadableFiles,
+  saveAssistantDownloadButtonArtifacts,
   saveChatGptDownloadableFiles,
   __test__,
 } from "../../src/browser/chatgptFiles.js";
 import type { ChromeClient } from "../../src/browser/types.js";
 import { setOracleHomeDirOverrideForTest } from "../../src/oracleHome.js";
+
+class FakeElement {
+  clickCount = 0;
+
+  constructor(
+    public textContent = "",
+    public attributes: Record<string, string> = {},
+    public className = "",
+    public children: FakeElement[] = [],
+  ) {}
+
+  click(): void {
+    this.clickCount += 1;
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes[name] ?? null;
+  }
+
+  querySelector(): FakeElement | null {
+    return null;
+  }
+
+  querySelectorAll(selector: string): FakeElement[] {
+    return selector === "button" ? this.children : [];
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes[name] = value;
+  }
+}
+
+function assistantTurn(buttons: FakeElement[]): FakeElement {
+  return new FakeElement("", { "data-turn": "assistant" }, "", buttons);
+}
+
+function behaviorButton(text: string, attributes: Record<string, string> = {}): FakeElement {
+  return new FakeElement(text, attributes, "behavior-btn");
+}
+
+function evaluateClickExpression(expression: string, turns: FakeElement[]): unknown[] {
+  const document = { querySelectorAll: () => turns };
+  return Function(
+    "document",
+    "HTMLElement",
+    `return ${expression};`,
+  )(document, FakeElement) as unknown[];
+}
 
 describe("readAssistantDownloadableFiles", () => {
   test("keeps ChatGPT file downloads and sandbox references but rejects external links", async () => {
@@ -439,10 +488,24 @@ describe("collectChatGptFileArtifacts", () => {
             },
           },
         })
-        .mockImplementationOnce(async () => {
+        .mockImplementationOnce(async ({ expression }: { expression?: string }) => {
+          const fallbackExpression = String(expression ?? "");
+          if (!fallbackExpression.includes("const ALLOW_GENERIC_DOWNLOAD_LABELS = true")) {
+            return { result: { value: [] } };
+          }
           await fs.mkdir(artifactsDir, { recursive: true });
           await fs.writeFile(path.join(artifactsDir, filename), csv, "utf8");
-          return { result: { value: [{ text: "Download the CSV", ariaLabel: "", testId: "" }] } };
+          return {
+            result: {
+              value: [
+                {
+                  text: "Download",
+                  ariaLabel: "",
+                  testId: "download-files-turn-action-button",
+                },
+              ],
+            },
+          };
         }),
     } as unknown as ChromeClient["Runtime"];
     const network = {
@@ -475,6 +538,133 @@ describe("collectChatGptFileArtifacts", () => {
       behavior: "allow",
       downloadPath: artifactsDir,
     });
+    const fallbackExpression = String(vi.mocked(runtime.evaluate).mock.calls[2]?.[0]?.expression);
+    expect(fallbackExpression).toContain("const ALLOW_GENERIC_DOWNLOAD_LABELS = true");
+    expect(fallbackExpression).toContain("const MAX_CLICKS = 1");
+    expect(fallbackExpression).toContain("download-files-turn-action-button");
+  });
+
+  test("clicks multiple assistant download buttons sequentially", async () => {
+    const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-chatgpt-file-sequential-"));
+    setOracleHomeDirOverrideForTest(tmpHome);
+    const sessionId = "collect-session";
+    const artifactsDir = path.join(tmpHome, "sessions", sessionId, "artifacts");
+    const runtime = {
+      evaluate: vi.fn().mockImplementation(async ({ expression }: { expression?: string }) => {
+        const clicked: Array<{ text: string; ariaLabel: string; testId: string }> = [];
+        const writes: string[] = [];
+        const text = String(expression ?? "");
+        const hasA = text.includes('"a.txt"');
+        const hasB = text.includes('"b.md"');
+        const hasC = text.includes('"c.zip"');
+        await fs.mkdir(artifactsDir, { recursive: true });
+        if (hasA && hasB && hasC) {
+          writes.push("A.txt", "C.zip");
+          clicked.push(
+            { text: "Download A.txt", ariaLabel: "", testId: "" },
+            { text: "Download B.md", ariaLabel: "", testId: "" },
+            { text: "Download C.zip", ariaLabel: "", testId: "" },
+          );
+        } else if (hasA) {
+          writes.push("A(1).txt");
+          clicked.push({ text: "Download A.txt", ariaLabel: "", testId: "" });
+        } else if (hasB) {
+          writes.push("B(1).md");
+          clicked.push({ text: "Download B.md", ariaLabel: "", testId: "" });
+        } else if (hasC) {
+          writes.push("C(1).zip");
+          clicked.push({ text: "Download C.zip", ariaLabel: "", testId: "" });
+        }
+        await Promise.all(
+          writes.map((filename) => fs.writeFile(path.join(artifactsDir, filename), filename)),
+        );
+        return { result: { value: clicked } };
+      }),
+    } as unknown as ChromeClient["Runtime"];
+    const page = {
+      setDownloadBehavior: vi.fn().mockResolvedValue({}),
+    } as unknown as ChromeClient["Page"];
+
+    const savedFiles = await saveAssistantDownloadButtonArtifacts({
+      Page: page,
+      Runtime: runtime,
+      sessionId,
+      files: [
+        {
+          url: "sandbox:/mnt/data/A.txt",
+          sandboxUrl: "sandbox:/mnt/data/A.txt",
+          filename: "A.txt",
+        },
+        { url: "sandbox:/mnt/data/B.md", sandboxUrl: "sandbox:/mnt/data/B.md", filename: "B.md" },
+        {
+          url: "sandbox:/mnt/data/C.zip",
+          sandboxUrl: "sandbox:/mnt/data/C.zip",
+          filename: "C.zip",
+        },
+      ],
+    });
+
+    expect(savedFiles.map((file) => file.filename).sort()).toEqual(["A.txt", "B.md", "C.zip"]);
+    expect(runtime.evaluate).toHaveBeenCalledTimes(3);
+    for (const call of vi.mocked(runtime.evaluate).mock.calls) {
+      const expression = String(call[0]?.expression ?? "");
+      expect(expression).not.toContain('"a.txt","b.md","c.zip"');
+    }
+  });
+
+  test("reports missing expected files after partial button fallback", async () => {
+    const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-chatgpt-file-missing-"));
+    setOracleHomeDirOverrideForTest(tmpHome);
+    const sessionId = "collect-session";
+    const artifactsDir = path.join(tmpHome, "sessions", sessionId, "artifacts");
+    const logger = vi.fn();
+    const runtime = {
+      evaluate: vi.fn().mockImplementation(async ({ expression }: { expression?: string }) => {
+        const text = String(expression ?? "");
+        await fs.mkdir(artifactsDir, { recursive: true });
+        if (text.includes('"a.txt"')) {
+          await fs.writeFile(path.join(artifactsDir, "A(1).txt"), "A");
+          return { result: { value: [{ text: "Download A.txt", ariaLabel: "", testId: "" }] } };
+        }
+        if (text.includes('"b.md"')) {
+          return { result: { value: [{ text: "Download B.md", ariaLabel: "", testId: "" }] } };
+        }
+        if (text.includes('"c.zip"')) {
+          await fs.writeFile(path.join(artifactsDir, "C(1).zip"), "C");
+          return { result: { value: [{ text: "Download C.zip", ariaLabel: "", testId: "" }] } };
+        }
+        return { result: { value: [] } };
+      }),
+    } as unknown as ChromeClient["Runtime"];
+    const page = {
+      setDownloadBehavior: vi.fn().mockResolvedValue({}),
+    } as unknown as ChromeClient["Page"];
+
+    const savedFiles = await saveAssistantDownloadButtonArtifacts({
+      Page: page,
+      Runtime: runtime,
+      logger,
+      sessionId,
+      downloadWaitMs: 25,
+      files: [
+        {
+          url: "sandbox:/mnt/data/A.txt",
+          sandboxUrl: "sandbox:/mnt/data/A.txt",
+          filename: "A.txt",
+        },
+        { url: "sandbox:/mnt/data/B.md", sandboxUrl: "sandbox:/mnt/data/B.md", filename: "B.md" },
+        {
+          url: "sandbox:/mnt/data/C.zip",
+          sandboxUrl: "sandbox:/mnt/data/C.zip",
+          filename: "C.zip",
+        },
+      ],
+    });
+
+    expect(savedFiles.map((file) => file.filename).sort()).toEqual(["A.txt", "C.zip"]);
+    expect(logger).toHaveBeenCalledWith(
+      expect.stringContaining("Download button fallback did not save expected file(s): B.md"),
+    );
   });
 
   test("merges DOM and answer-text references for the same file", async () => {
@@ -663,6 +853,70 @@ describe("collectChatGptFileArtifacts", () => {
     });
   });
 
+  test("click expression prefers expected-label buttons across all turns", () => {
+    const expectedButton = behaviorButton("Download file.csv");
+    const newerGenericButton = behaviorButton("Download");
+    const expression = __test__.buildClickAssistantDownloadButtonsExpression(
+      undefined,
+      ["file.csv"],
+      true,
+      { markClicked: true, maxClicks: 1 },
+    );
+
+    const clicked = evaluateClickExpression(expression, [
+      assistantTurn([expectedButton]),
+      assistantTurn([newerGenericButton]),
+    ]);
+
+    expect(clicked).toEqual([{ text: "Download file.csv", ariaLabel: "", testId: "" }]);
+    expect(expectedButton.clickCount).toBe(1);
+    expect(newerGenericButton.clickCount).toBe(0);
+  });
+
+  test("click expression preserves broad generic matching when no files are expected", () => {
+    const behaviorGeneric = behaviorButton("Download image");
+    const exactFallback = new FakeElement("", {
+      "data-testid": "download-files-turn-action-button",
+    });
+    const expression = __test__.buildClickAssistantDownloadButtonsExpression(undefined, [], true);
+
+    expect(
+      evaluateClickExpression(expression, [
+        assistantTurn([exactFallback]),
+        assistantTurn([behaviorGeneric]),
+      ]),
+    ).toEqual([
+      { text: "Download image", ariaLabel: "", testId: "" },
+      { text: "", ariaLabel: "", testId: "download-files-turn-action-button" },
+    ]);
+    expect(behaviorGeneric.clickCount).toBe(1);
+    expect(exactFallback.clickCount).toBe(1);
+  });
+
+  test("click expression falls back to generic buttons and skips already-clicked ones", () => {
+    const firstGeneric = behaviorButton("Download");
+    const secondGeneric = new FakeElement("", {
+      "data-testid": "download-files-turn-action-button",
+    });
+    const expression = (filename: string) =>
+      __test__.buildClickAssistantDownloadButtonsExpression(undefined, [filename], true, {
+        markClicked: true,
+        maxClicks: 1,
+      });
+    const turns = [assistantTurn([firstGeneric, secondGeneric])];
+
+    expect(evaluateClickExpression(expression("A.txt"), turns)).toEqual([
+      { text: "Download", ariaLabel: "", testId: "" },
+    ]);
+    expect(firstGeneric.getAttribute("data-oracle-download-clicked")).toBe("true");
+    expect(evaluateClickExpression(expression("B.md"), turns)).toEqual([
+      { text: "", ariaLabel: "", testId: "download-files-turn-action-button" },
+    ]);
+    expect(secondGeneric.getAttribute("data-oracle-download-clicked")).toBe("true");
+    expect(firstGeneric.clickCount).toBe(1);
+    expect(secondGeneric.clickCount).toBe(1);
+  });
+
   test("matches ChatGPT behavior download buttons with descriptive labels", () => {
     const fileExpression = __test__.buildAssistantDownloadableFilesExpression();
     const expression = __test__.buildClickAssistantDownloadButtonsExpression(undefined, [
@@ -673,19 +927,33 @@ describe("collectChatGptFileArtifacts", () => {
       ["oracle_pr245_file.csv"],
       false,
     );
+    const oneClickExpression = __test__.buildClickAssistantDownloadButtonsExpression(
+      undefined,
+      ["oracle_pr245_file.csv"],
+      true,
+      { markClicked: true, maxClicks: 1 },
+    );
 
     expect(fileExpression).toContain("files.push(...serializeFiles(messageRoot))");
     expect(fileExpression).not.toContain("if (files.length > 0) return files");
     expect(expression).toContain("/^download\\b/");
     expect(expression).not.toContain("/^download\b/");
     expect(expression).toContain('"oracle_pr245_file.csv"');
-    expect(expression).toContain("text === label || text.startsWith(label + ' ')");
+    expect(expression).toContain("const downloadLabel = 'download ' + label");
+    expect(expression).toContain("text === downloadLabel");
     expect(expression).toContain("document.querySelectorAll(CONVERSATION_SELECTOR)");
     expect(expression).not.toContain("document.querySelectorAll('button')");
-    expect(expression).toContain(
-      "[...primary, ...fallback].forEach((button) => selected.add(button))",
-    );
+    expect(expression).toContain("const expectedMatches = new Set()");
+    expect(expression).toContain("behaviorButtons.filter(expectedFileButton)");
+    expect(expression).toContain("behaviorButtons.filter(genericBehaviorButton)");
+    expect(expression).toContain("buttons.filter(genericFallbackButton)");
+    expect(expression).toContain("expectedMatches.size > 0");
+    expect(expression).toContain("genericBehaviorMatches.size > 0");
     expect(scopedExpression).toContain("const ALLOW_GENERIC_DOWNLOAD_LABELS = false");
+    expect(oneClickExpression).toContain("const ALLOW_GENERIC_DOWNLOAD_LABELS = true");
+    expect(oneClickExpression).toContain("const MARK_CLICKED = true");
+    expect(oneClickExpression).toContain("const MAX_CLICKS = 1");
+    expect(oneClickExpression).toContain("button.setAttribute(CLICKED_ATTRIBUTE, 'true')");
     const labels = __test__.resolveDownloadButtonLabels([
       {
         url: "sandbox:/mnt/data/oracle_pr245_file.csv",


### PR DESCRIPTION
## Summary

When Oracle saves ChatGPT-generated files by clicking the inline assistant download buttons, multiple files can be missed if the buttons are clicked all at once. This PR fixes that by clicking the download buttons one at a time, waiting for each file to finish saving before clicking the next one.

## Problem

I reproduced the issue with a browser run that asked ChatGPT to create three downloadable files:

- `A.txt`
- `B.md`
- `C.zip`

The prompt asked ChatGPT to put hidden random 10-character strings in the files and not reveal those strings in the chat response.

Oracle found all three downloadable links and clicked all three download buttons, but only saved two files. `B.md` was missing from the saved session files even though the ChatGPT response included a `B.md` download link.

Before this patch, the important terminal output was:

```text
[browser] Found 3 downloadable file link(s) in captured answer text.
[browser] Found 3 downloadable file candidate(s).
[browser] Failed to save downloadable file 1/3: download failed: 404
[browser] Failed to save downloadable file 2/3: download failed: 404
[browser] Failed to save downloadable file 3/3: download failed: 404
[browser] Clicked 3 assistant download button(s).
[browser] Saved 2 downloadable file artifact(s).
```

The saved files were:

```text
A.txt          10 bytes
C.zip         218 bytes
transcript.md 974 bytes
```

`B.md` was not saved.

## Cause

The direct `sandbox:/mnt/data/...` downloads returned `404`, so Oracle used the fallback path that clicks ChatGPT's inline download buttons.

That fallback selected all matching buttons and clicked them in one quick JavaScript loop. ChatGPT does not reliably start every generated-file download when several of these buttons are clicked at the same time. One button click can be ignored even though Oracle counted it as clicked.

## Fix

The fallback now saves expected files one by one:

1. Pick the matching download button for one expected file.
2. Click it.
3. Wait until one new completed file appears in the session files directory.
4. Move on to the next expected file.

If a file still does not appear, Oracle logs the expected missing filename. If Chrome saves a file with a duplicate-style name such as `A(1).txt`, Oracle renames it back to the expected name, such as `A.txt`, when that is safe.

The fix also keeps the older generic button behavior for ChatGPT pages that show a plain `Download` button instead of a filename-specific button. Filename-specific buttons are preferred when they exist, but generic buttons are still used as a fallback.

## Result after this patch

I repeated the same browser run after the change. Oracle again found three links and the direct downloads again returned `404`, so it used the button fallback. This time all three files were saved.

After this patch, the important terminal output was:

```text
[browser] Found 3 downloadable file link(s) in captured answer text.
[browser] Found 3 downloadable file candidate(s).
[browser] Failed to save downloadable file 1/3: download failed: 404
[browser] Failed to save downloadable file 2/3: download failed: 404
[browser] Failed to save downloadable file 3/3: download failed: 404
[browser] Clicked 3 assistant download button(s).
[browser] Saved 3 downloadable file artifact(s).
```

The saved files were:

```text
A.txt          10 bytes
B.md           10 bytes
C.zip         218 bytes
transcript.md 1053 bytes
```

`C.zip` contained the expected two files:

```text
C1.txt 10 bytes
C2.txt 10 bytes
```

## Tests

- `pnpm vitest run tests/browser/chatgptFiles.test.ts` ✅
- `pnpm vitest run tests/browser/chatgptFiles.test.ts tests/browser/chatgptImages.test.ts` ✅
- `pnpm run typecheck` ✅
- `pnpm run lint` ✅
- `pnpm exec oxfmt --check src/browser/chatgptFiles.ts tests/browser/chatgptFiles.test.ts` ✅
