### PR TITLE
fix(browser): wait for model/effort composer pill before failing selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.15.1 — Unreleased
 
+### Fixed
+
+- Browser: wait for the ChatGPT model/effort composer pill to mount before failing model selection. ChatGPT now renders the model picker as a composer pill that React mounts ~1–4s after the page becomes interactive — later on a cold profile such as cookie-sync's throwaway Chrome — which is past the previous bounded retry window, so `--browser-model-strategy select` could abort with "Unable to locate the ChatGPT model selector button" (and close the browser before the pill rendered). `ensureModelSelection` now re-evaluates while the button is missing up to a bounded deadline (`MODEL_BUTTON_WAIT_MS`); only a genuinely missing button waits — a real "option-not-found" still surfaces immediately.
+
 ## 0.15.0 — 2026-06-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## 0.15.1 — Unreleased
 
-### Fixed
-
-- Browser: wait for the ChatGPT model/effort composer pill to mount before failing model selection. ChatGPT now renders the model picker as a composer pill that React mounts ~1–4s after the page becomes interactive — later on a cold profile such as cookie-sync's throwaway Chrome — which is past the previous bounded retry window, so `--browser-model-strategy select` could abort with "Unable to locate the ChatGPT model selector button" (and close the browser before the pill rendered). `ensureModelSelection` now re-evaluates while the button is missing up to a bounded deadline (`MODEL_BUTTON_WAIT_MS`); only a genuinely missing button waits — a real "option-not-found" still surfaces immediately.
-
 ## 0.15.0 — 2026-06-19
 
 ### Added

--- a/src/browser/actions/modelSelection.ts
+++ b/src/browser/actions/modelSelection.ts
@@ -8,31 +8,53 @@ import {
 } from "../constants.js";
 import { logDomFailure } from "../domDebug.js";
 import { buildClickDispatcher } from "./domEvents.js";
+import { delay } from "../utils.js";
 
 const LEGACY_PRO_VERSION_WORD_TOKENS = ["5 4", "5 2", "5 1", "5 0", "gpt 5 pro"] as const;
 const LEGACY_PRO_VERSION_COMPACT_TOKENS = ["gpt54", "gpt52", "gpt51", "gpt50"] as const;
