### PR TITLE
fix(browser): clear stale ChatGPT cookies before navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Browser: retain runtime, model-selection, and redacted prompt-commit diagnostics in failed session metadata when ChatGPT submission verification times out. Fixes #286. Thanks @LeoLin990405!
 - API: forward configured reasoning effort through custom OpenAI-compatible chat-completions gateways.
+- Browser: clear stale ChatGPT temporary-conversation cookies before runs so accumulated `conv_key_*` entries do not bloat request headers and trigger header-size failures.
 - Browser: accept a stable, exact file-input name match when ChatGPT marks the composer ready but exposes no attachment chip or count, while still waiting through active uploads and rejecting missing or extra files. Fixes #275. Thanks @wangwllu!
 - Browser: avoid returning truncated Pro answers when completion controls appear during the thinking-to-answer transition. Thanks @xuan-wei!
 - Browser/Bridge: improve ChatGPT ZIP artifact capture before bridge transfer by broadening sandbox/file-card/download-control discovery, adding sanitized direct-download diagnostics, and falling back to scoped browser downloads when sandbox fetches fail. Thanks @DK625!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 - Browser: retain runtime, model-selection, and redacted prompt-commit diagnostics in failed session metadata when ChatGPT submission verification times out. Fixes #286. Thanks @LeoLin990405!
 - API: forward configured reasoning effort through custom OpenAI-compatible chat-completions gateways.
-- Browser: clear stale ChatGPT temporary-conversation cookies before runs so accumulated `conv_key_*` entries do not bloat request headers and trigger header-size failures.
+- Browser: clear stale ChatGPT temporary-conversation cookies before navigation while preserving keys for open or resumed conversations, preventing accumulated `conv_key_*` entries from triggering header-size failures. Thanks @jung0han!
 - Browser: accept a stable, exact file-input name match when ChatGPT marks the composer ready but exposes no attachment chip or count, while still waiting through active uploads and rejecting missing or extra files. Fixes #275. Thanks @wangwllu!
 - Browser: avoid returning truncated Pro answers when completion controls appear during the thinking-to-answer transition. Thanks @xuan-wei!
 - Browser/Bridge: improve ChatGPT ZIP artifact capture before bridge transfer by broadening sandbox/file-card/download-control discovery, adding sanitized direct-download diagnostics, and falling back to scoped browser downloads when sandbox fetches fail. Thanks @DK625!

--- a/src/browser/cookies.ts
+++ b/src/browser/cookies.ts
@@ -5,6 +5,47 @@ import { getCookies, type Cookie } from "@steipete/sweet-cookie";
 
 export class ChromeCookieSyncError extends Error {}
 
