### PR TITLE
docs(skill): remove personal credential guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Browser: persist late `/c/<id>` URLs during remote Chrome runs and prefer saved conversation targets over stale target IDs during reattach. Fixes #284. Thanks @LeoLin990405 and @StartupBros!
 - Browser: keep prompt baselines, assistant snapshots, and artifact capture on one top-level ChatGPT turn index so nested message nodes cannot hide a new response. Thanks @cp7553479!
 - Browser: reconfirm implausibly short ChatGPT captures after thinking-UI transitions, and fail closed rather than archiving when the response cannot be confirmed. Fixes #284. Thanks @LeoLin990405!
+- Skills: remove personal credential-reveal and machine-local checkout instructions from the distributed Oracle skill. Fixes #292. Thanks @HikaruEgashira!
 
 ## 0.15.1 — 2026-07-03
 

--- a/skills/oracle/SKILL.md
+++ b/skills/oracle/SKILL.md
@@ -98,11 +98,6 @@ Recommended defaults:
 - For advisory multi-model panels where partial success is useful, use `--allow-partial --write-output <path>` so successful model files and the `<stem>.oracle.json` manifest are easy to recover:
   - `oracle --models gpt-5.4,claude-4.6-sonnet,gemini-3-pro --allow-partial --write-output /tmp/panel.md -p "<task>"`
 - `--timeout 10m` is the normal user-facing API deadline; Oracle derives the HTTP transport timeout unless `--http-timeout` is explicitly set.
-- If the exported `OPENAI_API_KEY` is invalid and the user wants their personal OpenAI key, use `$one-password` in one persistent tmux session. Known item: `API Key - OpenAI - Personal`, field `api_key`. Inject only into the single Oracle command; never print the key:
-  - `OPENAI_API_KEY="$(op item get 'API Key - OpenAI - Personal' --account my.1password.com --fields label=api_key --reveal)" oracle --provider openai --engine api --model gpt-5.5-pro ...`
-- For debugging Oracle itself, prefer the local checkout after pulling `~/Projects/oracle`:
-  - `pnpm -C ~/Projects/oracle run build`
-  - `node ~/Projects/oracle/dist/scripts/run-cli.js ...`
 
 ## Sessions + slugs (don’t lose work)
 


### PR DESCRIPTION
Fixes #292.

Removes the named personal 1Password item, key-reveal command, and machine-local checkout paths from the user-copyable Oracle skill. Maintainer-local recovery guidance can remain in private configuration; the distributed skill now contains only portable instructions.

Verification:

- YAML-parsed the skill frontmatter before and after a documented Codex-style installation copy
- Scanned the installed copy for the named item, `op item get`, and the machine-local checkout path
- `pnpm run check`
- `pnpm run docs:check`

No credential value was accessed or exposed.
