### PR TITLE
fix(cli): recover Deep Research App tool-call wrapper captures via reattach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Browser: keep hidden macOS Chrome windows rendered off-screen so trusted prompt submissions land without retaining drafts or leaking them into later runs. Fixes #298 and #312. Thanks @LeoLin990405!
 - Browser: require positive terminal evidence before finalizing ChatGPT responses so settled preambles and mid-stream text cannot be captured as the completed answer. Thanks @StartupBros!
 - Browser: distinguish genuine Cloudflare interstitials from healthy ChatGPT pages that carry bot-management scripts or mention generic challenge text. Thanks @StartupBros!
+- Browser: recover completed Deep Research reports when the initial capture contains only the Deep Research App tool-call wrapper. Thanks @devYRPauli!
 
 ## 0.15.2 — 2026-07-06
 

--- a/src/cli/sessionDisplay.ts
+++ b/src/cli/sessionDisplay.ts
@@ -70,32 +70,40 @@ const DEEP_RESEARCH_TOOL_CALL_MARKERS = [
   "narzędzie wywołane",
 ];
 
+function isDeepResearchToolCallPlaceholder(answerText: string, outputTokens?: number): boolean {
+  const lines = answerText
+    .toLowerCase()
+    .split(/\r?\n/)
+    .map((line) => line.replace(/\s+/g, " ").trim())
+    .filter(Boolean);
+  if (!lines[0] || !DEEP_RESEARCH_TOOL_CALL_MARKERS.includes(lines[0])) {
+    return false;
+  }
+  if (lines.length === 1) {
+    return outputTokens == null || outputTokens <= 8;
+  }
+  const wrapper = lines.slice(1).join(" ");
+  const structuralSignals = [
+    wrapper.includes("deep research app"),
+    /\bcall tool\b/.test(wrapper),
+    /\brequest\s*\{/.test(wrapper),
+    /\bresponse\s*\{/.test(wrapper),
+    /\bsession[_ ]id\b/.test(wrapper),
+  ].filter(Boolean).length;
+  return wrapper.includes("deep research app") && structuralSignals >= 2;
+}
+
 export function isDeepResearchPlaceholderCapture(
   metadata: SessionMetadata,
   logText: string,
 ): boolean {
-  const answer = trimBeforeFirstAnswer(logText)
-    .replace(/^Answer:\s*/i, "")
-    .toLowerCase()
-    .replace(/\s+/g, " ")
-    .trim();
-  // A capture whose answer begins with a tool-call marker is a placeholder, not the
-  // report. This covers the bare stub ("called tool", a handful of tokens) and the
-  // ChatGPT "Deep Research App" connector's multi-line tool-call wrapper
-  // ("Called tool / Deep Research App / ... Response { session_id: ... }"). The wrapper
-  // is longer than the old outputTokens<=8 gate allowed, so match structurally on the
-  // leading marker instead of by exact text and token count.
-  if (!DEEP_RESEARCH_TOOL_CALL_MARKERS.some((marker) => answer.startsWith(marker))) {
+  if (/\[reattach\][^\n]*\nAnswer:/i.test(logText)) {
     return false;
   }
-  // A reattach appends a recovered "[reattach] ... Answer: <report>" section after the
-  // stale placeholder. trimBeforeFirstAnswer only skips the bare-stub form of that
-  // wrapper, so for the multi-line wrapper the leading placeholder still surfaces here.
-  // If a later Answer already exists the session is recovered; don't re-flag it as a
-  // placeholder and re-trigger reattach over the completed result.
-  const firstAnswer = logText.indexOf("Answer:");
-  const lastAnswer = logText.lastIndexOf("Answer:");
-  return lastAnswer <= firstAnswer;
+  const answer = trimBeforeFirstAnswer(logText).replace(/^Answer:\s*/i, "");
+  const modelUsage = metadata.models?.find((run) => run.model === metadata.model)?.usage;
+  const outputTokens = metadata.usage?.outputTokens ?? modelUsage?.outputTokens;
+  return isDeepResearchToolCallPlaceholder(answer, outputTokens);
 }
 
 async function writeReattachAnswer(
@@ -716,14 +724,11 @@ export function trimBeforeFirstAnswer(logText: string): string {
   if (index === -1) {
     return logText;
   }
-  const fromFirstAnswer = logText.slice(index);
-  if (
-    /^Answer:\s*(called tool|used tool|użyto narzędzia|narzędzie wywołane)\s*\n\[reattach\]/i.test(
-      fromFirstAnswer,
-    )
-  ) {
-    const laterIndex = logText.lastIndexOf(marker);
-    if (laterIndex > index) {
+  const laterIndex = logText.lastIndexOf(marker);
+  const reattachIndex = logText.indexOf("[reattach]", index + marker.length);
+  if (laterIndex > index && reattachIndex > index && reattachIndex < laterIndex) {
+    const firstCapture = logText.slice(index + marker.length, reattachIndex);
+    if (isDeepResearchToolCallPlaceholder(firstCapture)) {
       return logText.slice(laterIndex);
     }
   }

--- a/src/cli/sessionDisplay.ts
+++ b/src/cli/sessionDisplay.ts
@@ -63,20 +63,29 @@ function isDeepResearchBrowserSession(metadata: SessionMetadata): boolean {
   return metadata.mode === "browser" && metadata.browser?.config?.researchMode === "deep";
 }
 
-function isDeepResearchPlaceholderCapture(metadata: SessionMetadata, logText: string): boolean {
+const DEEP_RESEARCH_TOOL_CALL_MARKERS = [
+  "called tool",
+  "used tool",
+  "użyto narzędzia",
+  "narzędzie wywołane",
+];
+
+export function isDeepResearchPlaceholderCapture(
+  metadata: SessionMetadata,
+  logText: string,
+): boolean {
   const answer = trimBeforeFirstAnswer(logText)
     .replace(/^Answer:\s*/i, "")
     .toLowerCase()
     .replace(/\s+/g, " ")
     .trim();
-  const isToolOnly =
-    answer === "called tool" ||
-    answer === "used tool" ||
-    answer === "użyto narzędzia" ||
-    answer === "narzędzie wywołane";
-  const modelUsage = metadata.models?.find((run) => run.model === metadata.model)?.usage;
-  const outputTokens = metadata.usage?.outputTokens ?? modelUsage?.outputTokens;
-  return isToolOnly && (outputTokens == null || outputTokens <= 8);
+  // A capture whose answer begins with a tool-call marker is a placeholder, not the
+  // report. This covers the bare stub ("called tool", a handful of tokens) and the
+  // ChatGPT "Deep Research App" connector's multi-line tool-call wrapper
+  // ("Called tool / Deep Research App / ... Response { session_id: ... }"). The wrapper
+  // is longer than the old outputTokens<=8 gate allowed, so match structurally on the
+  // leading marker instead of by exact text and token count.
+  return DEEP_RESEARCH_TOOL_CALL_MARKERS.some((marker) => answer.startsWith(marker));
 }
 
 async function writeReattachAnswer(

--- a/src/cli/sessionDisplay.ts
+++ b/src/cli/sessionDisplay.ts
@@ -85,7 +85,17 @@ export function isDeepResearchPlaceholderCapture(
   // ("Called tool / Deep Research App / ... Response { session_id: ... }"). The wrapper
   // is longer than the old outputTokens<=8 gate allowed, so match structurally on the
   // leading marker instead of by exact text and token count.
-  return DEEP_RESEARCH_TOOL_CALL_MARKERS.some((marker) => answer.startsWith(marker));
+  if (!DEEP_RESEARCH_TOOL_CALL_MARKERS.some((marker) => answer.startsWith(marker))) {
+    return false;
+  }
+  // A reattach appends a recovered "[reattach] ... Answer: <report>" section after the
+  // stale placeholder. trimBeforeFirstAnswer only skips the bare-stub form of that
+  // wrapper, so for the multi-line wrapper the leading placeholder still surfaces here.
+  // If a later Answer already exists the session is recovered; don't re-flag it as a
+  // placeholder and re-trigger reattach over the completed result.
+  const firstAnswer = logText.indexOf("Answer:");
+  const lastAnswer = logText.lastIndexOf("Answer:");
+  return lastAnswer <= firstAnswer;
 }
 
 async function writeReattachAnswer(

--- a/tests/cli/sessionDisplay.test.ts
+++ b/tests/cli/sessionDisplay.test.ts
@@ -196,6 +196,19 @@ describe("trimBeforeFirstAnswer", () => {
 
     expect(trimBeforeFirstAnswer(input)).toBe("Answer:\nRecovered report");
   });
+
+  test("skips a stale Deep Research App wrapper before a recovered answer", () => {
+    const input =
+      "Answer:\n" +
+      "Called tool\n" +
+      "Deep Research App\n" +
+      "Response { session_id: abc123 }\n" +
+      "[reattach] captured assistant response from existing Chrome tab\n" +
+      "Answer:\n" +
+      "# Recovered report";
+
+    expect(trimBeforeFirstAnswer(input)).toBe("Answer:\n# Recovered report");
+  });
 });
 
 describe("isDeepResearchPlaceholderCapture", () => {
@@ -233,6 +246,14 @@ describe("isDeepResearchPlaceholderCapture", () => {
       "Answer:\n" +
       "# Research Report\n" +
       "The findings show that the market grew 12% year over year.\n";
+    expect(isDeepResearchPlaceholderCapture(deepResearchMeta, log)).toBe(false);
+  });
+
+  test("does not flag prose that happens to begin with a tool-call phrase", () => {
+    const log =
+      "Answer:\n" +
+      "Called tool adoption is accelerating across the market.\n" +
+      "The report analyzes the evidence in detail.\n";
     expect(isDeepResearchPlaceholderCapture(deepResearchMeta, log)).toBe(false);
   });
 

--- a/tests/cli/sessionDisplay.test.ts
+++ b/tests/cli/sessionDisplay.test.ts
@@ -7,6 +7,7 @@ import {
   formatTransportMetadata,
   formatUserErrorMetadata,
   trimBeforeFirstAnswer,
+  isDeepResearchPlaceholderCapture,
   attachSession,
 } from "../../src/cli/sessionDisplay.ts";
 import chalk from "chalk";
@@ -194,6 +195,45 @@ describe("trimBeforeFirstAnswer", () => {
       "Recovered report";
 
     expect(trimBeforeFirstAnswer(input)).toBe("Answer:\nRecovered report");
+  });
+});
+
+describe("isDeepResearchPlaceholderCapture", () => {
+  const deepResearchMeta: SessionMetadata = {
+    id: "sess",
+    createdAt: new Date().toISOString(),
+    status: "completed",
+    options: {},
+  };
+
+  test("flags the bare tool-only stub", () => {
+    const log = "Launching browser mode\nAnswer:\nCalled tool\n";
+    expect(isDeepResearchPlaceholderCapture(deepResearchMeta, log)).toBe(true);
+  });
+
+  test("flags the multi-line Deep Research App tool-call wrapper", () => {
+    const log =
+      "Launching browser mode\n" +
+      "Answer:\n" +
+      "Called tool\n" +
+      "Deep Research App\n" +
+      "Call tool\n" +
+      "Request { prompt: ... }\n" +
+      "Response { session_id: abc123 }\n";
+    expect(isDeepResearchPlaceholderCapture(deepResearchMeta, log)).toBe(true);
+  });
+
+  test("flags Polish tool-call markers", () => {
+    const log = "Answer:\nUżyto narzędzia\n";
+    expect(isDeepResearchPlaceholderCapture(deepResearchMeta, log)).toBe(true);
+  });
+
+  test("does not flag a real report answer", () => {
+    const log =
+      "Answer:\n" +
+      "# Research Report\n" +
+      "The findings show that the market grew 12% year over year.\n";
+    expect(isDeepResearchPlaceholderCapture(deepResearchMeta, log)).toBe(false);
   });
 });
 

--- a/tests/cli/sessionDisplay.test.ts
+++ b/tests/cli/sessionDisplay.test.ts
@@ -235,6 +235,19 @@ describe("isDeepResearchPlaceholderCapture", () => {
       "The findings show that the market grew 12% year over year.\n";
     expect(isDeepResearchPlaceholderCapture(deepResearchMeta, log)).toBe(false);
   });
+
+  test("does not re-flag a wrapper capture that was already recovered", () => {
+    const log =
+      "Answer:\n" +
+      "Called tool\n" +
+      "Deep Research App\n" +
+      "Response { session_id: abc123 }\n" +
+      "[reattach] captured assistant response from existing Chrome tab\n" +
+      "Answer:\n" +
+      "# Research Report\n" +
+      "The recovered findings.\n";
+    expect(isDeepResearchPlaceholderCapture(deepResearchMeta, log)).toBe(false);
+  });
 });
 
 describe("attachSession rendering", () => {


### PR DESCRIPTION
Fixes #297.

## Problem

The placeholder detector recognized only a bare `Called tool` answer with at most eight output tokens. ChatGPT's Deep Research App connector can instead save a multi-line tool-call wrapper containing `Deep Research App`, request/response fields, and a session id. That wrapper was replayed as the answer instead of triggering the existing reattach path that can recover the completed report.

The proposed prefix-only match was too broad: a legitimate report beginning with prose such as “Called tool adoption…” could be treated as incomplete and converted from completed to error. An already-recovered wrapper also remained ahead of the recovered report during rendering.

## Final design

- Preserve the existing token gate for bare localized tool-call stubs.
- Recognize a multi-line placeholder only when the first line is an exact known marker and the remaining lines contain the actual Deep Research App wrapper structure.
- Do not classify prose that merely begins with a marker phrase.
- Do not reattach again after a recorded reattach answer.
- When rendering an already-recovered wrapper session, skip the stale wrapper and select the later recovered `Answer:` block.

Contributor commits and authorship are preserved. The maintainer hardening commit adds the false-positive guard, recovered-render behavior, tests, and changelog entry.

## Validation

Exact final head: `ccd582bc326a0486cc525fbf83859cb4cae70924`.

- `pnpm vitest run tests/cli/sessionDisplay.test.ts tests/browser/pageActions.test.ts` — 107 passed, 1 skipped.
- `pnpm check` — passed.
- `pnpm test` — 1,502 passed, 43 skipped.
- Final AutoReview — no actionable findings.

## Exact-head live Pro proof

Signed-in ChatGPT Pro Deep Research session `pr300-deep-research-live` completed a sourced report in 2m07s and included the unique final marker `PR300-DEEP-RESEARCH-END-20260711`.

`oracle session pr300-deep-research-live --render --verbose-render` then:

- kept the session `completed`;
- rendered the complete report through the unique final marker;
- validated the saved Deep Research report and browser transcript artifacts;
- did not misclassify the normal report or convert it to an error.

Fresh exact-head CI is running.