+
+type ModelSelectionResult =
+  | { status: "already-selected"; label?: string | null }
+  | { status: "switched"; label?: string | null }
+  | {
+      status: "option-not-found";
+      hint?: { temporaryChat?: boolean; availableOptions?: string[] };
+    }
+  | { status: "button-missing" }
+  | undefined;
+
+// The model/effort picker is a composer pill that React mounts a beat after the page
+// becomes interactive (~1-4s on a cold profile, e.g. cookie-sync's throwaway Chrome).
+// Re-evaluate while it is still missing, up to a bounded deadline, so selection does not
+// give up before the pill renders. Only "button-missing" waits; a genuine
+// "option-not-found" surfaces immediately.
+const MODEL_BUTTON_WAIT_MS = 8000;
+const MODEL_BUTTON_POLL_MS = 250;
 
 export async function ensureModelSelection(
   Runtime: ChromeClient["Runtime"],
   desiredModel: string,
   logger: BrowserLogger,
   strategy: BrowserModelStrategy = "select",
+  options: { buttonWaitMs?: number; buttonPollMs?: number } = {},
 ): Promise<BrowserModelSelectionEvidence> {
-  const outcome = await Runtime.evaluate({
-    expression: buildModelSelectionExpression(desiredModel, strategy),
-    awaitPromise: true,
-    returnByValue: true,
-  });
+  const buttonWaitMs = options.buttonWaitMs ?? MODEL_BUTTON_WAIT_MS;
+  const buttonPollMs = options.buttonPollMs ?? MODEL_BUTTON_POLL_MS;
+  const deadline = Date.now() + Math.max(0, buttonWaitMs);
 
-  const result = outcome.result?.value as
-    | { status: "already-selected"; label?: string | null }
-    | { status: "switched"; label?: string | null }
-    | {
-        status: "option-not-found";
-        hint?: { temporaryChat?: boolean; availableOptions?: string[] };
-      }
-    | { status: "button-missing" }
-    | undefined;
+  let result: ModelSelectionResult;
+  for (;;) {
+    const outcome = await Runtime.evaluate({
+      expression: buildModelSelectionExpression(desiredModel, strategy),
+      awaitPromise: true,
+      returnByValue: true,
+    });
+    result = outcome.result?.value as ModelSelectionResult;
+    if (result?.status !== "button-missing" || Date.now() >= deadline) {
+      break;
+    }
+    await delay(buttonPollMs);
+  }
 
   switch (result?.status) {
     case "already-selected":

--- a/src/browser/actions/modelSelection.ts
+++ b/src/browser/actions/modelSelection.ts
@@ -43,6 +43,7 @@ export async function ensureModelSelection(
   const deadline = Date.now() + Math.max(0, buttonWaitMs);
 
   let result: ModelSelectionResult;
+  let announcedWait = false;
   for (;;) {
     const outcome = await Runtime.evaluate({
       expression: buildModelSelectionExpression(desiredModel, strategy),
@@ -52,6 +53,12 @@ export async function ensureModelSelection(
     result = outcome.result?.value as ModelSelectionResult;
     if (result?.status !== "button-missing" || Date.now() >= deadline) {
       break;
+    }
+    if (!announcedWait) {
+      announcedWait = true;
+      logger(
+        `Model picker button not mounted yet; waiting up to ${Math.round(buttonWaitMs / 1000)}s for the composer pill to render.`,
+      );
     }
     await delay(buttonPollMs);
   }

--- a/tests/browser/modelSelection.test.ts
+++ b/tests/browser/modelSelection.test.ts
@@ -1432,3 +1432,46 @@ describe("browser model selection matchers", () => {
     expect(expression).toContain("canTrustSelectedOption(option, normalizedText, testid)");
   });
 });
+
+describe("ensureModelSelection composer-pill wait", () => {
+  const noopLogger = (() => {}) as unknown as Parameters<typeof ensureModelSelection>[2];
+
+  const makeRuntime = (statuses: Array<Record<string, unknown>>) => {
+    let call = 0;
+    const evaluate = vi.fn(async () => {
+      const value = statuses[Math.min(call, statuses.length - 1)];
+      call += 1;
+      return { result: { value } };
+    });
+    return { evaluate } as unknown as Parameters<typeof ensureModelSelection>[0];
+  };
+
+  it("waits for a late-mounting model pill instead of failing on the first miss", async () => {
+    const Runtime = makeRuntime([
+      { status: "button-missing" },
+      { status: "button-missing" },
+      { status: "switched", label: "Pro Extended" },
+    ]);
+
+    const evidence = await ensureModelSelection(Runtime, "Pro", noopLogger, "select", {
+      buttonWaitMs: 1000,
+      buttonPollMs: 1,
+    });
+
+    expect(evidence.status).toBe("switched");
+    expect(evidence.resolvedLabel).toBe("Pro Extended");
+    expect(evidence.verified).toBe(true);
+    expect((Runtime.evaluate as ReturnType<typeof vi.fn>).mock.calls.length).toBe(3);
+  });
+
+  it("gives up once the button-wait deadline passes", async () => {
+    const Runtime = makeRuntime([{ status: "button-missing" }]);
+
+    await expect(
+      ensureModelSelection(Runtime, "Pro", noopLogger, "select", {
+        buttonWaitMs: 5,
+        buttonPollMs: 1,
+      }),
+    ).rejects.toThrow(/Unable to locate the ChatGPT model selector button/);
+  });
+});

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -76,7 +76,10 @@ describe("ensureModelSelection", () => {
     const runtime = {
       evaluate: vi.fn().mockResolvedValue({ result: { value: { status: "button-missing" } } }),
     } as unknown as ChromeClient["Runtime"];
-    await expect(ensureModelSelection(runtime, "Instant", logger)).rejects.toThrow(
+    // buttonWaitMs: 0 skips the composer-pill wait so this exercises the give-up path directly.
+    await expect(
+      ensureModelSelection(runtime, "Instant", logger, "select", { buttonWaitMs: 0 }),
+    ).rejects.toThrow(
       /Unable to locate the ChatGPT model selector button.*--browser-model-strategy current.*--browser-model-strategy ignore/s,
     );
   });


### PR DESCRIPTION
## Problem

`--browser-model-strategy select` (and Pro Extended verification) fails on fresh runs against ChatGPT's current UI with:

```
Browser automation failure (model-switcher-button)
Unable to locate the ChatGPT model selector button.
```

ChatGPT now renders the model/effort picker as a **composer pill** (`button.__composer-pill`, `aria-haspopup="menu"`, e.g. "Instant" / "Pro Extended"), which React mounts a beat after the page becomes interactive. On a **cold profile** — notably cookie-sync's throwaway Chrome with no asset cache — the pill mounts ~1–4s after `Prompt textarea ready`, **past** the bounded retry window around `ensureModelSelection`. The run then closes the browser before the picker has rendered.

Oracle already has the right selectors for the new UI (composer-pill + `menuitemradio`); it was just giving up too early.

> The `No cookies were applied` hint appended to the error is a red herring here: cookie sync had already authenticated (`Login check passed ... sessionAuthenticated=true`); `appliedCookies` is 0 only because the pill — not auth — was missing.

## Fix

`ensureModelSelection` re-evaluates the selection expression while the result is `button-missing`, up to a bounded deadline (`MODEL_BUTTON_WAIT_MS` = 8s, poll 250ms), then proceeds unchanged. Localized: **only** a missing button waits; a genuine `option-not-found` still surfaces immediately. The wait window is injectable via an `options` arg for deterministic tests.

## Tests

- New `tests/browser/modelSelection.test.ts` cases: waits for a late-mounting pill (resolves on the 3rd evaluate) and gives up once the deadline passes.
- `pageActions.test.ts > throws when button missing` now passes `buttonWaitMs: 0` to exercise the give-up path directly.
- `pnpm vitest run tests/browser/` → 571 passed / 1 skipped; `pnpm run check` (typecheck + oxlint + oxfmt) clean.

## Real-run validation

Browser run on a cold cookie-sync profile, after the fix:

```
Model selection evidence: requested=Pro; resolved=Pro Extended; status=switched; strategy=select; verified=yes.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
