### PR TITLE
fix(browser): keep ChatGPT turn indexes consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Browser: persist late `/c/<id>` URLs during remote Chrome runs and prefer saved conversation targets over stale target IDs during reattach. Fixes #284. Thanks @LeoLin990405 and @StartupBros!
+- Browser: keep prompt baselines, assistant snapshots, and artifact capture on one top-level ChatGPT turn index so nested message nodes cannot hide a new response. Thanks @cp7553479!
 
 ## 0.15.1 — 2026-07-03
 

--- a/src/browser/actions/assistantResponse.ts
+++ b/src/browser/actions/assistantResponse.ts
@@ -7,6 +7,7 @@ import {
   FINISHED_ACTIONS_SELECTOR,
   STOP_BUTTON_SELECTORS,
 } from "../constants.js";
+import { buildConversationTurnListExpression } from "../conversationTurns.js";
 import { delay } from "../utils.js";
 import {
   logDomFailure,
@@ -607,8 +608,7 @@ async function isCompletionVisible(Runtime: ChromeClient["Runtime"]): Promise<bo
           return Boolean(node.querySelector(ASSISTANT_SELECTOR) || node.querySelector('[data-testid*="assistant"]'));
         };
 
-        const preciseTurns = Array.from(document.querySelectorAll('[data-testid^="conversation-turn"]'));
-        const turns = preciseTurns.length > 0 ? preciseTurns : Array.from(document.querySelectorAll('${CONVERSATION_TURN_SELECTOR}'));
+        const turns = ${buildConversationTurnListExpression()};
         let lastAssistantTurn = null;
         for (let i = turns.length - 1; i >= 0; i--) {
           if (isAssistantTurn(turns[i])) {
@@ -741,7 +741,6 @@ function buildResponseObserverExpression(
   expectedConversationId?: string,
 ): string {
   const selectorsLiteral = JSON.stringify(ANSWER_SELECTORS);
-  const conversationLiteral = JSON.stringify(CONVERSATION_TURN_SELECTOR);
   const assistantLiteral = JSON.stringify(ASSISTANT_ROLE_SELECTOR);
   const minTurnLiteral =
     typeof minTurnIndex === "number" && Number.isFinite(minTurnIndex) && minTurnIndex >= 0
@@ -756,7 +755,6 @@ function buildResponseObserverExpression(
     const SELECTORS = ${selectorsLiteral};
     const STOP_SELECTOR = ${JSON.stringify(STOP_CONTROL_SELECTOR)};
     const FINISHED_SELECTOR = '${FINISHED_ACTIONS_SELECTOR}';
-    const CONVERSATION_SELECTOR = ${conversationLiteral};
     const ASSISTANT_SELECTOR = ${assistantLiteral};
     const EXPECTED_CONVERSATION_ID = ${expectedConversationLiteral};
     // Learned: settling avoids capturing mid-stream HTML; keep short.
@@ -879,8 +877,7 @@ function buildResponseObserverExpression(
 
     // Check if the last assistant turn has finished (scoped to avoid detecting old turns).
     const isLastAssistantTurnFinished = () => {
-      const preciseTurns = Array.from(document.querySelectorAll('[data-testid^="conversation-turn"]'));
-      const turns = preciseTurns.length > 0 ? preciseTurns : Array.from(document.querySelectorAll(CONVERSATION_SELECTOR));
+      const turns = ${buildConversationTurnListExpression()};
       let lastAssistantTurn = null;
       for (let i = turns.length - 1; i >= 0; i--) {
         if (isAssistantTurn(turns[i])) {
@@ -980,11 +977,9 @@ function buildResponseObserverExpression(
 }
 
 function buildAssistantExtractor(functionName: string): string {
-  const conversationLiteral = JSON.stringify(CONVERSATION_TURN_SELECTOR);
   const assistantLiteral = JSON.stringify(ASSISTANT_ROLE_SELECTOR);
   return `const ${functionName} = () => {
     ${buildClickDispatcher()}
-    const CONVERSATION_SELECTOR = ${conversationLiteral};
     const ASSISTANT_SELECTOR = ${assistantLiteral};
     const isAssistantTurn = (node) => {
       if (!(node instanceof HTMLElement)) return false;
@@ -1020,15 +1015,7 @@ function buildAssistantExtractor(functionName: string): string {
       }
     };
 
-    // Prefer the precise testid-based turn containers when present; the broad
-    // CONVERSATION_SELECTOR can double-count nested message divs and shift the
-    // assistant turnIndex out of sync with the baseline count.
-    const containerTurns = Array.from(
-      document.querySelectorAll('[data-testid^="conversation-turn"]'),
-    );
-    const turns = containerTurns.length > 0
-      ? containerTurns
-      : Array.from(document.querySelectorAll(CONVERSATION_SELECTOR));
+    const turns = ${buildConversationTurnListExpression()};
     for (let index = turns.length - 1; index >= 0; index -= 1) {
       const turn = turns[index];
       if (!isAssistantTurn(turn)) {
@@ -1113,13 +1100,10 @@ function buildMarkdownFallbackExtractor(minTurnLiteral?: string): string {
       }
     }
     if (!root) return null;
-    const CONVERSATION_SELECTOR = '${CONVERSATION_TURN_SELECTOR}';
-    const turnNodes = Array.from(document.querySelectorAll(CONVERSATION_SELECTOR));
+    const turnNodes = ${buildConversationTurnListExpression()};
     const hasTurns = turnNodes.length > 0;
     const resolveTurnIndex = (node) => {
-      const turn = node?.closest?.(CONVERSATION_SELECTOR);
-      if (!turn) return null;
-      const idx = turnNodes.indexOf(turn);
+      const idx = turnNodes.findIndex((turn) => turn === node || turn.contains?.(node));
       return idx >= 0 ? idx : null;
     };
     const isAfterMinTurn = (node) => {
@@ -1248,7 +1232,7 @@ function buildCopyExpression(meta: { messageId?: string | null; turnId?: string 
         if (testId.includes('assistant')) return true;
         return Boolean(node.querySelector(ASSISTANT_SELECTOR) || node.querySelector('[data-testid*="assistant"]'));
       };
-      const turns = Array.from(document.querySelectorAll(CONVERSATION_SELECTOR));
+      const turns = ${buildConversationTurnListExpression()};
       for (let i = turns.length - 1; i >= 0; i -= 1) {
         const turn = turns[i];
         if (!isAssistantTurn(turn)) continue;

--- a/src/browser/actions/assistantResponse.ts
+++ b/src/browser/actions/assistantResponse.ts
@@ -607,7 +607,8 @@ async function isCompletionVisible(Runtime: ChromeClient["Runtime"]): Promise<bo
           return Boolean(node.querySelector(ASSISTANT_SELECTOR) || node.querySelector('[data-testid*="assistant"]'));
         };
 
-        const turns = Array.from(document.querySelectorAll('${CONVERSATION_TURN_SELECTOR}'));
+        const preciseTurns = Array.from(document.querySelectorAll('[data-testid^="conversation-turn"]'));
+        const turns = preciseTurns.length > 0 ? preciseTurns : Array.from(document.querySelectorAll('${CONVERSATION_TURN_SELECTOR}'));
         let lastAssistantTurn = null;
         for (let i = turns.length - 1; i >= 0; i--) {
           if (isAssistantTurn(turns[i])) {
@@ -878,7 +879,8 @@ function buildResponseObserverExpression(
 
     // Check if the last assistant turn has finished (scoped to avoid detecting old turns).
     const isLastAssistantTurnFinished = () => {
-      const turns = Array.from(document.querySelectorAll(CONVERSATION_SELECTOR));
+      const preciseTurns = Array.from(document.querySelectorAll('[data-testid^="conversation-turn"]'));
+      const turns = preciseTurns.length > 0 ? preciseTurns : Array.from(document.querySelectorAll(CONVERSATION_SELECTOR));
       let lastAssistantTurn = null;
       for (let i = turns.length - 1; i >= 0; i--) {
         if (isAssistantTurn(turns[i])) {
@@ -1018,7 +1020,15 @@ function buildAssistantExtractor(functionName: string): string {
       }
     };
 
-    const turns = Array.from(document.querySelectorAll(CONVERSATION_SELECTOR));
+    // Prefer the precise testid-based turn containers when present; the broad
+    // CONVERSATION_SELECTOR can double-count nested message divs and shift the
+    // assistant turnIndex out of sync with the baseline count.
+    const containerTurns = Array.from(
+      document.querySelectorAll('[data-testid^="conversation-turn"]'),
+    );
+    const turns = containerTurns.length > 0
+      ? containerTurns
+      : Array.from(document.querySelectorAll(CONVERSATION_SELECTOR));
     for (let index = turns.length - 1; index >= 0; index -= 1) {
       const turn = turns[index];
       if (!isAssistantTurn(turn)) {

--- a/src/browser/actions/attachments.ts
+++ b/src/browser/actions/attachments.ts
@@ -1,11 +1,7 @@
 import path from "node:path";
 import type { ChromeClient, BrowserAttachment, BrowserLogger } from "../types.js";
-import {
-  CONVERSATION_TURN_SELECTOR,
-  INPUT_SELECTORS,
-  SEND_BUTTON_SELECTORS,
-  UPLOAD_STATUS_SELECTORS,
-} from "../constants.js";
+import { INPUT_SELECTORS, SEND_BUTTON_SELECTORS, UPLOAD_STATUS_SELECTORS } from "../constants.js";
+import { buildConversationTurnListExpression } from "../conversationTurns.js";
 import { delay } from "../utils.js";
 import { logDomFailure } from "../domDebug.js";
 import { transferAttachmentViaDataTransfer } from "./attachmentDataTransfer.js";
@@ -1810,14 +1806,12 @@ function buildUserTurnAttachmentExpression(options: {
   expectedPromptPrefix: string;
   expectedConversationId: string | null;
 }): string {
-  const conversationSelectorLiteral = JSON.stringify(CONVERSATION_TURN_SELECTOR);
   const minTurnLiteral = options.minTurnIndex === null ? "null" : String(options.minTurnIndex);
   const expectedPromptLiteral = JSON.stringify(options.expectedPromptPrefix);
   const expectedConversationLiteral = options.expectedConversationId
     ? JSON.stringify(options.expectedConversationId)
     : "null";
   return `(() => {
-    const CONVERSATION_SELECTOR = ${conversationSelectorLiteral};
     const MIN_TURN_INDEX = ${minTurnLiteral};
     const EXPECTED_PROMPT_PREFIX = ${expectedPromptLiteral};
     const EXPECTED_CONVERSATION_ID = ${expectedConversationLiteral};
@@ -1830,7 +1824,7 @@ function buildUserTurnAttachmentExpression(options: {
     ) {
       return { ok: false, conversationMismatch: true };
     }
-    const turns = Array.from(document.querySelectorAll(CONVERSATION_SELECTOR));
+    const turns = ${buildConversationTurnListExpression()};
     const userTurns = turns.map((node, index) => ({ node, index })).filter(({ node }) => {
       const attr = (node.getAttribute('data-message-author-role') || node.getAttribute('data-turn') || node.dataset?.turn || '').toLowerCase();
       if (attr === 'user') return true;

--- a/src/browser/actions/deepResearch.ts
+++ b/src/browser/actions/deepResearch.ts
@@ -8,8 +8,8 @@ import {
   DEEP_RESEARCH_DEFAULT_TIMEOUT_MS,
   FINISHED_ACTIONS_SELECTOR,
   STOP_BUTTON_SELECTOR,
-  CONVERSATION_TURN_SELECTOR,
 } from "../constants.js";
+import { buildConversationTurnListExpression } from "../conversationTurns.js";
 import { delay } from "../utils.js";
 import { isDeepResearchIncompleteText } from "../deepResearchResult.js";
 import { buildClickDispatcher } from "./domEvents.js";
@@ -744,9 +744,9 @@ async function readDeepResearchTargetOwnerTurnIndex(
         {
           objectId,
           functionDeclaration: `function() {
-            const selector = ${JSON.stringify(CONVERSATION_TURN_SELECTOR)};
-            const turn = this.closest(selector);
-            return turn ? Array.from(document.querySelectorAll(selector)).indexOf(turn) : null;
+            const turns = ${buildConversationTurnListExpression()};
+            const index = turns.findIndex((turn) => turn === this || turn.contains?.(this));
+            return index >= 0 ? index : null;
           }`,
           returnByValue: true,
         },
@@ -1052,7 +1052,6 @@ function buildDeepResearchStatusExpression(): string {
 function buildDeepResearchCompletionPollExpression(minTurnIndex: number): string {
   const finishedSelector = JSON.stringify(FINISHED_ACTIONS_SELECTOR);
   const stopSelector = JSON.stringify(STOP_BUTTON_SELECTOR);
-  const turnSelector = JSON.stringify(CONVERSATION_TURN_SELECTOR);
   return `(() => {
     const MIN_TURN_INDEX = ${minTurnIndex};
     const stopVisible = Boolean(document.querySelector(${stopSelector}));
@@ -1068,7 +1067,7 @@ function buildDeepResearchCompletionPollExpression(minTurnIndex: number): string
         String(node.getAttribute('data-testid') || '').toLowerCase().includes('conversation-turn') &&
           /chatgpt\\s+said/i.test(node.innerText || node.textContent || '');
     };
-    const conversationTurns = Array.from(document.querySelectorAll(${turnSelector}));
+    const conversationTurns = ${buildConversationTurnListExpression()};
     const allAssistantTurns = Array.from(document.querySelectorAll('[data-message-author-role="assistant"], [data-turn="assistant"]'));
     const scopedTurns = scopedToNewTurns
       ? conversationTurns.slice(MIN_TURN_INDEX).filter(isAssistantTurn)

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -4,10 +4,13 @@ import {
   PROMPT_PRIMARY_SELECTOR,
   PROMPT_FALLBACK_SELECTOR,
   SEND_BUTTON_SELECTORS,
-  CONVERSATION_TURN_SELECTOR,
   STOP_BUTTON_SELECTOR,
   ASSISTANT_ROLE_SELECTOR,
 } from "../constants.js";
+import {
+  buildConversationTurnCountExpression,
+  buildConversationTurnListExpression,
+} from "../conversationTurns.js";
 import { delay } from "../utils.js";
 import { logDomFailure } from "../domDebug.js";
 import { buildClickDispatcher } from "./domEvents.js";
@@ -792,7 +795,6 @@ async function verifyPromptCommitted(
   const inputSelectorsLiteral = JSON.stringify(INPUT_SELECTORS);
   const stopSelectorLiteral = JSON.stringify(STOP_BUTTON_SELECTOR);
   const assistantSelectorLiteral = JSON.stringify(ASSISTANT_ROLE_SELECTOR);
-  const turnSelectorLiteral = JSON.stringify(CONVERSATION_TURN_SELECTOR);
   let baseline: number | null =
     typeof baselineTurns === "number" && Number.isFinite(baselineTurns) && baselineTurns >= 0
       ? Math.floor(baselineTurns)
@@ -800,7 +802,7 @@ async function verifyPromptCommitted(
   if (baseline === null) {
     try {
       const { result } = await Runtime.evaluate({
-        expression: `document.querySelectorAll(${turnSelectorLiteral}).length`,
+        expression: buildConversationTurnCountExpression(),
         returnByValue: true,
       });
       const raw = typeof result?.value === "number" ? result.value : Number(result?.value);
@@ -827,8 +829,7 @@ async function verifyPromptCommitted(
 	    };
 	    const normalizedPrompt = normalize(${encodedPrompt});
 	    const normalizedPromptPrefix = normalizedPrompt.slice(0, 120);
-	    const CONVERSATION_SELECTOR = ${JSON.stringify(CONVERSATION_TURN_SELECTOR)};
-	    const articles = Array.from(document.querySelectorAll(CONVERSATION_SELECTOR));
+	    const articles = ${buildConversationTurnListExpression()};
 	    const normalizedTurns = articles.map((node) => normalize(node?.innerText));
 	    const readValue = (node) => {
 	      if (!node) return '';

--- a/src/browser/chatgptFiles.ts
+++ b/src/browser/chatgptFiles.ts
@@ -6,7 +6,8 @@ import type {
   ChromeClient,
   SavedBrowserFile,
 } from "./types.js";
-import { ASSISTANT_ROLE_SELECTOR, CONVERSATION_TURN_SELECTOR } from "./constants.js";
+import { ASSISTANT_ROLE_SELECTOR } from "./constants.js";
+import { buildConversationTurnListExpression } from "./conversationTurns.js";
 import {
   computeFileSha256,
   resolveSessionArtifactsDir,
@@ -326,11 +327,9 @@ function buildAssistantDownloadableFilesExpression(minTurnIndex?: number): strin
     typeof minTurnIndex === "number" && Number.isFinite(minTurnIndex) && minTurnIndex >= 0
       ? Math.floor(minTurnIndex)
       : -1;
-  const conversationLiteral = JSON.stringify(CONVERSATION_TURN_SELECTOR);
   const assistantLiteral = JSON.stringify(ASSISTANT_ROLE_SELECTOR);
   return `(() => {
     const MIN_TURN_INDEX = ${minTurnLiteral};
-    const CONVERSATION_SELECTOR = ${conversationLiteral};
     const ASSISTANT_SELECTOR = ${assistantLiteral};
     const isAssistantTurn = (node) => {
       if (!(node instanceof HTMLElement)) return false;
@@ -439,7 +438,7 @@ function buildAssistantDownloadableFilesExpression(minTurnIndex?: number): strin
       ].join(',')))
         .map(serializeCandidate)
         .filter(Boolean);
-    const turns = Array.from(document.querySelectorAll(CONVERSATION_SELECTOR));
+    const turns = ${buildConversationTurnListExpression()};
     const files = [];
     for (let index = turns.length - 1; index >= 0; index -= 1) {
       const turn = turns[index];
@@ -725,7 +724,6 @@ function buildClickAssistantDownloadButtonsExpression(
     typeof minTurnIndex === "number" && Number.isFinite(minTurnIndex) && minTurnIndex >= 0
       ? Math.floor(minTurnIndex)
       : -1;
-  const conversationLiteral = JSON.stringify(CONVERSATION_TURN_SELECTOR);
   const assistantLiteral = JSON.stringify(ASSISTANT_ROLE_SELECTOR);
   const expectedLabelsLiteral = JSON.stringify(expectedLabels);
   const allowGenericDownloadLabelsLiteral = JSON.stringify(allowGenericDownloadLabels);
@@ -739,7 +737,6 @@ function buildClickAssistantDownloadButtonsExpression(
       : 0;
   return `(() => {
     const MIN_TURN_INDEX = ${minTurnLiteral};
-    const CONVERSATION_SELECTOR = ${conversationLiteral};
     const ASSISTANT_SELECTOR = ${assistantLiteral};
     const EXPECTED_LABELS = ${expectedLabelsLiteral};
     const ALLOW_GENERIC_DOWNLOAD_LABELS = ${allowGenericDownloadLabelsLiteral};
@@ -862,7 +859,7 @@ function buildClickAssistantDownloadButtonsExpression(
     const genericBehaviorButton = (info) =>
       ALLOW_GENERIC_DOWNLOAD_LABELS && info.className.includes('behavior-btn') && hasDownloadIntent(info);
     const genericFallbackButton = (info) => ALLOW_GENERIC_DOWNLOAD_LABELS && hasDownloadIntent(info);
-    const turns = Array.from(document.querySelectorAll(CONVERSATION_SELECTOR));
+    const turns = ${buildConversationTurnListExpression()};
     const expectedMatches = new Set();
     const genericBehaviorMatches = new Set();
     const genericFallbackMatches = new Set();

--- a/src/browser/chatgptImages.ts
+++ b/src/browser/chatgptImages.ts
@@ -7,7 +7,8 @@ import type {
   ChromeClient,
   SavedBrowserImage,
 } from "./types.js";
-import { ASSISTANT_ROLE_SELECTOR, CONVERSATION_TURN_SELECTOR } from "./constants.js";
+import { ASSISTANT_ROLE_SELECTOR } from "./constants.js";
+import { buildConversationTurnListExpression } from "./conversationTurns.js";
 import { delay } from "./utils.js";
 import { readAssistantSnapshot } from "./pageActions.js";
 import { getOracleHomeDir } from "../oracleHome.js";
@@ -71,11 +72,9 @@ function buildAssistantImageExpression(minTurnIndex?: number): string {
     typeof minTurnIndex === "number" && Number.isFinite(minTurnIndex) && minTurnIndex >= 0
       ? Math.floor(minTurnIndex)
       : -1;
-  const conversationLiteral = JSON.stringify(CONVERSATION_TURN_SELECTOR);
   const assistantLiteral = JSON.stringify(ASSISTANT_ROLE_SELECTOR);
   return `(() => {
     const MIN_TURN_INDEX = ${minTurnLiteral};
-    const CONVERSATION_SELECTOR = ${conversationLiteral};
     const ASSISTANT_SELECTOR = ${assistantLiteral};
     const isGeneratedImage = (img) => {
       const url = new URL(img?.src || '', location.origin || 'https://chatgpt.com');
@@ -111,7 +110,7 @@ function buildAssistantImageExpression(minTurnIndex?: number): string {
       if (testId.includes('assistant')) return true;
       return Boolean(node.querySelector(ASSISTANT_SELECTOR) || node.querySelector('[data-testid*="assistant"]'));
     };
-    const turns = Array.from(document.querySelectorAll(CONVERSATION_SELECTOR));
+    const turns = ${buildConversationTurnListExpression()};
     for (let index = turns.length - 1; index >= 0; index -= 1) {
       const turn = turns[index];
       if (!isAssistantTurn(turn)) continue;

--- a/src/browser/constants.ts
+++ b/src/browser/constants.ts
@@ -38,11 +38,6 @@ export const CONVERSATION_TURN_SELECTOR =
   'article[data-testid^="conversation-turn"], div[data-testid^="conversation-turn"], section[data-testid^="conversation-turn"], ' +
   "article[data-message-author-role], div[data-message-author-role], section[data-message-author-role], " +
   "article[data-turn], div[data-turn], section[data-turn]";
-// Precise selector for top-level conversation turn containers.
-// CONVERSATION_TURN_SELECTOR above is a broad fallback that can double-count a
-// turn's nested message div (e.g. a child div[data-message-author-role]) and
-// inflate baseline/turn-index counts, which blocks assistant snapshots via the
-// minTurnIndex gate. Prefer this testid-based selector when the DOM provides it.
 export const CONVERSATION_TURN_CONTAINER_SELECTOR = '[data-testid^="conversation-turn"]';
 export const ASSISTANT_ROLE_SELECTOR =
   '[data-message-author-role="assistant"], [data-turn="assistant"]';

--- a/src/browser/constants.ts
+++ b/src/browser/constants.ts
@@ -38,6 +38,12 @@ export const CONVERSATION_TURN_SELECTOR =
   'article[data-testid^="conversation-turn"], div[data-testid^="conversation-turn"], section[data-testid^="conversation-turn"], ' +
   "article[data-message-author-role], div[data-message-author-role], section[data-message-author-role], " +
   "article[data-turn], div[data-turn], section[data-turn]";
+// Precise selector for top-level conversation turn containers.
+// CONVERSATION_TURN_SELECTOR above is a broad fallback that can double-count a
+// turn's nested message div (e.g. a child div[data-message-author-role]) and
+// inflate baseline/turn-index counts, which blocks assistant snapshots via the
+// minTurnIndex gate. Prefer this testid-based selector when the DOM provides it.
+export const CONVERSATION_TURN_CONTAINER_SELECTOR = '[data-testid^="conversation-turn"]';
 export const ASSISTANT_ROLE_SELECTOR =
   '[data-message-author-role="assistant"], [data-turn="assistant"]';
 export const CLOUDFLARE_SCRIPT_SELECTOR = 'script[src*="/challenge-platform/"]';

--- a/src/browser/conversationTurns.ts
+++ b/src/browser/conversationTurns.ts
@@ -1,0 +1,18 @@
+import { CONVERSATION_TURN_CONTAINER_SELECTOR, CONVERSATION_TURN_SELECTOR } from "./constants.js";
+
+/** Build a browser-context expression that returns one DOM node per conversation turn. */
+export function buildConversationTurnListExpression(rootExpression = "document"): string {
+  const containerSelector = JSON.stringify(CONVERSATION_TURN_CONTAINER_SELECTOR);
+  const fallbackSelector = JSON.stringify(CONVERSATION_TURN_SELECTOR);
+  return `(() => {
+    const root = ${rootExpression};
+    const containers = Array.from(root.querySelectorAll(${containerSelector}));
+    return containers.length > 0
+      ? containers
+      : Array.from(root.querySelectorAll(${fallbackSelector}));
+  })()`;
+}
+
+export function buildConversationTurnCountExpression(rootExpression = "document"): string {
+  return `(${buildConversationTurnListExpression(rootExpression)}).length`;
+}

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -55,7 +55,12 @@ import {
 import { estimateTokenCount, withRetries, delay } from "./utils.js";
 import { formatElapsed } from "../oracle/format.js";
 import type { BrowserModelSelectionEvidence } from "../sessionStore.js";
-import { CHATGPT_URL, CONVERSATION_TURN_SELECTOR, DEFAULT_MODEL_STRATEGY } from "./constants.js";
+import {
+  CHATGPT_URL,
+  CONVERSATION_TURN_CONTAINER_SELECTOR,
+  CONVERSATION_TURN_SELECTOR,
+  DEFAULT_MODEL_STRATEGY,
+} from "./constants.js";
 import type { LaunchedChrome } from "chrome-launcher";
 import { BrowserAutomationError } from "../oracle/errors.js";
 import { alignPromptEchoPair, buildPromptEchoMatcher } from "./reattachHelpers.js";
@@ -3899,12 +3904,20 @@ async function readConversationTurnCount(
   Runtime: ChromeClient["Runtime"],
   logger?: BrowserLogger,
 ): Promise<number | null> {
-  const selectorLiteral = JSON.stringify(CONVERSATION_TURN_SELECTOR);
+  // Prefer the precise testid-based turn-container selector to avoid the broad
+  // selector double-counting nested message divs (which inflates the baseline
+  // and wrongly suppresses assistant snapshots via the minTurnIndex gate).
+  const containerLiteral = JSON.stringify(CONVERSATION_TURN_CONTAINER_SELECTOR);
+  const fallbackLiteral = JSON.stringify(CONVERSATION_TURN_SELECTOR);
+  const expression = `(() => {
+    const precise = document.querySelectorAll(${containerLiteral}).length;
+    return precise > 0 ? precise : document.querySelectorAll(${fallbackLiteral}).length;
+  })()`;
   const attempts = 4;
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     try {
       const { result } = await Runtime.evaluate({
-        expression: `document.querySelectorAll(${selectorLiteral}).length`,
+        expression,
         returnByValue: true,
       });
       const raw = typeof result?.value === "number" ? result.value : Number(result?.value);

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -55,15 +55,11 @@ import {
 import { estimateTokenCount, withRetries, delay } from "./utils.js";
 import { formatElapsed } from "../oracle/format.js";
 import type { BrowserModelSelectionEvidence } from "../sessionStore.js";
-import {
-  CHATGPT_URL,
-  CONVERSATION_TURN_CONTAINER_SELECTOR,
-  CONVERSATION_TURN_SELECTOR,
-  DEFAULT_MODEL_STRATEGY,
-} from "./constants.js";
+import { CHATGPT_URL, DEFAULT_MODEL_STRATEGY } from "./constants.js";
 import type { LaunchedChrome } from "chrome-launcher";
 import { BrowserAutomationError } from "../oracle/errors.js";
 import { alignPromptEchoPair, buildPromptEchoMatcher } from "./reattachHelpers.js";
+import { buildConversationTurnCountExpression } from "./conversationTurns.js";
 import type { ProfileRunLock } from "./profileState.js";
 import {
   cleanupStaleProfileState,
@@ -3904,15 +3900,7 @@ async function readConversationTurnCount(
   Runtime: ChromeClient["Runtime"],
   logger?: BrowserLogger,
 ): Promise<number | null> {
-  // Prefer the precise testid-based turn-container selector to avoid the broad
-  // selector double-counting nested message divs (which inflates the baseline
-  // and wrongly suppresses assistant snapshots via the minTurnIndex gate).
-  const containerLiteral = JSON.stringify(CONVERSATION_TURN_CONTAINER_SELECTOR);
-  const fallbackLiteral = JSON.stringify(CONVERSATION_TURN_SELECTOR);
-  const expression = `(() => {
-    const precise = document.querySelectorAll(${containerLiteral}).length;
-    return precise > 0 ? precise : document.querySelectorAll(${fallbackLiteral}).length;
-  })()`;
+  const expression = buildConversationTurnCountExpression();
   const attempts = 4;
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     try {

--- a/src/browser/reattach.ts
+++ b/src/browser/reattach.ts
@@ -21,7 +21,8 @@ import {
 } from "./chromeLifecycle.js";
 import { resolveBrowserConfig } from "./config.js";
 import { syncCookies } from "./cookies.js";
-import { CHATGPT_URL, CONVERSATION_TURN_SELECTOR } from "./constants.js";
+import { CHATGPT_URL } from "./constants.js";
+import { buildConversationTurnListExpression } from "./conversationTurns.js";
 import { cleanupStaleProfileState } from "./profileState.js";
 import { readDevToolsActivePortInfo } from "./detect.js";
 import {
@@ -408,7 +409,7 @@ async function readPromptPreviewTurnIndex(
       const needle = ${JSON.stringify(preview.toLowerCase().replace(/\s+/g, " ").slice(0, 120))};
       if (!needle) return null;
       const normalize = (value) => String(value || '').toLowerCase().replace(/\\s+/g, ' ').trim();
-      const turns = Array.from(document.querySelectorAll(${JSON.stringify(CONVERSATION_TURN_SELECTOR)}));
+      const turns = ${buildConversationTurnListExpression()};
       let matched = null;
       for (const [index, node] of turns.entries()) {
         const attr = (node.getAttribute('data-message-author-role') || node.getAttribute('data-turn') || node.dataset?.turn || '').toLowerCase();

--- a/src/browser/reattachHelpers.ts
+++ b/src/browser/reattachHelpers.ts
@@ -1,5 +1,6 @@
 import type { BrowserLogger, ChromeClient } from "./types.js";
 import { CONVERSATION_TURN_SELECTOR } from "./constants.js";
+import { buildConversationTurnCountExpression } from "./conversationTurns.js";
 import { delay } from "./utils.js";
 import { readAssistantSnapshot } from "./pageActions.js";
 
@@ -308,10 +309,9 @@ export async function readConversationTurnIndex(
   Runtime: ChromeClient["Runtime"],
   logger?: BrowserLogger,
 ): Promise<number | null> {
-  const selectorLiteral = JSON.stringify(CONVERSATION_TURN_SELECTOR);
   try {
     const { result } = await Runtime.evaluate({
-      expression: `document.querySelectorAll(${selectorLiteral}).length`,
+      expression: buildConversationTurnCountExpression(),
       returnByValue: true,
     });
     const raw = typeof result?.value === "number" ? result.value : Number(result?.value);

--- a/tests/browser/chatgptFiles.test.ts
+++ b/tests/browser/chatgptFiles.test.ts
@@ -1147,7 +1147,7 @@ describe("collectChatGptFileArtifacts", () => {
     expect(expression).toContain('"oracle_pr245_file.csv"');
     expect(expression).toContain("const downloadLabel = 'download ' + label");
     expect(expression).toContain("value === downloadLabel");
-    expect(expression).toContain("document.querySelectorAll(CONVERSATION_SELECTOR)");
+    expect(expression).toContain('[data-testid^=\\"conversation-turn\\"]');
     expect(expression).not.toContain("document.querySelectorAll('button')");
     expect(expression).toContain("const expectedMatches = new Set()");
     expect(expression).toContain("controls.filter(expectedFileControl)");

--- a/tests/browser/conversationTurns.test.ts
+++ b/tests/browser/conversationTurns.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  buildConversationTurnCountExpression,
+  buildConversationTurnListExpression,
+} from "../../src/browser/conversationTurns.js";
+import {
+  CONVERSATION_TURN_CONTAINER_SELECTOR,
+  CONVERSATION_TURN_SELECTOR,
+} from "../../src/browser/constants.js";
+
+function evaluate(expression: string, responses: Map<string, unknown[]>): unknown {
+  const document = {
+    querySelectorAll: vi.fn((selector: string) => responses.get(selector) ?? []),
+  };
+  return Function("document", `return ${expression};`)(document);
+}
+
+describe("conversation turn expressions", () => {
+  test("prefers top-level turn containers over nested broad-selector matches", () => {
+    const containers = [{ id: "user" }, { id: "assistant" }];
+    const nestedMatches = [...containers, { id: "nested-assistant" }];
+    const responses = new Map([
+      [CONVERSATION_TURN_CONTAINER_SELECTOR, containers],
+      [CONVERSATION_TURN_SELECTOR, nestedMatches],
+    ]);
+
+    expect(evaluate(buildConversationTurnListExpression(), responses)).toEqual(containers);
+    expect(evaluate(buildConversationTurnCountExpression(), responses)).toBe(2);
+  });
+
+  test("falls back to the broad selector for older conversation markup", () => {
+    const legacyTurns = [{ id: "user" }, { id: "assistant" }];
+    const responses = new Map([
+      [CONVERSATION_TURN_CONTAINER_SELECTOR, []],
+      [CONVERSATION_TURN_SELECTOR, legacyTurns],
+    ]);
+
+    expect(evaluate(buildConversationTurnListExpression(), responses)).toEqual(legacyTurns);
+  });
+});

--- a/tests/browser/pageActionsExpressions.test.ts
+++ b/tests/browser/pageActionsExpressions.test.ts
@@ -8,6 +8,7 @@ import {
   buildUserTurnAttachmentExpressionForTest,
 } from "../../src/browser/pageActions.ts";
 import {
+  CONVERSATION_TURN_CONTAINER_SELECTOR,
   CONVERSATION_TURN_SELECTOR,
   ASSISTANT_ROLE_SELECTOR,
 } from "../../src/browser/constants.ts";
@@ -25,6 +26,78 @@ describe("browser automation expressions", () => {
     expect(expression).toContain("Generated image.");
     expect(expression).toContain("stopped thinking edit");
     expect(expression).toContain("thought for");
+  });
+
+  test("assistant extractor indexes top-level turns instead of nested role nodes", () => {
+    class FakeElement {
+      readonly dataset: Record<string, string> = {};
+
+      constructor(
+        private readonly attributes: Record<string, string>,
+        readonly innerText = "",
+        private readonly children: FakeElement[] = [],
+      ) {}
+
+      get textContent(): string {
+        return this.innerText;
+      }
+
+      get innerHTML(): string {
+        return this.innerText;
+      }
+
+      getAttribute(name: string): string | null {
+        return this.attributes[name] ?? null;
+      }
+
+      matches(): boolean {
+        return false;
+      }
+
+      querySelector(selector: string): FakeElement | null {
+        if (selector === ASSISTANT_ROLE_SELECTOR) {
+          return (
+            this.children.find(
+              (child) => child.getAttribute("data-message-author-role") === "assistant",
+            ) ?? null
+          );
+        }
+        return null;
+      }
+
+      querySelectorAll(): FakeElement[] {
+        return [];
+      }
+    }
+
+    const nestedUser = new FakeElement({ "data-message-author-role": "user" }, "old prompt");
+    const nestedAssistant = new FakeElement(
+      { "data-message-author-role": "assistant" },
+      "old answer",
+    );
+    const userTurn = new FakeElement({ "data-testid": "conversation-turn-1" }, "old prompt", [
+      nestedUser,
+    ]);
+    const assistantTurn = new FakeElement({ "data-testid": "conversation-turn-2" }, "old answer", [
+      nestedAssistant,
+    ]);
+    const document = {
+      querySelectorAll: (selector: string) => {
+        if (selector === CONVERSATION_TURN_CONTAINER_SELECTOR) return [userTurn, assistantTurn];
+        if (selector === CONVERSATION_TURN_SELECTOR) {
+          return [userTurn, nestedUser, assistantTurn, nestedAssistant];
+        }
+        return [];
+      },
+    };
+    const expression = buildAssistantExtractorForTest("capture");
+    const result = Function(
+      "document",
+      "HTMLElement",
+      `${expression}; return capture();`,
+    )(document, FakeElement) as { text?: string; turnIndex?: number } | null;
+
+    expect(result).toMatchObject({ text: "old answer", turnIndex: 1 });
   });
 
   test("conversation debug expression references conversation selector", () => {
@@ -46,6 +119,7 @@ describe("browser automation expressions", () => {
     expect(expression).toContain("role !== 'user'");
     expect(expression).toContain("copy-turn-action-button");
     expect(expression).toContain(CONVERSATION_TURN_SELECTOR);
+    expect(expression).toContain("turn.contains?.(node)");
   });
 
   test("markdown fallback does not self-reference MIN_TURN_INDEX literal", () => {

--- a/tests/browser/promptComposer.test.ts
+++ b/tests/browser/promptComposer.test.ts
@@ -4,6 +4,10 @@ import {
   clearPromptComposer,
   submitPrompt,
 } from "../../src/browser/actions/promptComposer.js";
+import {
+  CONVERSATION_TURN_CONTAINER_SELECTOR,
+  CONVERSATION_TURN_SELECTOR,
+} from "../../src/browser/constants.js";
 
 describe("promptComposer", () => {
   test("fails composer clearing when stale text remains", async () => {
@@ -52,6 +56,55 @@ describe("promptComposer", () => {
 
       const promise = promptComposer.verifyPromptCommitted(runtime as never, "hello", 150);
       // Attach the rejection handler before timers advance to avoid unhandled-rejection warnings.
+      const assertion = expect(promise).rejects.toThrow(/prompt did not appear/i);
+      await vi.advanceTimersByTimeAsync(250);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("does not count nested broad-selector matches as new turns in a reused conversation", async () => {
+    vi.useFakeTimers();
+    try {
+      const topLevelTurns = [{ innerText: "old user" }, { innerText: "old assistant" }];
+      const nestedMatches = [
+        topLevelTurns[0],
+        { innerText: "old user" },
+        topLevelTurns[1],
+        { innerText: "old assistant" },
+      ];
+      const document = {
+        querySelector: () => null,
+        querySelectorAll: (selector: string) => {
+          if (selector === CONVERSATION_TURN_CONTAINER_SELECTOR) return topLevelTurns;
+          if (selector === CONVERSATION_TURN_SELECTOR) return nestedMatches;
+          return [];
+        },
+      };
+      class FakeTextArea {}
+      const runtime = {
+        evaluate: vi.fn(async ({ expression }: { expression: string }) => ({
+          result: {
+            value: Function(
+              "document",
+              "HTMLTextAreaElement",
+              "location",
+              `return ${expression};`,
+            )(document, FakeTextArea, { href: "https://chatgpt.com/c/reused" }),
+          },
+        })),
+      } as unknown as {
+        evaluate: (args: { expression: string; returnByValue?: boolean }) => Promise<unknown>;
+      };
+
+      const promise = promptComposer.verifyPromptCommitted(
+        runtime as never,
+        "new prompt",
+        150,
+        undefined,
+        2,
+      );
       const assertion = expect(promise).rejects.toThrow(/prompt did not appear/i);
       await vi.advanceTimersByTimeAsync(250);
       await assertion;


### PR DESCRIPTION
## Problem

Current ChatGPT markup nests role-bearing message nodes inside top-level `conversation-turn` containers. The legacy broad selector matches both layers, so browser baselines and later response/artifact readers can count different turn indexes. Image-only replies are especially vulnerable: the new response is rendered, but the `minTurnIndex` gate can suppress it until timeout.

## Fix

- Add one shared precise-first conversation-turn expression, retaining the broad selector only as a legacy-markup fallback.
- Use that same coordinate system for prompt commit verification, response snapshots and markdown fallback, image/file artifact capture, attachment checks, Deep Research, and reattachment.
- Resolve fallback content and iframe owners by containment in the selected top-level turn list, avoiding nested-node index drift.
- Add focused regressions for nested broad-selector matches, reused conversations, assistant turn indexes, and legacy fallback behavior.
- Add an Unreleased changelog entry thanking @cp7553479.

## Verification

- `pnpm run check`
- `pnpm run build`
- `pnpm test`: 1,401 passed, 43 skipped
- Focused rebased-head browser suite: 139 passed
- Structured pre-ship review: clean, no actionable findings
- Authenticated live Chrome/CDP test: one initial text turn plus a same-conversation image follow-up completed in 64.7s; Oracle captured the follow-up and saved a real 1,768,098-byte PNG at 1254×1254.

The broad selector remains available for older/project DOM shapes; current ChatGPT markup now uses one top-level index from submission through artifact capture.
