### PR TITLE
feat(config): add user model overrides for custom gateways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Config: add user-only `modelOverrides` in `~/.oracle/config.json` to override a known model's on-wire `apiModel`, reasoning effort, input limit, and pricing — for custom OpenAI-compatible `--base-url` gateways (e.g. a LiteLLM proxy) that rename model ids or need a non-default effort. Overrides apply to known models only (tokenizer inherited), support `reasoning: null` to clear effort, and are ignored from project configs so they cannot reroute model traffic. Fixes #273.
+- API: forward reasoning effort as `reasoning_effort` through the OpenAI-compatible chat/completions adapter used for custom/proxy base URLs (OpenRouter, LiteLLM, vLLM, etc.). Previously the adapter only sent `model`, `messages`, and `max_tokens`, so a reasoning model's effort was silently dropped on any custom `--base-url`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.15.1 — Unreleased
 
+### Added
+
+- Config: add user-only `modelOverrides` in `~/.oracle/config.json` to override a known model's on-wire `apiModel`, reasoning effort, input limit, and pricing — for custom OpenAI-compatible `--base-url` gateways (e.g. a LiteLLM proxy) that rename model ids or need a non-default effort. Overrides apply to known models only (tokenizer inherited), support `reasoning: null` to clear effort, and are ignored from project configs so they cannot reroute model traffic. Fixes #273.
+
 ### Fixed
 
 - Browser: wait up to eight seconds for the ChatGPT model/effort composer pill to mount before failing explicit selection, while leaving `option-not-found` failures immediate. Thanks @gustavosmendes!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Added
 
-- Config: add user-only `modelOverrides` in `~/.oracle/config.json` to override a known model's on-wire `apiModel`, reasoning effort, input limit, and pricing — for custom OpenAI-compatible `--base-url` gateways (e.g. a LiteLLM proxy) that rename model ids or need a non-default effort. Overrides apply to known models only (tokenizer inherited), support `reasoning: null` to clear effort, and are ignored from project configs so they cannot reroute model traffic. Fixes #273.
-- API: forward reasoning effort as `reasoning_effort` through the OpenAI-compatible chat/completions adapter used for custom/proxy base URLs (OpenRouter, LiteLLM, vLLM, etc.). Previously the adapter only sent `model`, `messages`, and `max_tokens`, so a reasoning model's effort was silently dropped on any custom `--base-url`.
+- API: add user-only `modelOverrides` for remapping known models and their metadata on custom OpenAI-compatible gateways. Fixes #273. Thanks @wangwllu!
 
 ### Fixed
 
+- API: forward configured reasoning effort through custom OpenAI-compatible chat-completions gateways.
 - Browser: wait up to eight seconds for the ChatGPT model/effort composer pill to mount before failing explicit selection, while leaving `option-not-found` failures immediate. Thanks @gustavosmendes!
 
 ## 0.15.0 — 2026-06-19

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -17,10 +17,11 @@ import chalk from "chalk";
 import type { SessionMetadata, SessionMode, BrowserSessionConfig } from "../src/sessionStore.js";
 import { sessionStore, pruneOldSessions } from "../src/sessionStore.js";
 import { DEFAULT_MODEL, MODEL_CONFIGS } from "../src/oracle/config.js";
-import { isKnownModel } from "../src/oracle/modelResolver.js";
+import { isKnownModel, resolveOverriddenApiModel } from "../src/oracle/modelResolver.js";
 import type {
   ApiProviderMode,
   ModelName,
+  ModelOverridesConfig,
   PreviewMode,
   RunOracleOptions,
 } from "../src/oracle/types.js";