+export async function clearChatGptConversationCookies(
+  Network: ChromeClient["Network"],
+  logger: BrowserLogger,
+): Promise<number> {
+  try {
+    const { cookies = [] } = await Network.getAllCookies();
+    const targets = cookies.filter((cookie) => isChatGptConversationCookie(cookie));
+    if (targets.length === 0) {
+      return 0;
+    }
+
+    let deleted = 0;
+    for (const cookie of targets) {
+      try {
+        await Network.deleteCookies({
+          name: cookie.name,
+          domain: cookie.domain,
+          path: cookie.path ?? "/",
+        });
+        deleted += 1;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger(
+          `[cookies] Failed to clear stale ChatGPT conversation cookie ${cookie.name}: ${message}`,
+        );
+      }
+    }
+
+    if (deleted > 0) {
+      logger(
+        `[cookies] Cleared ${deleted} stale ChatGPT conversation cookie${deleted === 1 ? "" : "s"}.`,
+      );
+    }
+    return deleted;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger(`[cookies] Failed to inspect ChatGPT conversation cookies: ${message}`);
+    return 0;
+  }
+}
+
 export async function syncCookies(
   Network: ChromeClient["Network"],
   url: string,
@@ -130,6 +171,16 @@ async function readChromeCookies(
   }
 
   return Array.from(merged.values());
+}
+
+function isChatGptConversationCookie(cookie: { name?: string; domain?: string }): boolean {
+  if (!cookie.name?.startsWith("conv")) {
+    return false;
+  }
+  const domain = String(cookie.domain ?? "")
+    .replace(/^\./, "")
+    .toLowerCase();
+  return domain === "chatgpt.com" || domain === "chat.openai.com";
 }
 
 function normalizeInlineCookies(rawCookies: CookieParam[], fallbackHost: string): CookieParam[] {

--- a/src/browser/cookies.ts
+++ b/src/browser/cookies.ts
@@ -5,13 +5,39 @@ import { getCookies, type Cookie } from "@steipete/sweet-cookie";
 
 export class ChromeCookieSyncError extends Error {}
 
-export async function clearChatGptConversationCookies(
+export async function clearStaleChatGptConversationCookies(
   Network: ChromeClient["Network"],
+  Target: ChromeClient["Target"],
   logger: BrowserLogger,
+  options: { preserveConversationIds?: readonly (string | null | undefined)[] } = {},
 ): Promise<number> {
   try {
+    const preservedNames = new Set(
+      (options.preserveConversationIds ?? [])
+        .filter((id): id is string => Boolean(id))
+        .map((id) => `conv_key_${id}`),
+    );
+    try {
+      const { targetInfos = [] } = await Target.getTargets();
+      for (const target of targetInfos) {
+        const conversationId = extractChatGptConversationId(target.url ?? "");
+        if (conversationId) {
+          preservedNames.add(`conv_key_${conversationId}`);
+        }
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger(
+        `[cookies] Failed to inspect active ChatGPT conversations; skipping stale cookie cleanup: ${message}`,
+      );
+      return 0;
+    }
+
     const { cookies = [] } = await Network.getAllCookies();
-    const targets = cookies.filter((cookie) => isChatGptConversationCookie(cookie));
+    const targets = cookies.filter(
+      (cookie) =>
+        isChatGptConversationCookie(cookie) && !preservedNames.has(String(cookie.name ?? "")),
+    );
     if (targets.length === 0) {
       return 0;
     }
@@ -27,9 +53,7 @@ export async function clearChatGptConversationCookies(
         deleted += 1;
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        logger(
-          `[cookies] Failed to clear stale ChatGPT conversation cookie ${cookie.name}: ${message}`,
-        );
+        logger(`[cookies] Failed to clear a stale ChatGPT conversation cookie: ${message}`);
       }
     }
 
@@ -174,13 +198,26 @@ async function readChromeCookies(
 }
 
 function isChatGptConversationCookie(cookie: { name?: string; domain?: string }): boolean {
-  if (!cookie.name?.startsWith("conv")) {
+  if (!cookie.name?.startsWith("conv_key_")) {
     return false;
   }
   const domain = String(cookie.domain ?? "")
     .replace(/^\./, "")
     .toLowerCase();
   return domain === "chatgpt.com" || domain === "chat.openai.com";
+}
+
+function extractChatGptConversationId(url: string): string | undefined {
+  try {
+    const parsed = new URL(url);
+    const domain = parsed.hostname.toLowerCase();
+    if (domain !== "chatgpt.com" && domain !== "chat.openai.com") {
+      return undefined;
+    }
+    return parsed.pathname.match(/\/c\/([a-zA-Z0-9-]+)/)?.[1];
+  } catch {
+    return undefined;
+  }
 }
 
 function normalizeInlineCookies(rawCookies: CookieParam[], fallbackHost: string): CookieParam[] {

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -23,7 +23,7 @@ import {
   closeRemoteChromeTarget,
   closeBlankChromeTabs,
 } from "./chromeLifecycle.js";
-import { syncCookies } from "./cookies.js";
+import { clearChatGptConversationCookies, syncCookies } from "./cookies.js";
 import {
   navigateToChatGPT,
   navigateToPromptReadyWithFallback,
@@ -1201,6 +1201,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
           : "Skipping Chrome cookie sync (--browser-no-cookie-sync)",
       );
     }
+    await clearChatGptConversationCookies(Network, logger);
 
     if (cookieSyncEnabled && !manualLogin && (appliedCookies ?? 0) === 0 && !config.inlineCookies) {
       // Learned: if the profile has no ChatGPT cookies, browser mode will just bounce to login.
@@ -2849,6 +2850,7 @@ async function runRemoteBrowserMode(
 
     // Skip cookie sync for remote Chrome - it already has cookies
     logger("Skipping cookie sync for remote Chrome (using existing session)");
+    await clearChatGptConversationCookies(Network, logger);
 
     if (config.resumeConversationUrl) {
       await navigateToChatGPT(Page, Runtime, config.resumeConversationUrl, logger);

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -23,7 +23,7 @@ import {
   closeRemoteChromeTarget,
   closeBlankChromeTabs,
 } from "./chromeLifecycle.js";
-import { clearChatGptConversationCookies, syncCookies } from "./cookies.js";
+import { clearStaleChatGptConversationCookies, syncCookies } from "./cookies.js";
 import {
   navigateToChatGPT,
   navigateToPromptReadyWithFallback,
@@ -1106,7 +1106,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
       } else {
         const strictTabIsolation = Boolean(manualLogin && reusedChrome);
         const devtoolsRetries = manualLogin ? 6 : 0;
-        const connection = await connectWithNewTab(chrome.port, logger, config.url, chromeHost, {
+        const connection = await connectWithNewTab(chrome.port, logger, "about:blank", chromeHost, {
           fallbackToDefault: !strictTabIsolation,
           retries: devtoolsRetries,
           retryDelayMs: 500,
@@ -1142,7 +1142,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
     });
     const raceWithDisconnect = <T>(promise: Promise<T>): Promise<T> =>
       Promise.race([promise, disconnectPromise]);
-    const { Network, Page, Runtime, Input, DOM } = client;
+    const { Network, Page, Runtime, Input, DOM, Target } = client;
 
     if (!config.headless && config.hideWindow) {
       await hideChromeWindow(chrome, logger);
@@ -1201,7 +1201,12 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
           : "Skipping Chrome cookie sync (--browser-no-cookie-sync)",
       );
     }
-    await clearChatGptConversationCookies(Network, logger);
+    await clearStaleChatGptConversationCookies(Network, Target, logger, {
+      preserveConversationIds: [
+        extractConversationIdFromUrl(config.resumeConversationUrl ?? ""),
+        extractConversationIdFromUrl(lastUrl ?? ""),
+      ],
+    });
 
     if (cookieSyncEnabled && !manualLogin && (appliedCookies ?? 0) === 0 && !config.inlineCookies) {
       // Learned: if the profile has no ChatGPT cookies, browser mode will just bounce to login.
@@ -2797,9 +2802,16 @@ async function runRemoteBrowserMode(
         `Attached to existing remote ChatGPT tab ${attached.targetId}${attached.tab.url ? ` (${attached.tab.url})` : ""}`,
       );
     } else {
-      connection = await connectToRemoteChrome(host, port, logger, config.url, browserWSEndpoint, {
-        approvalWaitMs: config.attachRunning && browserWSEndpoint ? 20_000 : undefined,
-      });
+      connection = await connectToRemoteChrome(
+        host,
+        port,
+        logger,
+        "about:blank",
+        browserWSEndpoint,
+        {
+          approvalWaitMs: config.attachRunning && browserWSEndpoint ? 20_000 : undefined,
+        },
+      );
       client = connection.client;
       remoteTargetId = connection.targetId ?? null;
       ownsTarget = true;
@@ -2816,7 +2828,7 @@ async function runRemoteBrowserMode(
       connectionClosedUnexpectedly = true;
     };
     client.on("disconnect", markConnectionLost);
-    const { Network, Page, Runtime, Input, DOM } = client;
+    const { Network, Page, Runtime, Input, DOM, Target } = client;
 
     const domainEnablers = [Network.enable({}), Page.enable(), Runtime.enable()];
     if (DOM && typeof DOM.enable === "function") {
@@ -2850,7 +2862,12 @@ async function runRemoteBrowserMode(
 
     // Skip cookie sync for remote Chrome - it already has cookies
     logger("Skipping cookie sync for remote Chrome (using existing session)");
-    await clearChatGptConversationCookies(Network, logger);
+    await clearStaleChatGptConversationCookies(Network, Target, logger, {
+      preserveConversationIds: [
+        extractConversationIdFromUrl(config.resumeConversationUrl ?? ""),
+        extractConversationIdFromUrl(lastUrl ?? ""),
+      ],
+    });
 
     if (config.resumeConversationUrl) {
       await navigateToChatGPT(Page, Runtime, config.resumeConversationUrl, logger);

--- a/src/browser/projectSourcesRunner.ts
+++ b/src/browser/projectSourcesRunner.ts
@@ -10,7 +10,7 @@ import {
   registerTerminationHooks,
 } from "./chromeLifecycle.js";
 import { resolveBrowserConfig } from "./config.js";
-import { syncCookies } from "./cookies.js";
+import { clearStaleChatGptConversationCookies, syncCookies } from "./cookies.js";
 import {
   installJavaScriptDialogAutoDismissal,
   navigateToChatGPT,
@@ -180,7 +180,7 @@ export async function runBrowserProjectSources(
     const raceWithDisconnect = <T>(promise: Promise<T>): Promise<T> =>
       Promise.race([promise, disconnectPromise]);
 
-    const { Network, Page, Runtime, Input, DOM } = client;
+    const { Network, Page, Runtime, Input, DOM, Target } = client;
     if (!config.headless && config.hideWindow) {
       await hideChromeWindow(chrome, logger);
     }
@@ -200,6 +200,7 @@ export async function runBrowserProjectSources(
       manualLogin,
       logger,
     });
+    await clearStaleChatGptConversationCookies(Network, Target, logger);
 
     await raceWithDisconnect(navigateToChatGPT(Page, Runtime, CHATGPT_URL, logger));
     await raceWithDisconnect(

--- a/src/browser/reattach.ts
+++ b/src/browser/reattach.ts
@@ -20,7 +20,7 @@ import {
   listRemoteChromeTargets,
 } from "./chromeLifecycle.js";
 import { resolveBrowserConfig } from "./config.js";
-import { syncCookies } from "./cookies.js";
+import { clearStaleChatGptConversationCookies, syncCookies } from "./cookies.js";
 import { CHATGPT_URL } from "./constants.js";
 import { buildConversationTurnListExpression } from "./conversationTurns.js";
 import { cleanupStaleProfileState } from "./profileState.js";
@@ -271,7 +271,7 @@ async function resumeBrowserSessionViaNewChrome(
   const chrome = await launchChrome(resolved, userDataDir, logger);
   const chromeHost = (chrome as unknown as { host?: string }).host ?? "127.0.0.1";
   const client = await connectToChrome(chrome.port, logger, chromeHost);
-  const { Network, Page, Runtime, DOM } = client;
+  const { Network, Page, Runtime, DOM, Target } = client;
 
   if (Runtime?.enable) {
     await Runtime.enable();
@@ -293,6 +293,14 @@ async function resumeBrowserSessionViaNewChrome(
       waitMs: resolved.cookieSyncWaitMs ?? 0,
     });
   }
+
+  await clearStaleChatGptConversationCookies(Network, Target, logger, {
+    preserveConversationIds: [
+      runtime.conversationId,
+      extractConversationIdFromUrl(runtime.tabUrl ?? ""),
+      extractConversationIdFromUrl(resolved.url),
+    ],
+  });
 
   await navigateToChatGPT(Page, Runtime, CHATGPT_URL, logger);
   await ensureNotBlocked(Runtime, resolved.headless, logger);

--- a/tests/browser/cookies.test.ts
+++ b/tests/browser/cookies.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import {
-  clearChatGptConversationCookies,
+  clearStaleChatGptConversationCookies,
   syncCookies,
   ChromeCookieSyncError,
 } from "../../src/browser/cookies.js";
@@ -16,23 +16,33 @@ beforeEach(() => {
   logger.mockReset();
 });
 
-describe("clearChatGptConversationCookies", () => {
-  test("deletes only ChatGPT conv cookies", async () => {
+describe("clearStaleChatGptConversationCookies", () => {
+  test("deletes only stale ChatGPT conversation keys", async () => {
     const deleteCookies = vi.fn().mockResolvedValue(undefined);
     const Network = {
       getAllCookies: vi.fn().mockResolvedValue({
         cookies: [
           { name: "conv_key_123", domain: "chatgpt.com", path: "/" },
           { name: "conv_key_456", domain: ".chat.openai.com", path: "/" },
+          { name: "conv_key_active-open", domain: ".chatgpt.com", path: "/" },
           { name: "__Secure-next-auth.session-token", domain: "chatgpt.com", path: "/" },
+          { name: "conv_tracking", domain: "chatgpt.com", path: "/" },
           { name: "Conversion", domain: "www.googleadservices.com", path: "/" },
           { name: "conv_tracking", domain: "example.com", path: "/" },
         ],
       }),
       deleteCookies,
     } as unknown as ChromeClient["Network"];
+    const Target = {
+      getTargets: vi.fn().mockResolvedValue({
+        targetInfos: [
+          { type: "page", url: "https://chatgpt.com/c/active-open" },
+          { type: "page", url: "https://example.com/c/not-chatgpt" },
+        ],
+      }),
+    } as unknown as ChromeClient["Target"];
 
-    const deleted = await clearChatGptConversationCookies(Network, logger);
+    const deleted = await clearStaleChatGptConversationCookies(Network, Target, logger);
 
     expect(deleted).toBe(2);
     expect(deleteCookies).toHaveBeenCalledTimes(2);
@@ -49,6 +59,34 @@ describe("clearChatGptConversationCookies", () => {
     expect(logger).toHaveBeenCalledWith("[cookies] Cleared 2 stale ChatGPT conversation cookies.");
   });
 
+  test("preserves keys for conversations that may be resumed", async () => {
+    const deleteCookies = vi.fn().mockResolvedValue(undefined);
+    const Network = {
+      getAllCookies: vi.fn().mockResolvedValue({
+        cookies: [
+          { name: "conv_key_active-id", domain: ".chatgpt.com", path: "/" },
+          { name: "conv_key_stale-id", domain: ".chatgpt.com", path: "/" },
+        ],
+      }),
+      deleteCookies,
+    } as unknown as ChromeClient["Network"];
+    const Target = {
+      getTargets: vi.fn().mockResolvedValue({ targetInfos: [] }),
+    } as unknown as ChromeClient["Target"];
+
+    const deleted = await clearStaleChatGptConversationCookies(Network, Target, logger, {
+      preserveConversationIds: [undefined, "active-id"],
+    });
+
+    expect(deleted).toBe(1);
+    expect(deleteCookies).toHaveBeenCalledOnce();
+    expect(deleteCookies).toHaveBeenCalledWith({
+      name: "conv_key_stale-id",
+      domain: ".chatgpt.com",
+      path: "/",
+    });
+  });
+
   test("continues when individual stale cookie deletion fails", async () => {
     const deleteCookies = vi
       .fn()
@@ -63,12 +101,15 @@ describe("clearChatGptConversationCookies", () => {
       }),
       deleteCookies,
     } as unknown as ChromeClient["Network"];
+    const Target = {
+      getTargets: vi.fn().mockResolvedValue({ targetInfos: [] }),
+    } as unknown as ChromeClient["Target"];
 
-    const deleted = await clearChatGptConversationCookies(Network, logger);
+    const deleted = await clearStaleChatGptConversationCookies(Network, Target, logger);
 
     expect(deleted).toBe(1);
     expect(logger).toHaveBeenCalledWith(
-      expect.stringContaining("Failed to clear stale ChatGPT conversation cookie conv_key_failed"),
+      "[cookies] Failed to clear a stale ChatGPT conversation cookie: locked",
     );
     expect(logger).toHaveBeenCalledWith("[cookies] Cleared 1 stale ChatGPT conversation cookie.");
   });
@@ -78,12 +119,33 @@ describe("clearChatGptConversationCookies", () => {
       getAllCookies: vi.fn().mockRejectedValue(new Error("devtools unavailable")),
       deleteCookies: vi.fn(),
     } as unknown as ChromeClient["Network"];
+    const Target = {
+      getTargets: vi.fn().mockResolvedValue({ targetInfos: [] }),
+    } as unknown as ChromeClient["Target"];
 
-    const deleted = await clearChatGptConversationCookies(Network, logger);
+    const deleted = await clearStaleChatGptConversationCookies(Network, Target, logger);
 
     expect(deleted).toBe(0);
     expect(logger).toHaveBeenCalledWith(
       "[cookies] Failed to inspect ChatGPT conversation cookies: devtools unavailable",
+    );
+  });
+
+  test("skips cleanup when active conversation discovery fails", async () => {
+    const Network = {
+      getAllCookies: vi.fn(),
+      deleteCookies: vi.fn(),
+    } as unknown as ChromeClient["Network"];
+    const Target = {
+      getTargets: vi.fn().mockRejectedValue(new Error("target discovery unavailable")),
+    } as unknown as ChromeClient["Target"];
+
+    const deleted = await clearStaleChatGptConversationCookies(Network, Target, logger);
+
+    expect(deleted).toBe(0);
+    expect(Network.getAllCookies).not.toHaveBeenCalled();
+    expect(logger).toHaveBeenCalledWith(
+      "[cookies] Failed to inspect active ChatGPT conversations; skipping stale cookie cleanup: target discovery unavailable",
     );
   });
 });

--- a/tests/browser/cookies.test.ts
+++ b/tests/browser/cookies.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { syncCookies, ChromeCookieSyncError } from "../../src/browser/cookies.js";
+import {
+  clearChatGptConversationCookies,
+  syncCookies,
+  ChromeCookieSyncError,
+} from "../../src/browser/cookies.js";
 import type { ChromeClient } from "../../src/browser/types.js";
 
 const getCookies = vi.hoisted(() => vi.fn());
@@ -10,6 +14,78 @@ const logger = vi.fn();
 beforeEach(() => {
   getCookies.mockReset();
   logger.mockReset();
+});
+
+describe("clearChatGptConversationCookies", () => {
+  test("deletes only ChatGPT conv cookies", async () => {
+    const deleteCookies = vi.fn().mockResolvedValue(undefined);
+    const Network = {
+      getAllCookies: vi.fn().mockResolvedValue({
+        cookies: [
+          { name: "conv_key_123", domain: "chatgpt.com", path: "/" },
+          { name: "conv_key_456", domain: ".chat.openai.com", path: "/" },
+          { name: "__Secure-next-auth.session-token", domain: "chatgpt.com", path: "/" },
+          { name: "Conversion", domain: "www.googleadservices.com", path: "/" },
+          { name: "conv_tracking", domain: "example.com", path: "/" },
+        ],
+      }),
+      deleteCookies,
+    } as unknown as ChromeClient["Network"];
+
+    const deleted = await clearChatGptConversationCookies(Network, logger);
+
+    expect(deleted).toBe(2);
+    expect(deleteCookies).toHaveBeenCalledTimes(2);
+    expect(deleteCookies).toHaveBeenCalledWith({
+      name: "conv_key_123",
+      domain: "chatgpt.com",
+      path: "/",
+    });
+    expect(deleteCookies).toHaveBeenCalledWith({
+      name: "conv_key_456",
+      domain: ".chat.openai.com",
+      path: "/",
+    });
+    expect(logger).toHaveBeenCalledWith("[cookies] Cleared 2 stale ChatGPT conversation cookies.");
+  });
+
+  test("continues when individual stale cookie deletion fails", async () => {
+    const deleteCookies = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("locked"))
+      .mockResolvedValueOnce(undefined);
+    const Network = {
+      getAllCookies: vi.fn().mockResolvedValue({
+        cookies: [
+          { name: "conv_key_failed", domain: "chatgpt.com", path: "/" },
+          { name: "conv_key_ok", domain: "chatgpt.com", path: "/" },
+        ],
+      }),
+      deleteCookies,
+    } as unknown as ChromeClient["Network"];
+
+    const deleted = await clearChatGptConversationCookies(Network, logger);
+
+    expect(deleted).toBe(1);
+    expect(logger).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to clear stale ChatGPT conversation cookie conv_key_failed"),
+    );
+    expect(logger).toHaveBeenCalledWith("[cookies] Cleared 1 stale ChatGPT conversation cookie.");
+  });
+
+  test("does not fail browser runs when cookies cannot be inspected", async () => {
+    const Network = {
+      getAllCookies: vi.fn().mockRejectedValue(new Error("devtools unavailable")),
+      deleteCookies: vi.fn(),
+    } as unknown as ChromeClient["Network"];
+
+    const deleted = await clearChatGptConversationCookies(Network, logger);
+
+    expect(deleted).toBe(0);
+    expect(logger).toHaveBeenCalledWith(
+      "[cookies] Failed to inspect ChatGPT conversation cookies: devtools unavailable",
+    );
+  });
 });
 
 describe("syncCookies", () => {


### PR DESCRIPTION
## Summary

- Open new local and remote targets at `about:blank`, so stale cookies can be removed before the first ChatGPT request.
- Delete only `conv_key_*` cookies on ChatGPT domains.
- Preserve keys belonging to every currently open ChatGPT conversation and any explicitly resumed conversation.
- Skip cleanup if active-target discovery fails; cookie cleanup must not risk another concurrent Oracle run.
- Cover normal local runs, remote Chrome, reattach, and Project Sources.

## Why

Per-conversation keys can accumulate until ChatGPT requests exceed header limits. A public reproduction recorded 63 `conv_key_*` cookies causing HTTP 431, with service restored after deleting those volatile keys: https://github.com/ratacat/pro-cli/blob/f4dbaafe572e662cfd6d40e5c296566dd0a80e03/docs/chatgpt-431-cookie-bloat.md

The original branch cleaned after the new target had already navigated and omitted reattach/Project Sources. It also deleted every conversation key, including keys for concurrent or resumed work. This revision fixes those ordering and ownership boundaries.

## Verification

- `pnpm test`: 1,415 passed, 43 skipped
- `pnpm run check`
- `pnpm run build`
- Autoreview clean

Authenticated remote-Chrome proof seeded twelve stale 2.5 KB keys plus one small key for a synthetic open conversation (30,016 value bytes total). Oracle:

1. opened its dedicated target at `about:blank`;
2. reported clearing exactly twelve stale keys;
3. navigated to ChatGPT only afterward;
4. passed login and returned the exact requested marker;
5. left zero stale proof keys while preserving the open conversation key.

No cookie values are logged. Thanks @jung0han for the original patch.
