### PR TITLE
ci: route public @types packages to npmjs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@types:registry=https://registry.npmjs.org/


### PR DESCRIPTION
## Summary

- add repo-local npm registry routing for the public `@types` scope
- prevents Dependabot/pnpm from resolving public DefinitelyTyped packages through `npm.pkg.github.com` when GitHub Packages credentials are injected
- does not add tokens, auth settings, dependency changes, or lockfile churn

## Evidence

The failed Dependabot run `28263178842` includes `credentials-metadata` for `npm.pkg.github.com`, then resolves `@types/chrome-remote-interface`, `@types/inquirer`, and `@types/node` against GitHub Packages. It later fails updating the lockfile with:

```text
ERR_PNPM_NO_MATCHING_VERSION No matching version found for @types/chrome-remote-interface@^0.34.0 while fetching it from https://npm.pkg.github.com/
ERR_PNPM_NO_MATCHING_VERSION No matching version found for @types/inquirer@^9.0.10 while fetching it from https://npm.pkg.github.com/
```

This matches the public-registry routing drift already fixed in `osc-progress` and `tokentally`.

## Verification

- `pnpm config get @types:registry` -> `https://registry.npmjs.org/`
- `pnpm view @types/inquirer@9.0.10 version` -> `9.0.10`
- `pnpm view @types/chrome-remote-interface@0.34.0 version` -> `0.34.0`
- `CI=true npx --yes pnpm@10.33.2 install --frozen-lockfile`
- `CI=true npx --yes pnpm@10.33.2 run check`
- `CI=true npx --yes pnpm@10.33.2 test`
- `CI=true npx --yes pnpm@10.33.2 run build`
- `CI=true npx --yes pnpm@10.33.2 run docs:check`
- `CI=true npx --yes pnpm@10.33.2 run docs:site`
- `git diff --check`