@@ -195,6 +196,7 @@ type ResolvedCliOptions = Omit<CliOptions, "model"> & {
   model: ModelName;
   models?: ModelName[];
   effectiveModelId?: string;
+  modelOverrides?: ModelOverridesConfig;
   writeOutputPath?: string;
   previousResponseId?: string;
   followupSessionId?: string;
@@ -1328,6 +1330,7 @@ function buildRunOptions(
     browserResumeConversationUrl:
       overrides.browserResumeConversationUrl ?? options.browserResumeConversationUrl,
     effectiveModelId: overrides.effectiveModelId ?? options.effectiveModelId ?? options.model,
+    modelOverrides: overrides.modelOverrides ?? options.modelOverrides,
     file: overrides.file ?? options.file ?? [],
     maxFileSizeBytes: overrides.maxFileSizeBytes ?? options.maxFileSizeBytes,
     slug: overrides.slug ?? options.slug,
@@ -1951,11 +1954,16 @@ async function runRootCommand(options: CliOptions): Promise<void> {
   }
   const resolvedModel: ModelName =
     normalizedMultiModels[0] ?? (isGemini ? resolveApiModel(cliModelArg) : resolvedModelCandidate);
-  const effectiveModelId = resolvedModel.startsWith("gemini")
-    ? resolveGeminiModelId(resolvedModel)
-    : isKnownModel(resolvedModel)
-      ? (MODEL_CONFIGS[resolvedModel].apiModel ?? resolvedModel)
-      : resolvedModel;
+  // A user-config apiModel override (known models only) wins over Gemini alias
+  // remapping and the bundled apiModel, so it becomes the on-wire request id.
+  const overriddenApiModel = resolveOverriddenApiModel(resolvedModel, userConfig.modelOverrides);
+  const effectiveModelId =
+    overriddenApiModel ??
+    (resolvedModel.startsWith("gemini")
+      ? resolveGeminiModelId(resolvedModel)
+      : isKnownModel(resolvedModel)
+        ? (MODEL_CONFIGS[resolvedModel].apiModel ?? resolvedModel)
+        : resolvedModel);
   const resolvedBaseUrl = normalizeBaseUrl(
     options.baseUrl ?? (isClaude ? process.env.ANTHROPIC_BASE_URL : process.env.OPENAI_BASE_URL),
   );
@@ -1968,6 +1976,7 @@ async function runRootCommand(options: CliOptions): Promise<void> {
   }
   resolvedOptions.baseUrl = resolvedBaseUrl;
   resolvedOptions.effectiveModelId = effectiveModelId;
+  resolvedOptions.modelOverrides = userConfig.modelOverrides;
   resolvedOptions.provider = providerMode;
   resolvedOptions.writeOutputPath = resolveOutputPath(options.writeOutput, process.cwd());
 

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -1956,7 +1956,8 @@ async function runRootCommand(options: CliOptions): Promise<void> {
     normalizedMultiModels[0] ?? (isGemini ? resolveApiModel(cliModelArg) : resolvedModelCandidate);
   // A user-config apiModel override (known models only) wins over Gemini alias
   // remapping and the bundled apiModel, so it becomes the on-wire request id.
-  const overriddenApiModel = resolveOverriddenApiModel(resolvedModel, userConfig.modelOverrides);
+  const apiModelOverrides = engine === "api" ? userConfig.modelOverrides : undefined;
+  const overriddenApiModel = resolveOverriddenApiModel(resolvedModel, apiModelOverrides);
   const effectiveModelId =
     overriddenApiModel ??
     (resolvedModel.startsWith("gemini")
@@ -1976,7 +1977,7 @@ async function runRootCommand(options: CliOptions): Promise<void> {
   }
   resolvedOptions.baseUrl = resolvedBaseUrl;
   resolvedOptions.effectiveModelId = effectiveModelId;
-  resolvedOptions.modelOverrides = userConfig.modelOverrides;
+  resolvedOptions.modelOverrides = apiModelOverrides;
   resolvedOptions.provider = providerMode;
   resolvedOptions.writeOutputPath = resolveOutputPath(options.writeOutput, process.cwd());
 

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -1635,6 +1635,7 @@ function buildRunOptionsFromMetadata(metadata: SessionMetadata): RunOracleOption
     previousResponseId: stored.previousResponseId,
     browserResumeConversationUrl: stored.browserResumeConversationUrl,
     effectiveModelId: stored.effectiveModelId ?? stored.model,
+    modelOverrides: stored.modelOverrides,
     file: stored.file ?? [],
     maxFileSizeBytes: stored.maxFileSizeBytes,
     slug: stored.slug,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,6 +68,15 @@ JSON5 parsing, so trailing commas and comments are allowed.
   sessionRetentionHours: 72, // prune cached sessions older than 72h before each run (0 disables)
   promptSuffix: "// signed-off by me", // appended to every prompt
   apiBaseUrl: "https://api.openai.com/v1", // override for LiteLLM / custom gateways
+  // API-only, user-config-only overrides for known model keys.
+  modelOverrides: {
+    "gpt-5.5": {
+      apiModel: "gateway-model", // on-wire id exposed by the gateway
+      reasoning: { effort: "xhigh" }, // or null to clear the bundled effort
+      inputLimit: 1050000,
+      pricing: { inputPerToken: 0.000005, outputPerToken: 0.00003 },
+    },
+  },
 }
 ```
 
@@ -94,7 +103,7 @@ values. This lets a parent folder set broad defaults and override a specific
 ChatGPT Project URL in a package subdirectory.
 
 Project configs intentionally support only workflow defaults. They cannot set
-provider routing or secret/executable fields such as `apiBaseUrl`, `azure`,
+provider routing or secret/executable fields such as `apiBaseUrl`, `modelOverrides`, `azure`,
 `browser.remoteHost`, `browser.remoteToken`, `browser.chromePath`, or
 `browser.chromeCookiePath`. Keep tokens and machine-local executable/profile
 paths in `~/.oracle/config.json`, environment variables, or explicit CLI flags.
@@ -105,11 +114,12 @@ CLI flags and explicit override environment variables → effective config (proj
 
 - The effective config starts with `~/.oracle/config.json`, then layers project `.oracle/config.json` files from parent to child. `engine`, `model`, `search`, `filesReport`, `heartbeatSeconds`, `maxFileSizeBytes`, and `apiBaseUrl` in the effective config override auto-detected values unless explicitly set on the CLI or through a supported override environment variable.
 - Project `.oracle/config.json` files can override safe workflow defaults such as `engine`, `model`, `search`, `filesReport`, `heartbeatSeconds`, `maxFileSizeBytes`, `promptSuffix`, and allowed `browser.*` workflow settings.
-- Provider routing and machine-local fields (`apiBaseUrl`, `azure`, remote browser host/token defaults, Chrome binary/profile paths, cookie DB paths, and session retention cleanup) are ignored in project configs and are read only from the user config, environment variables, or explicit CLI flags.
+- Provider routing and machine-local fields (`apiBaseUrl`, `modelOverrides`, `azure`, remote browser host/token defaults, Chrome binary/profile paths, cookie DB paths, and session retention cleanup) are ignored in project configs and are read only from the user config, environment variables, or explicit CLI flags.
 - `ORACLE_ENGINE=api|browser` is a global override for engine selection (useful for MCP/Codex setups); it wins over `config.json`.
 - If `azure.endpoint` (or `--azure-endpoint`) is set, Oracle reads `AZURE_OPENAI_API_KEY` first and falls back to `OPENAI_API_KEY` for GPT models.
 - Remote browser defaults follow the same order: `--remote-host/--remote-token` win, then `browser.remoteHost` / `browser.remoteToken` in the config, then `ORACLE_REMOTE_HOST` / `ORACLE_REMOTE_TOKEN` if still unset.
 - `OPENAI_API_KEY` only influences engine selection when neither the CLI nor `config.json` specify an engine (API when present, otherwise browser).
+- `modelOverrides` applies only to API runs and existing built-in model keys. It can replace the on-wire `apiModel`, reasoning effort, input limit, and per-token pricing; unspecified fields and the bundled tokenizer remain unchanged. Invalid override values are ignored. Project configs cannot set this field.
 - `ORACLE_NOTIFY*` env vars still layer on top of the config’s `notify` block.
 - `sessionRetentionHours` controls the default value for `--retain-hours`. When unset, `ORACLE_RETAIN_HOURS` (if present) becomes the fallback, and the CLI flag still wins over both.
 - `ORACLE_MAX_FILE_SIZE_BYTES` overrides `maxFileSizeBytes` when set. Oracle validates it as a positive integer number of bytes before reading any `--file` inputs.

--- a/docs/openai-endpoints.md
+++ b/docs/openai-endpoints.md
@@ -83,6 +83,23 @@ Or via `config.json`:
 }
 ```
 
+If a gateway exposes a different on-wire model id, add an API-only override to the user config at `~/.oracle/config.json`:
+
+```json5
+{
+  apiBaseUrl: "http://localhost:4000",
+  model: "gpt-5.5",
+  modelOverrides: {
+    "gpt-5.5": {
+      apiModel: "gateway-model",
+      reasoning: { effort: "high" },
+    },
+  },
+}
+```
+
+Overrides accept existing built-in model keys only and are ignored in project `.oracle/config.json` files. See [Local configuration](configuration.md) for the full field list and precedence.
+
 ## Model aliases
 
 Oracle keeps a stable CLI-facing model set, but some names are aliases for the concrete API model ids it sends:

--- a/src/cli/runOptions.ts
+++ b/src/cli/runOptions.ts
@@ -118,7 +118,8 @@ export function resolveRunOptionsFromConfig({
   }
 
   const chosenModel: ModelName = uniqueMultiModels[0] ?? resolvedModel;
-  const effectiveModelId = resolveEffectiveModelId(chosenModel, userConfig?.modelOverrides);
+  const apiModelOverrides = fixedEngine === "api" ? userConfig?.modelOverrides : undefined;
+  const effectiveModelId = resolveEffectiveModelId(chosenModel, apiModelOverrides);
 
   const runOptions: RunOracleOptions = {
     prompt: promptWithSuffix,
@@ -133,7 +134,7 @@ export function resolveRunOptionsFromConfig({
     baseUrl,
     azure,
     effectiveModelId,
-    modelOverrides: userConfig?.modelOverrides,
+    modelOverrides: apiModelOverrides,
   };
 
   return { runOptions, resolvedEngine: fixedEngine, engineCoercedToApi };
@@ -154,10 +155,7 @@ function resolveAzureOptions(
   };
 }
 
-function resolveEffectiveModelId(
-  model: ModelName,
-  modelOverrides?: ModelOverridesConfig,
-): string {
+function resolveEffectiveModelId(model: ModelName, modelOverrides?: ModelOverridesConfig): string {
   // A user-config override of a known model's apiModel must win, since this id
   // becomes the on-wire request model id in run.ts (including for Gemini aliases).
   const overridden = resolveOverriddenApiModel(model, modelOverrides);

--- a/src/cli/runOptions.ts
+++ b/src/cli/runOptions.ts
@@ -1,4 +1,4 @@
-import type { RunOracleOptions, ModelName, AzureOptions } from "../oracle.js";
+import type { RunOracleOptions, ModelName, AzureOptions, ModelOverridesConfig } from "../oracle.js";
 import { DEFAULT_MODEL, MODEL_CONFIGS } from "../oracle.js";
 import type { UserConfig } from "../config.js";
 import type { EngineMode } from "./engine.js";
@@ -10,6 +10,7 @@ import {
   normalizeBaseUrl,
 } from "./options.js";
 import { resolveGeminiModelId } from "../oracle/gemini.js";
+import { resolveOverriddenApiModel } from "../oracle/modelResolver.js";
 import { PromptValidationError } from "../oracle/errors.js";
 import { normalizeChatGptModelForBrowser } from "./browserConfig.js";
 import { resolveConfiguredMaxFileSizeBytes } from "./fileSize.js";
@@ -117,7 +118,7 @@ export function resolveRunOptionsFromConfig({
   }
 
   const chosenModel: ModelName = uniqueMultiModels[0] ?? resolvedModel;
-  const effectiveModelId = resolveEffectiveModelId(chosenModel);
+  const effectiveModelId = resolveEffectiveModelId(chosenModel, userConfig?.modelOverrides);
 
   const runOptions: RunOracleOptions = {
     prompt: promptWithSuffix,
@@ -132,6 +133,7 @@ export function resolveRunOptionsFromConfig({
     baseUrl,
     azure,
     effectiveModelId,
+    modelOverrides: userConfig?.modelOverrides,
   };
 
   return { runOptions, resolvedEngine: fixedEngine, engineCoercedToApi };
@@ -152,7 +154,16 @@ function resolveAzureOptions(
   };
 }
 
-function resolveEffectiveModelId(model: ModelName): string {
+function resolveEffectiveModelId(
+  model: ModelName,
+  modelOverrides?: ModelOverridesConfig,
+): string {
+  // A user-config override of a known model's apiModel must win, since this id
+  // becomes the on-wire request model id in run.ts (including for Gemini aliases).
+  const overridden = resolveOverriddenApiModel(model, modelOverrides);
+  if (overridden) {
+    return overridden;
+  }
   if (typeof model === "string" && model.startsWith("gemini")) {
     return resolveGeminiModelId(model);
   }

--- a/src/cli/sessionRunner.ts
+++ b/src/cli/sessionRunner.ts
@@ -175,6 +175,7 @@ export async function performSessionRun({
       const modelConfig = await resolveModelConfig(primaryModel, {
         baseUrl: runOptions.baseUrl,
         openRouterApiKey: process.env.OPENROUTER_API_KEY,
+        modelOverrides: runOptions.modelOverrides,
       });
       const files = await readFiles(runOptions.file ?? [], {
         cwd,

--- a/src/config.ts
+++ b/src/config.ts
@@ -98,8 +98,8 @@ export interface UserConfig {
   azure?: AzureConfig;
   sessionRetentionHours?: number;
   /**
-   * Per-model overrides merged over known model configs (apiModel, reasoning,
-   * inputLimit, pricing). User-config only: intentionally excluded from
+   * API-only per-model overrides merged over known model configs (apiModel,
+   * reasoning, inputLimit, pricing). User-config only: intentionally excluded from
    * {@link sanitizeProjectConfig} so untrusted project configs cannot reroute
    * model traffic.
    */

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,7 @@ import type {
   BrowserModelStrategy,
   BrowserResearchMode,
 } from "./browser/types.js";
-import type { ThinkingTimeLevel } from "./oracle/types.js";
+import type { ThinkingTimeLevel, ModelOverridesConfig } from "./oracle/types.js";
 
 export type EnginePreference = "api" | "browser";
 
@@ -97,6 +97,13 @@ export interface UserConfig {
   apiBaseUrl?: string;
   azure?: AzureConfig;
   sessionRetentionHours?: number;
+  /**
+   * Per-model overrides merged over known model configs (apiModel, reasoning,
+   * inputLimit, pricing). User-config only: intentionally excluded from
+   * {@link sanitizeProjectConfig} so untrusted project configs cannot reroute
+   * model traffic.
+   */
+  modelOverrides?: ModelOverridesConfig;
 }
 
 export const PROJECT_CONFIG_RELATIVE_PATH = path.join(".oracle", "config.json");
@@ -262,6 +269,9 @@ function sanitizeProjectConfig(config: UserConfig): UserConfig {
   if (config.filesReport !== undefined) sanitized.filesReport = config.filesReport;
   if (config.background !== undefined) sanitized.background = config.background;
   if (config.promptSuffix !== undefined) sanitized.promptSuffix = config.promptSuffix;
+  // NOTE: `modelOverrides` is intentionally NOT copied here. Model routing
+  // overrides are user-config only; allowing them from project configs would let
+  // an untrusted repository silently redirect API calls (apiModel) or reasoning.
 
   if (config.browser) {
     sanitized.browser = {};

--- a/src/oracle/client.ts
+++ b/src/oracle/client.ts
@@ -181,9 +181,14 @@ function buildOpenRouterCompletionClient(instance: OpenAI): ClientLike {
       model: body.model,
       messages,
       max_tokens: body.max_output_tokens,
+      // Forward reasoning effort for OpenAI-compatible chat/completions gateways
+      // (OpenAI, OpenRouter, LiteLLM, vLLM, etc.). Without this, a `reasoning`
+      // override or a known reasoning model silently loses its effort on any
+      // custom base URL, since this adapter is the only request path for them.
+      ...(body.reasoning?.effort ? { reasoning_effort: body.reasoning.effort } : {}),
     };
-    const streaming: ChatCompletionCreateParamsStreaming = { ...base, stream: true };
-    const nonStreaming: ChatCompletionCreateParamsNonStreaming = { ...base, stream: false };
+    const streaming = { ...base, stream: true } as ChatCompletionCreateParamsStreaming;
+    const nonStreaming = { ...base, stream: false } as ChatCompletionCreateParamsNonStreaming;
     return { streaming, nonStreaming };
   };
 

--- a/src/oracle/client.ts
+++ b/src/oracle/client.ts
@@ -177,18 +177,15 @@ function buildOpenRouterCompletionClient(instance: OpenAI): ClientLike {
         content: textParts,
       });
     }
-    const base = {
+    const base: Omit<ChatCompletionCreateParamsNonStreaming, "stream"> = {
       model: body.model,
       messages,
       max_tokens: body.max_output_tokens,
-      // Forward reasoning effort for OpenAI-compatible chat/completions gateways
-      // (OpenAI, OpenRouter, LiteLLM, vLLM, etc.). Without this, a `reasoning`
-      // override or a known reasoning model silently loses its effort on any
-      // custom base URL, since this adapter is the only request path for them.
+      // Custom gateways use Chat Completions, whose effort field differs from Responses.
       ...(body.reasoning?.effort ? { reasoning_effort: body.reasoning.effort } : {}),
     };
-    const streaming = { ...base, stream: true } as ChatCompletionCreateParamsStreaming;
-    const nonStreaming = { ...base, stream: false } as ChatCompletionCreateParamsNonStreaming;
+    const streaming: ChatCompletionCreateParamsStreaming = { ...base, stream: true };
+    const nonStreaming: ChatCompletionCreateParamsNonStreaming = { ...base, stream: false };
     return { streaming, nonStreaming };
   };
 

--- a/src/oracle/modelResolver.ts
+++ b/src/oracle/modelResolver.ts
@@ -1,5 +1,13 @@
 import { createRequire } from "node:module";
-import type { ModelConfig, ModelName, KnownModelName, TokenizerFn, ProModelName } from "./types.js";
+import type {
+  ModelConfig,
+  ModelName,
+  KnownModelName,
+  TokenizerFn,
+  ProModelName,
+  ModelOverridesConfig,
+  ReasoningEffort,
+} from "./types.js";
 import { MODEL_CONFIGS, PRO_MODELS } from "./config.js";
 import { pricingFromUsdPerToken } from "tokentally";
 
@@ -156,6 +164,21 @@ export async function resolveModelConfig(
     baseUrl?: string;
     openRouterApiKey?: string;
     fetcher?: FetchFn;
+    modelOverrides?: ModelOverridesConfig;
+  } = {},
+): Promise<ModelConfig> {
+  const base = await resolveBaseModelConfig(model, options);
+  // Apply user-config per-model overrides last, after known/OpenRouter/synthesized
+  // resolution, so an explicit override always wins.
+  return applyModelOverride(base, model, options.modelOverrides);
+}
+
+async function resolveBaseModelConfig(
+  model: ModelName,
+  options: {
+    baseUrl?: string;
+    openRouterApiKey?: string;
+    fetcher?: FetchFn;
   } = {},
 ): Promise<ModelConfig> {
   const known = isKnownModel(model) ? (MODEL_CONFIGS[model] as ModelConfig) : null;
@@ -231,6 +254,102 @@ export async function resolveModelConfig(
 
 export function isProModel(model: ModelName): boolean {
   return isKnownModel(model) && PRO_MODELS.has(model as KnownModelName & ProModelName);
+}
+
+const VALID_REASONING_EFFORTS: readonly ReasoningEffort[] = ["low", "medium", "high", "xhigh"];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Returns the override's `apiModel` for a *known* model when present and non-empty,
+ * otherwise `undefined`. Single source of truth for the override apiModel rule,
+ * shared by {@link applyModelOverride} and the CLI's `effectiveModelId` resolution.
+ */
+export function resolveOverriddenApiModel(
+  model: ModelName,
+  overrides?: ModelOverridesConfig,
+): string | undefined {
+  if (!overrides || !isKnownModel(model)) return undefined;
+  const override: unknown = overrides[model];
+  if (!isRecord(override)) return undefined;
+  if (typeof override.apiModel === "string" && override.apiModel.trim() !== "") {
+    return override.apiModel.trim();
+  }
+  return undefined;
+}
+
+/**
+ * Apply a user-config per-model override on top of a resolved config.
+ *
+ * Scope is intentionally narrow: only *known* models can be overridden, so the
+ * tokenizer (a function, not expressible in JSON) and any unspecified fields are
+ * inherited from the base config. Override fields are validated defensively
+ * because they come from user-authored JSON5.
+ */
+export function applyModelOverride(
+  base: ModelConfig,
+  model: ModelName,
+  overrides?: ModelOverridesConfig,
+): ModelConfig {
+  if (!overrides || !isKnownModel(model)) return base;
+  const override: unknown = overrides[model];
+  if (!isRecord(override)) return base;
+
+  const result: ModelConfig = { ...base };
+
+  const apiModel = resolveOverriddenApiModel(model, overrides);
+  if (apiModel) {
+    result.apiModel = apiModel;
+  }
+
+  if (Object.hasOwn(override, "reasoning")) {
+    const reasoning = override.reasoning;
+    if (reasoning === null) {
+      // Explicit null clears the known model's reasoning effort.
+      result.reasoning = null;
+    } else if (
+      isRecord(reasoning) &&
+      typeof reasoning.effort === "string" &&
+      VALID_REASONING_EFFORTS.includes(reasoning.effort as ReasoningEffort)
+    ) {
+      result.reasoning = { effort: reasoning.effort as ReasoningEffort };
+    }
+    // Malformed reasoning override is ignored (base value preserved).
+  }
+
+  if (
+    typeof override.inputLimit === "number" &&
+    Number.isSafeInteger(override.inputLimit) &&
+    override.inputLimit > 0
+  ) {
+    result.inputLimit = override.inputLimit;
+  }
+  // Non-positive or non-integer inputLimit (e.g. 0, 0.5, NaN, Infinity) is ignored.
+
+  if (Object.hasOwn(override, "pricing")) {
+    const pricing = override.pricing;
+    if (pricing === null) {
+      result.pricing = null;
+    } else if (
+      isRecord(pricing) &&
+      typeof pricing.inputPerToken === "number" &&
+      Number.isFinite(pricing.inputPerToken) &&
+      pricing.inputPerToken >= 0 &&
+      typeof pricing.outputPerToken === "number" &&
+      Number.isFinite(pricing.outputPerToken) &&
+      pricing.outputPerToken >= 0
+    ) {
+      result.pricing = {
+        inputPerToken: pricing.inputPerToken,
+        outputPerToken: pricing.outputPerToken,
+      };
+    }
+    // Malformed pricing override is ignored (base value preserved).
+  }
+
+  return result;
 }
 
 export function resetOpenRouterCatalogCacheForTest(): void {

--- a/src/oracle/multiModelRunner.ts
+++ b/src/oracle/multiModelRunner.ts
@@ -13,6 +13,7 @@ import {
 } from "../oracle.js";
 import type { SessionStore } from "../sessionStore.js";
 import { sessionStore } from "../sessionStore.js";
+import { resolveOverriddenApiModel } from "./modelResolver.js";
 import { findOscProgressSequences, OSC_PROGRESS_PREFIX } from "osc-progress";
 
 export interface MultiModelRunParams {
@@ -154,7 +155,9 @@ function startModelExecution({
     const result = await runOracleImpl(
       {
         ...perModelOptions,
-        effectiveModelId: model,
+        // Respect a user-config apiModel override for this known model; falls back
+        // to the canonical model id (unchanged behavior) when no override applies.
+        effectiveModelId: resolveOverriddenApiModel(model, runOptions.modelOverrides) ?? model,
         // Drop per-model preamble; the aggregate runner prints the shared header and tips once.
         suppressHeader: true,
         suppressAnswerHeader: true,

--- a/src/oracle/run.ts
+++ b/src/oracle/run.ts
@@ -40,7 +40,7 @@ import { createMarkdownStreamer } from "markdansi";
 import { executeBackgroundResponse } from "./background.js";
 import { formatTokenEstimate, formatTokenValue, resolvePreviewMode } from "./runUtils.js";
 import { estimateUsdCost } from "tokentally";
-import { isOpenRouterBaseUrl, isProModel, resolveModelConfig } from "./modelResolver.js";
+import { isOpenRouterBaseUrl, isProModel, resolveModelConfig, resolveOverriddenApiModel } from "./modelResolver.js";
 import { validateProviderRouting } from "./providerRouting.js";
 import {
   formatRouteTargetForLog,
@@ -204,6 +204,7 @@ export async function runOracle(
   const modelConfig = await resolveModelConfig(options.model, {
     baseUrl,
     openRouterApiKey: resolverOpenRouterApiKey,
+    modelOverrides: options.modelOverrides,
   });
   const isLongRunningModel = isProTierModel;
   const supportsBackground = modelConfig.supportsBackground !== false;
@@ -269,6 +270,8 @@ export async function runOracle(
   const effectiveModelId =
     azureDeploymentName ??
     options.effectiveModelId ??
+    // A user-config apiModel override (known models only) wins over Gemini alias remapping.
+    resolveOverriddenApiModel(options.model, options.modelOverrides) ??
     (options.model.startsWith("gemini")
       ? resolveGeminiModelId(options.model)
       : (modelConfig.apiModel ?? modelConfig.model));

--- a/src/oracle/run.ts
+++ b/src/oracle/run.ts
@@ -40,7 +40,12 @@ import { createMarkdownStreamer } from "markdansi";
 import { executeBackgroundResponse } from "./background.js";
 import { formatTokenEstimate, formatTokenValue, resolvePreviewMode } from "./runUtils.js";
 import { estimateUsdCost } from "tokentally";
-import { isOpenRouterBaseUrl, isProModel, resolveModelConfig, resolveOverriddenApiModel } from "./modelResolver.js";
+import {
+  isOpenRouterBaseUrl,
+  isProModel,
+  resolveModelConfig,
+  resolveOverriddenApiModel,
+} from "./modelResolver.js";
 import { validateProviderRouting } from "./providerRouting.js";
 import {
   formatRouteTargetForLog,

--- a/src/oracle/types.ts
+++ b/src/oracle/types.ts
@@ -79,7 +79,7 @@ export interface ModelConfig {
 }
 
 /**
- * User-config override for a single known model entry. Lets users running against
+ * API-only user-config override for a single known model entry. Lets users running against
  * custom OpenAI-compatible gateways (e.g. a LiteLLM proxy) remap the on-wire model
  * id and reasoning effort without editing bundled model configs. Applied on top of
  * an existing {@link MODEL_CONFIGS} entry, so the tokenizer and other fields are

--- a/src/oracle/types.ts
+++ b/src/oracle/types.ts
@@ -78,6 +78,30 @@ export interface ModelConfig {
   searchToolType?: ToolConfig["type"];
 }
 
+/**
+ * User-config override for a single known model entry. Lets users running against
+ * custom OpenAI-compatible gateways (e.g. a LiteLLM proxy) remap the on-wire model
+ * id and reasoning effort without editing bundled model configs. Applied on top of
+ * an existing {@link MODEL_CONFIGS} entry, so the tokenizer and other fields are
+ * inherited from the known model.
+ */
+export interface ModelConfigOverride {
+  /** On-wire model id sent to the API (overrides the known entry's apiModel/model). */
+  apiModel?: string;
+  /** Reasoning effort override; `null` explicitly clears the known model's reasoning. */
+  reasoning?: { effort: ReasoningEffort } | null;
+  /** Context window override (positive integer). */
+  inputLimit?: number;
+  /** Pricing override; `null` clears the known entry's pricing. */
+  pricing?: {
+    inputPerToken: number;
+    outputPerToken: number;
+  } | null;
+}
+
+/** Map of known model name -> override, sourced from user config only. */
+export type ModelOverridesConfig = Record<string, ModelConfigOverride>;
+
 export interface FileContent {
   path: string;
   content: string;
@@ -169,6 +193,8 @@ export interface RunOracleOptions {
   baseUrl?: string;
   azure?: AzureOptions;
   sessionId?: string;
+  /** User-config per-model overrides (apiModel/reasoning/inputLimit/pricing) applied over known model configs. */
+  modelOverrides?: ModelOverridesConfig;
   effectiveModelId?: string;
   verbose?: boolean;
   heartbeatIntervalMs?: number;

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -16,6 +16,7 @@ import type {
   AzureOptions,
   BrowserBundleFormat,
   ModelName,
+  ModelOverridesConfig,
   PartialMode,
   ThinkingTimeLevel,
 } from "./oracle.js";
@@ -207,6 +208,7 @@ export interface StoredRunOptions {
   baseUrl?: string;
   azure?: AzureOptions;
   effectiveModelId?: string;
+  modelOverrides?: ModelOverridesConfig;
   renderPlain?: boolean;
   writeOutputPath?: string;
   partialMode?: PartialMode;
@@ -533,6 +535,7 @@ export async function initializeSession(
       followupSessionId: options.followupSessionId,
       followupModel: options.followupModel,
       effectiveModelId: options.effectiveModelId,
+      modelOverrides: options.modelOverrides,
       maxInput: options.maxInput,
       system: options.system,
       maxOutput: options.maxOutput,

--- a/tests/cli/integrationCli.test.ts
+++ b/tests/cli/integrationCli.test.ts
@@ -963,6 +963,72 @@ module.exports = () => ({
   );
 
   test(
+    "persists model overrides for detached --exec-session runs",
+    async () => {
+      const oracleHome = await mkdtemp(path.join(os.tmpdir(), "oracle-model-overrides-"));
+      const env = {
+        ...process.env,
+        // biome-ignore lint/style/useNamingConvention: env var name
+        OPENAI_API_KEY: "sk-integration",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        ORACLE_HOME_DIR: oracleHome,
+        // biome-ignore lint/style/useNamingConvention: env var name
+        ORACLE_CLIENT_FACTORY: CLIENT_FACTORY,
+        // biome-ignore lint/style/useNamingConvention: env var name
+        ORACLE_NO_DETACH: "1",
+        // biome-ignore lint/style/useNamingConvention: env var name
+        ORACLE_DISABLE_KEYTAR: "1",
+      };
+      await writeFile(
+        path.join(oracleHome, "config.json"),
+        JSON.stringify({
+          modelOverrides: {
+            "gpt-5.5": { apiModel: "gateway-model", reasoning: { effort: "xhigh" } },
+          },
+        }),
+      );
+
+      await execFileAsync(
+        process.execPath,
+        ["--import", "tsx", CLI_ENTRY, "--prompt", "Persist model override", "--model", "gpt-5.5"],
+        { env },
+      );
+
+      const sessionsDir = path.join(oracleHome, "sessions");
+      const [sessionId] = await readdir(sessionsDir);
+      const metadata = JSON.parse(
+        await readFile(path.join(sessionsDir, sessionId, "meta.json"), "utf8"),
+      );
+      expect(metadata.options?.modelOverrides?.["gpt-5.5"]).toEqual({
+        apiModel: "gateway-model",
+        reasoning: { effort: "xhigh" },
+      });
+
+      await rm(path.join(oracleHome, "config.json"));
+      await execFileAsync(
+        process.execPath,
+        ["--import", "tsx", CLI_ENTRY, "--exec-session", sessionId],
+        {
+          env: {
+            ...env,
+            // biome-ignore lint/style/useNamingConvention: env var name
+            ORACLE_TEST_REQUIRE_MODEL: "gateway-model",
+            // biome-ignore lint/style/useNamingConvention: env var name
+            ORACLE_TEST_REQUIRE_REASONING_EFFORT: "xhigh",
+          },
+        },
+      );
+      const rerunMetadata = JSON.parse(
+        await readFile(path.join(sessionsDir, sessionId, "meta.json"), "utf8"),
+      );
+      expect(rerunMetadata.status).toBe("completed");
+
+      await rm(oracleHome, { recursive: true, force: true });
+    },
+    INTEGRATION_TIMEOUT,
+  );
+
+  test(
     "accepts direct response ids in --followup and persists chain metadata",
     async () => {
       const oracleHome = await mkdtemp(path.join(os.tmpdir(), "oracle-followup-resp-"));

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -265,6 +265,81 @@ describe("loadUserConfig", () => {
     expect(result.paths).toEqual([path.join(tempDir, "config.json")]);
   });
 
+  it("parses modelOverrides from user config", async () => {
+    await fs.writeFile(
+      path.join(tempDir, "config.json"),
+      `{
+        model: "gpt-5.5",
+        modelOverrides: {
+          "gpt-5.5": {
+            apiModel: "gpt-5.5-mygateway",
+            reasoning: { effort: "xhigh" },
+            inputLimit: 1050000,
+          },
+        },
+      }`,
+      "utf8",
+    );
+
+    const result = await loadUserConfig();
+    expect(result.loaded).toBe(true);
+    expect(result.config.modelOverrides?.["gpt-5.5"]).toEqual({
+      apiModel: "gpt-5.5-mygateway",
+      reasoning: { effort: "xhigh" },
+      inputLimit: 1050000,
+    });
+  });
+
+  it("does not let project configs set modelOverrides", async () => {
+    await fs.writeFile(
+      path.join(tempDir, "config.json"),
+      `{ model: "gpt-5.5" }`,
+      "utf8",
+    );
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-repo-"));
+    await fs.mkdir(path.join(repoDir, ".oracle"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoDir, PROJECT_CONFIG_RELATIVE_PATH),
+      `{
+        modelOverrides: {
+          "gpt-5.5": { apiModel: "evil-rerouted-model" },
+        },
+      }`,
+      "utf8",
+    );
+
+    const result = await loadUserConfig({ cwd: repoDir });
+
+    expect(result.config.modelOverrides).toBeUndefined();
+  });
+
+  it("keeps user modelOverrides when a project config overrides other settings", async () => {
+    await fs.writeFile(
+      path.join(tempDir, "config.json"),
+      `{
+        model: "gpt-5.5",
+        modelOverrides: {
+          "gpt-5.5": { apiModel: "gpt-5.5-mygateway" },
+        },
+      }`,
+      "utf8",
+    );
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-repo-"));
+    await fs.mkdir(path.join(repoDir, ".oracle"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoDir, PROJECT_CONFIG_RELATIVE_PATH),
+      `{ model: "gpt-5.4" }`,
+      "utf8",
+    );
+
+    const result = await loadUserConfig({ cwd: repoDir });
+
+    // Project config can change the allowed `model` setting...
+    expect(result.config.model).toBe("gpt-5.4");
+    // ...but the user's modelOverrides must survive intact.
+    expect(result.config.modelOverrides?.["gpt-5.5"]?.apiModel).toBe("gpt-5.5-mygateway");
+  });
+
   afterAll(() => {
     setOracleHomeDirOverrideForTest(null);
   });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -272,7 +272,7 @@ describe("loadUserConfig", () => {
         model: "gpt-5.5",
         modelOverrides: {
           "gpt-5.5": {
-            apiModel: "gpt-5.5-mygateway",
+            apiModel: "gateway-model",
             reasoning: { effort: "xhigh" },
             inputLimit: 1050000,
           },
@@ -284,18 +284,14 @@ describe("loadUserConfig", () => {
     const result = await loadUserConfig();
     expect(result.loaded).toBe(true);
     expect(result.config.modelOverrides?.["gpt-5.5"]).toEqual({
-      apiModel: "gpt-5.5-mygateway",
+      apiModel: "gateway-model",
       reasoning: { effort: "xhigh" },
       inputLimit: 1050000,
     });
   });
 
   it("does not let project configs set modelOverrides", async () => {
-    await fs.writeFile(
-      path.join(tempDir, "config.json"),
-      `{ model: "gpt-5.5" }`,
-      "utf8",
-    );
+    await fs.writeFile(path.join(tempDir, "config.json"), `{ model: "gpt-5.5" }`, "utf8");
     const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-repo-"));
     await fs.mkdir(path.join(repoDir, ".oracle"), { recursive: true });
     await fs.writeFile(
@@ -319,7 +315,7 @@ describe("loadUserConfig", () => {
       `{
         model: "gpt-5.5",
         modelOverrides: {
-          "gpt-5.5": { apiModel: "gpt-5.5-mygateway" },
+          "gpt-5.5": { apiModel: "gateway-model" },
         },
       }`,
       "utf8",
@@ -337,7 +333,7 @@ describe("loadUserConfig", () => {
     // Project config can change the allowed `model` setting...
     expect(result.config.model).toBe("gpt-5.4");
     // ...but the user's modelOverrides must survive intact.
-    expect(result.config.modelOverrides?.["gpt-5.5"]?.apiModel).toBe("gpt-5.5-mygateway");
+    expect(result.config.modelOverrides?.["gpt-5.5"]?.apiModel).toBe("gateway-model");
   });
 
   afterAll(() => {

--- a/tests/fixtures/mockClientFactory.cjs
+++ b/tests/fixtures/mockClientFactory.cjs
@@ -43,6 +43,18 @@ function mockClientFactory() {
         if (process.env.ORACLE_TEST_REQUIRE_PREV === "1" && !body.previous_response_id) {
           throw new Error("MISSING_PREVIOUS_RESPONSE_ID");
         }
+        if (
+          process.env.ORACLE_TEST_REQUIRE_MODEL &&
+          body.model !== process.env.ORACLE_TEST_REQUIRE_MODEL
+        ) {
+          throw new Error(`UNEXPECTED_MODEL:${body.model}`);
+        }
+        if (
+          process.env.ORACLE_TEST_REQUIRE_REASONING_EFFORT &&
+          body.reasoning?.effort !== process.env.ORACLE_TEST_REQUIRE_REASONING_EFFORT
+        ) {
+          throw new Error(`UNEXPECTED_REASONING_EFFORT:${body.reasoning?.effort}`);
+        }
         responseCounter += 1;
         const response = {
           id: `resp_mock${Date.now()}${responseCounter}`,

--- a/tests/oracle/clientFactory.test.ts
+++ b/tests/oracle/clientFactory.test.ts
@@ -156,7 +156,7 @@ describe("createDefaultClientFactory", () => {
               choices: [{ message: { role: "assistant", content: "42" } }],
               usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
               created: 0,
-              model: "gpt-5.5-mygateway",
+              model: "gateway-model",
               object: "chat.completion",
             };
           },
@@ -171,7 +171,7 @@ describe("createDefaultClientFactory", () => {
     const client = factory("key", { model: "gpt-5.5", baseUrl: "https://litellm.test/v1" });
 
     await client.responses.create({
-      model: "gpt-5.5-mygateway",
+      model: "gateway-model",
       instructions: "sys",
       input: [{ role: "user", content: [{ type: "input_text", text: "2+2?" }] }],
       reasoning: { effort: "xhigh" },
@@ -180,7 +180,7 @@ describe("createDefaultClientFactory", () => {
 
     expect(captured).toHaveLength(1);
     expect(captured[0]).toMatchObject({
-      model: "gpt-5.5-mygateway",
+      model: "gateway-model",
       reasoning_effort: "xhigh",
       max_tokens: 64,
       stream: false,

--- a/tests/oracle/clientFactory.test.ts
+++ b/tests/oracle/clientFactory.test.ts
@@ -130,6 +130,113 @@ describe("createDefaultClientFactory", () => {
     });
   });
 
+  test("forwards reasoning effort through the custom-gateway chat/completions adapter", async () => {
+    process.env.ORACLE_CLIENT_FACTORY = "";
+    const captured: Array<Record<string, unknown>> = [];
+
+    class MockOpenAI {
+      responses = {
+        create: async () => ({ id: "unused", status: "completed" }),
+        stream: async () => ({
+          [Symbol.asyncIterator]: () => ({
+            async next() {
+              return { done: true, value: undefined };
+            },
+          }),
+          finalResponse: async () => ({ id: "unused", status: "completed" }),
+        }),
+        retrieve: async (id: string) => ({ id, status: "completed" }),
+      };
+      chat = {
+        completions: {
+          create: async (params: Record<string, unknown>) => {
+            captured.push(params);
+            return {
+              id: "cmpl-test",
+              choices: [{ message: { role: "assistant", content: "42" } }],
+              usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+              created: 0,
+              model: "gpt-5.5-mygateway",
+              object: "chat.completion",
+            };
+          },
+        },
+      };
+    }
+
+    vi.doMock("openai", () => ({ __esModule: true, default: MockOpenAI }));
+
+    const { createDefaultClientFactory } = await import("../../src/oracle/client.js");
+    const factory = createDefaultClientFactory();
+    const client = factory("key", { model: "gpt-5.5", baseUrl: "https://litellm.test/v1" });
+
+    await client.responses.create({
+      model: "gpt-5.5-mygateway",
+      instructions: "sys",
+      input: [{ role: "user", content: [{ type: "input_text", text: "2+2?" }] }],
+      reasoning: { effort: "xhigh" },
+      max_output_tokens: 64,
+    });
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toMatchObject({
+      model: "gpt-5.5-mygateway",
+      reasoning_effort: "xhigh",
+      max_tokens: 64,
+      stream: false,
+    });
+  });
+
+  test("omits reasoning_effort when the request has no reasoning", async () => {
+    process.env.ORACLE_CLIENT_FACTORY = "";
+    const captured: Array<Record<string, unknown>> = [];
+
+    class MockOpenAI {
+      responses = {
+        create: async () => ({ id: "unused", status: "completed" }),
+        stream: async () => ({
+          [Symbol.asyncIterator]: () => ({
+            async next() {
+              return { done: true, value: undefined };
+            },
+          }),
+          finalResponse: async () => ({ id: "unused", status: "completed" }),
+        }),
+        retrieve: async (id: string) => ({ id, status: "completed" }),
+      };
+      chat = {
+        completions: {
+          create: async (params: Record<string, unknown>) => {
+            captured.push(params);
+            return {
+              id: "cmpl-test",
+              choices: [{ message: { role: "assistant", content: "ok" } }],
+              usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+              created: 0,
+              model: "m",
+              object: "chat.completion",
+            };
+          },
+        },
+      };
+    }
+
+    vi.doMock("openai", () => ({ __esModule: true, default: MockOpenAI }));
+
+    const { createDefaultClientFactory } = await import("../../src/oracle/client.js");
+    const factory = createDefaultClientFactory();
+    const client = factory("key", { model: "gpt-5.1", baseUrl: "https://litellm.test/v1" });
+
+    await client.responses.create({
+      model: "gpt-5.1",
+      instructions: "sys",
+      input: [{ role: "user", content: [{ type: "input_text", text: "hi" }] }],
+    });
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).not.toHaveProperty("reasoning_effort");
+  });
+
   test("creates OpenAI clients for default and Azure paths", async () => {
     process.env.ORACLE_CLIENT_FACTORY = "";
     const { createDefaultClientFactory } = await import("../../src/oracle/client.js");

--- a/tests/oracle/modelResolver.override.test.ts
+++ b/tests/oracle/modelResolver.override.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyModelOverride,
+  resolveModelConfig,
+  resolveOverriddenApiModel,
+} from "../../src/oracle/modelResolver.js";
+import { MODEL_CONFIGS } from "../../src/oracle/config.js";
+import type { ModelConfig, ModelOverridesConfig } from "../../src/oracle/types.js";
+
+const KNOWN_MODEL = "gpt-5.5";
+const baseConfig = MODEL_CONFIGS[KNOWN_MODEL] as ModelConfig;
+
+describe("applyModelOverride", () => {
+  it("returns base unchanged when no overrides provided", () => {
+    expect(applyModelOverride(baseConfig, KNOWN_MODEL, undefined)).toBe(baseConfig);
+  });
+
+  it("overrides apiModel + reasoning effort while inheriting tokenizer", () => {
+    const result = applyModelOverride(baseConfig, KNOWN_MODEL, {
+      [KNOWN_MODEL]: { apiModel: "gpt-5.5-mygateway", reasoning: { effort: "high" } },
+    });
+    expect(result.apiModel).toBe("gpt-5.5-mygateway");
+    expect(result.reasoning).toEqual({ effort: "high" });
+    // Tokenizer and other fields inherited from the known config.
+    expect(result.tokenizer).toBe(baseConfig.tokenizer);
+    expect(result.inputLimit).toBe(baseConfig.inputLimit);
+    // Base config is not mutated.
+    expect(baseConfig.apiModel).not.toBe("gpt-5.5-mygateway");
+  });
+
+  it("clears reasoning when override sets reasoning: null", () => {
+    const withReasoning: ModelConfig = { ...baseConfig, reasoning: { effort: "xhigh" } };
+    const result = applyModelOverride(withReasoning, KNOWN_MODEL, {
+      [KNOWN_MODEL]: { reasoning: null },
+    });
+    expect(result.reasoning).toBeNull();
+  });
+
+  it("overrides inputLimit and pricing", () => {
+    const result = applyModelOverride(baseConfig, KNOWN_MODEL, {
+      [KNOWN_MODEL]: {
+        inputLimit: 1_050_000,
+        pricing: { inputPerToken: 0.000005, outputPerToken: 0.00003 },
+      },
+    });
+    expect(result.inputLimit).toBe(1_050_000);
+    expect(result.pricing).toEqual({ inputPerToken: 0.000005, outputPerToken: 0.00003 });
+  });
+
+  it("ignores malformed reasoning effort (preserves base)", () => {
+    const withReasoning: ModelConfig = { ...baseConfig, reasoning: { effort: "high" } };
+    const result = applyModelOverride(withReasoning, KNOWN_MODEL, {
+      [KNOWN_MODEL]: { reasoning: { effort: "ludicrous" } },
+    } as unknown as ModelOverridesConfig);
+    expect(result.reasoning).toEqual({ effort: "high" });
+  });
+
+  it("ignores invalid inputLimit / pricing values (preserves base)", () => {
+    const result = applyModelOverride(baseConfig, KNOWN_MODEL, {
+      [KNOWN_MODEL]: {
+        inputLimit: -5,
+        pricing: { inputPerToken: "free", outputPerToken: 1 },
+      },
+    } as unknown as ModelOverridesConfig);
+    expect(result.inputLimit).toBe(baseConfig.inputLimit);
+    expect(result.pricing ?? null).toEqual(baseConfig.pricing ?? null);
+  });
+
+  it("rejects non-integer / non-finite inputLimit (preserves base)", () => {
+    for (const bad of [0, 0.5, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const result = applyModelOverride(baseConfig, KNOWN_MODEL, {
+        [KNOWN_MODEL]: { inputLimit: bad },
+      } as unknown as ModelOverridesConfig);
+      expect(result.inputLimit).toBe(baseConfig.inputLimit);
+    }
+  });
+
+  it("does not override unknown models", () => {
+    const synthetic: ModelConfig = {
+      model: "some-custom-model",
+      tokenizer: baseConfig.tokenizer,
+      inputLimit: 200_000,
+      reasoning: null,
+    };
+    const result = applyModelOverride(synthetic, "some-custom-model", {
+      "some-custom-model": { apiModel: "should-be-ignored" },
+    } as unknown as ModelOverridesConfig);
+    expect(result.apiModel).toBeUndefined();
+    expect(result).toBe(synthetic);
+  });
+
+  it("ignores an empty / whitespace apiModel", () => {
+    const result = applyModelOverride(baseConfig, KNOWN_MODEL, {
+      [KNOWN_MODEL]: { apiModel: "   " },
+    });
+    expect(result.apiModel).toBe(baseConfig.apiModel);
+  });
+});
+
+describe("resolveModelConfig with modelOverrides", () => {
+  it("applies overrides for a known model on a custom (non-OpenRouter) endpoint", async () => {
+    const config = await resolveModelConfig(KNOWN_MODEL, {
+      baseUrl: "https://my-gateway.example/v1",
+      modelOverrides: {
+        [KNOWN_MODEL]: { apiModel: "gpt-5.5-mygateway", reasoning: { effort: "xhigh" } },
+      },
+    });
+    expect(config.apiModel).toBe("gpt-5.5-mygateway");
+    expect(config.reasoning).toEqual({ effort: "xhigh" });
+  });
+
+  it("leaves config untouched when no override matches the model", async () => {
+    const config = await resolveModelConfig(KNOWN_MODEL, {
+      baseUrl: "https://my-gateway.example/v1",
+      modelOverrides: { "gpt-5.4": { apiModel: "other" } },
+    });
+    expect(config.apiModel).toBe(baseConfig.apiModel);
+  });
+});
+
+describe("resolveOverriddenApiModel", () => {
+  it("returns the override apiModel for a known model", () => {
+    expect(
+      resolveOverriddenApiModel(KNOWN_MODEL, {
+        [KNOWN_MODEL]: { apiModel: "gpt-5.5-mygateway" },
+      }),
+    ).toBe("gpt-5.5-mygateway");
+  });
+
+  it("returns undefined for unknown models, empty apiModel, or no overrides", () => {
+    expect(resolveOverriddenApiModel(KNOWN_MODEL, undefined)).toBeUndefined();
+    expect(
+      resolveOverriddenApiModel("some-custom-model", {
+        "some-custom-model": { apiModel: "x" },
+      } as unknown as ModelOverridesConfig),
+    ).toBeUndefined();
+    expect(
+      resolveOverriddenApiModel(KNOWN_MODEL, { [KNOWN_MODEL]: { apiModel: "   " } }),
+    ).toBeUndefined();
+    expect(resolveOverriddenApiModel(KNOWN_MODEL, { [KNOWN_MODEL]: { reasoning: null } })).toBeUndefined();
+  });
+});

--- a/tests/oracle/modelResolver.override.test.ts
+++ b/tests/oracle/modelResolver.override.test.ts
@@ -17,15 +17,15 @@ describe("applyModelOverride", () => {
 
   it("overrides apiModel + reasoning effort while inheriting tokenizer", () => {
     const result = applyModelOverride(baseConfig, KNOWN_MODEL, {
-      [KNOWN_MODEL]: { apiModel: "gpt-5.5-mygateway", reasoning: { effort: "high" } },
+      [KNOWN_MODEL]: { apiModel: "gateway-model", reasoning: { effort: "high" } },
     });
-    expect(result.apiModel).toBe("gpt-5.5-mygateway");
+    expect(result.apiModel).toBe("gateway-model");
     expect(result.reasoning).toEqual({ effort: "high" });
     // Tokenizer and other fields inherited from the known config.
     expect(result.tokenizer).toBe(baseConfig.tokenizer);
     expect(result.inputLimit).toBe(baseConfig.inputLimit);
     // Base config is not mutated.
-    expect(baseConfig.apiModel).not.toBe("gpt-5.5-mygateway");
+    expect(baseConfig.apiModel).not.toBe("gateway-model");
   });
 
   it("clears reasoning when override sets reasoning: null", () => {
@@ -102,10 +102,10 @@ describe("resolveModelConfig with modelOverrides", () => {
     const config = await resolveModelConfig(KNOWN_MODEL, {
       baseUrl: "https://my-gateway.example/v1",
       modelOverrides: {
-        [KNOWN_MODEL]: { apiModel: "gpt-5.5-mygateway", reasoning: { effort: "xhigh" } },
+        [KNOWN_MODEL]: { apiModel: "gateway-model", reasoning: { effort: "xhigh" } },
       },
     });
-    expect(config.apiModel).toBe("gpt-5.5-mygateway");
+    expect(config.apiModel).toBe("gateway-model");
     expect(config.reasoning).toEqual({ effort: "xhigh" });
   });
 
@@ -122,9 +122,9 @@ describe("resolveOverriddenApiModel", () => {
   it("returns the override apiModel for a known model", () => {
     expect(
       resolveOverriddenApiModel(KNOWN_MODEL, {
-        [KNOWN_MODEL]: { apiModel: "gpt-5.5-mygateway" },
+        [KNOWN_MODEL]: { apiModel: "gateway-model" },
       }),
-    ).toBe("gpt-5.5-mygateway");
+    ).toBe("gateway-model");
   });
 
   it("returns undefined for unknown models, empty apiModel, or no overrides", () => {
@@ -137,6 +137,8 @@ describe("resolveOverriddenApiModel", () => {
     expect(
       resolveOverriddenApiModel(KNOWN_MODEL, { [KNOWN_MODEL]: { apiModel: "   " } }),
     ).toBeUndefined();
-    expect(resolveOverriddenApiModel(KNOWN_MODEL, { [KNOWN_MODEL]: { reasoning: null } })).toBeUndefined();
+    expect(
+      resolveOverriddenApiModel(KNOWN_MODEL, { [KNOWN_MODEL]: { reasoning: null } }),
+    ).toBeUndefined();
   });
 });

--- a/tests/runOptions.test.ts
+++ b/tests/runOptions.test.ts
@@ -70,13 +70,13 @@ describe("resolveRunOptionsFromConfig", () => {
       model: "gpt-5.5",
       userConfig: {
         modelOverrides: {
-          "gpt-5.5": { apiModel: "gpt-5.5-mygateway", reasoning: { effort: "xhigh" } },
+          "gpt-5.5": { apiModel: "gateway-model", reasoning: { effort: "xhigh" } },
         },
       },
     });
     // The override apiModel must become the on-wire model id (run.ts sets requestBody.model = effectiveModelId).
-    expect(runOptions.effectiveModelId).toBe("gpt-5.5-mygateway");
-    expect(runOptions.modelOverrides?.["gpt-5.5"]?.apiModel).toBe("gpt-5.5-mygateway");
+    expect(runOptions.effectiveModelId).toBe("gateway-model");
+    expect(runOptions.modelOverrides?.["gpt-5.5"]?.apiModel).toBe("gateway-model");
   });
 
   it("lets modelOverrides.apiModel win over Gemini alias remapping", () => {
@@ -85,10 +85,23 @@ describe("resolveRunOptionsFromConfig", () => {
       engine: "api",
       model: "gemini-3-pro",
       userConfig: {
-        modelOverrides: { "gemini-3-pro": { apiModel: "gemini-3-pro-mygateway" } },
+        modelOverrides: { "gemini-3-pro": { apiModel: "gateway-model" } },
       },
     });
-    expect(runOptions.effectiveModelId).toBe("gemini-3-pro-mygateway");
+    expect(runOptions.effectiveModelId).toBe("gateway-model");
+  });
+
+  it("ignores API model overrides in browser mode", () => {
+    const { runOptions } = resolveRunOptionsFromConfig({
+      prompt: basePrompt,
+      engine: "browser",
+      model: "gpt-5.5",
+      userConfig: {
+        modelOverrides: { "gpt-5.5": { apiModel: "gateway-model" } },
+      },
+    });
+    expect(runOptions.effectiveModelId).toBe("gpt-5.5");
+    expect(runOptions.modelOverrides).toBeUndefined();
   });
 
   it("appends prompt suffix from config", () => {

--- a/tests/runOptions.test.ts
+++ b/tests/runOptions.test.ts
@@ -63,6 +63,34 @@ describe("resolveRunOptionsFromConfig", () => {
     expect(runOptions.model).toBe("gpt-5.1");
   });
 
+  it("threads modelOverrides and sets effectiveModelId from the override apiModel", () => {
+    const { runOptions } = resolveRunOptionsFromConfig({
+      prompt: basePrompt,
+      engine: "api",
+      model: "gpt-5.5",
+      userConfig: {
+        modelOverrides: {
+          "gpt-5.5": { apiModel: "gpt-5.5-mygateway", reasoning: { effort: "xhigh" } },
+        },
+      },
+    });
+    // The override apiModel must become the on-wire model id (run.ts sets requestBody.model = effectiveModelId).
+    expect(runOptions.effectiveModelId).toBe("gpt-5.5-mygateway");
+    expect(runOptions.modelOverrides?.["gpt-5.5"]?.apiModel).toBe("gpt-5.5-mygateway");
+  });
+
+  it("lets modelOverrides.apiModel win over Gemini alias remapping", () => {
+    const { runOptions } = resolveRunOptionsFromConfig({
+      prompt: basePrompt,
+      engine: "api",
+      model: "gemini-3-pro",
+      userConfig: {
+        modelOverrides: { "gemini-3-pro": { apiModel: "gemini-3-pro-mygateway" } },
+      },
+    });
+    expect(runOptions.effectiveModelId).toBe("gemini-3-pro-mygateway");
+  });
+
   it("appends prompt suffix from config", () => {
     const { runOptions } = resolveRunOptionsFromConfig({
       prompt: "Hi there, this exceeds twenty characters.",

--- a/tests/sessionManager.test.ts
+++ b/tests/sessionManager.test.ts
@@ -78,6 +78,9 @@ describe("session lifecycle", () => {
         maxOutput: 456,
         silent: false,
         filesReport: true,
+        modelOverrides: {
+          "gpt-5.2-pro": { apiModel: "gateway-model", reasoning: { effort: "high" } },
+        },
       },
       "/tmp/cwd",
     );
@@ -89,6 +92,9 @@ describe("session lifecycle", () => {
     expect(storedMeta.options.previousResponseId).toBe("resp-parent-123");
     expect(storedMeta.options.followupSessionId).toBe("parent-session");
     expect(storedMeta.options.followupModel).toBe("gpt-5.1");
+    expect(storedMeta.options.modelOverrides).toEqual({
+      "gpt-5.2-pro": { apiModel: "gateway-model", reasoning: { effort: "high" } },
+    });
     expect(storedMeta.options.browserFollowUps).toEqual([
       "challenge the plan",
       "summarize final recommendation",


### PR DESCRIPTION
## Summary

Closes #273.

Adds a user-config-only `modelOverrides` map so custom OpenAI-compatible gateways (for example LiteLLM-style proxies) can remap a known model's on-wire `apiModel` and model metadata without editing bundled `MODEL_CONFIGS`.

Example:

```json5
{
  "apiBaseUrl": "https://gateway.example/v1",
  "model": "gpt-5.5",
  "modelOverrides": {
    "gpt-5.5": {
      "apiModel": "gateway-model",
      "reasoning": { "effort": "xhigh" },
      "inputLimit": 1050000,
      "pricing": { "inputPerToken": 0.000005, "outputPerToken": 0.00003 }
    }
  }
}
```

## Design

- User config only: project configs cannot set `modelOverrides`, so an untrusted repo cannot reroute model traffic.
- Known models only: tokenizer and unspecified fields are inherited from the existing `MODEL_CONFIGS` entry.
- Narrow field whitelist: `apiModel`, `reasoning`, `inputLimit`, `pricing`.
- Defensive validation for JSON5 input:
  - `apiModel` must be non-empty (trimmed before use).
  - `reasoning: null` explicitly clears a known model's effort; invalid effort is ignored.
  - `inputLimit` must be a positive safe integer.
  - `pricing` must contain finite, non-negative token prices; `pricing: null` clears pricing.
- Applies overrides last, after known/OpenRouter/generic resolution.
- The override `apiModel` also feeds `effectiveModelId` across API CLI, direct/programmatic, and multi-model paths. Browser runs ignore API model overrides.

## Reasoning transport fix

This also fixes a related gap surfaced during review: the OpenAI-compatible chat/completions adapter (used for **all** custom/proxy base URLs — OpenRouter, LiteLLM, vLLM, etc.) only forwarded `model`, `messages`, and `max_tokens`. Any reasoning model's effort was silently dropped on a custom `--base-url`. The adapter now forwards `reasoning_effort` when present.

## Real-gateway behavior proof

Captured the actual on-wire request oracle sends, by pointing it at a local capture server (localhost, dummy key — no secrets). Config under test remaps the known model `gpt-5.5` to a renamed gateway id and pins reasoning effort.

`modelOverrides: { "gpt-5.5": { apiModel: "gateway-model", reasoning: { effort: "xhigh" } } }`

```
CAPTURED_REQUEST {"path":"/v1/chat/completions","model":"gateway-model","reasoning_effort":"xhigh","stream":true}
```

The on-wire `model` is the overridden id (not `gpt-5.5`) and `reasoning_effort` is forwarded.

With `reasoning: null` (clear effort) the same override still remaps the model id but drops the effort:

```
CAPTURED_REQUEST {"path":"/v1/chat/completions","model":"gateway-model","reasoning_effort":null,"stream":true}
```

A live run against a real OpenAI-compatible gateway shows the resolved id in the header (key masked by oracle):

```
Calling gpt-5.5 (API: gateway-model) — 4.26k tokens, no files.
Provider: OpenAI-compatible | base: <redacted-gateway>/v1 | key: OPENAI_API_KEY
Resolved model: gpt-5.5 → gateway-model
Answer:
PROOF-OVERRIDE-OK
```

I also confirmed out-of-band that the gateway honors `reasoning_effort` (reasoning token usage scaled from ~489 at `low` to ~4606 at `xhigh` on the same prompt).

## Tests

- `pnpm run lint`
- `pnpm run build`
- `pnpm test` — full suite green (`1359 passed`, `43 skipped`).
- Maintainer exact-wire smoke: built CLI against an isolated user config and localhost OpenAI-compatible capture server; observed `/v1/chat/completions`, `model: gateway-model`, `reasoning_effort: xhigh`, and `stream: true`, then received `PROOF-OVERRIDE-OK` through the CLI.
- `pnpm run check`, `pnpm run build`, `pnpm run docs:check`, and `pnpm run docs:site`.
- Autoreview: no actionable findings at exact head.
- New coverage: resolver override matrix (apiModel/reasoning/inputLimit/pricing validation, `reasoning: null` clearing, unknown-model no-op), config parse + project-config security boundary + user-override merge survival, runOptions effectiveModelId-from-override (incl. Gemini), and the chat/completions adapter forwarding `reasoning_effort`.

I strip local base-url env vars for the full test run because otherwise provider-routing tests pick up the developer environment's custom endpoints.

## Review notes

This intentionally does not add CLI flags like `--api-model` because those become ambiguous with `--models a,b`. The per-model map keeps multi-model behavior explicit and local to each known model key.
