### PR TITLE
fix(browser): avoid truncating Pro/Pro-Extended answers captured mid-stream at the thinking→answer transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - API: forward configured reasoning effort through custom OpenAI-compatible chat-completions gateways.
 - Browser: accept a stable, exact file-input name match when ChatGPT marks the composer ready but exposes no attachment chip or count, while still waiting through active uploads and rejecting missing or extra files. Fixes #275. Thanks @wangwllu!
+- Browser: avoid returning truncated Pro answers when completion controls appear during the thinking-to-answer transition. Thanks @xuan-wei!
 - Browser: wait up to eight seconds for the ChatGPT model/effort composer pill to mount before failing explicit selection, while leaving `option-not-found` failures immediate. Thanks @gustavosmendes!
 - Browser: activate ChatGPT Deep Research after the final composer reset, select the current tools-menu row shape, and use trusted mouse clicks for Deep Research and send actions so the request reaches the real research-plan flow instead of being submitted as an ordinary Pro prompt. Fixes #281. Thanks @wbzjt!
 

--- a/src/browser/actions/assistantResponse.ts
+++ b/src/browser/actions/assistantResponse.ts
@@ -5,7 +5,6 @@ import {
   CONVERSATION_TURN_SELECTOR,
   COPY_BUTTON_SELECTOR,
   FINISHED_ACTIONS_SELECTOR,
-  MIN_TRUSTWORTHY_ANSWER_CHARS,
   STOP_BUTTON_SELECTOR,
 } from "../constants.js";
 import { delay } from "../utils.js";
@@ -234,14 +233,14 @@ export async function waitForAssistantResponse(
       isCompletionVisible(Runtime),
     ]);
     // Completion controls can appear briefly while Pro is still replacing its thinking UI.
-    // Confirm short captures with the stability-based watchdog before trusting them.
+    // Confirm every capture from that transition with the stability-based watchdog; a
+    // partial first paragraph can be arbitrarily long.
     const candidateText = String(candidate?.text ?? "").trim();
