### PR TITLE
[codex] Fix browser attachment input readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - API: forward configured reasoning effort through custom OpenAI-compatible chat-completions gateways.
+- Browser: accept a stable, exact file-input name match when ChatGPT marks the composer ready but exposes no attachment chip or count, while still waiting through active uploads and rejecting missing or extra files. Fixes #275. Thanks @wangwllu!
 - Browser: wait up to eight seconds for the ChatGPT model/effort composer pill to mount before failing explicit selection, while leaving `option-not-found` failures immediate. Thanks @gustavosmendes!
 - Browser: activate ChatGPT Deep Research after the final composer reset, select the current tools-menu row shape, and use trusted mouse clicks for Deep Research and send actions so the request reaches the real research-plan flow instead of being submitted as an ordinary Pro prompt. Fixes #281. Thanks @wbzjt!
 

--- a/src/browser/actions/attachments.ts
+++ b/src/browser/actions/attachments.ts
@@ -1335,7 +1335,14 @@ export async function waitForAttachmentCompletion(
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   const expectedNormalized = expectedNames.map((name) => name.toLowerCase());
+  const expectedInputBasenames = expectedNormalized
+    .map((name) => name.split("/").pop()?.split("\\").pop() ?? name)
+    .map((name) => name.toLowerCase().replace(/\s+/g, " ").trim())
+    .filter(Boolean);
+  const expectedInputSignature = expectedInputBasenames.slice().sort().join("\0");
   let inputMatchSince: number | null = null;
+  let inputOnlyReadySince: number | null = null;
+  let inputOnlySignature = "";
   let sawInputMatch = false;
   let attachmentMatchSince: number | null = null;
   let lastVerboseLog = 0;
@@ -1640,6 +1647,28 @@ export async function waitForAttachmentCompletion(
         attachmentMatchSince = null;
       }
 
+      const inputOnlySignatureNow = inputNames.slice().sort().join("\0");
+      const inputOnlyNamesSatisfied =
+        expectedInputBasenames.length > 0 && inputOnlySignatureNow === expectedInputSignature;
+      const inputOnlyReady =
+        inputOnlyNamesSatisfied &&
+        value.state === "ready" &&
+        value.uploading === false &&
+        !value.filesAttached &&
+        fileCount === 0;
+      if (inputOnlyReady) {
+        if (inputOnlyReadySince === null || inputOnlySignature !== inputOnlySignatureNow) {
+          inputOnlyReadySince = Date.now();
+          inputOnlySignature = inputOnlySignatureNow;
+        }
+        if (Date.now() - inputOnlyReadySince > 1500) {
+          return;
+        }
+      } else {
+        inputOnlyReadySince = null;
+        inputOnlySignature = "";
+      }
+
       // Fallback: if the file input has the expected names, allow progress once that condition is stable.
       // Some ChatGPT surfaces only render the filename after sending the message.
       const inputMissing = expectedNormalized.filter((expected) => {
@@ -1655,8 +1684,7 @@ export async function waitForAttachmentCompletion(
       // Don't include 'disabled' - a disabled button likely means upload is still in progress.
       const inputStateOk = value.state === "ready" || value.state === "missing";
       const inputSeenNow = inputMissing.length === 0 || fileCountSatisfied;
-      const inputEvidenceOk =
-        Boolean(value.filesAttached) || Boolean(value.uploading) || fileCountSatisfied;
+      const inputEvidenceOk = Boolean(value.filesAttached) || fileCountSatisfied;
       const stableThresholdMs = value.uploading ? 3000 : 1500;
       if (inputSeenNow && inputStateOk && inputEvidenceOk) {
         if (inputMatchSince === null) {

--- a/tests/browser/attachmentsCompletion.test.ts
+++ b/tests/browser/attachmentsCompletion.test.ts
@@ -15,7 +15,7 @@ const useRealTime = () => {
 };
 
 describe("attachment completion fallbacks", () => {
-  test("waitForAttachmentCompletion resolves when file input contains expected name (no UI chip)", async () => {
+  test("waitForAttachmentCompletion resolves when ready file input contains expected name (no UI chip)", async () => {
     useFakeTime();
 
     const runtime = {
@@ -24,9 +24,10 @@ describe("attachment completion fallbacks", () => {
           value: {
             state: "ready",
             uploading: false,
-            filesAttached: true,
+            filesAttached: false,
             attachedNames: [],
             inputNames: ["oracle-attach-verify.txt"],
+            fileCount: 0,
           },
         },
       }),
@@ -38,7 +39,7 @@ describe("attachment completion fallbacks", () => {
     useRealTime();
   });
 
-  test("waitForAttachmentCompletion resolves even when uploading is flagged, once input match is stable", async () => {
+  test("waitForAttachmentCompletion does not resolve input-only match while upload is still flagged", async () => {
     useFakeTime();
 
     const runtime = {
@@ -50,14 +51,90 @@ describe("attachment completion fallbacks", () => {
             filesAttached: false,
             attachedNames: [],
             inputNames: ["oracle-attach-verify.txt"],
+            fileCount: 0,
           },
         },
       }),
     } as unknown as ChromeClient["Runtime"];
 
-    const promise = waitForAttachmentCompletion(runtime, 10_000, ["oracle-attach-verify.txt"]);
-    await vi.advanceTimersByTimeAsync(5_000);
+    const promise = waitForAttachmentCompletion(runtime, 800, ["oracle-attach-verify.txt"]);
+    const assertion = expect(promise).rejects.toThrow(/did not finish uploading/i);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await assertion;
+    useRealTime();
+  });
+
+  test("waitForAttachmentCompletion resolves when all ready file input names match", async () => {
+    useFakeTime();
+
+    const runtime = {
+      evaluate: vi.fn().mockResolvedValue({
+        result: {
+          value: {
+            state: "ready",
+            uploading: false,
+            filesAttached: false,
+            attachedNames: [],
+            inputNames: ["a.txt", "b.txt"],
+            fileCount: 0,
+          },
+        },
+      }),
+    } as unknown as ChromeClient["Runtime"];
+
+    const promise = waitForAttachmentCompletion(runtime, 10_000, ["a.txt", "b.txt"]);
+    await vi.advanceTimersByTimeAsync(2_000);
     await expect(promise).resolves.toBeUndefined();
+    useRealTime();
+  });
+
+  test("waitForAttachmentCompletion times out when ready file input misses an expected name", async () => {
+    useFakeTime();
+
+    const runtime = {
+      evaluate: vi.fn().mockResolvedValue({
+        result: {
+          value: {
+            state: "ready",
+            uploading: false,
+            filesAttached: false,
+            attachedNames: [],
+            inputNames: ["a.txt"],
+            fileCount: 0,
+          },
+        },
+      }),
+    } as unknown as ChromeClient["Runtime"];
+
+    const promise = waitForAttachmentCompletion(runtime, 800, ["a.txt", "b.txt"]);
+    const assertion = expect(promise).rejects.toThrow(/did not finish uploading/i);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await assertion;
+    useRealTime();
+  });
+
+  test("waitForAttachmentCompletion times out when ready file input has an unexpected extra name", async () => {
+    useFakeTime();
+
+    const runtime = {
+      evaluate: vi.fn().mockResolvedValue({
+        result: {
+          value: {
+            state: "ready",
+            uploading: false,
+            filesAttached: false,
+            attachedNames: [],
+            inputNames: ["oracle-attach-verify.txt", "unexpected-extra.txt"],
+            fileCount: 0,
+          },
+        },
+      }),
+    } as unknown as ChromeClient["Runtime"];
+
+    const promise = waitForAttachmentCompletion(runtime, 2_000, ["oracle-attach-verify.txt"]);
+    const assertion = expect(promise).rejects.toThrow(/did not finish uploading/i);
+    await vi.advanceTimersByTimeAsync(3_000);
+    await assertion;
     useRealTime();
   });
 


### PR DESCRIPTION
## Summary

- Fix the browser attachment-readiness fallback for the #275 state where ChatGPT exposes the exact expected file names through the native file input and marks the composer ready, but shows no chip or count evidence.
- Require an exact normalized basename multiset, `state="ready"`, no active upload, no chip/count evidence, and 1.5 seconds of stability before accepting that narrow fallback.
- Stop treating `uploading=true` as positive evidence in the older fallback.
- Cover exact one-file and multi-file matches plus uploading, missing-name, and extra-name rejection.

Fixes #275.

## Verification

- `pnpm vitest run tests/browser/attachmentsCompletion.test.ts tests/browser/pageActions.test.ts` — 71 passed, 1 intentional skip.
- `pnpm run check` — passed.
- `pnpm run build` — passed.
- Autoreview — clean.

## Live ChatGPT proof

Built this exact branch and ran an authenticated Pro browser upload with `--browser-attachments always`. Oracle transferred a 41-byte text file, observed the real attachment state, logged `All attachments uploaded` and `Clicked send button`, and ChatGPT returned the unique file-only marker exactly:

```text
ORACLE_PR276_LIVE_ATTACHMENT_OK_20260702
```

The current ChatGPT UI exposed normal chip evidence during this run. The issue-specific no-chip/input-names-only tuple is externally controlled and did not occur here; its acceptance and rejection boundaries are covered by the exact-multiset regression tests above.
