### PR TITLE
fix(browser): persist runtime metadata and commit-probe diagnostics when prompt commit verification fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Browser: retain runtime, model-selection, and redacted prompt-commit diagnostics in failed session metadata when ChatGPT submission verification times out. Fixes #286. Thanks @LeoLin990405!
 - API: forward configured reasoning effort through custom OpenAI-compatible chat-completions gateways.
 - Browser: accept a stable, exact file-input name match when ChatGPT marks the composer ready but exposes no attachment chip or count, while still waiting through active uploads and rejecting missing or extra files. Fixes #275. Thanks @wangwllu!
 - Browser: avoid returning truncated Pro answers when completion controls appear during the thinking-to-answer transition. Thanks @xuan-wei!

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -888,20 +888,13 @@ async function verifyPromptCommitted(
     };
   })()`;
 
+  let lastProbe: CommitProbeState | undefined;
   while (Date.now() < deadline) {
     const { result } = await Runtime.evaluate({ expression: script, returnByValue: true });
-    const info = result.value as {
-      baseline?: number;
-      userMatched?: boolean;
-      prefixMatched?: boolean;
-      lastMatched?: boolean;
-      hasNewTurn?: boolean;
-      stopVisible?: boolean;
-      assistantVisible?: boolean;
-      composerCleared?: boolean;
-      inConversation?: boolean;
-      turnsCount?: number;
-    };
+    const info = result.value as CommitProbeState | undefined;
+    if (info && typeof info === "object") {
+      lastProbe = info;
+    }
     const turnsCount = (result.value as { turnsCount?: number } | undefined)?.turnsCount;
     const matchesPrompt = Boolean(info?.lastMatched || info?.userMatched || info?.prefixMatched);
     const baselineUnknown =
@@ -918,14 +911,13 @@ async function verifyPromptCommitted(
     }
     await delay(100);
   }
+  const finalProbe = await Runtime.evaluate({ expression: script, returnByValue: true })
+    .then((res) => res?.result?.value as CommitProbeState | undefined)
+    .catch(() => undefined);
+  const probe = finalProbe && typeof finalProbe === "object" ? finalProbe : lastProbe;
   if (logger) {
     logger(
-      `Prompt commit check failed; latest state: ${await Runtime.evaluate({
-        expression: script,
-        returnByValue: true,
-      })
-        .then((res) => JSON.stringify(res?.result?.value))
-        .catch(() => "unavailable")}`,
+      `Prompt commit check failed; latest state: ${probe ? JSON.stringify(probe) : "unavailable"}`,
     );
     await logDomFailure(Runtime, logger, "prompt-commit");
   }
@@ -940,7 +932,51 @@ async function verifyPromptCommitted(
       },
     );
   }
-  throw new Error("Prompt did not appear in conversation before timeout (send may have failed)");
+  throw new BrowserAutomationError(
+    "Prompt did not appear in conversation before timeout (send may have failed)",
+    {
+      stage: "submit-prompt",
+      code: "prompt-commit-timeout",
+      promptLength: prompt.trim().length,
+      timeoutMs,
+      commitProbe: probe ? summarizeCommitProbe(probe) : undefined,
+    },
+  );
+}
+
+interface CommitProbeState {
+  baseline?: number;
+  userMatched?: boolean;
+  prefixMatched?: boolean;
+  lastMatched?: boolean;
+  hasNewTurn?: boolean;
+  stopVisible?: boolean;
+  assistantVisible?: boolean;
+  composerCleared?: boolean;
+  inConversation?: boolean;
+  turnsCount?: number;
+  href?: string;
+  editorValue?: string;
+  fallbackValue?: string;
+  lastTurn?: string;
+}
+
+// Keep booleans/counts but replace free text with lengths so session metadata stays lean.
+function summarizeCommitProbe(probe: CommitProbeState): Record<string, unknown> {
+  return {
+    baseline: probe.baseline,
+    turnsCount: probe.turnsCount,
+    userMatched: probe.userMatched,
+    prefixMatched: probe.prefixMatched,
+    lastMatched: probe.lastMatched,
+    hasNewTurn: probe.hasNewTurn,
+    stopVisible: probe.stopVisible,
+    assistantVisible: probe.assistantVisible,
+    composerCleared: probe.composerCleared,
+    inConversation: probe.inConversation,
+    editorLength: typeof probe.editorValue === "string" ? probe.editorValue.length : undefined,
+    lastTurnLength: typeof probe.lastTurn === "string" ? probe.lastTurn.length : undefined,
+  };
 }
 
 // biome-ignore lint/style/useNamingConvention: test-only export used in vitest suite

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -883,6 +883,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
   let lastTargetId: string | undefined;
   let lastUrl: string | undefined;
   let promptSubmitted = false;
+  let modelSelectionEvidence: BrowserModelSelectionEvidence | undefined;
   let tabLease: BrowserTabLease | null = null;
   const emitRuntimeHint = async (): Promise<void> => {
     if (!chrome?.port) {
@@ -901,7 +902,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
       controllerPid: process.pid,
     };
     try {
-      await runtimeHintCb?.(hint);
+      await runtimeHintCb?.(hint, modelSelectionEvidence);
       await tabLease?.update({
         chromeHost,
         chromePort: chrome.port,
@@ -1073,7 +1074,6 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
   let answerMarkdown = "";
   let answerHtml = "";
   let runStatus: "attempted" | "complete" = "attempted";
-  let modelSelectionEvidence: BrowserModelSelectionEvidence | undefined;
   let connectionClosedUnexpectedly = false;
   let stopThinkingMonitor: (() => void) | null = null;
   let removeDialogHandler: (() => void) | null = null;
@@ -2728,23 +2728,27 @@ async function runRemoteBrowserMode(
   let tabLease: BrowserTabLease | null = null;
   let lastUrl: string | undefined;
   let promptSubmitted = false;
+  let modelSelectionEvidence: BrowserModelSelectionEvidence | undefined;
   let attachedExistingTab = false;
   let ownsTarget = true;
   const runtimeHintCb = options.runtimeHintCb;
   const emitRuntimeHint = async () => {
     if (!runtimeHintCb) return;
     try {
-      await runtimeHintCb({
-        chromePort: port,
-        chromeHost: host,
-        chromeBrowserWSEndpoint: browserWSEndpoint,
-        chromeProfileRoot,
-        chromeTargetId: remoteTargetId ?? undefined,
-        tabUrl: lastUrl,
-        conversationId: lastUrl ? extractConversationIdFromUrl(lastUrl) : undefined,
-        promptSubmitted,
-        controllerPid: process.pid,
-      });
+      await runtimeHintCb(
+        {
+          chromePort: port,
+          chromeHost: host,
+          chromeBrowserWSEndpoint: browserWSEndpoint,
+          chromeProfileRoot,
+          chromeTargetId: remoteTargetId ?? undefined,
+          tabUrl: lastUrl,
+          conversationId: lastUrl ? extractConversationIdFromUrl(lastUrl) : undefined,
+          promptSubmitted,
+          controllerPid: process.pid,
+        },
+        modelSelectionEvidence,
+      );
       await tabLease?.update({
         chromeHost: host,
         chromePort: port,
@@ -2769,7 +2773,6 @@ async function runRemoteBrowserMode(
   let answerHtml = "";
   let connectionClosedUnexpectedly = false;
   let runStatus: "attempted" | "complete" = "attempted";
-  let modelSelectionEvidence: BrowserModelSelectionEvidence | undefined;
   let stopThinkingMonitor: (() => void) | null = null;
   let removeDialogHandler: (() => void) | null = null;
   let connection: Awaited<ReturnType<typeof connectToRemoteChrome>> | null = null;

--- a/src/browser/sessionRunner.ts
+++ b/src/browser/sessionRunner.ts
@@ -46,7 +46,10 @@ interface RunBrowserSessionArgs {
 export interface BrowserSessionRunnerDeps {
   assemblePrompt?: typeof assembleBrowserPrompt;
   executeBrowser?: typeof runBrowserMode;
-  persistRuntimeHint?: (runtime: BrowserRuntimeMetadata) => Promise<void> | void;
+  persistRuntimeHint?: (
+    runtime: BrowserRuntimeMetadata,
+    modelSelection?: BrowserModelSelectionEvidence,
+  ) => Promise<void> | void;
 }
 
 const LARGE_PRO_FAST_INPUT_TOKEN_THRESHOLD = 25_000;
@@ -215,11 +218,16 @@ export async function runBrowserSessionExecution(
       generateImagePath: runOptions.generateImage,
       outputPath: runOptions.outputPath,
       followUpPrompts: runOptions.browserFollowUps,
-      runtimeHintCb: async (runtime) => {
-        await persistRuntimeHint({
+      runtimeHintCb: async (runtime, modelSelection) => {
+        const runtimeWithController = {
           ...runtime,
           controllerPid: runtime.controllerPid ?? process.pid,
-        });
+        };
+        if (modelSelection) {
+          await persistRuntimeHint(runtimeWithController, modelSelection);
+        } else {
+          await persistRuntimeHint(runtimeWithController);
+        }
       },
     });
   } catch (error) {

--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -140,8 +140,11 @@ export interface BrowserRunOptions {
   outputPath?: string;
   /** Additional prompts to submit in the same browser conversation after the initial answer. */
   followUpPrompts?: string[];
-  /** Optional hook to persist runtime info (port/url/target) as soon as Chrome is ready. */
-  runtimeHintCb?: (hint: BrowserRuntimeMetadata) => void | Promise<void>;
+  /** Optional hook to persist runtime info and current model evidence as soon as Chrome is ready. */
+  runtimeHintCb?: (
+    hint: BrowserRuntimeMetadata,
+    modelSelection?: BrowserModelSelectionEvidence,
+  ) => void | Promise<void>;
 }
 
 export interface BrowserArchiveResult {

--- a/src/cli/sessionRunner.ts
+++ b/src/cli/sessionRunner.ts
@@ -114,6 +114,9 @@ export async function performSessionRun({
             status: "running",
             browser: { config: browserConfig, runtime },
           });
+          // Keep the in-memory copy fresh so error paths fall back to the
+          // latest persisted runtime instead of clobbering it with undefined.
+          sessionMeta.browser = { config: browserConfig, runtime };
         },
       };
       const result = await runBrowserSessionExecution(
@@ -675,7 +678,7 @@ export async function performSessionRun({
       browser: browserConfig
         ? {
             config: browserConfig,
-            runtime: browserRuntime ?? undefined,
+            runtime: browserRuntime ?? sessionMeta.browser?.runtime,
           }
         : undefined,
       response: responseMetadata,

--- a/src/cli/sessionRunner.ts
+++ b/src/cli/sessionRunner.ts
@@ -6,6 +6,7 @@ import type {
   SessionMode,
   BrowserSessionConfig,
   BrowserRuntimeMetadata,
+  BrowserModelSelectionEvidence,
   SessionArtifact,
   SessionModelRun,
 } from "../sessionStore.js";
@@ -87,6 +88,9 @@ export async function performSessionRun({
     write(chunk);
     return muteStdout ? true : process.stdout.write(chunk);
   };
+  let currentBrowser: SessionMetadata["browser"] = browserConfig
+    ? { config: browserConfig }
+    : sessionMeta.browser;
   await sessionStore.updateSession(sessionMeta.id, {
     status: "running",
     startedAt: new Date().toISOString(),
@@ -109,14 +113,22 @@ export async function performSessionRun({
       }
       const runnerDeps = {
         ...browserDeps,
-        persistRuntimeHint: async (runtime: BrowserRuntimeMetadata) => {
+        persistRuntimeHint: async (
+          runtime: BrowserRuntimeMetadata,
+          modelSelection?: BrowserModelSelectionEvidence,
+        ) => {
+          const browser = {
+            config: browserConfig,
+            runtime,
+            ...(modelSelection ? { modelSelection } : {}),
+          };
           await sessionStore.updateSession(sessionMeta.id, {
             status: "running",
-            browser: { config: browserConfig, runtime },
+            browser,
           });
-          // Keep the in-memory copy fresh so error paths fall back to the
-          // latest persisted runtime instead of clobbering it with undefined.
-          sessionMeta.browser = { config: browserConfig, runtime };
+          // Keep this attempt's copy fresh so error paths fall back to the
+          // latest persisted browser evidence instead of stale session input.
+          currentBrowser = browser;
         },
       };
       const result = await runBrowserSessionExecution(
@@ -525,7 +537,7 @@ export async function performSessionRun({
     if (connectionLost && mode === "browser" && browserCanReattach) {
       const runtime = (userError.details as { runtime?: BrowserRuntimeMetadata } | undefined)
         ?.runtime;
-      const recoverableRuntime = runtime ?? sessionMeta.browser?.runtime;
+      const recoverableRuntime = runtime ?? currentBrowser?.runtime;
       if (
         !hasRecoverableChatGptConversation(recoverableRuntime) &&
         recoverableRuntime?.promptSubmitted !== true
@@ -553,6 +565,7 @@ export async function performSessionRun({
           errorMessage: message,
           mode,
           browser: {
+            ...currentBrowser,
             config: browserConfig,
             runtime: recoverableRuntime,
           },
@@ -577,8 +590,9 @@ export async function performSessionRun({
         errorMessage: message,
         mode,
         browser: {
+          ...currentBrowser,
           config: browserConfig,
-          runtime: runtime ?? sessionMeta.browser?.runtime,
+          runtime: runtime ?? currentBrowser?.runtime,
         },
         response: { status: "running", incompleteReason: "chrome-disconnected" },
       });
@@ -607,8 +621,9 @@ export async function performSessionRun({
         errorMessage: message,
         mode,
         browser: {
+          ...currentBrowser,
           config: browserConfig,
-          runtime: runtime ?? sessionMeta.browser?.runtime,
+          runtime: runtime ?? currentBrowser?.runtime,
         },
         response: { status: "incomplete", incompleteReason: "incomplete-capture" },
         error: {
@@ -619,11 +634,12 @@ export async function performSessionRun({
       });
       const autoReattachIntervalMs = browserConfig?.autoReattachIntervalMs ?? 0;
       if (autoReattachIntervalMs > 0) {
-        const autoRuntime = runtime ?? sessionMeta.browser?.runtime;
+        const autoRuntime = runtime ?? currentBrowser?.runtime;
         const success = await autoReattachUntilComplete({
           sessionMeta,
           runtime: autoRuntime ?? undefined,
           browserConfig,
+          browserMetadata: currentBrowser,
           runOptions,
           modelForStatus,
           notificationSettings,
@@ -633,7 +649,7 @@ export async function performSessionRun({
           return;
         }
       }
-      logBrowserReattachGuidance(runtime ?? sessionMeta.browser?.runtime);
+      logBrowserReattachGuidance(runtime ?? currentBrowser?.runtime);
       return;
     }
     if (cloudflareChallenge && mode === "browser") {
@@ -668,7 +684,7 @@ export async function performSessionRun({
         ? (userError?.details as { runtime?: BrowserRuntimeMetadata } | undefined)?.runtime
         : undefined;
     if (!cloudflareChallenge && browserCanReattach) {
-      logBrowserReattachGuidance(browserRuntime ?? sessionMeta.browser?.runtime);
+      logBrowserReattachGuidance(browserRuntime ?? currentBrowser?.runtime);
     }
     await sessionStore.updateSession(sessionMeta.id, {
       status: "error",
@@ -677,8 +693,9 @@ export async function performSessionRun({
       mode,
       browser: browserConfig
         ? {
+            ...currentBrowser,
             config: browserConfig,
-            runtime: browserRuntime ?? sessionMeta.browser?.runtime,
+            runtime: browserRuntime ?? currentBrowser?.runtime,
           }
         : undefined,
       response: responseMetadata,
@@ -1062,6 +1079,7 @@ async function autoReattachUntilComplete({
   sessionMeta,
   runtime,
   browserConfig,
+  browserMetadata,
   runOptions,
   modelForStatus,
   notificationSettings,
@@ -1070,6 +1088,7 @@ async function autoReattachUntilComplete({
   sessionMeta: SessionMetadata;
   runtime?: BrowserRuntimeMetadata;
   browserConfig?: BrowserSessionConfig;
+  browserMetadata?: SessionMetadata["browser"];
   runOptions: RunOracleOptions;
   modelForStatus?: string;
   notificationSettings: NotificationSettings;
@@ -1164,6 +1183,7 @@ async function autoReattachUntilComplete({
         },
         errorMessage: undefined,
         browser: {
+          ...browserMetadata,
           config: browserConfig,
           runtime,
         },

--- a/tests/browser/promptComposer.test.ts
+++ b/tests/browser/promptComposer.test.ts
@@ -60,6 +60,68 @@ describe("promptComposer", () => {
     }
   });
 
+  test("commit timeout throws a structured error with probe diagnostics", async () => {
+    vi.useFakeTimers();
+    try {
+      const probe = {
+        baseline: 10,
+        turnsCount: 10,
+        userMatched: false,
+        prefixMatched: false,
+        lastMatched: false,
+        hasNewTurn: false,
+        stopVisible: false,
+        assistantVisible: false,
+        composerCleared: true,
+        inConversation: false,
+        editorValue: "",
+        lastTurn: "previous turn text",
+      };
+      const runtime = {
+        evaluate: vi
+          .fn()
+          // Baseline read (turn count)
+          .mockResolvedValueOnce({ result: { value: 10 } })
+          // Polls + final diagnostic probe
+          .mockResolvedValue({ result: { value: probe } }),
+      } as unknown as {
+        evaluate: (args: { expression: string; returnByValue?: boolean }) => Promise<unknown>;
+      };
+
+      const promise = promptComposer.verifyPromptCommitted(runtime as never, "hello", 150);
+      const assertion = promise.then(
+        () => {
+          throw new Error("expected verifyPromptCommitted to reject");
+        },
+        (error: unknown) => error,
+      );
+      await vi.advanceTimersByTimeAsync(250);
+      const error = (await assertion) as {
+        name?: string;
+        details?: Record<string, unknown>;
+        message?: string;
+      };
+      expect(error.message).toMatch(/prompt did not appear/i);
+      expect(error.name).toBe("BrowserAutomationError");
+      expect(error.details).toMatchObject({
+        stage: "submit-prompt",
+        code: "prompt-commit-timeout",
+        commitProbe: expect.objectContaining({
+          hasNewTurn: false,
+          composerCleared: true,
+          turnsCount: 10,
+          lastTurnLength: "previous turn text".length,
+        }),
+      });
+      // Free text must not leak into the structured details.
+      const commitProbe = error.details?.commitProbe as Record<string, unknown>;
+      expect(commitProbe).not.toHaveProperty("lastTurn");
+      expect(commitProbe).not.toHaveProperty("editorValue");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("allows prompt match even if baseline turn count cannot be read", async () => {
     const runtime = {
       evaluate: vi

--- a/tests/browser/sessionRunner.test.ts
+++ b/tests/browser/sessionRunner.test.ts
@@ -20,13 +20,24 @@ describe("runBrowserSessionExecution", () => {
     const log = vi.fn();
     const persistRuntimeHint = vi.fn();
     const executeBrowser = vi.fn(async (options) => {
-      await options.runtimeHintCb?.({
-        chromePort: 9999,
-        chromeHost: "127.0.0.1",
-        chromeTargetId: "t-1",
-        tabUrl: "https://chatgpt.com/c/foo",
-        conversationId: "foo",
-      });
+      await options.runtimeHintCb?.(
+        {
+          chromePort: 9999,
+          chromeHost: "127.0.0.1",
+          chromeTargetId: "t-1",
+          tabUrl: "https://chatgpt.com/c/foo",
+          conversationId: "foo",
+        },
+        {
+          requestedModel: "Pro",
+          resolvedLabel: "Pro",
+          strategy: "select",
+          status: "already-selected",
+          verified: true,
+          source: "chatgpt-model-picker",
+          capturedAt: "2026-07-03T00:00:00.000Z",
+        },
+      );
       return {
         answerText: "ok",
         answerMarkdown: "ok",
@@ -70,6 +81,7 @@ describe("runBrowserSessionExecution", () => {
     expect(result.artifacts).toEqual([{ kind: "transcript", path: "/tmp/transcript.md" }]);
     expect(persistRuntimeHint).toHaveBeenCalledWith(
       expect.objectContaining({ chromePort: 9999, chromeHost: "127.0.0.1", chromeTargetId: "t-1" }),
+      expect.objectContaining({ resolvedLabel: "Pro", verified: true }),
     );
     expect(log).toHaveBeenCalled();
   });

--- a/tests/cli/sessionRunner.test.ts
+++ b/tests/cli/sessionRunner.test.ts
@@ -1190,10 +1190,26 @@ describe("performSessionRun", () => {
       stage: "execute-browser",
     });
     vi.mocked(runBrowserSessionExecution).mockRejectedValueOnce(automationError);
+    const staleSessionMeta = {
+      ...baseSessionMeta,
+      browser: {
+        config: { desiredModel: "Old Pro" },
+        runtime: { promptSubmitted: true, tabUrl: "https://chatgpt.com/c/old" },
+        modelSelection: {
+          requestedModel: "Old Pro",
+          resolvedLabel: "Old Pro",
+          strategy: "select" as const,
+          status: "already-selected" as const,
+          verified: true,
+          source: "chatgpt-model-picker" as const,
+          capturedAt: "2026-07-02T00:00:00.000Z",
+        },
+      },
+    };
 
     await expect(
       performSessionRun({
-        sessionMeta: baseSessionMeta,
+        sessionMeta: staleSessionMeta,
         runOptions: baseRunOptions,
         mode: "browser",
         browserConfig: { chromePath: null },
@@ -1210,6 +1226,8 @@ describe("performSessionRun", () => {
       errorMessage: "automation failed",
       browser: expect.objectContaining({ config: expect.any(Object) }),
     });
+    expect(finalUpdate?.browser?.runtime).toBeUndefined();
+    expect(finalUpdate?.browser).not.toHaveProperty("modelSelection");
     expect(sessionStoreMock.updateModelRun).toHaveBeenCalledWith(
       baseSessionMeta.id,
       "gpt-5.2-pro",
@@ -1230,13 +1248,29 @@ describe("performSessionRun", () => {
       // Simulate the runtime hint emitted right after the send click,
       // before commit verification fails.
       await (
-        deps as { persistRuntimeHint?: (runtime: Record<string, unknown>) => Promise<void> }
-      ).persistRuntimeHint?.({
-        chromePort: 9222,
-        chromeHost: "127.0.0.1",
-        tabUrl: "https://chatgpt.com/c/demo",
-        promptSubmitted: true,
-      });
+        deps as {
+          persistRuntimeHint?: (
+            runtime: Record<string, unknown>,
+            modelSelection?: Record<string, unknown>,
+          ) => Promise<void>;
+        }
+      ).persistRuntimeHint?.(
+        {
+          chromePort: 9222,
+          chromeHost: "127.0.0.1",
+          tabUrl: "https://chatgpt.com/c/demo",
+          promptSubmitted: true,
+        },
+        {
+          requestedModel: "Pro",
+          resolvedLabel: "Pro",
+          strategy: "select",
+          status: "already-selected",
+          verified: true,
+          source: "chatgpt-model-picker",
+          capturedAt: "2026-07-03T00:00:00.000Z",
+        },
+      );
       throw automationError;
     });
 
@@ -1262,6 +1296,7 @@ describe("performSessionRun", () => {
           promptSubmitted: true,
           tabUrl: "https://chatgpt.com/c/demo",
         }),
+        modelSelection: expect.objectContaining({ resolvedLabel: "Pro", verified: true }),
       }),
       error: expect.objectContaining({
         details: expect.objectContaining({ code: "prompt-commit-timeout" }),
@@ -1281,7 +1316,26 @@ describe("performSessionRun", () => {
         },
       },
     );
-    vi.mocked(runBrowserSessionExecution).mockRejectedValueOnce(automationError);
+    vi.mocked(runBrowserSessionExecution).mockImplementationOnce(async (_args, deps) => {
+      await deps?.persistRuntimeHint?.(
+        {
+          chromePort: 9222,
+          chromeHost: "127.0.0.1",
+          tabUrl: "https://chatgpt.com/c/demo",
+          promptSubmitted: true,
+        },
+        {
+          requestedModel: "Pro",
+          resolvedLabel: "Pro",
+          strategy: "select",
+          status: "already-selected",
+          verified: true,
+          source: "chatgpt-model-picker",
+          capturedAt: "2026-07-03T00:00:00.000Z",
+        },
+      );
+      throw automationError;
+    });
 
     await performSessionRun({
       sessionMeta: baseSessionMeta,
@@ -1298,7 +1352,10 @@ describe("performSessionRun", () => {
     expect(finalUpdate).toMatchObject({
       status: "running",
       response: { status: "running", incompleteReason: "chrome-disconnected" },
-      browser: expect.objectContaining({ runtime: expect.objectContaining({ chromePort: 9222 }) }),
+      browser: expect.objectContaining({
+        runtime: expect.objectContaining({ chromePort: 9222 }),
+        modelSelection: expect.objectContaining({ resolvedLabel: "Pro", verified: true }),
+      }),
     });
     expect(sessionStoreMock.updateModelRun).toHaveBeenCalledWith(
       baseSessionMeta.id,
@@ -1421,7 +1478,26 @@ describe("performSessionRun", () => {
         },
       },
     );
-    vi.mocked(runBrowserSessionExecution).mockRejectedValueOnce(automationError);
+    vi.mocked(runBrowserSessionExecution).mockImplementationOnce(async (_args, deps) => {
+      await deps?.persistRuntimeHint?.(
+        {
+          chromePort: 9222,
+          chromeHost: "127.0.0.1",
+          tabUrl: "https://chatgpt.com/c/demo",
+          promptSubmitted: true,
+        },
+        {
+          requestedModel: "Pro",
+          resolvedLabel: "Pro",
+          strategy: "select",
+          status: "already-selected",
+          verified: true,
+          source: "chatgpt-model-picker",
+          capturedAt: "2026-07-03T00:00:00.000Z",
+        },
+      );
+      throw automationError;
+    });
 
     await performSessionRun({
       sessionMeta: baseSessionMeta,
@@ -1438,7 +1514,10 @@ describe("performSessionRun", () => {
     expect(finalUpdate).toMatchObject({
       status: "error",
       response: { status: "incomplete", incompleteReason: "incomplete-capture" },
-      browser: expect.objectContaining({ runtime: expect.objectContaining({ chromePort: 9222 }) }),
+      browser: expect.objectContaining({
+        runtime: expect.objectContaining({ chromePort: 9222 }),
+        modelSelection: expect.objectContaining({ resolvedLabel: "Pro", verified: true }),
+      }),
       error: expect.objectContaining({
         details: expect.objectContaining({
           code: "chatgpt-ui-warning",
@@ -1601,7 +1680,26 @@ describe("performSessionRun", () => {
       stage: "assistant-timeout",
       runtime: { chromePort: 9222, chromeHost: "127.0.0.1", tabUrl: "https://chatgpt.com/c/demo" },
     });
-    vi.mocked(runBrowserSessionExecution).mockRejectedValueOnce(automationError);
+    vi.mocked(runBrowserSessionExecution).mockImplementationOnce(async (_args, deps) => {
+      await deps?.persistRuntimeHint?.(
+        {
+          chromePort: 9222,
+          chromeHost: "127.0.0.1",
+          tabUrl: "https://chatgpt.com/c/demo",
+          promptSubmitted: true,
+        },
+        {
+          requestedModel: "Pro",
+          resolvedLabel: "Pro",
+          strategy: "select",
+          status: "already-selected",
+          verified: true,
+          source: "chatgpt-model-picker",
+          capturedAt: "2026-07-03T00:00:00.000Z",
+        },
+      );
+      throw automationError;
+    });
     vi.mocked(resumeBrowserSession).mockResolvedValue({
       answerText: "ok text",
       answerMarkdown: "ok markdown",
@@ -1644,6 +1742,9 @@ describe("performSessionRun", () => {
         { kind: "deep-research-report", path: "/tmp/deep-research-report.md" },
       ],
       response: { status: "completed" },
+      browser: expect.objectContaining({
+        modelSelection: expect.objectContaining({ resolvedLabel: "Pro", verified: true }),
+      }),
     });
     expect(vi.mocked(sendSessionNotification)).toHaveBeenCalled();
   });

--- a/tests/cli/sessionRunner.test.ts
+++ b/tests/cli/sessionRunner.test.ts
@@ -1221,6 +1221,54 @@ describe("performSessionRun", () => {
     expect(logLines).not.toContain("This run did not return cleanly");
   });
 
+  test("preserves persisted runtime hints when browser automation fails without runtime details", async () => {
+    const automationError = new BrowserAutomationError(
+      "Prompt did not appear in conversation before timeout (send may have failed)",
+      { stage: "submit-prompt", code: "prompt-commit-timeout" },
+    );
+    vi.mocked(runBrowserSessionExecution).mockImplementationOnce(async (_args, deps) => {
+      // Simulate the runtime hint emitted right after the send click,
+      // before commit verification fails.
+      await (
+        deps as { persistRuntimeHint?: (runtime: Record<string, unknown>) => Promise<void> }
+      ).persistRuntimeHint?.({
+        chromePort: 9222,
+        chromeHost: "127.0.0.1",
+        tabUrl: "https://chatgpt.com/c/demo",
+        promptSubmitted: true,
+      });
+      throw automationError;
+    });
+
+    await expect(
+      performSessionRun({
+        sessionMeta: { ...baseSessionMeta },
+        runOptions: baseRunOptions,
+        mode: "browser",
+        browserConfig: { chromePath: null },
+        cwd: "/tmp",
+        log,
+        write,
+        version: cliVersion,
+      }),
+    ).rejects.toThrow(/prompt did not appear/i);
+
+    const finalUpdate = sessionStoreMock.updateSession.mock.calls.at(-1)?.[1];
+    expect(finalUpdate).toMatchObject({
+      status: "error",
+      browser: expect.objectContaining({
+        config: expect.any(Object),
+        runtime: expect.objectContaining({
+          promptSubmitted: true,
+          tabUrl: "https://chatgpt.com/c/demo",
+        }),
+      }),
+      error: expect.objectContaining({
+        details: expect.objectContaining({ code: "prompt-commit-timeout" }),
+      }),
+    });
+  });
+
   test("keeps session running when browser connection is lost", async () => {
     const automationError = new BrowserAutomationError(
       "Chrome window closed before oracle finished.",


### PR DESCRIPTION
Fixes the failed-session metadata loss reported in #286: when browser-mode prompt commit verification times out, the stored session now keeps `browser.runtime` (promptSubmitted, tabUrl, conversationId) and gains structured diagnostics explaining *which* commit signal failed.

## Root cause

The config-only metadata in #286 is an overwrite, not a missing write:

1. After the send click, `markPromptSubmitted` → runtime hint persists `browser.runtime` with `promptSubmitted: true` (`src/browser/index.ts`).
2. `verifyPromptCommitted` times out and throws a **plain `Error`** (`src/browser/actions/promptComposer.ts`) — the DOM probe state it already collects (match flags, turn counts, composer state) goes to the verbose log only, never into the error.
3. The wrapper re-throws as `BrowserAutomationError` with generic `stage: "execute-browser"` and no `runtime` in details (`src/browser/sessionRunner.ts`).
4. The CLI generic error path persists `browser: { config, runtime: undefined }`, and `updateSessionMetadata` does a top-level shallow merge (`src/sessionManager.ts`) — clobbering the runtime persisted in step 1.

## Changes

- `verifyPromptCommitted` timeout now throws `BrowserAutomationError` with `stage: "submit-prompt"`, `code: "prompt-commit-timeout"`, and a lean `commitProbe` summary of the last DOM probe (booleans/counts only; free text is reduced to lengths so no conversation content lands in metadata). Error message unchanged. The new code does not collide with the `dead-composer` / `prompt-too-large` retry paths.
- `persistRuntimeHint` also refreshes the in-memory `sessionMeta.browser`, and the generic error path falls back to it — same pattern the `connection-lost` / `assistant-timeout` paths already use (their `sessionMeta.browser?.runtime` fallback previously always saw the stale at-start value; it now sees the latest hint, which also makes the reattach guidance fire for failed submissions).
- Tests: structured error + diagnostics assertions in `tests/browser/promptComposer.test.ts`; runtime-preservation-through-failure in `tests/cli/sessionRunner.test.ts`.

## Live validation (macOS)

I could **not** reproduce the commit failure itself on macOS, including with the exact reported model config:

- macOS 15 / branded Chrome / `--copy-profile` throwaway profile / Node 26 / behind an HTTP proxy (China network)
- Run 1: the ~315-token structured no-file prompt from #286, `--browser-model-strategy current` → completed in 19.8s
- Run 2: same prompt, `--model gpt-5.5-pro` default select strategy → model picker evidence `requested=Pro, resolved=Pro, status=switched, verified=true`, completed in 1m05s

So the false-negative heuristic trigger looks specific to the reporter's environment (Arch + Chromium 149 + manual-login persistent profile + Node 25) rather than to prompt shape. Per the review on #286 I've left the commit heuristic untouched — with this PR, the next live occurrence will self-report `commitProbe` in both the log and the failed session's `error.details`, which should pin down exactly which signal misses.

## Checks

- `pnpm run check` (typecheck + oxlint + oxfmt) clean
- `pnpm vitest run` — 1379 passed, 43 skipped, 0 failed
- Live browser smokes above ran against this branch (no "Answer now" clicks; conversations archived)
