### PR TITLE
fix(browser): stop-control liveness fallback when thinking selectors miss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Browser/Bridge: improve ChatGPT ZIP artifact capture before bridge transfer by broadening sandbox/file-card/download-control discovery, adding sanitized direct-download diagnostics, and falling back to scoped browser downloads when sandbox fetches fail. Thanks @DK625!
 - Browser: wait up to eight seconds for the ChatGPT model/effort composer pill to mount before failing explicit selection, while leaving `option-not-found` failures immediate. Thanks @gustavosmendes!
 - Browser: activate ChatGPT Deep Research after the final composer reset, select the current tools-menu row shape, and use trusted mouse clicks for Deep Research and send actions so the request reaches the real research-plan flow instead of being submitted as an ordinary Pro prompt. Fixes #281. Thanks @wbzjt!
+- Browser: report `response streaming` from the thinking-status heartbeat when a visible stop control is the only remaining liveness signal, so ChatGPT selector drift no longer logs an active generation as `no thinking status detected yet`. Fixes #284.
 
 ## 0.15.0 — 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Browser/Bridge: improve ChatGPT ZIP artifact capture before bridge transfer by broadening sandbox/file-card/download-control discovery, adding sanitized direct-download diagnostics, and falling back to scoped browser downloads when sandbox fetches fail. Thanks @DK625!
 - Browser: wait up to eight seconds for the ChatGPT model/effort composer pill to mount before failing explicit selection, while leaving `option-not-found` failures immediate. Thanks @gustavosmendes!
 - Browser: activate ChatGPT Deep Research after the final composer reset, select the current tools-menu row shape, and use trusted mouse clicks for Deep Research and send actions so the request reaches the real research-plan flow instead of being submitted as an ordinary Pro prompt. Fixes #281. Thanks @wbzjt!
-- Browser: report `response streaming` from the thinking-status heartbeat when a visible stop control is the only remaining liveness signal, so ChatGPT selector drift no longer logs an active generation as `no thinking status detected yet`. Fixes #284.
+- Browser: report `response streaming` when a visible stop control is the only remaining liveness signal, and share that signal with completion capture so selector drift cannot finalize a still-streaming answer. Refs #284. Thanks @StartupBros!
 
 ## 0.15.0 — 2026-06-19
 