-    const suspiciousRace = completionVisible && candidateText.length < MIN_TRUSTWORTHY_ANSWER_CHARS;
-    if (stopVisible || suspiciousRace) {
+    if (stopVisible || completionVisible) {
       logger(
         stopVisible
           ? "Assistant still generating; waiting for completion"
-          : "Captured suspiciously short answer at completion; re-polling for completion",
+          : "Completion controls surfaced; confirming stable assistant response",
       );
       const completed = await pollAssistantCompletion(
         Runtime,
@@ -252,9 +251,6 @@ export async function waitForAssistantResponse(
       if (completed && String(completed.text ?? "").trim().length >= candidateText.length) {
         return completed;
       }
-    } else if (completionVisible) {
-      // No-op: completion UI surfaced, stop button is gone, and the captured answer is
-      // long enough to trust.
     }
   }
 

--- a/src/browser/actions/assistantResponse.ts
+++ b/src/browser/actions/assistantResponse.ts
@@ -233,16 +233,8 @@ export async function waitForAssistantResponse(
       isStopButtonVisible(Runtime),
       isCompletionVisible(Runtime),
     ]);
-    // Guard against the evaluation path racing ahead and capturing only the first
-    // tokens of the real answer. At the thinking->answer transition, ChatGPT Pro /
-    // Pro Extended briefly drops the stop button AND surfaces the finished-action
-    // (copy/share) buttons on the turn while only the first 1-13 tokens have rendered.
-    // The evaluation path then fires on those finished-action buttons and breaks early
-    // while stopVisible is momentarily false. So when the completion UI is showing but
-    // the captured answer is trivially short, treat it as a mid-stream race and fall
-    // back to the robust watchdog poller, which requires the stop button gone AND the
-    // text to stay unchanged for several seconds before it trusts completion. We never
-    // return something shorter than what we already captured.
+    // Completion controls can appear briefly while Pro is still replacing its thinking UI.
+    // Confirm short captures with the stability-based watchdog before trusting them.
     const candidateText = String(candidate?.text ?? "").trim();
     const suspiciousRace = completionVisible && candidateText.length < MIN_TRUSTWORTHY_ANSWER_CHARS;
     if (stopVisible || suspiciousRace) {

--- a/src/browser/actions/assistantResponse.ts
+++ b/src/browser/actions/assistantResponse.ts
@@ -5,6 +5,7 @@ import {
   CONVERSATION_TURN_SELECTOR,
   COPY_BUTTON_SELECTOR,
   FINISHED_ACTIONS_SELECTOR,
+  MIN_TRUSTWORTHY_ANSWER_CHARS,
   STOP_BUTTON_SELECTOR,
 } from "../constants.js";
 import { delay } from "../utils.js";
@@ -232,19 +233,36 @@ export async function waitForAssistantResponse(
       isStopButtonVisible(Runtime),
       isCompletionVisible(Runtime),
     ]);
-    if (stopVisible) {
-      logger("Assistant still generating; waiting for completion");
+    // Guard against the evaluation path racing ahead and capturing only the first
+    // tokens of the real answer. At the thinking->answer transition, ChatGPT Pro /
+    // Pro Extended briefly drops the stop button AND surfaces the finished-action
+    // (copy/share) buttons on the turn while only the first 1-13 tokens have rendered.
+    // The evaluation path then fires on those finished-action buttons and breaks early
+    // while stopVisible is momentarily false. So when the completion UI is showing but
+    // the captured answer is trivially short, treat it as a mid-stream race and fall
+    // back to the robust watchdog poller, which requires the stop button gone AND the
+    // text to stay unchanged for several seconds before it trusts completion. We never
+    // return something shorter than what we already captured.
+    const candidateText = String(candidate?.text ?? "").trim();
+    const suspiciousRace = completionVisible && candidateText.length < MIN_TRUSTWORTHY_ANSWER_CHARS;
+    if (stopVisible || suspiciousRace) {
+      logger(
+        stopVisible
+          ? "Assistant still generating; waiting for completion"
+          : "Captured suspiciously short answer at completion; re-polling for completion",
+      );
       const completed = await pollAssistantCompletion(
         Runtime,
         remainingMs,
         minTurnIndex,
         expectedConversationId,
       );
-      if (completed) {
+      if (completed && String(completed.text ?? "").trim().length >= candidateText.length) {
         return completed;
       }
     } else if (completionVisible) {
-      // No-op: completion UI surfaced and stop button is gone.
+      // No-op: completion UI surfaced, stop button is gone, and the captured answer is
+      // long enough to trust.
     }
   }
 

--- a/src/browser/constants.ts
+++ b/src/browser/constants.ts
@@ -93,5 +93,3 @@ export const DEEP_RESEARCH_AUTO_CONFIRM_WAIT_MS = 70_000;
 export const DEEP_RESEARCH_DEFAULT_TIMEOUT_MS = 2_400_000;
 export const FINISHED_ACTIONS_SELECTOR =
   'button[data-testid="copy-turn-action-button"], button[data-testid="good-response-turn-action-button"], button[data-testid="bad-response-turn-action-button"], button[aria-label="Share"]';
-// Shorter completion-UI captures need watchdog stability confirmation.
-export const MIN_TRUSTWORTHY_ANSWER_CHARS = 80;

--- a/src/browser/constants.ts
+++ b/src/browser/constants.ts
@@ -93,3 +93,10 @@ export const DEEP_RESEARCH_AUTO_CONFIRM_WAIT_MS = 70_000;
 export const DEEP_RESEARCH_DEFAULT_TIMEOUT_MS = 2_400_000;
 export const FINISHED_ACTIONS_SELECTOR =
   'button[data-testid="copy-turn-action-button"], button[data-testid="good-response-turn-action-button"], button[data-testid="bad-response-turn-action-button"], button[aria-label="Share"]';
+// Minimum length (in characters) of a captured answer we trust as complete when the
+// completion UI is already showing. At the Pro / Pro Extended thinking->answer
+// transition, ChatGPT briefly drops the stop button and surfaces finished-action
+// buttons while only the first tokens have rendered, so a trivially short capture seen
+// alongside the completion UI is a mid-stream race and must fall back to the watchdog
+// poller rather than be trusted as the final answer.
+export const MIN_TRUSTWORTHY_ANSWER_CHARS = 80;

--- a/src/browser/constants.ts
+++ b/src/browser/constants.ts
@@ -93,10 +93,5 @@ export const DEEP_RESEARCH_AUTO_CONFIRM_WAIT_MS = 70_000;
 export const DEEP_RESEARCH_DEFAULT_TIMEOUT_MS = 2_400_000;
 export const FINISHED_ACTIONS_SELECTOR =
   'button[data-testid="copy-turn-action-button"], button[data-testid="good-response-turn-action-button"], button[data-testid="bad-response-turn-action-button"], button[aria-label="Share"]';
-// Minimum length (in characters) of a captured answer we trust as complete when the
-// completion UI is already showing. At the Pro / Pro Extended thinking->answer
-// transition, ChatGPT briefly drops the stop button and surfaces finished-action
-// buttons while only the first tokens have rendered, so a trivially short capture seen
-// alongside the completion UI is a mid-stream race and must fall back to the watchdog
-// poller rather than be trusted as the final answer.
+// Shorter completion-UI captures need watchdog stability confirmation.
 export const MIN_TRUSTWORTHY_ANSWER_CHARS = 80;

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -883,6 +883,85 @@ describe("waitForAssistantResponse", () => {
     }
   });
 
+  test("re-polls a short completion capture until the full answer is stable", async () => {
+    vi.useFakeTimers();
+    try {
+      const short = { text: "The first line.", messageId: "mid", turnId: "tid" };
+      const complete = {
+        text: "The first line. This is the rest of the answer after the thinking transition finished.",
+        messageId: "mid",
+        turnId: "tid",
+      };
+      let snapshotCalls = 0;
+      const evaluate = vi
+        .fn()
+        .mockImplementation(async (params: { expression?: string; awaitPromise?: boolean }) => {
+          if (params.awaitPromise) {
+            return { result: { type: "object", value: short } };
+          }
+          const expression = String(params.expression ?? "");
+          if (expression.includes("extractAssistantTurn")) {
+            snapshotCalls += 1;
+            if (snapshotCalls === 1) {
+              await new Promise((resolve) => setTimeout(resolve, 50));
+            }
+            return { result: { value: snapshotCalls <= 5 ? short : complete } };
+          }
+          if (expression.includes("Find the LAST assistant turn")) {
+            return { result: { value: true } };
+          }
+          return { result: { value: false } };
+        });
+
+      const promise = waitForAssistantResponse(
+        { evaluate } as unknown as ChromeClient["Runtime"],
+        30_000,
+        logger,
+      );
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      await expect(promise).resolves.toMatchObject({ text: complete.text });
+      expect(logger).toHaveBeenCalledWith(
+        "Captured suspiciously short answer at completion; re-polling for completion",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("keeps a legitimate short completion after watchdog confirmation", async () => {
+    vi.useFakeTimers();
+    try {
+      const answer = { text: "Yes.", messageId: "mid", turnId: "tid" };
+      const evaluate = vi
+        .fn()
+        .mockImplementation(async (params: { expression?: string; awaitPromise?: boolean }) => {
+          if (params.awaitPromise) {
+            return { result: { type: "object", value: answer } };
+          }
+          const expression = String(params.expression ?? "");
+          if (expression.includes("extractAssistantTurn")) {
+            return { result: { value: answer } };
+          }
+          if (expression.includes("Find the LAST assistant turn")) {
+            return { result: { value: true } };
+          }
+          return { result: { value: false } };
+        });
+
+      const promise = waitForAssistantResponse(
+        { evaluate } as unknown as ChromeClient["Runtime"],
+        30_000,
+        logger,
+      );
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      await expect(promise).resolves.toMatchObject({ text: "Yes." });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("response observer watches character data mutations", async () => {
     let capturedExpression = "";
     const runtime = {

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -883,12 +883,14 @@ describe("waitForAssistantResponse", () => {
     }
   });
 
-  test("re-polls a short completion capture until the full answer is stable", async () => {
+  test("re-polls a completion capture longer than 80 characters until the full answer is stable", async () => {
     vi.useFakeTimers();
     try {
-      const short = { text: "The first line.", messageId: "mid", turnId: "tid" };
+      const partialText =
+        "The first paragraph already exceeds eighty characters, but the answer is still rendering during the transition.";
+      const partial = { text: partialText, messageId: "mid", turnId: "tid" };
       const complete = {
-        text: "The first line. This is the rest of the answer after the thinking transition finished.",
+        text: `${partialText} This is the rest of the answer after the thinking transition finished.`,
         messageId: "mid",
         turnId: "tid",
       };
@@ -897,7 +899,7 @@ describe("waitForAssistantResponse", () => {
         .fn()
         .mockImplementation(async (params: { expression?: string; awaitPromise?: boolean }) => {
           if (params.awaitPromise) {
-            return { result: { type: "object", value: short } };
+            return { result: { type: "object", value: partial } };
           }
           const expression = String(params.expression ?? "");
           if (expression.includes("extractAssistantTurn")) {
@@ -905,7 +907,7 @@ describe("waitForAssistantResponse", () => {
             if (snapshotCalls === 1) {
               await new Promise((resolve) => setTimeout(resolve, 50));
             }
-            return { result: { value: snapshotCalls <= 5 ? short : complete } };
+            return { result: { value: snapshotCalls <= 5 ? partial : complete } };
           }
           if (expression.includes("Find the LAST assistant turn")) {
             return { result: { value: true } };
@@ -922,7 +924,7 @@ describe("waitForAssistantResponse", () => {
 
       await expect(promise).resolves.toMatchObject({ text: complete.text });
       expect(logger).toHaveBeenCalledWith(
-        "Captured suspiciously short answer at completion; re-polling for completion",
+        "Completion controls surfaced; confirming stable assistant response",
       );
     } finally {
       vi.useRealTimers();
@@ -957,6 +959,9 @@ describe("waitForAssistantResponse", () => {
       await vi.advanceTimersByTimeAsync(15_000);
 
       await expect(promise).resolves.toMatchObject({ text: "Yes." });
+      expect(logger).toHaveBeenCalledWith(
+        "Completion controls surfaced; confirming stable assistant response",
+      );
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
## Summary

- Prevent browser-mode Pro answers from being returned during ChatGPT's thinking-to-answer transition, when completion controls can appear before response text is stable.
- Route every completion-control capture through the existing stability watchdog instead of trusting a fixed text-length threshold; partial first paragraphs can exceed any small threshold.
- Never replace the already captured candidate with a shorter watchdog result.
- Cover a partial capture longer than 80 characters growing into the complete answer, plus a legitimate short answer remaining intact after stability confirmation.

## Verification

- `pnpm vitest run tests/browser/pageActions.test.ts` — 58 passed, 1 intentional skip.
- `pnpm run check` — passed.
- `pnpm run build` — passed.
- Autoreview — clean after replacing the original sub-80-character heuristic with unconditional completion-control stability confirmation.

## Live ChatGPT proof

Built this exact implementation and ran authenticated Pro browser captures:

- Long-response smoke: Oracle waited through Pro thinking, captured all eight requested numbered items, and included the unique required final-tail marker `ORACLE_PR278_FINAL_TAIL_OK_20260702` (261 output tokens, 55.2 seconds).
- Short-response smoke: Oracle returned the exact requested marker `ORACLE_PR278_SHORT_OK_20260702` intact.

The external transition race is timing-dependent; deterministic regression tests exercise the completion-control path with both a >80-character partial capture and a stable short answer.
