### PR TITLE
fix(browser): preserve Deep Research selection through submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - API: forward configured reasoning effort through custom OpenAI-compatible chat-completions gateways.
 - Browser: wait up to eight seconds for the ChatGPT model/effort composer pill to mount before failing explicit selection, while leaving `option-not-found` failures immediate. Thanks @gustavosmendes!
+- Browser: activate ChatGPT Deep Research after the final composer reset, select the current tools-menu row shape, and use trusted mouse clicks for Deep Research and send actions so the request reaches the real research-plan flow instead of being submitted as an ordinary Pro prompt.
 
 ## 0.15.0 — 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - API: forward configured reasoning effort through custom OpenAI-compatible chat-completions gateways.
 - Browser: wait up to eight seconds for the ChatGPT model/effort composer pill to mount before failing explicit selection, while leaving `option-not-found` failures immediate. Thanks @gustavosmendes!
-- Browser: activate ChatGPT Deep Research after the final composer reset, select the current tools-menu row shape, and use trusted mouse clicks for Deep Research and send actions so the request reaches the real research-plan flow instead of being submitted as an ordinary Pro prompt.
+- Browser: activate ChatGPT Deep Research after the final composer reset, select the current tools-menu row shape, and use trusted mouse clicks for Deep Research and send actions so the request reaches the real research-plan flow instead of being submitted as an ordinary Pro prompt. Fixes #281. Thanks @wbzjt!
 
 ## 0.15.0 — 2026-06-19
 

