### PR TITLE
fix(browser): bound Instant model selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Browser: wait for the current ChatGPT Intelligence pill before falling back to the default thinking level. This lets `--browser-model-strategy current --browser-thinking-time extra-high` select and verify Extra High before submitting (thanks @alex-on-java).
+- Browser: wait for the current ChatGPT Intelligence pill before falling back to the default thinking level, and make `--browser-model-strategy select` prefer concrete requested variants over version-only submenu wrappers with bounded retries. This lets current-model runs select and verify Extra High before submitting and prevents explicit Instant selection from hanging (thanks @alex-on-java and @servrox).
 
 ## 0.14.1 — 2026-06-15
 

--- a/src/browser/actions/modelSelection.ts
+++ b/src/browser/actions/modelSelection.ts
@@ -711,10 +711,27 @@ function buildModelSelectionExpression(
         normalizedTestId.includes('pro');
       const candidateHasInstant =
         normalizedText.includes('instant') || normalizedTestId.includes('instant');
+      const candidateSelectsConfiguredVersion =
+        Boolean(getConfigurationDialog()) &&
+        candidateSelectsDesiredVersion &&
+        (node?.getAttribute?.('role') === 'option' ||
+          node?.getAttribute?.('role') === 'menuitemradio');
+      const candidateOpensInstantSubmenu =
+        wantsInstant &&
+        candidateSelectsDesiredVersion &&
+        !candidateHasInstant &&
+        (normalizedTestId.includes('submenu') ||
+          node?.getAttribute?.('aria-haspopup') === 'menu' ||
+          node?.getAttribute?.('data-has-submenu') !== null);
       if (wantsPro && candidateHasThinking) return 0;
       if (wantsPro && candidateHasLegacyProVersion && !candidateSelectsDesiredVersion) return 0;
       if (wantsPro && !candidateHasPro && !candidateSelectsDesiredVersion) return 0;
-      if (wantsInstant && !candidateHasInstant && !candidateSelectsDesiredVersion) return 0;
+      if (
+        wantsInstant &&
+        !candidateHasInstant &&
+        !candidateOpensInstantSubmenu &&
+        !candidateSelectsConfiguredVersion
+      ) return 0;
       if (wantsThinking && candidateHasPro) return 0;
       if (wantsThinking && !candidateHasThinking && !candidateSelectsDesiredVersion) return 0;
       if (desiredVersion === '5-5' && normalizedText && !candidateGpt55VisibleAlias) {
@@ -753,9 +770,13 @@ function buildModelSelectionExpression(
       if (
         desiredVersion &&
         candidateTextVersion === desiredVersion &&
+        !candidateOpensInstantSubmenu &&
         !(wantsThinking && desiredVersion === '5-5' && normalizedText === 'gpt 5 5')
       ) {
         score += 1200;
+      }
+      if (candidateOpensInstantSubmenu) {
+        score += 300;
       }
       if (candidateOpensVersionSubmenu) {
         score += 500;
@@ -861,6 +882,9 @@ function buildModelSelectionExpression(
       const currentButtonLabel = normalizeText(getButtonLabel());
       return !labelHasProWord(currentButtonLabel) && !hasProComposerPill();
     };
+    const openedSubmenuKeys = new Set();
+    const submenuKey = (normalizedText, testid) =>
+      normalizeText(testid ?? '') + '|' + normalizedText;
 
     const findBestOption = () => {
       // Walk through every menu item and keep whichever earns the highest score.
@@ -875,6 +899,10 @@ function buildModelSelectionExpression(
           const text = option.textContent ?? '';
           const normalizedText = normalizeText(text);
           const testid = option.getAttribute('data-testid') ?? '';
+          const optionSubmenuKey = submenuKey(normalizedText, testid);
+          if (isSubmenuOption(option, testid) && openedSubmenuKeys.has(optionSubmenuKey)) {
+            continue;
+          }
           let score = scoreOption(normalizedText, testid, option);
           if (score <= 0) {
             continue;
@@ -884,7 +912,14 @@ function buildModelSelectionExpression(
           }
           const label = getOptionLabel(option);
           if (!bestMatch || score > bestMatch.score) {
-            bestMatch = { node: option, label, score, testid, normalizedText };
+            bestMatch = {
+              node: option,
+              label,
+              score,
+              testid,
+              normalizedText,
+              submenuKey: optionSubmenuKey,
+            };
           }
         }
       }
@@ -976,6 +1011,13 @@ function buildModelSelectionExpression(
       const openDelay = () => new Promise((r) => setTimeout(r, INITIAL_WAIT_MS));
       let initialized = false;
       const attempt = async () => {
+        if (performance.now() - start > MAX_WAIT_MS) {
+          resolve({
+            status: 'option-not-found',
+            hint: { temporaryChat: detectTemporaryChat(), availableOptions: collectAvailableOptions() },
+          });
+          return;
+        }
         if (!initialized) {
           initialized = true;
           await openDelay();
@@ -998,6 +1040,7 @@ function buildModelSelectionExpression(
           // Keep scanning once the submenu opens instead of treating the submenu click as a final switch.
           const isSubmenu = isSubmenuOption(match.node, match.testid);
           if (isSubmenu) {
+            openedSubmenuKeys.add(match.submenuKey);
             openSubmenuOption(match.node);
             setTimeout(attempt, REOPEN_INTERVAL_MS / 2);
             return;

--- a/tests/browser/modelSelection.test.ts
+++ b/tests/browser/modelSelection.test.ts
@@ -215,6 +215,7 @@ const evaluateMenuModelSelectionExpression = async (
 const evaluateIntelligenceModelSelectionExpression = async (
   targetModel: string,
   initialButtonLabel = "Extra High",
+  includeInstant = true,
 ): Promise<unknown> => {
   class FakeEventTarget {
     dispatchEvent(_event: unknown): boolean {
@@ -330,11 +331,20 @@ const evaluateIntelligenceModelSelectionExpression = async (
     },
   );
   const initialIsPro = initialButtonLabel.toLowerCase().includes("pro");
+  const instantOption = new FakeElement(
+    "Instant",
+    { role: "menuitemradio", "aria-checked": "false" },
+    [],
+    () => {
+      proPillActive = false;
+      modelButton.textContent = "Instant";
+    },
+  );
   const intelligenceMenu = new FakeElement(
     "IntelligenceInstantMediumHighExtra HighPro ExtendedGPT-5.5",
     { role: "menu", "data-testid": "composer-intelligence-picker-content" },
     [
-      new FakeElement("Instant", { role: "menuitemradio", "aria-checked": "false" }),
+      ...(includeInstant ? [instantOption] : []),
       new FakeElement("Medium", { role: "menuitemradio", "aria-checked": "false" }),
       new FakeElement("High", { role: "menuitemradio", "aria-checked": "false" }),
       new FakeElement(
@@ -985,9 +995,10 @@ describe("browser model selection matchers", () => {
   it("hard-rejects non-Instant candidates when targeting Instant", () => {
     const expression = buildModelSelectionExpressionForTest("GPT-5.5 Instant");
     expect(expression).toContain("const candidateHasInstant =");
-    expect(expression).toContain(
-      "if (wantsInstant && !candidateHasInstant && !candidateSelectsDesiredVersion) return 0;",
-    );
+    expect(expression).toContain("const candidateOpensInstantSubmenu =");
+    expect(expression).toContain("const candidateSelectsConfiguredVersion =");
+    expect(expression).toContain("!candidateOpensInstantSubmenu &&");
+    expect(expression).toContain("!candidateSelectsConfiguredVersion");
   });
 
   it("selects the observed bare GPT-5.5 row when its label is Instant", async () => {
@@ -1341,6 +1352,22 @@ describe("browser model selection matchers", () => {
     await expect(evaluateIntelligenceModelSelectionExpression("Thinking 5.5")).resolves.toEqual({
       status: "already-selected",
       label: "Thinking 5.5",
+    });
+  });
+
+  it("prefers the concrete Instant row over the GPT-5.5 submenu wrapper", async () => {
+    await expect(evaluateIntelligenceModelSelectionExpression("GPT-5.5 Instant")).resolves.toEqual({
+      status: "switched",
+      label: "Instant",
+    });
+  });
+
+  it("bounds GPT-5.5 submenu retries when Instant is unavailable", async () => {
+    await expect(
+      evaluateIntelligenceModelSelectionExpression("GPT-5.5 Instant", "Extra High", false),
+    ).resolves.toMatchObject({
+      status: "option-not-found",
+      hint: { availableOptions: expect.arrayContaining(["GPT-5.5"]) },
     });
   });
 


### PR DESCRIPTION
Fixes #263.

## Changes

- rank concrete GPT-5.5 Instant above generic GPT-5.5 submenu rows
- prevent reopening the same submenu after React replaces its DOM node
- enforce the model-selection deadline across retries
- add live-shaped regression coverage for successful and missing Instant options

## Proof

- `pnpm test` — 1,300 passed, 43 skipped
- format, typecheck, lint, and focused model-selection tests passed
- autoreview: no accepted/actionable findings
- live authenticated browser E2E: requested `gpt-5.5-instant` with strategy `select`; picker reported verified `already-selected`; ChatGPT returned exactly `ORACLE_ISSUE_263_INSTANT_SELECT_OK`
