### PR TITLE
Raise default file attachment size guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Browser: wait up to eight seconds for the ChatGPT model/effort composer pill to mount before failing explicit selection, while leaving `option-not-found` failures immediate. Thanks @gustavosmendes!
+- CLI/Browser/MCP: raise the default per-file attachment guard from 1 MB to 500 MB, keep lower config/env/CLI overrides enforced, and preserve the effective limit through remote browser execution.
 
 ## 0.15.0 — 2026-06-19
 

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -390,7 +390,7 @@ program
   )
   .option(
     "-f, --file <paths...>",
-    "Files/directories or glob patterns to attach (prefix with !pattern to exclude). Oversized files are rejected automatically (default cap: 1 MB; configurable via ORACLE_MAX_FILE_SIZE_BYTES or config.maxFileSizeBytes).",
+    "Files/directories or glob patterns to attach (prefix with !pattern to exclude). Oversized files are rejected automatically (default cap: 500 MB; configurable via ORACLE_MAX_FILE_SIZE_BYTES or config.maxFileSizeBytes).",
     collectPaths,
     [],
   )

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -104,7 +104,7 @@ For the most reliable shared setup: run one signed-in Chrome with remote debuggi
 ## Cost / safety hygiene
 
 - **Always preview Pro runs.** `--dry-run summary --files-report` before a Pro API call on a large bundle. Token counts are a close-enough proxy for dollars.
-- **Cap file size.** `~/.oracle/config.json` → `maxFileSizeBytes`, or `ORACLE_MAX_FILE_SIZE_BYTES`. Default is 1 MB per file.
+- **Cap file size.** `~/.oracle/config.json` → `maxFileSizeBytes`, or `ORACLE_MAX_FILE_SIZE_BYTES`. Default is 500 MB per file.
 - **Excludes are your friend.** `--file "src/**" --file "!**/*.test.ts" --file "!**/*.snap"` cuts most fixtures.
 - **API mode runs cost real money.** If your agent runs Oracle autonomously, scope it: pin `--model`, set `--timeout`, and review the session log. Many users gate API mode behind explicit user consent and let browser mode run free.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -138,7 +138,7 @@ See [Browser Mode](browser-mode.md) for usage.
 | `ANTHROPIC_API_KEY`                 | Enables Claude API mode.                                |
 | `OPENROUTER_API_KEY`                | Enables OpenRouter ids.                                 |
 | `ORACLE_HOME_DIR`                   | Override `~/.oracle/` root.                             |
-| `ORACLE_MAX_FILE_SIZE_BYTES`        | Per-file size cap (default 1 MB).                       |
+| `ORACLE_MAX_FILE_SIZE_BYTES`        | Per-file size cap (default 500 MB).                     |
 | `ORACLE_BROWSER_COOKIES_JSON`       | Inline ChatGPT cookies (JSON / base64).                 |
 | `ORACLE_BROWSER_COOKIES_FILE`       | Path to cookies JSON.                                   |
 | `ORACLE_BROWSER_ATTACHMENT_TIMEOUT` | Attachment upload/readiness timeout for browser mode.   |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,7 +62,7 @@ JSON5 parsing, so trailing commas and comments are allowed.
   },
 
   heartbeatSeconds: 30, // default heartbeat interval
-  maxFileSizeBytes: 2097152, // raise/lower the per-file attachment guard (bytes)
+  maxFileSizeBytes: 2097152, // lower/raise the default 500 MB per-file attachment guard (bytes)
   filesReport: false, // default per-file token report
   background: true, // default background mode for API runs
   sessionRetentionHours: 72, // prune cached sessions older than 72h before each run (0 disables)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -30,7 +30,7 @@ The bundle Oracle ships is deterministic given the same args and same files. Tha
 - Default-ignored dirs: `node_modules`, `dist`, `coverage`, `.git`, `.turbo`, `.next`, `build`, `tmp`. Pass them explicitly to override.
 - Symlinks are not followed.
 - Dotfiles are filtered unless the glob has a dot-segment (`--file ".github/**"`).
-- File size cap defaults to 1 MB. Override with `ORACLE_MAX_FILE_SIZE_BYTES` or `maxFileSizeBytes` in config.
+- File size cap defaults to 500 MB. Override with `ORACLE_MAX_FILE_SIZE_BYTES` or `maxFileSizeBytes` in config.
 
 ## Engine selection
 

--- a/skills/oracle/SKILL.md
+++ b/skills/oracle/SKILL.md
@@ -64,7 +64,7 @@ Recommended defaults:
   - Honors `.gitignore` when expanding globs.
   - Does not follow symlinks (glob expansion uses `followSymbolicLinks: false`).
   - Dotfiles are filtered unless you explicitly opt in with a pattern that includes a dot-segment (e.g. `--file ".github/**"`).