--- a/docs/browser-mode.md
+++ b/docs/browser-mode.md
@@ -163,7 +163,7 @@ oracle --engine browser \
   -p "Research the current browser support for WebGPU in enterprise-managed Chrome and cite sources."
 ```
 
-Oracle activates ChatGPT Deep Research through the composer `/Deepresearch` command and falls back to the composer tools menu when the slash flow is not available. It waits for the research plan to auto-confirm, logs high-level progress, then captures the final report from the Deep Research report surface instead of trusting the assistant tool-call wrapper.
+Oracle activates ChatGPT Deep Research through the composer tools menu, recognizing both the `Deep research` label and current `Get a detailed report` menu variants. It waits for the research plan to auto-confirm, logs high-level progress, then captures the final report from the Deep Research report surface instead of trusting the assistant tool-call wrapper.
 
 If ChatGPT initially exposes only `Called tool` / `Used tool`, Oracle treats that as an incomplete capture for Deep Research rather than a final answer. Reattach the existing session with `oracle session <id> --render` so Oracle can recover the lazy-loaded report from the existing Chrome tab; do not rerun the research unless the browser session is unrecoverable.
 

--- a/src/browser/actions/deepResearch.ts
+++ b/src/browser/actions/deepResearch.ts
@@ -1248,6 +1248,8 @@ function buildActivateDeepResearchExpression(): string {
     const isDeepResearchText = (text) => (
       text === target ||
       text.startsWith(target + ' ') ||
+      text === 'get a detailed report' ||
+      text.startsWith('get a detailed report ') ||
       (text.includes(target) && text.includes('detailed report')) ||
       text.replace(/\\s+/g, '').startsWith('deepresearch')
     );

--- a/src/browser/actions/deepResearch.ts
+++ b/src/browser/actions/deepResearch.ts
@@ -24,8 +24,8 @@ type ActivateOutcome =
   | { status: "pill-not-confirmed"; clickPoint?: { x?: number; y?: number } };
 
 /**
- * Activates Deep Research mode through ChatGPT's slash command, with the
- * composer tools menu as a fallback for older UI variants.
+ * Activates Deep Research mode through ChatGPT's composer tools menu and
+ * verifies the selected tool pill before prompt submission.
  */
 export async function activateDeepResearch(
   Runtime: ChromeClient["Runtime"],
@@ -1131,7 +1131,6 @@ function buildFindDeepResearchPillExpression(functionName = "findDeepResearchPil
         '.__composer-pill-composite',
         '.__composer-pill',
         '[class*="composer-pill"]',
-        '[class*="pill"]',
       ].join(',');
       const candidates = Array.from(document.querySelectorAll(selectors));
       const composerRoots = Array.from(document.querySelectorAll('[data-testid="composer"], form, [class*="composer"]'));
@@ -1208,6 +1207,7 @@ function buildActivateDeepResearchExpression(): string {
       '[role="menuitemradio"]',
       '[role="option"]',
       '[cmdk-item]',
+      'button',
       '.__menu-item',
       '[class*="__menu-item"]',
       '[class*="menu-item"]',

--- a/src/browser/actions/deepResearch.ts
+++ b/src/browser/actions/deepResearch.ts
@@ -21,7 +21,7 @@ type ActivateOutcome =
   | { status: "already-active" }
   | { status: "plus-button-missing" }
   | { status: "dropdown-item-missing"; available?: string[] }
-  | { status: "pill-not-confirmed" };
+  | { status: "pill-not-confirmed"; clickPoint?: { x?: number; y?: number } };
 
 /**
  * Activates Deep Research mode through ChatGPT's slash command, with the
@@ -29,7 +29,7 @@ type ActivateOutcome =
  */
 export async function activateDeepResearch(
   Runtime: ChromeClient["Runtime"],
-  _Input: ChromeClient["Input"],
+  Input: ChromeClient["Input"],
   logger: BrowserLogger,
 ): Promise<void> {
   const expression = buildActivateDeepResearchExpression();
@@ -62,16 +62,60 @@ export async function activateDeepResearch(
         { stage: "deep-research-activate", code: "dropdown-item-missing" },
       );
     }
-    case "pill-not-confirmed":
+    case "pill-not-confirmed": {
+      const point = result.clickPoint;
+      if (typeof point?.x === "number" && typeof point.y === "number") {
+        await clickTrustedPoint(Runtime, Input, point.x, point.y);
+        if (await waitForDeepResearchPill(Runtime)) {
+          logger("Deep Research mode activated");
+          return;
+        }
+      }
       throw new BrowserAutomationError(
         "Deep Research pill did not appear after selection. The UI may have changed.",
         { stage: "deep-research-activate", code: "pill-not-confirmed" },
       );
+    }
     default:
       throw new BrowserAutomationError("Unexpected result from Deep Research activation.", {
         stage: "deep-research-activate",
       });
   }
+}
+
+async function clickTrustedPoint(
+  Runtime: ChromeClient["Runtime"],
+  Input: ChromeClient["Input"],
+  x: number,
+  y: number,
+): Promise<void> {
+  if (Input && typeof Input.dispatchMouseEvent === "function") {
+    await Input.dispatchMouseEvent({ type: "mouseMoved", x, y });
+    await Input.dispatchMouseEvent({ type: "mousePressed", x, y, button: "left", clickCount: 1 });
+    await Input.dispatchMouseEvent({ type: "mouseReleased", x, y, button: "left", clickCount: 1 });
+    return;
+  }
+  await Runtime.evaluate({
+    expression: `(() => {
+      const el = document.elementFromPoint(${JSON.stringify(x)}, ${JSON.stringify(y)});
+      if (!(el instanceof HTMLElement)) return false;
+      el.click();
+      return true;
+    })()`,
+    returnByValue: true,
+  });
+}
+
+async function waitForDeepResearchPill(
+  Runtime: ChromeClient["Runtime"],
+  timeoutMs = 5000,
+): Promise<boolean> {
+  const { result } = await Runtime.evaluate({
+    expression: buildWaitForDeepResearchPillExpression(timeoutMs),
+    awaitPromise: true,
+    returnByValue: true,
+  });
+  return Boolean(result?.value);
 }
 
 /**
@@ -1079,31 +1123,60 @@ export function buildDeepResearchCompletionPollExpressionForTest(minTurnIndex = 
   return buildDeepResearchCompletionPollExpression(minTurnIndex);
 }
 
-function buildActivateDeepResearchExpression(): string {
-  const plusBtnSelector = JSON.stringify(DEEP_RESEARCH_PLUS_BUTTON);
-  const targetText = JSON.stringify(DEEP_RESEARCH_DROPDOWN_ITEM_TEXT);
+function buildFindDeepResearchPillExpression(functionName = "findDeepResearchPill"): string {
   const pillLabel = JSON.stringify(DEEP_RESEARCH_PILL_LABEL);
-
-  // pillLabel is used inside the expression for verification
-  void pillLabel;
-
-  return `(async () => {
-    ${buildClickDispatcher()}
-
-    const findDeepResearchPill = () => {
-      const pills = document.querySelectorAll('.__composer-pill-composite, .__composer-pill, [class*="composer-pill"]');
-      for (const pill of pills) {
-        const text = pill.textContent?.trim() || '';
-        const aria = pill.getAttribute('aria-label') ||
+  return `const ${functionName} = () => {
+      const label = ${pillLabel}.toLowerCase();
+      const selectors = [
+        '.__composer-pill-composite',
+        '.__composer-pill',
+        '[class*="composer-pill"]',
+        '[class*="pill"]',
+      ].join(',');
+      const candidates = Array.from(document.querySelectorAll(selectors));
+      const composerRoots = Array.from(document.querySelectorAll('[data-testid="composer"], form, [class*="composer"]'));
+      for (const root of composerRoots) {
+        candidates.push(...Array.from(root.querySelectorAll('button, [role="button"], [class*="pill"], [class*="composer-pill"]')));
+      }
+      const seen = new Set();
+      for (const pill of candidates) {
+        if (!(pill instanceof Element) || seen.has(pill)) continue;
+        seen.add(pill);
+        const rect = pill.getBoundingClientRect?.();
+        if (!rect || rect.width <= 0 || rect.height <= 0) continue;
+        const text = (pill.textContent || '').replace(/\\s+/g, ' ').trim().toLowerCase();
+        const aria = (
+          pill.getAttribute('aria-label') ||
           pill.querySelector('button')?.getAttribute('aria-label') ||
-          '';
-        if (text.toLowerCase().includes('deep research') ||
-            aria.toLowerCase().includes('deep research')) {
+          ''
+        ).toLowerCase();
+        if (text.includes(label) || aria.includes(label)) {
           return pill;
         }
       }
       return null;
-    };
+    };`;
+}
+
+function buildWaitForDeepResearchPillExpression(timeoutMs: number): string {
+  return `(async () => {
+    ${buildFindDeepResearchPillExpression()}
+    const deadline = Date.now() + ${JSON.stringify(Math.max(timeoutMs, 0))};
+    while (Date.now() < deadline) {
+      if (findDeepResearchPill()) return true;
+      await new Promise(resolve => setTimeout(resolve, 200));
+    }
+    return Boolean(findDeepResearchPill());
+  })()`;
+}
+
+function buildActivateDeepResearchExpression(): string {
+  const plusBtnSelector = JSON.stringify(DEEP_RESEARCH_PLUS_BUTTON);
+  const targetText = JSON.stringify(DEEP_RESEARCH_DROPDOWN_ITEM_TEXT);
+
+  return `(async () => {
+    ${buildClickDispatcher()}
+    ${buildFindDeepResearchPillExpression()}
 
     const waitForPill = () => new Promise((resolve) => {
       let elapsed = 0;
@@ -1118,24 +1191,102 @@ function buildActivateDeepResearchExpression(): string {
       setTimeout(tick, 200);
     });
 
-    const clearComposer = (composer) => {
-      if (!composer) return;
-      if ('value' in composer) composer.value = '';
-      else composer.textContent = '';
-      composer.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'deleteContentBackward', data: null }));
+    const menuItemSelector = [
+      '[data-radix-collection-item]',
+      '[role="option"]',
+      '[cmdk-item]',
+      'button',
+      '[role="menuitem"]',
+      '[role="menuitemradio"]',
+      '.__menu-item',
+      '[class*="__menu-item"]',
+      '[class*="menu-item"]',
+    ].join(',');
+    const dropdownItemSelector = [
+      '[data-radix-collection-item]',
+      '[role="menuitem"]',
+      '[role="menuitemradio"]',
+      '[role="option"]',
+      '[cmdk-item]',
+      '.__menu-item',
+      '[class*="__menu-item"]',
+      '[class*="menu-item"]',
+    ].join(',');
+    const popoverSelector = [
+      '.popover',
+      '[class*="popover"]',
+      '[data-radix-popper-content-wrapper]',
+      '[data-floating-ui-portal]',
+    ].join(',');
+    const target = ${targetText}.toLowerCase();
+    const normalizeText = (value) => String(value || '').replace(/\\s+/g, ' ').trim().toLowerCase();
+    const getText = (item) => normalizeText(item.textContent || item.getAttribute?.('aria-label') || '');
+    const isInPopover = (item) => Boolean(item.closest?.(popoverSelector));
+    const isVisible = (item) => {
+      const rect = item.getBoundingClientRect?.();
+      if (!rect || rect.width <= 0 || rect.height <= 0) return false;
+      const style = window.getComputedStyle?.(item);
+      return !style || (style.visibility !== 'hidden' && style.display !== 'none');
     };
-
-    const setComposerText = (composer, text) => {
-      composer.focus?.();
-      if ('value' in composer) composer.value = text;
-      else composer.textContent = text;
-      composer.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: text }));
+    const findPopoverSearchInput = () => Array.from(
+      document.querySelectorAll('input, textarea, [contenteditable="true"]')
+    ).find(item => {
+      const type = (item.getAttribute?.('type') || '').toLowerCase();
+      const testId = (item.getAttribute?.('data-testid') || '').toLowerCase();
+      return isInPopover(item) &&
+        isVisible(item) &&
+        type !== 'file' &&
+        testId !== 'upload-photos-input';
+    }) || null;
+    const setSearchText = (input, text) => {
+      input.focus?.();
+      if ('value' in input) input.value = text;
+      else input.textContent = text;
+      input.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: text }));
+      input.dispatchEvent(new Event('change', { bubbles: true }));
     };
-
-    const findDeepResearchItem = () => {
-      const target = ${targetText}.toLowerCase();
-      const candidates = Array.from(document.querySelectorAll('[data-radix-collection-item], [role="option"], [cmdk-item], button, [role="menuitem"], [role="menuitemradio"]'));
-      return candidates.find(item => (item.textContent || '').trim().toLowerCase() === target) || null;
+    const isDeepResearchText = (text) => (
+      text === target ||
+      text.startsWith(target + ' ') ||
+      (text.includes(target) && text.includes('detailed report')) ||
+      text.replace(/\\s+/g, '').startsWith('deepresearch')
+    );
+    const getClickableItem = (item) => item.closest?.(
+      '[data-radix-collection-item], [role="option"], [cmdk-item], button, [role="menuitem"], [role="menuitemradio"], .__menu-item, [class*="__menu-item"], [class*="menu-item"]'
+    ) || item;
+    const findDeepResearchItem = (options = {}) => {
+      const matches = Array.from(document.querySelectorAll(menuItemSelector))
+        .filter(item => {
+          const text = getText(item);
+          return text &&
+            text.length <= 180 &&
+            isVisible(item) &&
+            (!options.requirePopover || isInPopover(item)) &&
+            isDeepResearchText(text);
+        })
+        .map(item => {
+          const text = getText(item);
+          const clickable = getClickableItem(item);
+          const exact = text === target ? 0 : 1;
+          const menuRow = /(^|\\s)__menu-item(\\s|$)/.test(clickable.className || '') ? 0 : 1;
+          return { item: clickable, score: exact + menuRow, textLength: text.length };
+        })
+        .sort((a, b) => a.score - b.score || a.textLength - b.textLength);
+      return matches[0]?.item || null;
+    };
+    const collectAvailableItems = (options = {}) => {
+      const seen = new Set();
+      return Array.from(document.querySelectorAll(dropdownItemSelector))
+        .filter(item => !options.requirePopover || isInPopover(item))
+        .filter(item => isVisible(item))
+        .map(item => (item.textContent || '').replace(/\\s+/g, ' ').trim())
+        .filter(text => text && text.length <= 180)
+        .filter(text => {
+          const key = text.toLowerCase();
+          if (seen.has(key)) return false;
+          seen.add(key);
+          return true;
+        });
     };
 
     // Step 0: Check if already active
@@ -1143,20 +1294,8 @@ function buildActivateDeepResearchExpression(): string {
       return { status: 'already-active' };
     }
 
-    // Step 1: Prefer the official slash command flow.
-    const composer = document.querySelector('[contenteditable="true"], textarea');
-    if (composer) {
-      setComposerText(composer, '/Deepresearch');
-      await new Promise(resolve => setTimeout(resolve, 600));
-      const slashItem = findDeepResearchItem();
-      if (slashItem) {
-        dispatchClickSequence(slashItem);
-        if (await waitForPill()) return { status: 'activated' };
-      }
-      clearComposer(composer);
-    }
-
-    // Step 2: Fall back to the composer tools menu.
+    // Step 1: Open the composer tools menu. Avoid slash commands because they
+    // mutate the main composer and can be submitted as normal prompt text.
     const plusBtn = document.querySelector(${plusBtnSelector}) ||
       Array.from(document.querySelectorAll('button')).find(
         b => (b.getAttribute('aria-label') || '').toLowerCase().includes('add files')
@@ -1164,14 +1303,21 @@ function buildActivateDeepResearchExpression(): string {
     if (!plusBtn) return { status: 'plus-button-missing' };
     dispatchClickSequence(plusBtn);
 
-    // Step 3: Wait for dropdown
+    // Step 2: Wait for dropdown
     const waitForDropdown = () => new Promise((resolve) => {
       let elapsed = 0;
       const tick = () => {
-        const items = document.querySelectorAll('[data-radix-collection-item], [role="menuitem"], [role="menuitemradio"], [role="option"], [cmdk-item]');
-        if (items.length > 0) { resolve(items); return; }
+        const items = collectAvailableItems({ requirePopover: true });
+        if (findDeepResearchItem({ requirePopover: true }) || items.some(text => {
+          const normalized = normalizeText(text);
+          return normalized.includes('add photos') ||
+            normalized.includes('create image') ||
+            normalized.includes('web search') ||
+            normalized.includes('deep research') ||
+            normalized.includes('get a detailed report');
+        })) { resolve(items); return; }
         elapsed += 150;
-        if (elapsed > 3000) { resolve(null); return; }
+        if (elapsed > 3000) { resolve(items.length ? items : null); return; }
         setTimeout(tick, 150);
       };
       setTimeout(tick, 150);
@@ -1179,25 +1325,33 @@ function buildActivateDeepResearchExpression(): string {
     const items = await waitForDropdown();
     if (!items) return { status: 'dropdown-item-missing', available: [] };
 
-    // Step 4: Find "Deep research" item
-    const target = ${targetText}.toLowerCase();
-    let match = null;
-    const available = [];
-    for (const item of items) {
-      const text = (item.textContent || '').trim();
-      available.push(text);
-      if (text.toLowerCase() === target) {
-        match = item;
+    // Step 3: Find "Deep research" item. Some ChatGPT variants only reveal it
+    // after typing in the tools menu search field.
+    let match = findDeepResearchItem({ requirePopover: true });
+    let available = Array.isArray(items) ? items : collectAvailableItems({ requirePopover: true });
+    if (!match) {
+      const searchInput = findPopoverSearchInput();
+      if (searchInput) {
+        setSearchText(searchInput, ${targetText});
+        await new Promise(resolve => setTimeout(resolve, 600));
+        match = findDeepResearchItem({ requirePopover: true });
+        available = collectAvailableItems({ requirePopover: true });
       }
     }
     if (!match) return { status: 'dropdown-item-missing', available };
 
-    // Step 5: Click it
+    // Step 4: Click it
+    match.scrollIntoView?.({ block: 'center', inline: 'center' });
+    await new Promise(resolve => setTimeout(resolve, 100));
+    const rect = match.getBoundingClientRect();
+    const clickPoint = rect && rect.width > 0 && rect.height > 0
+      ? { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 }
+      : undefined;
     dispatchClickSequence(match);
 
-    // Step 6: Verify pill appeared
+    // Step 5: Verify pill appeared
     const pillConfirmed = await waitForPill();
-    return pillConfirmed ? { status: 'activated' } : { status: 'pill-not-confirmed' };
+    return pillConfirmed ? { status: 'activated' } : { status: 'pill-not-confirmed', clickPoint };
   })()`;
 }
 

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -212,6 +212,7 @@ export async function submitPrompt(
 
   const clicked = await attemptSendButton(
     runtime,
+    input,
     logger,
     deps?.attachmentNames,
     deps?.attachmentTimeoutMs,
@@ -643,6 +644,7 @@ export function buildAttachmentReadyExpressionForTest(attachmentNames: Attachmen
 
 async function attemptSendButton(
   Runtime: ChromeClient["Runtime"],
+  Input: ChromeClient["Input"],
   _logger?: BrowserLogger,
   attachmentNames?: AttachmentReadyInput[],
   attachmentTimeoutMs?: number | null,
@@ -675,10 +677,15 @@ async function attemptSendButton(
       candidates.push(...Array.from(document.querySelectorAll(selector)));
     }
     const button = candidates.find((node) => isVisible(node) && isEnabled(node)) || null;
-    if (!button) return 'missing';
-    // Use unified pointer/mouse sequence to satisfy React handlers.
+    if (!button) return { status: 'missing' };
+    button.scrollIntoView({ block: 'center', inline: 'center' });
+    const rect = button.getBoundingClientRect();
+    if (rect.width > 0 && rect.height > 0) {
+      return { status: 'point', x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+    }
+    // Last-resort fallback for unusual DOMs where the button is visible but has no useful rect.
     dispatchClickSequence(button);
-    return 'clicked';
+    return { status: 'clicked' };
   })()`;
 
   // Give attachment-bearing submissions more headroom. ChatGPT's chip render can
@@ -698,10 +705,24 @@ async function attemptSendButton(
       }
     }
     const { result } = await Runtime.evaluate({ expression: script, returnByValue: true });
-    if (result.value === "clicked") {
+    const value = result.value as
+      | { status?: "clicked" | "missing" | "point"; x?: number; y?: number }
+      | string
+      | undefined;
+    const status = typeof value === "string" ? value : value?.status;
+    if (
+      status === "point" &&
+      typeof value === "object" &&
+      typeof value.x === "number" &&
+      typeof value.y === "number"
+    ) {
+      await clickTrustedPoint(Runtime, Input, value.x, value.y);
       return true;
     }
-    if (result.value === "missing") {
+    if (status === "clicked") {
+      return true;
+    }
+    if (status === "missing") {
       break;
     }
     await delay(100);
@@ -720,6 +741,29 @@ async function attemptSendButton(
     );
   }
   return false;
+}
+
+async function clickTrustedPoint(
+  Runtime: ChromeClient["Runtime"],
+  Input: ChromeClient["Input"],
+  x: number,
+  y: number,
+): Promise<void> {
+  if (Input && typeof Input.dispatchMouseEvent === "function") {
+    await Input.dispatchMouseEvent({ type: "mouseMoved", x, y });
+    await Input.dispatchMouseEvent({ type: "mousePressed", x, y, button: "left", clickCount: 1 });
+    await Input.dispatchMouseEvent({ type: "mouseReleased", x, y, button: "left", clickCount: 1 });
+    return;
+  }
+  await Runtime.evaluate({
+    expression: `(() => {
+      const el = document.elementFromPoint(${JSON.stringify(x)}, ${JSON.stringify(y)});
+      if (!(el instanceof HTMLElement)) return false;
+      el.click();
+      return true;
+    })()`,
+    returnByValue: true,
+  });
 }
 
 function sendButtonTimeoutMs(

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1418,25 +1418,6 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
         }),
       );
     }
-    if (deepResearch) {
-      await raceWithDisconnect(
-        withRetries(() => activateDeepResearch(Runtime, Input, logger), {
-          retries: 2,
-          delayMs: 500,
-          onRetry: (attempt, error) => {
-            if (options.verbose) {
-              logger(
-                `[retry] Deep Research activation attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
-              );
-            }
-          },
-        }),
-      );
-      await raceWithDisconnect(ensurePromptReady(Runtime, config.inputTimeoutMs, logger));
-      logger(
-        `Prompt textarea ready (after Deep Research activation, ${promptText.length.toLocaleString()} chars queued)`,
-      );
-    }
     const profileLockTimeoutMs = manualLogin ? (config.profileLockTimeoutMs ?? 0) : 0;
     let profileLock: ProfileRunLock | null = null;
     const acquireProfileLockIfNeeded = async () => {
@@ -1495,6 +1476,25 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
         const attachmentWaitBudget = Math.max(config.attachmentTimeoutMs ?? 0, waitBudget);
         await waitForAttachmentCompletion(Runtime, attachmentWaitBudget, attachmentNames, logger);
         logger("All attachments uploaded");
+      }
+      if (deepResearch) {
+        await raceWithDisconnect(
+          withRetries(() => activateDeepResearch(Runtime, Input, logger), {
+            retries: 2,
+            delayMs: 500,
+            onRetry: (attempt, error) => {
+              if (options.verbose) {
+                logger(
+                  `[retry] Deep Research activation attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
+                );
+              }
+            },
+          }),
+        );
+        await raceWithDisconnect(ensurePromptReady(Runtime, config.inputTimeoutMs, logger));
+        logger(
+          `Prompt textarea ready (after Deep Research activation, ${prompt.length.toLocaleString()} chars queued)`,
+        );
       }
       let baselineTurns = await readConversationTurnCount(Runtime, logger);
       // Learned: return baselineTurns so assistant polling can ignore earlier content.
@@ -2918,24 +2918,6 @@ async function runRemoteBrowserMode(
         },
       );
     }
-    if (deepResearch) {
-      await withRetries(() => activateDeepResearch(Runtime, Input, logger), {
-        retries: 2,
-        delayMs: 500,
-        onRetry: (attempt, error) => {
-          if (options.verbose) {
-            logger(
-              `[retry] Deep Research activation attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
-            );
-          }
-        },
-      });
-      await ensurePromptReady(Runtime, config.inputTimeoutMs, logger);
-      logger(
-        `Prompt textarea ready (after Deep Research activation, ${promptText.length.toLocaleString()} chars queued)`,
-      );
-    }
-
     const submitOnce = async (prompt: string, submissionAttachments: BrowserAttachment[]) => {
       const baselineSnapshot = await readAssistantSnapshot(Runtime).catch(() => null);
       const baselineAssistantText =
@@ -2966,6 +2948,23 @@ async function runRemoteBrowserMode(
         const attachmentWaitBudget = Math.max(config.attachmentTimeoutMs ?? 0, waitBudget);
         await waitForAttachmentCompletion(Runtime, attachmentWaitBudget, attachmentNames, logger);
         logger("All attachments uploaded");
+      }
+      if (deepResearch) {
+        await withRetries(() => activateDeepResearch(Runtime, Input, logger), {
+          retries: 2,
+          delayMs: 500,
+          onRetry: (attempt, error) => {
+            if (options.verbose) {
+              logger(
+                `[retry] Deep Research activation attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
+              );
+            }
+          },
+        });
+        await ensurePromptReady(Runtime, config.inputTimeoutMs, logger);
+        logger(
+          `Prompt textarea ready (after Deep Research activation, ${prompt.length.toLocaleString()} chars queued)`,
+        );
       }
       let baselineTurns = await readConversationTurnCount(Runtime, logger);
       const providerState: Record<string, unknown> = {

--- a/tests/browser/deepResearch.test.ts
+++ b/tests/browser/deepResearch.test.ts
@@ -177,6 +177,8 @@ describe("Deep Research activation expression", () => {
     expect(expression).toContain(".__menu-item");
     expect(expression).toContain("popover");
     expect(expression).toContain("detailed report");
+    expect(expression).toContain("text === 'get a detailed report'");
+    expect(expression).toContain("text.startsWith('get a detailed report ')");
     expect(expression).toContain('[class*="composer-pill"]');
     expect(expression).toContain("deep research");
     expect(expression).toContain("already-active");

--- a/tests/browser/deepResearch.test.ts
+++ b/tests/browser/deepResearch.test.ts
@@ -132,6 +132,29 @@ describe("activateDeepResearch", () => {
     ).rejects.toThrow(/pill did not appear/);
   });
 
+  it("falls back to a trusted point click when the menu row ignores synthetic clicks", async () => {
+    const dispatchMouseEvent = vi.fn(async () => undefined);
+    mockInput = { dispatchMouseEvent };
+    mockRuntime.evaluate
+      .mockResolvedValueOnce({
+        result: { value: { status: "pill-not-confirmed", clickPoint: { x: 12, y: 34 } } },
+      })
+      .mockResolvedValueOnce({ result: { value: true } });
+
+    await expect(
+      activateDeepResearch(mockRuntime as never, mockInput as never, mockLogger),
+    ).resolves.toBeUndefined();
+    expect(dispatchMouseEvent).toHaveBeenCalledTimes(3);
+    expect(dispatchMouseEvent).toHaveBeenCalledWith({
+      type: "mousePressed",
+      x: 12,
+      y: 34,
+      button: "left",
+      clickCount: 1,
+    });
+    expect(mockLogger).toHaveBeenCalledWith("Deep Research mode activated");
+  });
+
   it("throws on unexpected result", async () => {
     mockRuntime.evaluate.mockResolvedValueOnce({
       result: { value: { status: "unknown-status" } },
@@ -143,13 +166,17 @@ describe("activateDeepResearch", () => {
 });
 
 describe("Deep Research activation expression", () => {
-  it("prefers the slash command and keeps the plus-menu fallback", () => {
+  it("uses the composer tools menu without mutating the queued prompt", () => {
     const expression = buildActivateDeepResearchExpressionForTest();
 
-    expect(expression).toContain("/Deepresearch");
+    expect(expression).not.toContain("/Deepresearch");
     expect(expression).toContain("findDeepResearchItem");
+    expect(expression).toContain("findPopoverSearchInput");
     expect(expression).toContain("composer-plus-btn");
     expect(expression).toContain('role="menuitemradio"');
+    expect(expression).toContain(".__menu-item");
+    expect(expression).toContain("popover");
+    expect(expression).toContain("detailed report");
     expect(expression).toContain('[class*="composer-pill"]');
     expect(expression).toContain("deep research");
     expect(expression).toContain("already-active");

--- a/tests/browser/promptComposer.test.ts
+++ b/tests/browser/promptComposer.test.ts
@@ -98,7 +98,7 @@ describe("promptComposer", () => {
       const runtime = {
         evaluate: vi.fn(async ({ expression }: { expression: string }) => {
           if (expression.includes("dispatchClickSequence")) {
-            return { result: { value: "disabled" } };
+            return { result: { value: { status: "disabled" } } };
           }
           return { result: { value: true } };
         }),
@@ -109,6 +109,7 @@ describe("promptComposer", () => {
       const promise = promptComposer.attemptSendButton(
         runtime as never,
         (() => undefined) as never,
+        undefined,
         ["oracle-attach-verify.txt"],
       );
       const assertion = expect(promise).rejects.toThrow(/after 45s/i);
@@ -141,8 +142,8 @@ describe("promptComposer", () => {
             result: { value: { editorText: "hello", fallbackValue: "", activeValue: "hello" } },
           };
         }
-        if (expression.includes("dispatchClickSequence(button)")) {
-          return { result: { value: "clicked" } };
+        if (expression.includes("button.scrollIntoView")) {
+          return { result: { value: { status: "clicked" } } };
         }
         return {
           result: {


### PR DESCRIPTION
## Summary

- Move ChatGPT Deep Research activation into the final submit path after composer reset/attachment upload, so the tool selection is not cleared before prompt submission.
- Support the current ChatGPT tools-menu DOM shape, including `.__menu-item` rows and `Deep research` / `Get a detailed report` labels.
- Use trusted CDP mouse clicks for the Deep Research row fallback and send button so React/ChatGPT handlers receive real pointer events.
- Document the tools-menu contract and add regression coverage for both label variants.

Fixes #281.

## Verification

- `pnpm vitest run tests/browser/deepResearch.test.ts tests/browser/promptComposer.test.ts tests/browser/index.test.ts tests/cli/browserConfig.test.ts` — 164 passed.
- `pnpm run check` — passed.
- `pnpm run build` — passed.
- Autoreview — clean after fixing its detailed-report-only label finding.

## Live ChatGPT proof

Authenticated ChatGPT browser runs against this exact implementation:

- Normal Instant submission returned the unique requested marker and logged `Clicked send button`.
- Pro + `--browser-research deep` logged `Deep Research mode activated`, submitted the user turn with the visible `Deep research` marker, displayed the active research plan/task UI, completed the research run, and returned the requested current OpenAI Help Center source: https://help.openai.com/en/articles/10500283-deep-research-in-chatgpt

No connected apps or private data were used for the research request.
