### PR TITLE
fix(browser): recover remote Chrome sessions reliably

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.15.2 — Unreleased
 
+### Fixed
+
+- Browser: persist late `/c/<id>` URLs during remote Chrome runs and prefer saved conversation targets over stale target IDs during reattach. Fixes #284. Thanks @StartupBros!
+
 ## 0.15.1 — 2026-07-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Browser: persist late `/c/<id>` URLs during remote Chrome runs and prefer saved conversation targets over stale target IDs during reattach. Fixes #284. Thanks @StartupBros!
+- Browser: persist late `/c/<id>` URLs during remote Chrome runs and prefer saved conversation targets over stale target IDs during reattach. Fixes #284. Thanks @LeoLin990405 and @StartupBros!
 
 ## 0.15.1 — 2026-07-03
 

--- a/src/browser/chromeLifecycle.ts
+++ b/src/browser/chromeLifecycle.ts
@@ -505,6 +505,7 @@ function createSessionBoundChromeClient(browser: ChromeClient, sessionId: string
     Runtime: bindDomain("Runtime"),
     Input: bindDomain("Input"),
     DOM: bindDomain("DOM"),
+    Emulation: bindDomain("Emulation"),
     on: browserWithEvents.on.bind(browserWithEvents),
     once: browserWithEvents.once.bind(browserWithEvents),
     off:

--- a/src/browser/conversationUrlMonitor.ts
+++ b/src/browser/conversationUrlMonitor.ts
@@ -1,0 +1,82 @@
+import type { BrowserLogger } from "./types.js";
+import { delay } from "./utils.js";
+
+export interface ConversationUrlMonitor {
+  update: (label: string, timeoutMs?: number) => Promise<boolean>;
+  schedule: (label: string, timeoutMs?: number) => Promise<boolean>;
+  isInFlight: () => boolean;
+  stop: () => Promise<void>;
+}
+
+export function createConversationUrlMonitor(options: {
+  readUrl: () => Promise<string | null | undefined>;
+  persistUrl: (url: string) => Promise<void>;
+  logger: BrowserLogger;
+  pollIntervalMs?: number;
+  wait?: (ms: number) => Promise<void>;
+  now?: () => number;
+}): ConversationUrlMonitor {
+  const pollIntervalMs = options.pollIntervalMs ?? 250;
+  const wait = options.wait ?? delay;
+  const now = options.now ?? Date.now;
+  let inFlight: Promise<boolean> | null = null;
+  let stopped = false;
+  const activePersists = new Set<Promise<void>>();
+
+  const update = async (label: string, timeoutMs = 10_000): Promise<boolean> => {
+    const startedAt = now();
+    while (!stopped && now() - startedAt < timeoutMs) {
+      try {
+        const url = await options.readUrl();
+        if (stopped) {
+          return false;
+        }
+        if (url && isConversationUrl(url)) {
+          options.logger(`[browser] conversation url (${label}) = ${url}`);
+          const persist = options.persistUrl(url);
+          activePersists.add(persist);
+          try {
+            await persist;
+          } finally {
+            activePersists.delete(persist);
+          }
+          return true;
+        }
+      } catch {
+        // The page can navigate or disconnect between polls; keep trying until timeout.
+      }
+      await wait(pollIntervalMs);
+    }
+    return false;
+  };
+
+  const schedule = (label: string, timeoutMs?: number): Promise<boolean> => {
+    if (stopped) {
+      return Promise.resolve(false);
+    }
+    if (inFlight) {
+      return inFlight;
+    }
+    // The /c/ URL can appear after submit. Persist it without blocking response capture.
+    inFlight = update(label, timeoutMs)
+      .catch(() => false)
+      .finally(() => {
+        inFlight = null;
+      });
+    return inFlight;
+  };
+
+  return {
+    update,
+    schedule,
+    isInFlight: () => inFlight !== null,
+    stop: async () => {
+      stopped = true;
+      await Promise.allSettled(activePersists);
+    },
+  };
+}
+
+function isConversationUrl(url: string): boolean {
+  return /\/c\/[a-z0-9-]+/i.test(url);
+}

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -101,6 +101,10 @@ import {
   resolveManualLoginWaitMs,
 } from "./manualLoginProfile.js";
 import { describeBrowserControlPlan, formatBrowserControlPlan } from "./controlPlan.js";
+import {
+  createConversationUrlMonitor,
+  type ConversationUrlMonitor,
+} from "./conversationUrlMonitor.js";
 
 export type { BrowserAutomationConfig, BrowserRunOptions, BrowserRunResult } from "./types.js";
 export { CHATGPT_URL, DEFAULT_MODEL_STRATEGY, DEFAULT_MODEL_TARGET } from "./constants.js";
@@ -885,6 +889,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
   let promptSubmitted = false;
   let modelSelectionEvidence: BrowserModelSelectionEvidence | undefined;
   let tabLease: BrowserTabLease | null = null;
+  let conversationUrlMonitor: ConversationUrlMonitor | null = null;
   const emitRuntimeHint = async (): Promise<void> => {
     if (!chrome?.port) {
       return;
@@ -920,6 +925,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
     }
     promptSubmitted = true;
     await emitRuntimeHint();
+    void conversationUrlMonitor?.schedule("post-submit", config.timeoutMs ?? 120_000);
   };
   if (config.debug || process.env.CHATGPT_DEVTOOLS_TRACE === "1") {
     logger(
@@ -1321,43 +1327,22 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
         await emitRuntimeHint();
       }
     };
-    let conversationHintInFlight: Promise<boolean> | null = null;
-    const updateConversationHint = async (label: string, timeoutMs = 10_000): Promise<boolean> => {
-      if (!chrome?.port) {
-        return false;
-      }
-      const start = Date.now();
-      while (Date.now() - start < timeoutMs) {
-        try {
-          const { result } = await Runtime.evaluate({
-            expression: "location.href",
-            returnByValue: true,
-          });
-          if (typeof result?.value === "string" && result.value.includes("/c/")) {
-            lastUrl = result.value;
-            logger(`[browser] conversation url (${label}) = ${lastUrl}`);
-            await emitRuntimeHint();
-            return true;
-          }
-        } catch {
-          // ignore; keep polling until timeout
-        }
-        await delay(250);
-      }
-      return false;
-    };
-    const scheduleConversationHint = (label: string, timeoutMs?: number): void => {
-      if (conversationHintInFlight) {
-        return;
-      }
-      // Learned: the /c/ URL can update after the answer; emit hints in the background.
-      // Run in the background so prompt submission/streaming isn't blocked by slow URL updates.
-      conversationHintInFlight = updateConversationHint(label, timeoutMs)
-        .catch(() => false)
-        .finally(() => {
-          conversationHintInFlight = null;
+    const activeConversationUrlMonitor = createConversationUrlMonitor({
+      readUrl: async () => {
+        const { result } = await Runtime.evaluate({
+          expression: "location.href",
+          returnByValue: true,
         });
-    };
+        return typeof result?.value === "string" ? result.value : null;
+      },
+      persistUrl: async (url) => {
+        lastUrl = url;
+        await emitRuntimeHint();
+      },
+      logger,
+    });
+    conversationUrlMonitor = activeConversationUrlMonitor;
+    const updateConversationHint = conversationUrlMonitor.update;
     await captureRuntimeSnapshot();
     const modelStrategy = config.modelStrategy ?? DEFAULT_MODEL_STRATEGY;
     if (config.desiredModel && modelStrategy !== "ignore" && !isResumingConversation) {
@@ -1551,8 +1536,6 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
           }
         }
       }
-      // Reattach needs a /c/ URL; ChatGPT can update it late, so poll in the background.
-      scheduleConversationHint("post-submit", config.timeoutMs ?? 120_000);
       return {
         baselineTurns,
         baselineAssistantText,
@@ -2263,6 +2246,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
       normalizedError,
     );
   } finally {
+    await conversationUrlMonitor?.stop();
     try {
       if (!connectionClosedUnexpectedly) {
         await client?.close();
@@ -2731,6 +2715,7 @@ async function runRemoteBrowserMode(
   let modelSelectionEvidence: BrowserModelSelectionEvidence | undefined;
   let attachedExistingTab = false;
   let ownsTarget = true;
+  let conversationUrlMonitor: ConversationUrlMonitor | null = null;
   const runtimeHintCb = options.runtimeHintCb;
   const emitRuntimeHint = async () => {
     if (!runtimeHintCb) return;
@@ -2766,6 +2751,7 @@ async function runRemoteBrowserMode(
     }
     promptSubmitted = true;
     await emitRuntimeHint();
+    void conversationUrlMonitor?.schedule("post-submit", config.timeoutMs ?? 120_000);
   };
   const startedAt = Date.now();
   let answerText = "";
@@ -2836,6 +2822,29 @@ async function runRemoteBrowserMode(
     }
     await Promise.all(domainEnablers);
     removeDialogHandler = installJavaScriptDialogAutoDismissal(Page, logger);
+    try {
+      await client.Emulation.setFocusEmulationEnabled({ enabled: true });
+      logger("[browser] Focus emulation enabled for remote target");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger(`[browser] Focus emulation unavailable: ${message}`);
+    }
+
+    const activeConversationUrlMonitor = createConversationUrlMonitor({
+      readUrl: async () => {
+        const { result } = await Runtime.evaluate({
+          expression: "location.href",
+          returnByValue: true,
+        });
+        return typeof result?.value === "string" ? result.value : null;
+      },
+      persistUrl: async (url) => {
+        lastUrl = url;
+        await emitRuntimeHint();
+      },
+      logger,
+    });
+    conversationUrlMonitor = activeConversationUrlMonitor;
 
     // Skip cookie sync for remote Chrome - it already has cookies
     logger("Skipping cookie sync for remote Chrome (using existing session)");
@@ -3045,7 +3054,7 @@ async function runRemoteBrowserMode(
           targetBaselineCaptured: deepResearchTargetBaselineCaptured,
         },
       );
-      await emitRuntimeHint();
+      await activeConversationUrlMonitor.update("post-deep-research", 15_000).catch(() => false);
       const durationMs = Date.now() - startedAt;
       const tokens = estimateTokenCount(researchResult.text);
       const reportArtifact = await saveOptionalArtifact(
@@ -3230,11 +3239,7 @@ async function runRemoteBrowserMode(
     ): Promise<BrowserConversationTurn & { answerHtml: string }> => {
       let turnAnswer: AssistantAnswer;
       try {
-        const conversationUrl = await readConversationUrl(Runtime).catch(() => null);
-        if (conversationUrl && isConversationUrl(conversationUrl)) {
-          lastUrl = conversationUrl;
-          await emitRuntimeHint();
-        }
+        await activeConversationUrlMonitor.update("assistant-wait", 15_000).catch(() => false);
         turnAnswer = await waitWithThinkingMonitor(() =>
           waitForAssistantOrGeneratedImageResponse({
             Runtime,
@@ -3260,15 +3265,9 @@ async function runRemoteBrowserMode(
           if (rechecked) {
             turnAnswer = rechecked;
           } else {
-            try {
-              const conversationUrl = await readConversationUrl(Runtime);
-              if (conversationUrl) {
-                lastUrl = conversationUrl;
-              }
-            } catch {
-              // ignore
-            }
-            await emitRuntimeHint();
+            await activeConversationUrlMonitor
+              .update("assistant-timeout", 15_000)
+              .catch(() => false);
             const diagnostics = await captureBrowserDiagnostics(
               Runtime,
               logger,
@@ -3301,6 +3300,7 @@ async function runRemoteBrowserMode(
           throw error;
         }
       }
+      await activeConversationUrlMonitor.update("post-response", 15_000).catch(() => false);
       const baselineNormalized = baselineAssistantText
         ? normalizeForComparison(baselineAssistantText)
         : "";
@@ -3601,6 +3601,7 @@ async function runRemoteBrowserMode(
       },
     });
   } finally {
+    await conversationUrlMonitor?.stop();
     try {
       await closeRemoteConnectionAfterRun({
         connectionClosedUnexpectedly,

--- a/src/browser/reattachHelpers.ts
+++ b/src/browser/reattachHelpers.ts
@@ -21,15 +21,26 @@ type PromptEchoMatcher = { isEcho: (text: string) => boolean };
 
 export function pickTarget(
   targets: TargetInfoLite[],
-  runtime: { chromeTargetId?: string; tabUrl?: string },
+  runtime: { chromeTargetId?: string; tabUrl?: string; conversationId?: string },
 ): TargetInfoLite | undefined {
   if (!Array.isArray(targets) || targets.length === 0) {
     return undefined;
   }
-  if (runtime.chromeTargetId) {
-    const byId = targets.find((t) => (t.targetId ?? t.id) === runtime.chromeTargetId);
-    if (byId) return byId;
+  const conversationId =
+    runtime.conversationId ?? extractConversationIdFromUrl(runtime.tabUrl ?? "");
+  const byId = runtime.chromeTargetId
+    ? targets.find((target) => (target.targetId ?? target.id) === runtime.chromeTargetId)
+    : undefined;
+  if (conversationId) {
+    if (byId && extractConversationIdFromUrl(byId.url ?? "") === conversationId) {
+      return byId;
+    }
+    const byConversation = targets.find(
+      (target) => extractConversationIdFromUrl(target.url ?? "") === conversationId,
+    );
+    if (byConversation) return byConversation;
   }
+  if (byId) return byId;
   if (runtime.tabUrl) {
     const byUrl =
       targets.find((t) => t.url?.startsWith(runtime.tabUrl as string)) ||

--- a/tests/browser/chromeLifecycle.test.ts
+++ b/tests/browser/chromeLifecycle.test.ts
@@ -278,6 +278,7 @@ describe("closeBlankChromeTabs", () => {
       Runtime: { enable: vi.fn(async () => ({})), evaluate: vi.fn(async () => ({ result: {} })) },
       Input: { dispatchKeyEvent: vi.fn(async () => ({})) },
       DOM: { enable: vi.fn(async () => ({})) },
+      Emulation: { setFocusEmulationEnabled: vi.fn(async () => ({})) },
       on: vi.fn(),
       once: vi.fn(),
       removeListener: vi.fn(),
@@ -307,6 +308,11 @@ describe("closeBlankChromeTabs", () => {
       flatten: true,
     });
     expect(connection.targetId).toBe("target-9");
+    await connection.client.Emulation.setFocusEmulationEnabled({ enabled: true });
+    expect(browserClient.Emulation.setFocusEmulationEnabled).toHaveBeenCalledWith(
+      { enabled: true },
+      "session-9",
+    );
     await (
       connection.client as typeof connection.client & {
         send: (method: string, params: unknown, sessionId: string) => Promise<unknown>;

--- a/tests/browser/conversationUrlMonitor.test.ts
+++ b/tests/browser/conversationUrlMonitor.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test, vi } from "vitest";
+import { createConversationUrlMonitor } from "../../src/browser/conversationUrlMonitor.js";
+import type { BrowserLogger } from "../../src/browser/types.js";
+
+describe("createConversationUrlMonitor", () => {
+  test("persists a conversation URL that appears after prompt submission", async () => {
+    const readUrl = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce("https://chatgpt.com/")
+      .mockResolvedValue("https://chatgpt.com/c/issue-284");
+    const persistUrl = vi.fn(async () => {});
+    const logger = vi.fn() as BrowserLogger;
+    let now = 0;
+    const monitor = createConversationUrlMonitor({
+      readUrl,
+      persistUrl,
+      logger,
+      wait: async () => {
+        now += 250;
+      },
+      now: () => now,
+    });
+
+    await expect(monitor.schedule("post-submit", 1_000)).resolves.toBe(true);
+
+    expect(persistUrl).toHaveBeenCalledWith("https://chatgpt.com/c/issue-284");
+    expect(logger).toHaveBeenCalledWith(
+      "[browser] conversation url (post-submit) = https://chatgpt.com/c/issue-284",
+    );
+  });
+
+  test("keeps polling through read errors until the URL appears", async () => {
+    let reads = 0;
+    const persistUrl = vi.fn(async () => {});
+    const monitor = createConversationUrlMonitor({
+      readUrl: async () => {
+        reads += 1;
+        if (reads < 3) {
+          throw new Error("evaluate failed");
+        }
+        return "https://chatgpt.com/c/recovered";
+      },
+      persistUrl,
+      logger: vi.fn() as BrowserLogger,
+      wait: async () => {},
+      now: () => reads * 250,
+    });
+
+    await expect(monitor.update("assistant-wait", 5_000)).resolves.toBe(true);
+
+    expect(reads).toBe(3);
+    expect(persistUrl).toHaveBeenCalledWith("https://chatgpt.com/c/recovered");
+  });
+
+  test("shares one in-flight poll between background callers", async () => {
+    let resolveRead: ((url: string) => void) | undefined;
+    const readUrl = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveRead = resolve;
+        }),
+    );
+    const monitor = createConversationUrlMonitor({
+      readUrl,
+      persistUrl: async () => {},
+      logger: vi.fn() as BrowserLogger,
+    });
+
+    const first = monitor.schedule("post-submit", 1_000);
+    const second = monitor.schedule("assistant-wait", 1_000);
+    expect(monitor.isInFlight()).toBe(true);
+    expect(readUrl).toHaveBeenCalledTimes(1);
+
+    resolveRead?.("https://chatgpt.com/c/shared");
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+    expect(monitor.isInFlight()).toBe(false);
+  });
+
+  test("stops a background poll when its browser run ends", async () => {
+    const readUrl = vi.fn(async () => "https://chatgpt.com/");
+    let monitor: ReturnType<typeof createConversationUrlMonitor>;
+    monitor = createConversationUrlMonitor({
+      readUrl,
+      persistUrl: async () => {},
+      logger: vi.fn() as BrowserLogger,
+      wait: async () => {
+        await monitor.stop();
+      },
+    });
+
+    await expect(monitor.schedule("post-submit", 120_000)).resolves.toBe(false);
+    expect(readUrl).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not persist a URL read after the monitor stops", async () => {
+    let resolveRead: ((url: string) => void) | undefined;
+    const persistUrl = vi.fn(async () => {});
+    const monitor = createConversationUrlMonitor({
+      readUrl: () =>
+        new Promise<string>((resolve) => {
+          resolveRead = resolve;
+        }),
+      persistUrl,
+      logger: vi.fn() as BrowserLogger,
+    });
+
+    const scheduled = monitor.schedule("post-submit", 1_000);
+    await monitor.stop();
+    resolveRead?.("https://chatgpt.com/c/late");
+
+    await expect(scheduled).resolves.toBe(false);
+    expect(persistUrl).not.toHaveBeenCalled();
+  });
+
+  test("waits for persistence already underway when stopping", async () => {
+    let resolvePersist: (() => void) | undefined;
+    const persistUrl = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvePersist = resolve;
+        }),
+    );
+    const monitor = createConversationUrlMonitor({
+      readUrl: async () => "https://chatgpt.com/c/persisting",
+      persistUrl,
+      logger: vi.fn() as BrowserLogger,
+    });
+
+    const scheduled = monitor.schedule("post-submit", 1_000);
+    await vi.waitFor(() => expect(persistUrl).toHaveBeenCalledOnce());
+    let stopped = false;
+    const stopping = monitor.stop().then(() => {
+      stopped = true;
+    });
+    await Promise.resolve();
+    expect(stopped).toBe(false);
+
+    resolvePersist?.();
+    await stopping;
+    await expect(scheduled).resolves.toBe(true);
+  });
+
+  test("does not treat the ChatGPT root URL as a conversation", async () => {
+    const persistUrl = vi.fn(async () => {});
+    let now = 0;
+    const monitor = createConversationUrlMonitor({
+      readUrl: async () => "https://chatgpt.com/",
+      persistUrl,
+      logger: vi.fn() as BrowserLogger,
+      wait: async () => {
+        now += 250;
+      },
+      now: () => now,
+    });
+
+    await expect(monitor.update("assistant-timeout", 500)).resolves.toBe(false);
+
+    expect(persistUrl).not.toHaveBeenCalled();
+  });
+});

--- a/tests/browser/reattach.test.ts
+++ b/tests/browser/reattach.test.ts
@@ -330,15 +330,36 @@ describe("reattach helpers", () => {
     );
   });
 
-  test("pickTarget prefers chromeTargetId, then tabUrl, then first page", () => {
+  test("pickTarget prefers a saved conversation over a stale target id", () => {
     const targets = [
       { targetId: "t-1", type: "page", url: "https://chatgpt.com/c/first" },
       { targetId: "t-2", type: "page", url: "https://chatgpt.com/c/second" },
       { targetId: "t-3", type: "page", url: "about:blank" },
     ];
     expect(pickTarget(targets, { chromeTargetId: "t-2" })).toEqual(targets[1]);
+    expect(
+      pickTarget(targets, {
+        chromeTargetId: "t-2",
+        tabUrl: "https://chatgpt.com/c/first",
+        conversationId: "first",
+      }),
+    ).toEqual(targets[0]);
     expect(pickTarget(targets, { tabUrl: "https://chatgpt.com/c/first" })).toEqual(targets[0]);
     expect(pickTarget(targets, {})).toEqual(targets[0]);
+  });
+
+  test("pickTarget keeps the saved target among duplicate conversation tabs", () => {
+    const targets = [
+      { targetId: "duplicate", type: "page", url: "https://chatgpt.com/c/same" },
+      { targetId: "submitted", type: "page", url: "https://chatgpt.com/c/same" },
+    ];
+
+    expect(
+      pickTarget(targets, {
+        chromeTargetId: "submitted",
+        conversationId: "same",
+      }),
+    ).toEqual(targets[1]);
   });
 
   test("pickTarget understands CDP list ids", () => {


### PR DESCRIPTION
Fixes the remaining remote-CDP recovery half of #284.

Remote runs could fail in two related ways: background targets could drop the synthetic send click, and runs interrupted mid-response persisted only the ChatGPT root URL. Reattach then trusted a stale CDP target ID and could not recover the live conversation.

## Changes

- Enable CDP focus emulation for remote targets, including flattened browser-WebSocket page sessions.
- Extract one shared conversation URL monitor for local and remote browser modes.
- Persist late `/c/<id>` URLs immediately after prompt submission without blocking response capture.
- Fence monitor shutdown so detached persistence cannot overwrite completed/error session metadata.
- Prefer the saved conversation during reattach while preserving the exact target when duplicate tabs show that conversation.
- Add focused regression coverage and changelog credit for @LeoLin990405 and reporter @StartupBros.

## Verification

- `pnpm run check`
- Focused browser tests: 36 passed
- Full Vitest suite: 1,396 passed / 43 skipped
- `pnpm run build`
- Autoreview convergence: no actionable findings

## Live remote-CDP proof

Tested the rewritten branch against an authenticated Chrome 149 instance over CDP:

1. Remote GPT-5.5 Pro target opened and focus emulation succeeded.
2. Prompt committed in the background target.
3. The `/c/<id>` URL was persisted by the post-submit monitor while the response was still generating.
4. The controller was intentionally cancelled after metadata contained the Chrome port, target ID, conversation URL/ID, and `promptSubmitted=true`.
5. `oracle session pr289-remote-reattach-live --render` reattached to the saved conversation, observed the assistant still generating, captured the final response, saved a validated transcript artifact, and marked the session completed.

No “Answer now” interaction was used. Conversation archiving was disabled for the recovery proof.