--- a/src/browser/actions/assistantResponse.ts
+++ b/src/browser/actions/assistantResponse.ts
@@ -5,7 +5,7 @@ import {
   CONVERSATION_TURN_SELECTOR,
   COPY_BUTTON_SELECTOR,
   FINISHED_ACTIONS_SELECTOR,
-  STOP_BUTTON_SELECTOR,
+  STOP_BUTTON_SELECTORS,
 } from "../constants.js";
 import { delay } from "../utils.js";
 import {
@@ -16,6 +16,7 @@ import {
 import { buildClickDispatcher } from "./domEvents.js";
 
 const ASSISTANT_POLL_TIMEOUT_ERROR = "assistant-response-watchdog-timeout";
+const STOP_CONTROL_SELECTOR = STOP_BUTTON_SELECTORS.join(", ");
 const THINKING_STATUS_LABELS = [
   "thinking",
   "pro thinking",
@@ -59,8 +60,8 @@ function isAnswerNowPlaceholderText(normalized: string): boolean {
 
 function buildActiveThinkingStatusPredicateJs(fnName: string): string {
   const labelsLiteral = JSON.stringify(THINKING_STATUS_LABELS);
-  const stopSelectorLiteral = JSON.stringify(STOP_BUTTON_SELECTOR);
-  return `const ${fnName} = (snapshot) => {
+  return `${buildStopButtonVisibilityPredicateJs("isStopControlVisible")}
+  const ${fnName} = (snapshot) => {
     const normalized = String(snapshot?.text ?? '').toLowerCase().replace(/\\s+/g, ' ').trim();
     if (!normalized) return false;
     const labels = ${labelsLiteral};
@@ -68,7 +69,7 @@ function buildActiveThinkingStatusPredicateJs(fnName: string): string {
       labels.includes(normalized) ||
       (normalized.startsWith('thought for ') && normalized.length <= 40) ||
       (normalized.startsWith('pro thinking') && normalized.length <= 40);
-    return matches && Boolean(document.querySelector(${stopSelectorLiteral}));
+    return matches && isStopControlVisible();
   };`;
 }
 
@@ -552,7 +553,7 @@ async function pollAssistantCompletion(
 async function isStopButtonVisible(Runtime: ChromeClient["Runtime"]): Promise<boolean> {
   try {
     const { result } = await Runtime.evaluate({
-      expression: `Boolean(document.querySelector('${STOP_BUTTON_SELECTOR}'))`,
+      expression: buildStopButtonVisibilityExpression(),
       returnByValue: true,
     });
     return Boolean(result?.value);
@@ -560,6 +561,33 @@ async function isStopButtonVisible(Runtime: ChromeClient["Runtime"]): Promise<bo
     return false;
   }
 }
+
+function buildStopButtonVisibilityExpression(): string {
+  return `(() => {
+    ${buildStopButtonVisibilityPredicateJs("isStopControlVisible")}
+    return isStopControlVisible();
+  })()`;
+}
+
+function buildStopButtonVisibilityPredicateJs(fnName: string): string {
+  const selectorLiteral = JSON.stringify(STOP_CONTROL_SELECTOR);
+  return `const ${fnName} = () => {
+    const isVisible = (node) => {
+      if (!(node instanceof HTMLElement)) return false;
+      const rect = node.getBoundingClientRect();
+      if (!rect || rect.width <= 0 || rect.height <= 0) return false;
+      const style = window.getComputedStyle(node);
+      return !(
+        style.display === 'none' ||
+        style.visibility === 'hidden' ||
+        (style.opacity !== '' && Number(style.opacity) === 0)
+      );
+    };
+    return Array.from(document.querySelectorAll(${selectorLiteral})).some((node) => isVisible(node));
+  };`;
+}
+
+export const buildStopButtonVisibilityExpressionForTest = buildStopButtonVisibilityExpression;
 
 async function isCompletionVisible(Runtime: ChromeClient["Runtime"]): Promise<boolean> {
   try {
@@ -725,7 +753,7 @@ function buildResponseObserverExpression(
   return `(() => {
     ${buildClickDispatcher()}
     const SELECTORS = ${selectorsLiteral};
-    const STOP_SELECTOR = '${STOP_BUTTON_SELECTOR}';
+    const STOP_SELECTOR = ${JSON.stringify(STOP_CONTROL_SELECTOR)};
     const FINISHED_SELECTOR = '${FINISHED_ACTIONS_SELECTOR}';
     const CONVERSATION_SELECTOR = ${conversationLiteral};
     const ASSISTANT_SELECTOR = ${assistantLiteral};
@@ -783,7 +811,6 @@ function buildResponseObserverExpression(
     const captureViaObserver = () =>
       new Promise((resolve, reject) => {
         const deadline = Date.now() + ${timeoutMs};
-        let stopInterval = null;
         let timeoutId = null;
         let cleanedUp = false;
         let observer = null;
@@ -792,10 +819,6 @@ function buildResponseObserverExpression(
         const cleanup = () => {
           if (cleanedUp) return;
           cleanedUp = true;
-          if (stopInterval) {
-            clearInterval(stopInterval);
-            stopInterval = null;
-          }
           if (timeoutId) {
             clearTimeout(timeoutId);
             timeoutId = null;
@@ -846,20 +869,6 @@ function buildResponseObserverExpression(
 
         observer = new MutationObserver(observerCallback);
         observer.observe(document.body, { childList: true, subtree: true, characterData: true });
-
-        stopInterval = setInterval(() => {
-          if (cleanedUp) return;
-          const stop = document.querySelector(STOP_SELECTOR);
-          if (!stop) {
-            return;
-          }
-          const isStopButton =
-            stop.getAttribute('data-testid') === 'stop-button' || stop.getAttribute('aria-label')?.toLowerCase()?.includes('stop');
-          if (isStopButton) {
-            return;
-          }
-          dispatchClickSequence(stop);
-        }, 500);
 
         timeoutId = setTimeout(() => {
           cleanup();

--- a/src/browser/actions/thinkingStatus.ts
+++ b/src/browser/actions/thinkingStatus.ts
@@ -1,6 +1,10 @@
 import type { BrowserLogger, ChromeClient } from "../types.js";
 import { formatElapsed } from "../../oracle/format.js";
-import { ASSISTANT_ROLE_SELECTOR, CONVERSATION_TURN_SELECTOR } from "../constants.js";
+import {
+  ASSISTANT_ROLE_SELECTOR,
+  CONVERSATION_TURN_SELECTOR,
+  STOP_BUTTON_SELECTOR,
+} from "../constants.js";
 
 const THINKING_STALE_HINT_MS = 10 * 60_000;
 
@@ -162,6 +166,7 @@ async function readThinkingStatus(
 
 const SAFE_THINKING_STATUS_MESSAGES = new Set([
   "active",
+  "response streaming",
   "thinking sidecar active",
   "thinking sidecar opened",
 ]);
@@ -194,13 +199,20 @@ function buildThinkingStatusExpression(): string {
     '[aria-live="polite"]',
   ];
   const keywords = ["pro thinking", "thinking", "reasoning"];
+  const stopSelectors = [
+    STOP_BUTTON_SELECTOR,
+    '[data-testid="composer-stop-button"]',
+    'button[aria-label*="stop" i]',
+  ];
   const selectorLiteral = JSON.stringify(selectors);
   const keywordsLiteral = JSON.stringify(keywords);
+  const stopSelectorsLiteral = JSON.stringify(stopSelectors);
   return `(async () => {
     const CONVERSATION_SELECTOR = ${conversationLiteral};
     const ASSISTANT_SELECTOR = ${assistantLiteral};
     const selectors = ${selectorLiteral};
     const keywords = ${keywordsLiteral};
+    const stopSelectors = ${stopSelectorsLiteral};
     const normalize = (value) =>
       String(value || '')
         .normalize('NFD')
@@ -419,6 +431,20 @@ function buildThinkingStatusExpression(): string {
           source: 'inline',
         };
       }
+    }
+    // Last-resort liveness fallback: selector drift can hide every thinking
+    // indicator while a response is still generating, and returning null here
+    // reads as "dead" downstream. The stop/interrupt control is a stable,
+    // language-independent signal that generation is active; it lives in the
+    // composer, so isComposerAdjacent must not filter it.
+    const stopVisible = stopSelectors.some((selector) =>
+      Array.from(document.querySelectorAll(selector)).some((node) => isVisible(node)),
+    );
+    if (stopVisible) {
+      return {
+        message: 'response streaming',
+        source: 'inline',
+      };
     }
     return null;
   })()`;

--- a/src/browser/actions/thinkingStatus.ts
+++ b/src/browser/actions/thinkingStatus.ts
@@ -3,7 +3,7 @@ import { formatElapsed } from "../../oracle/format.js";
 import {
   ASSISTANT_ROLE_SELECTOR,
   CONVERSATION_TURN_SELECTOR,
-  STOP_BUTTON_SELECTOR,
+  STOP_BUTTON_SELECTORS,
 } from "../constants.js";
 
 const THINKING_STALE_HINT_MS = 10 * 60_000;
@@ -199,20 +199,16 @@ function buildThinkingStatusExpression(): string {
     '[aria-live="polite"]',
   ];
   const keywords = ["pro thinking", "thinking", "reasoning"];
-  const stopSelectors = [
-    STOP_BUTTON_SELECTOR,
-    '[data-testid="composer-stop-button"]',
-    'button[aria-label*="stop" i]',
-  ];
+  const stopSelector = STOP_BUTTON_SELECTORS.join(", ");
   const selectorLiteral = JSON.stringify(selectors);
   const keywordsLiteral = JSON.stringify(keywords);
-  const stopSelectorsLiteral = JSON.stringify(stopSelectors);
+  const stopSelectorLiteral = JSON.stringify(stopSelector);
   return `(async () => {
     const CONVERSATION_SELECTOR = ${conversationLiteral};
     const ASSISTANT_SELECTOR = ${assistantLiteral};
     const selectors = ${selectorLiteral};
     const keywords = ${keywordsLiteral};
-    const stopSelectors = ${stopSelectorsLiteral};
+    const stopSelector = ${stopSelectorLiteral};
     const normalize = (value) =>
       String(value || '')
         .normalize('NFD')
@@ -437,8 +433,8 @@ function buildThinkingStatusExpression(): string {
     // reads as "dead" downstream. The stop/interrupt control is a stable,
     // language-independent signal that generation is active; it lives in the
     // composer, so isComposerAdjacent must not filter it.
-    const stopVisible = stopSelectors.some((selector) =>
-      Array.from(document.querySelectorAll(selector)).some((node) => isVisible(node)),
+    const stopVisible = Array.from(document.querySelectorAll(stopSelector)).some((node) =>
+      isVisible(node),
     );
     if (stopVisible) {
       return {

--- a/src/browser/constants.ts
+++ b/src/browser/constants.ts
@@ -72,6 +72,11 @@ export const UPLOAD_STATUS_SELECTORS = [
 ];
 
 export const STOP_BUTTON_SELECTOR = '[data-testid="stop-button"]';
+export const STOP_BUTTON_SELECTORS = [
+  STOP_BUTTON_SELECTOR,
+  '[data-testid="composer-stop-button"]',
+  'button[aria-label*="stop" i]',
+];
 export const SEND_BUTTON_SELECTORS = [
   'button[data-testid="send-button"]',
   'button[data-testid*="composer-send"]',

--- a/tests/browser/assistantResponseStatus.test.ts
+++ b/tests/browser/assistantResponseStatus.test.ts
@@ -3,15 +3,28 @@ import { describe, expect, test } from "vitest";
 import {
   buildActiveThinkingStatusPredicateJsForTest,
   buildAssistantSnapshotExpressionForTest,
+  buildStopButtonVisibilityExpressionForTest,
   matchesThinkingStatusLabelForTest,
 } from "../../src/browser/actions/assistantResponse.js";
+import { STOP_BUTTON_SELECTORS } from "../../src/browser/constants.js";
 
 function evaluatePredicate(text: string, generating: boolean): boolean {
   const predicate = buildActiveThinkingStatusPredicateJsForTest("isActiveThinkingStatus");
+  class FakeHtmlElement {
+    getBoundingClientRect() {
+      return { width: 120, height: 40 };
+    }
+  }
   const context = createContext({
+    Array,
+    Number,
     String,
+    HTMLElement: FakeHtmlElement,
     document: {
-      querySelector: () => (generating ? {} : null),
+      querySelectorAll: () => (generating ? [new FakeHtmlElement()] : []),
+    },
+    window: {
+      getComputedStyle: () => ({ display: "block", visibility: "visible", opacity: "1" }),
     },
   });
   return new Script(
@@ -47,5 +60,73 @@ describe("assistant thinking-status capture", () => {
     expect(expression).toContain("isActiveThinkingStatus");
     expect(expression).toContain('data-testid=\\"stop-button\\"');
     expect(expression).toContain("const fallback = extractFallback();");
+  });
+
+  test("shares all stop-control selectors with completion capture", () => {
+    let observedSelector = "";
+    new Script(buildStopButtonVisibilityExpressionForTest()).runInContext(
+      createContext({
+        Array,
+        Number,
+        HTMLElement: class {},
+        document: {
+          querySelectorAll: (selector: string) => {
+            observedSelector = selector;
+            return [];
+          },
+        },
+        window: { getComputedStyle: () => ({}) },
+      }),
+    );
+    expect(observedSelector).toBe(STOP_BUTTON_SELECTORS.join(", "));
+  });
+
+  test.each([
+    {
+      width: 120,
+      height: 40,
+      display: "block",
+      visibility: "visible",
+      opacity: "1",
+      expected: true,
+    },
+    {
+      width: 0,
+      height: 40,
+      display: "block",
+      visibility: "visible",
+      opacity: "1",
+      expected: false,
+    },
+    {
+      width: 120,
+      height: 40,
+      display: "none",
+      visibility: "visible",
+      opacity: "1",
+      expected: false,
+    },
+  ])("requires a visible stop control before blocking completion: %o", (fixture) => {
+    class FakeHtmlElement {
+      getBoundingClientRect() {
+        return { width: fixture.width, height: fixture.height };
+      }
+    }
+    const result = new Script(buildStopButtonVisibilityExpressionForTest()).runInContext(
+      createContext({
+        Array,
+        Number,
+        HTMLElement: FakeHtmlElement,
+        document: { querySelectorAll: () => [new FakeHtmlElement()] },
+        window: {
+          getComputedStyle: () => ({
+            display: fixture.display,
+            visibility: fixture.visibility,
+            opacity: fixture.opacity,
+          }),
+        },
+      }),
+    );
+    expect(result).toBe(fixture.expected);
   });
 });

--- a/tests/browser/thinking.test.ts
+++ b/tests/browser/thinking.test.ts
@@ -304,6 +304,10 @@ describe("formatThinkingLog", () => {
     expect(sanitizeThinkingText("Thinking: check auth before tests")).toBe("active");
   });
 
+  test("preserves the response streaming liveness message", () => {
+    expect(sanitizeThinkingText("response streaming")).toBe("response streaming");
+  });
+
   test("normalizes sidecar progress snapshots from the browser", async () => {
     const runtime = {
       evaluate: vi.fn().mockResolvedValue({
@@ -484,5 +488,32 @@ describe("thinking status browser expression", () => {
 
     expect(clicked).toBe(false);
     expect(result).toBeNull();
+  });
+
+  test("falls back to the visible stop control when no thinking indicator matches", async () => {
+    const document = new FakeDocument();
+    const composer = new FakeElement("div", "", { "data-testid": "composer-footer-actions" });
+    composer.append(
+      new FakeElement("button", "", {
+        "data-testid": "stop-button",
+        "aria-label": "Stop streaming",
+      }),
+    );
+    document.append(composer);
+
+    const result = await runThinkingStatusExpression(document);
+
+    expect(result).toEqual({ message: "response streaming", source: "inline" });
+  });
+
+  test("prefers a thinking indicator over the stop control fallback", async () => {
+    const document = new FakeDocument();
+    const composer = new FakeElement("div", "", { "data-testid": "composer-footer-actions" });
+    composer.append(new FakeElement("button", "", { "data-testid": "stop-button" }));
+    document.append(new FakeElement("span", "Thinking", { class: "loading-shimmer" }), composer);
+
+    const result = await runThinkingStatusExpression(document);
+
+    expect(result).toEqual({ message: "active", source: "inline" });
   });
 });

--- a/tests/browser/thinking.test.ts
+++ b/tests/browser/thinking.test.ts
@@ -158,12 +158,16 @@ function matchesSelectorList(node: FakeElement, selector: string): boolean {
 }
 
 function matchesSimpleSelector(node: FakeElement, selector: string): boolean {
-  const tagMatch = selector.match(/^[a-z]+/i);
+  const caseInsensitiveAttrs = new Set(
+    [...selector.matchAll(/\[([a-zA-Z0-9_-]+)[^\]]*\s+i\]/g)].map((match) => match[1]),
+  );
+  const normalizedSelector = selector.replace(/\s+i\]/g, "]");
+  const tagMatch = normalizedSelector.match(/^[a-z]+/i);
   if (tagMatch && node.tagName.toLowerCase() !== tagMatch[0].toLowerCase()) {
     return false;
   }
 
-  const classMatches = [...selector.matchAll(/\.([a-zA-Z0-9_-]+)/g)];
+  const classMatches = [...normalizedSelector.matchAll(/\.([a-zA-Z0-9_-]+)/g)];
   for (const match of classMatches) {
     if (!node.className.split(/\s+/).includes(match[1] ?? "")) {
       return false;
@@ -171,17 +175,22 @@ function matchesSimpleSelector(node: FakeElement, selector: string): boolean {
   }
 
   const attrMatches = [
-    ...selector.matchAll(/\[([a-zA-Z0-9_-]+)([*^]?=)?(?:"([^"]*)"|'([^']*)'|([^\]]+))?\]/g),
+    ...normalizedSelector.matchAll(
+      /\[([a-zA-Z0-9_-]+)([*^]?=)?(?:"([^"]*)"|'([^']*)'|([^\]]+))?\]/g,
+    ),
   ];
   for (const match of attrMatches) {
     const attr = match[1] ?? "";
     const operator = match[2];
     const expected = match[3] ?? match[4] ?? match[5] ?? "";
-    const actual = node.getAttribute(attr);
+    const rawActual = node.getAttribute(attr);
+    const insensitive = caseInsensitiveAttrs.has(attr);
+    const actual = insensitive ? rawActual?.toLowerCase() : rawActual;
+    const comparableExpected = insensitive ? expected.toLowerCase() : expected;
     if (!operator && actual == null) return false;
-    if (operator === "=" && actual !== expected) return false;
-    if (operator === "*=" && !String(actual ?? "").includes(expected)) return false;
-    if (operator === "^=" && !String(actual ?? "").startsWith(expected)) return false;
+    if (operator === "=" && actual !== comparableExpected) return false;
+    if (operator === "*=" && !String(actual ?? "").includes(comparableExpected)) return false;
+    if (operator === "^=" && !String(actual ?? "").startsWith(comparableExpected)) return false;
   }
 
   return true;
@@ -490,20 +499,36 @@ describe("thinking status browser expression", () => {
     expect(result).toBeNull();
   });
 
-  test("falls back to the visible stop control when no thinking indicator matches", async () => {
+  test.each([
+    { "data-testid": "stop-button" },
+    { "data-testid": "composer-stop-button" },
+    { "aria-label": "Stop streaming" },
+  ] as Record<string, string>[])(
+    "falls back to a visible stop control when no thinking indicator matches: %o",
+    async (attrs) => {
+      const document = new FakeDocument();
+      const composer = new FakeElement("div", "", { "data-testid": "composer-footer-actions" });
+      composer.append(new FakeElement("button", "", attrs));
+      document.append(composer);
+
+      const result = await runThinkingStatusExpression(document);
+
+      expect(result).toEqual({ message: "response streaming", source: "inline" });
+    },
+  );
+
+  test("ignores a hidden stop control", async () => {
     const document = new FakeDocument();
-    const composer = new FakeElement("div", "", { "data-testid": "composer-footer-actions" });
-    composer.append(
-      new FakeElement("button", "", {
-        "data-testid": "stop-button",
-        "aria-label": "Stop streaming",
-      }),
+    document.append(
+      new FakeElement(
+        "button",
+        "",
+        { "data-testid": "composer-stop-button" },
+        visibleRect({ width: 0 }),
+      ),
     );
-    document.append(composer);
 
-    const result = await runThinkingStatusExpression(document);
-
-    expect(result).toEqual({ message: "response streaming", source: "inline" });
+    await expect(runThinkingStatusExpression(document)).resolves.toBeNull();
   });
 
   test("prefers a thinking indicator over the stop control fallback", async () => {


### PR DESCRIPTION
Refs #284. The stale remote-CDP conversation-target recovery described there remains open.

## Problem

The thinking-status monitor is selector/keyword based. When ChatGPT's UI drifts, every selector misses and the monitor logs `no thinking status detected yet` for an entire live generation — observed 2026-07-02 with 11+ minutes of active Pro Extended thinking reported as no-status. Because that line is the CLI's only liveness signal, downstream tooling (and humans) reasonably treat it as a dead submission and kill or re-run live sessions, double-spending Pro quota.

## Fix

Last-resort fallback in the status expression, evaluated only after all existing indicator paths miss: a **visible stop/interrupt control** means a response is actively generating, so report `{ message: 'response streaming', source: 'inline' }` instead of returning null. The stop control is a stable, language-independent signal (reuses the existing `STOP_BUTTON_SELECTOR` constant plus two drift-tolerant variants, mirroring how `assistantResponse.ts` layers them). `'response streaming'` is whitelisted in `SAFE_THINKING_STATUS_MESSAGES` so it survives sanitization. Deliberately NOT filtered by `isComposerAdjacent` (the stop control lives in the composer); existing indicator paths still take precedence.

Maintainer hardening shares the same visibility-aware stop-control selectors with assistant completion capture. This prevents a still-streaming response from being finalized when ChatGPT exposes an alternate stop control, while hidden controls do not block completion.

## Testing

- `pnpm run check`: clean.
- Focused thinking/completion coverage: 96 passed, 1 pre-existing skip.
- Full Vitest suite: 1,387 passed, 43 skipped.
- Real Chrome/CDP expression proof: visible alternate stop control reported `response streaming` and blocked completion; hidden control returned no heartbeat and did not block completion; richer thinking status retained precedence.
- Autoreview: clean, no actionable findings.