-  - Default cap: files > 1 MB are rejected unless you raise `ORACLE_MAX_FILE_SIZE_BYTES` or `maxFileSizeBytes` in `~/.oracle/config.json`.
+  - Default cap: files > 500 MB are rejected unless you raise `ORACLE_MAX_FILE_SIZE_BYTES` or `maxFileSizeBytes` in `~/.oracle/config.json`.
 
 ## Budget + observability
 

--- a/src/browser/prompt.ts
+++ b/src/browser/prompt.ts
@@ -10,6 +10,7 @@ import {
   TOKENIZER_OPTIONS,
   formatFileSections,
 } from "../oracle.js";
+import { DEFAULT_MAX_FILE_SIZE_BYTES } from "../oracle/files.js";
 import { isKnownModel } from "../oracle/modelResolver.js";
 import { buildPromptMarkdown } from "../oracle/promptAssembly.js";
 import type { BrowserAttachment } from "./types.js";
@@ -265,7 +266,7 @@ export async function assembleBrowserPrompt(
     .filter((file) => !isRawUploadFile(file.path))
     .map((file) => file.path);
   const rawUploadFiles = discoveredFiles.filter((file) => isRawUploadFile(file.path));
-  const maxFileSizeBytes = runOptions.maxFileSizeBytes;
+  const maxFileSizeBytes = runOptions.maxFileSizeBytes ?? DEFAULT_MAX_FILE_SIZE_BYTES;
 
   const rawUploadAttachments: BrowserAttachment[] = await Promise.all(
     rawUploadFiles.map(async ({ path: filePath }) => {

--- a/src/browser/sessionRunner.ts
+++ b/src/browser/sessionRunner.ts
@@ -211,6 +211,7 @@ export async function runBrowserSessionExecution(
       log: automationLogger,
       heartbeatIntervalMs: runOptions.heartbeatIntervalMs,
       verbose: runOptions.verbose,
+      maxFileSizeBytes: runOptions.maxFileSizeBytes,
       sessionId: runOptions.sessionId,
       generateImagePath: runOptions.generateImage,
       outputPath: runOptions.outputPath,

--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -132,6 +132,8 @@ export interface BrowserRunOptions {
   log?: BrowserLogger;
   heartbeatIntervalMs?: number;
   verbose?: boolean;
+  /** Effective per-file attachment guard in bytes, propagated for remote/browser execution metadata. */
+  maxFileSizeBytes?: number;
   /** Session id used for cross-process browser slot diagnostics. */
   sessionId?: string;
   /** Browser-only image generation output path. */

--- a/src/cli/fileSize.ts
+++ b/src/cli/fileSize.ts
@@ -1,5 +1,5 @@
 import type { UserConfig } from "../config.js";
-import { normalizeMaxFileSizeBytes } from "../oracle/files.js";
+import { DEFAULT_MAX_FILE_SIZE_BYTES, normalizeMaxFileSizeBytes } from "../oracle/files.js";
 
 export function resolveConfiguredMaxFileSizeBytes(
   userConfig?: UserConfig,
@@ -12,5 +12,5 @@ export function resolveConfiguredMaxFileSizeBytes(
   if (userConfig?.maxFileSizeBytes !== undefined) {
     return normalizeMaxFileSizeBytes(userConfig.maxFileSizeBytes, "config.maxFileSizeBytes");
   }
-  return undefined;
+  return DEFAULT_MAX_FILE_SIZE_BYTES;
 }

--- a/src/oracle/files.ts
+++ b/src/oracle/files.ts
@@ -4,7 +4,7 @@ import fg from "fast-glob";
 import type { FileContent, FileSection, MinimalFsModule, FsStats } from "./types.js";
 import { FileValidationError } from "./errors.js";
 
-export const DEFAULT_MAX_FILE_SIZE_BYTES = 1 * 1024 * 1024; // 1 MB
+export const DEFAULT_MAX_FILE_SIZE_BYTES = 500 * 1024 * 1024; // 500 MB
 const DEFAULT_FS = fs as MinimalFsModule;
 const DEFAULT_IGNORED_DIRS = new Set([
   "node_modules",

--- a/src/remote/client.ts
+++ b/src/remote/client.ts
@@ -30,6 +30,7 @@ export function createRemoteBrowserExecutor({ host, token }: RemoteExecutorOptio
       options: {
         heartbeatIntervalMs: options.heartbeatIntervalMs,
         verbose: options.verbose,
+        maxFileSizeBytes: options.maxFileSizeBytes,
         sessionId: options.sessionId,
         followUpPrompts: options.followUpPrompts,
       },

--- a/src/remote/server.ts
+++ b/src/remote/server.ts
@@ -249,6 +249,7 @@ export async function createRemoteServer(
         log: automationLogger,
         heartbeatIntervalMs: payload.options.heartbeatIntervalMs,
         verbose: payload.options.verbose,
+        maxFileSizeBytes: payload.options.maxFileSizeBytes,
         sessionId: payload.options.sessionId,
         followUpPrompts: payload.options.followUpPrompts,
       });

--- a/src/remote/types.ts
+++ b/src/remote/types.ts
@@ -20,6 +20,7 @@ export interface RemoteRunPayload {
   options: {
     heartbeatIntervalMs?: number;
     verbose?: boolean;
+    maxFileSizeBytes?: number;
     sessionId?: string;
     followUpPrompts?: string[];
   };

--- a/tests/cli/runOracle/prompt-and-utils.test.ts
+++ b/tests/cli/runOracle/prompt-and-utils.test.ts
@@ -303,12 +303,27 @@ describe("oracle utility helpers", () => {
     }
   });
 
-  test("readFiles rejects files larger than 1 MB", async () => {
+  test("readFiles accepts repo-sized archives above the former 1 MB default", async () => {
     const dir = await mkdtemp(path.join(os.tmpdir(), "oracle-readfiles-large-"));
     try {
       const largeFile = path.join(dir, "huge.bin");
       await writeFile(largeFile, "a".repeat(1_200_000), "utf8");
-      await expect(readFiles([largeFile], { cwd: dir })).rejects.toThrow(/exceed the 1 MB limit/i);
+      const files = await readFiles([largeFile], { cwd: dir });
+      expect(files).toHaveLength(1);
+      expect(files[0].path).toBe(largeFile);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("readFiles still rejects files larger than a configured lower limit", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "oracle-readfiles-large-configured-"));
+    try {
+      const largeFile = path.join(dir, "huge.bin");
+      await writeFile(largeFile, "a".repeat(1_200_000), "utf8");
+      await expect(
+        readFiles([largeFile], { cwd: dir, maxFileSizeBytes: 1_000_000 }),
+      ).rejects.toThrow(/exceed the 976\.6 KB limit/i);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/tests/remote/server.test.ts
+++ b/tests/remote/server.test.ts
@@ -40,6 +40,7 @@ describe("remote browser service", () => {
           runBrowser: async (options) => {
             runLog.push(options.prompt);
             expect(options.sessionId).toBe("remote-session-id");
+            expect(options.maxFileSizeBytes).toBe(123_456_789);
             expect(options.followUpPrompts).toEqual(["follow up"]);
             expect(options.attachments).toHaveLength(1);
             const attachment = options.attachments?.[0];
@@ -84,6 +85,7 @@ describe("remote browser service", () => {
           ],
         },
         config: {},
+        maxFileSizeBytes: 123_456_789,
         sessionId: "remote-session-id",
         followUpPrompts: ["follow up"],
         log: (message?: string) => {

--- a/tests/runOptions.test.ts
+++ b/tests/runOptions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { resolveRunOptionsFromConfig } from "../src/cli/runOptions.js";
 import { estimateRequestTokens } from "../src/oracle/tokenEstimate.js";
 import { DEFAULT_MODEL, MODEL_CONFIGS } from "../src/oracle/config.js";
+import { DEFAULT_MAX_FILE_SIZE_BYTES } from "../src/oracle/files.js";
 
 describe("resolveRunOptionsFromConfig", () => {
   const basePrompt = "This prompt is comfortably above twenty characters.";
@@ -85,6 +86,14 @@ describe("resolveRunOptionsFromConfig", () => {
       userConfig: { heartbeatSeconds: 5 },
     });
     expect(runOptions.heartbeatIntervalMs).toBe(5000);
+  });
+
+  it("defaults maxFileSizeBytes to the browser attachment guard", () => {
+    const { runOptions } = resolveRunOptionsFromConfig({
+      prompt: basePrompt,
+      env: {},
+    });
+    expect(runOptions.maxFileSizeBytes).toBe(DEFAULT_MAX_FILE_SIZE_BYTES);
   });
 
   it("uses maxFileSizeBytes from config", () => {


### PR DESCRIPTION
## Summary
- raise the default per-file attachment guard from 1 MB to 500 MB
- keep CLI/env/config lower limits enforced and documented
- propagate maxFileSizeBytes through remote browser execution payloads

## Tests
- pnpm install
- pnpm exec vitest run tests/cli/runOracle/prompt-and-utils.test.ts tests/browser/prompt.test.ts tests/runOptions.test.ts tests/remote/server.test.ts tests/cli/integrationCli.test.ts --testNamePattern "readFiles|repo-sized|configured lower|passes maxFileSizeBytes|raw files|defaults maxFileSizeBytes|uses maxFileSizeBytes|ORACLE_MAX_FILE_SIZE_BYTES|remote browser service|honors --max-file-size-bytes"
- pnpm run lint
- pnpm test
- pnpm run format:check
- pnpm run build
- synthetic 1.5 MB zip dry-run through browser attachment path