### PR TITLE
fix(browser): require completion proof for short captures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Browser: persist late `/c/<id>` URLs during remote Chrome runs and prefer saved conversation targets over stale target IDs during reattach. Fixes #284. Thanks @LeoLin990405 and @StartupBros!
 - Browser: keep prompt baselines, assistant snapshots, and artifact capture on one top-level ChatGPT turn index so nested message nodes cannot hide a new response. Thanks @cp7553479!
+- Browser: reconfirm implausibly short ChatGPT captures after thinking-UI transitions, and fail closed rather than archiving when the response cannot be confirmed. Fixes #284. Thanks @LeoLin990405!
 
 ## 0.15.1 — 2026-07-03
 

--- a/src/browser/actions/assistantResponse.ts
+++ b/src/browser/actions/assistantResponse.ts
@@ -18,6 +18,28 @@ import { buildClickDispatcher } from "./domEvents.js";
 
 const ASSISTANT_POLL_TIMEOUT_ERROR = "assistant-response-watchdog-timeout";
 const STOP_CONTROL_SELECTOR = STOP_BUTTON_SELECTORS.join(", ");
+// Captures shorter than this are treated as not-yet-confident: a legitimate
+// short reply survives the stability watchdog unchanged, but a mid-stream
+// snapshot grabbed during thinking-UI flapping (e.g. a single "I") does not.
+const MIN_CONFIDENT_ANSWER_LENGTH = 16;
+
+// Decide whether a fast-path capture must be reconfirmed by the stability
+// watchdog before it is trusted as the final answer. The fast evaluation path
+// can win the race mid-stream while ChatGPT is swapping its thinking UI for the
+// answer — in that window the stop button is already gone and completion
+// controls have not appeared yet, so a partial capture looks "done". Confirm
+// when the stop button or completion controls are visible, and also when the
+// capture is implausibly short (the flapping case that returns a stub answer).
+export function shouldConfirmAssistantCompletion(args: {
+  candidateLength: number;
+  stopVisible: boolean;
+  completionVisible: boolean;
+}): boolean {
+  if (args.stopVisible || args.completionVisible) {
+    return true;
+  }
+  return args.candidateLength > 0 && args.candidateLength < MIN_CONFIDENT_ANSWER_LENGTH;
+}
 const THINKING_STATUS_LABELS = [
   "thinking",
   "pro thinking",
@@ -238,11 +260,21 @@ export async function waitForAssistantResponse(
     // Confirm every capture from that transition with the stability-based watchdog; a
     // partial first paragraph can be arbitrarily long.
     const candidateText = String(candidate?.text ?? "").trim();
-    if (stopVisible || completionVisible) {
+    const suspiciouslyShort =
+      candidateText.length > 0 && candidateText.length < MIN_CONFIDENT_ANSWER_LENGTH;
+    if (
+      shouldConfirmAssistantCompletion({
+        candidateLength: candidateText.length,
+        stopVisible,
+        completionVisible,
+      })
+    ) {
       logger(
         stopVisible
           ? "Assistant still generating; waiting for completion"
-          : "Completion controls surfaced; confirming stable assistant response",
+          : completionVisible
+            ? "Completion controls surfaced; confirming stable assistant response"
+            : "Captured an implausibly short response; confirming it is not a mid-stream capture",
       );
       const completed = await pollAssistantCompletion(
         Runtime,
@@ -252,6 +284,11 @@ export async function waitForAssistantResponse(
       );
       if (completed && String(completed.text ?? "").trim().length >= candidateText.length) {
         return completed;
+      }
+      if (suspiciouslyShort) {
+        logger(
+          "[browser] Short response did not grow under the stability watchdog; treating as final.",
+        );
       }
     }
   }

--- a/src/browser/actions/assistantResponse.ts
+++ b/src/browser/actions/assistantResponse.ts
@@ -18,18 +18,12 @@ import { buildClickDispatcher } from "./domEvents.js";
 
 const ASSISTANT_POLL_TIMEOUT_ERROR = "assistant-response-watchdog-timeout";
 const STOP_CONTROL_SELECTOR = STOP_BUTTON_SELECTORS.join(", ");
-// Captures shorter than this are treated as not-yet-confident: a legitimate
-// short reply survives the stability watchdog unchanged, but a mid-stream
-// snapshot grabbed during thinking-UI flapping (e.g. a single "I") does not.
 const MIN_CONFIDENT_ANSWER_LENGTH = 16;
 
-// Decide whether a fast-path capture must be reconfirmed by the stability
-// watchdog before it is trusted as the final answer. The fast evaluation path
-// can win the race mid-stream while ChatGPT is swapping its thinking UI for the
-// answer — in that window the stop button is already gone and completion
-// controls have not appeared yet, so a partial capture looks "done". Confirm
-// when the stop button or completion controls are visible, and also when the
-// capture is implausibly short (the flapping case that returns a stub answer).
+function isImplausiblyShortAnswer(candidateLength: number): boolean {
+  return candidateLength > 0 && candidateLength < MIN_CONFIDENT_ANSWER_LENGTH;
+}
+
 export function shouldConfirmAssistantCompletion(args: {
   candidateLength: number;
   stopVisible: boolean;
@@ -38,7 +32,7 @@ export function shouldConfirmAssistantCompletion(args: {
   if (args.stopVisible || args.completionVisible) {
     return true;
   }
-  return args.candidateLength > 0 && args.candidateLength < MIN_CONFIDENT_ANSWER_LENGTH;
+  return isImplausiblyShortAnswer(args.candidateLength);
 }
 const THINKING_STATUS_LABELS = [
   "thinking",
@@ -180,7 +174,9 @@ export async function waitForAssistantResponse(
         error instanceof Error &&
         error.message === ASSISTANT_POLL_TIMEOUT_ERROR
       ) {
-        evaluation = await evaluationPromise;
+        evaluationPromise.catch(() => undefined);
+        await terminateRuntimeExecution(Runtime);
+        throw error;
       } else if (source === "poll") {
         throw error;
       } else if (source === "evaluation") {
@@ -251,6 +247,8 @@ export async function waitForAssistantResponse(
   // The evaluation path can race ahead of completion. If ChatGPT is still streaming, wait for the watchdog poller.
   const elapsedMs = Date.now() - start;
   const remainingMs = Math.max(0, timeoutMs - elapsedMs);
+  const candidateText = String(candidate?.text ?? "").trim();
+  const suspiciouslyShort = isImplausiblyShortAnswer(candidateText.length);
   if (remainingMs > 0) {
     const [stopVisible, completionVisible] = await Promise.all([
       isStopButtonVisible(Runtime),
@@ -259,9 +257,6 @@ export async function waitForAssistantResponse(
     // Completion controls can appear briefly while Pro is still replacing its thinking UI.
     // Confirm every capture from that transition with the stability-based watchdog; a
     // partial first paragraph can be arbitrarily long.
-    const candidateText = String(candidate?.text ?? "").trim();
-    const suspiciouslyShort =
-      candidateText.length > 0 && candidateText.length < MIN_CONFIDENT_ANSWER_LENGTH;
     if (
       shouldConfirmAssistantCompletion({
         candidateLength: candidateText.length,
@@ -285,12 +280,13 @@ export async function waitForAssistantResponse(
       if (completed && String(completed.text ?? "").trim().length >= candidateText.length) {
         return completed;
       }
-      if (suspiciouslyShort) {
-        logger(
-          "[browser] Short response did not grow under the stability watchdog; treating as final.",
-        );
-      }
     }
+  }
+
+  if (suspiciouslyShort) {
+    throw new Error(
+      "assistant-response short capture could not be confirmed before timeout; refusing to finalize it",
+    );
   }
 
   return candidate;
@@ -386,6 +382,7 @@ async function recoverAssistantResponse(
   if (recoveryTimeoutMs === 0) {
     return null;
   }
+  const recoveryStartedAt = Date.now();
   const recovered = await waitForCondition(
     async () => {
       const snapshot = await readAssistantSnapshot(Runtime, minTurnIndex, expectedConversationId);
@@ -395,6 +392,11 @@ async function recoverAssistantResponse(
     400,
   );
   if (recovered) {
+    if (isImplausiblyShortAnswer(recovered.text.length)) {
+      logger("Recovered an implausibly short response; waiting for completion proof");
+      const remainingMs = Math.max(0, recoveryTimeoutMs - (Date.now() - recoveryStartedAt));
+      return pollAssistantCompletion(Runtime, remainingMs, minTurnIndex, expectedConversationId);
+    }
     logger("Recovered assistant response via polling fallback");
     return recovered;
   }
@@ -560,8 +562,8 @@ async function pollAssistantCompletion(
       if (isGeneratedImageAssistantAnswer(normalized)) {
         return normalized;
       }
-      const shortAnswer = currentLength > 0 && currentLength < 16;
-      const mediumAnswer = currentLength >= 16 && currentLength < 40;
+      const shortAnswer = isImplausiblyShortAnswer(currentLength);
+      const mediumAnswer = currentLength >= MIN_CONFIDENT_ANSWER_LENGTH && currentLength < 40;
       const longAnswer = currentLength >= 40 && currentLength < 500;
       // Learned: short answers need a longer stability window or they truncate.
       // Learned: long streaming responses (esp. thinking models) can pause mid-stream;
@@ -575,7 +577,7 @@ async function pollAssistantCompletion(
         const stableEnough = stableCycles >= requiredStableCycles && stableMs >= minStableMs;
         const completionEnough =
           completionVisible && stableCycles >= completionStableTarget && stableMs >= minStableMs;
-        if (completionEnough || stableEnough) {
+        if (completionEnough || (!shortAnswer && stableEnough)) {
           return normalized;
         }
       }
@@ -938,8 +940,8 @@ function buildResponseObserverExpression(
       // Learned: long streaming responses (esp. thinking models) can pause mid-stream;
       // use progressively longer windows to avoid truncation (#71).
       const initialLength = snapshot?.text?.length ?? 0;
-      const shortAnswer = initialLength > 0 && initialLength < 16;
-      const mediumAnswer = initialLength >= 16 && initialLength < 40;
+      const shortAnswer = initialLength > 0 && initialLength < ${MIN_CONFIDENT_ANSWER_LENGTH};
+      const mediumAnswer = initialLength >= ${MIN_CONFIDENT_ANSWER_LENGTH} && initialLength < 40;
       const longAnswer = initialLength >= 40 && initialLength < 500;
       const settleWindowMs = shortAnswer ? 12_000 : mediumAnswer ? 5_000 : longAnswer ? 8_000 : 10_000;
       const settleIntervalMs = 400;

--- a/tests/browser/assistantResponseStatus.test.ts
+++ b/tests/browser/assistantResponseStatus.test.ts
@@ -5,6 +5,7 @@ import {
   buildAssistantSnapshotExpressionForTest,
   buildStopButtonVisibilityExpressionForTest,
   matchesThinkingStatusLabelForTest,
+  shouldConfirmAssistantCompletion,
 } from "../../src/browser/actions/assistantResponse.js";
 import { STOP_BUTTON_SELECTORS } from "../../src/browser/constants.js";
 
@@ -128,5 +129,76 @@ describe("assistant thinking-status capture", () => {
       }),
     );
     expect(result).toBe(fixture.expected);
+  });
+});
+
+describe("shouldConfirmAssistantCompletion", () => {
+  test("confirms while the stop button is visible", () => {
+    expect(
+      shouldConfirmAssistantCompletion({
+        candidateLength: 500,
+        stopVisible: true,
+        completionVisible: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("confirms while completion controls are visible", () => {
+    expect(
+      shouldConfirmAssistantCompletion({
+        candidateLength: 500,
+        stopVisible: false,
+        completionVisible: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("confirms an implausibly short capture even when no controls are visible", () => {
+    // The thinking-UI flapping case: stop button already gone, completion
+    // controls not yet shown, a stub answer ("I") captured mid-stream.
+    expect(
+      shouldConfirmAssistantCompletion({
+        candidateLength: 1,
+        stopVisible: false,
+        completionVisible: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("trusts a long capture once controls have cleared", () => {
+    expect(
+      shouldConfirmAssistantCompletion({
+        candidateLength: 500,
+        stopVisible: false,
+        completionVisible: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("does not force confirmation for an empty capture (handled elsewhere)", () => {
+    expect(
+      shouldConfirmAssistantCompletion({
+        candidateLength: 0,
+        stopVisible: false,
+        completionVisible: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("uses length 16 as the confidence boundary", () => {
+    expect(
+      shouldConfirmAssistantCompletion({
+        candidateLength: 15,
+        stopVisible: false,
+        completionVisible: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldConfirmAssistantCompletion({
+        candidateLength: 16,
+        stopVisible: false,
+        completionVisible: false,
+      }),
+    ).toBe(false);
   });
 });

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -837,12 +837,17 @@ describe("waitForAssistantResponse", () => {
       evaluate: vi.fn().mockResolvedValue({
         result: {
           type: "object",
-          value: { text: "Answer", html: "<p>Answer</p>", messageId: "mid", turnId: "tid" },
+          value: {
+            text: "Answer to the question.",
+            html: "<p>Answer to the question.</p>",
+            messageId: "mid",
+            turnId: "tid",
+          },
         },
       }),
     } as unknown as ChromeClient["Runtime"];
     const result = await waitForAssistantResponse(runtime, 1000, logger);
-    expect(result.text).toBe("Answer");
+    expect(result.text).toBe("Answer to the question.");
     expect(result.meta).toEqual({ messageId: "mid", turnId: "tid" });
   });
 
@@ -850,7 +855,16 @@ describe("waitForAssistantResponse", () => {
     vi.useFakeTimers();
     try {
       let snapshotCalls = 0;
-      const payload = { text: "Answer", html: "<p>Answer</p>", messageId: "mid", turnId: "tid" };
+      // Use a confident-length answer so the fast path returns directly; a
+      // sub-16-char capture would (intentionally) trigger the short-response
+      // confirmation watchdog, which this test is not exercising.
+      const answerText = "Answer to the question.";
+      const payload = {
+        text: answerText,
+        html: `<p>${answerText}</p>`,
+        messageId: "mid",
+        turnId: "tid",
+      };
       const evaluate = vi
         .fn()
         .mockImplementation(async (params: { expression?: string; awaitPromise?: boolean }) => {
@@ -873,7 +887,7 @@ describe("waitForAssistantResponse", () => {
       const promise = waitForAssistantResponse(runtime, 30_000, logger);
       await vi.advanceTimersByTimeAsync(2_000);
       const result = await promise;
-      expect(result.text).toBe("Answer");
+      expect(result.text).toBe(answerText);
 
       const callsAtReturn = evaluate.mock.calls.length;
       await vi.advanceTimersByTimeAsync(5_000);

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -897,6 +897,114 @@ describe("waitForAssistantResponse", () => {
     }
   });
 
+  test("reconfirms a short no-control capture and returns the grown answer", async () => {
+    vi.useFakeTimers();
+    try {
+      const startedAt = Date.now();
+      const partial = { text: "I", messageId: "mid", turnId: "tid" };
+      const complete = {
+        text: "I finished the answer after the thinking transition.",
+        messageId: "mid",
+        turnId: "tid",
+      };
+      let snapshotCalls = 0;
+      const evaluate = vi
+        .fn()
+        .mockImplementation(async (params: { expression?: string; awaitPromise?: boolean }) => {
+          if (params.awaitPromise) {
+            return { result: { type: "object", value: partial } };
+          }
+          const expression = String(params.expression ?? "");
+          if (expression.includes("extractAssistantTurn")) {
+            snapshotCalls += 1;
+            if (snapshotCalls === 1) {
+              await new Promise((resolve) => setTimeout(resolve, 50));
+            }
+            return {
+              result: { value: Date.now() - startedAt < 3_500 ? partial : complete },
+            };
+          }
+          return { result: { value: false } };
+        });
+
+      const promise = waitForAssistantResponse(
+        { evaluate } as unknown as ChromeClient["Runtime"],
+        30_000,
+        logger,
+      );
+      await vi.advanceTimersByTimeAsync(12_000);
+
+      await expect(promise).resolves.toMatchObject({ text: complete.text });
+      expect(logger).toHaveBeenCalledWith(
+        "Captured an implausibly short response; confirming it is not a mid-stream capture",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("rejects a stable short capture without a completion signal", async () => {
+    vi.useFakeTimers();
+    try {
+      const partial = { text: "I", messageId: "mid", turnId: "tid" };
+      const evaluate = vi
+        .fn()
+        .mockImplementation(async (params: { expression?: string; awaitPromise?: boolean }) => {
+          if (params.awaitPromise) {
+            return { result: { type: "object", value: partial } };
+          }
+          const expression = String(params.expression ?? "");
+          if (expression.includes("extractAssistantTurn")) {
+            return { result: { value: partial } };
+          }
+          return { result: { value: false } };
+        });
+
+      const promise = waitForAssistantResponse(
+        { evaluate } as unknown as ChromeClient["Runtime"],
+        15_000,
+        logger,
+      );
+      const assertion = expect(promise).rejects.toThrow(/refusing to finalize/i);
+      await vi.advanceTimersByTimeAsync(16_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("rejects a stable short watchdog capture when the observer hangs", async () => {
+    vi.useFakeTimers();
+    try {
+      const partial = { text: "I", messageId: "mid", turnId: "tid" };
+      const evaluate = vi
+        .fn()
+        .mockImplementation(async (params: { expression?: string; awaitPromise?: boolean }) => {
+          if (params.awaitPromise) {
+            return new Promise(() => undefined);
+          }
+          const expression = String(params.expression ?? "");
+          if (expression.includes("extractAssistantTurn")) {
+            return { result: { value: partial } };
+          }
+          return { result: { value: false } };
+        });
+      const terminateExecution = vi.fn().mockResolvedValue(undefined);
+
+      const promise = waitForAssistantResponse(
+        { evaluate, terminateExecution } as unknown as ChromeClient["Runtime"],
+        15_000,
+        logger,
+      );
+      const assertion = expect(promise).rejects.toThrow(/watchdog-timeout/i);
+      await vi.advanceTimersByTimeAsync(16_000);
+      await assertion;
+      expect(terminateExecution).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("re-polls a completion capture longer than 80 characters until the full answer is stable", async () => {
     vi.useFakeTimers();
     try {
@@ -1018,8 +1126,8 @@ describe("waitForAssistantResponse", () => {
           return {
             result: {
               value: {
-                text: "Recovered",
-                html: "<p>Recovered</p>",
+                text: "Recovered assistant response.",
+                html: "<p>Recovered assistant response.</p>",
                 messageId: "mid",
                 turnId: "tid",
               },
@@ -1030,7 +1138,7 @@ describe("waitForAssistantResponse", () => {
       });
     const runtime = { evaluate } as unknown as ChromeClient["Runtime"];
     const result = await waitForAssistantResponse(runtime, 200, logger);
-    expect(result.text).toBe("Recovered");
+    expect(result.text).toBe("Recovered assistant response.");
     expect(evaluate).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Addresses the remaining premature-capture path from #284.

## Failure

ChatGPT can briefly expose a one-character assistant turn while replacing its thinking UI. During that window, stop and completion controls can both be absent. Stability alone is not completion proof: the first live injection reproduced the race and showed that a stable `I` could still be finalized and archived.

## Fix

- Treat responses under 16 characters as suspicious across observer, watchdog, and recovery paths.
- While a response remains suspiciously short, require visible completion controls; ordinary text stability is insufficient.
- If the response grows beyond the suspicious threshold, retain the existing stability behavior.
- Fail closed when a short response cannot be confirmed, and bound a hung observer when its watchdog expires.
- Keep the threshold shared between TypeScript polling and the generated browser observer.

## Verification

- `pnpm run check`
- `pnpm test`: 1,410 passed, 43 skipped
- `pnpm run build`
- Autoreview clean after one accepted return-path finding and regression fix

Authenticated Chrome/CDP proof used a reversible injector to hide stop/completion controls and force the newest assistant DOM to exactly `I` for six seconds. Oracle rejected that stub through 76 forced cycles; after release, the DOM recovered to 921 characters, Oracle returned the full answer with marker `ORACLE293-FINAL-7C91`, saved the transcript, and only then archived the conversation. Injector and Oracle both exited successfully.

Thanks @LeoLin990405 for the original diagnosis and patch.
