### PR TITLE
fix(browser): finalize assistant turns on positive completion proof (stop preamble/mid-stream capture)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Browser: keep hidden macOS Chrome windows rendered off-screen so trusted prompt submissions land without retaining drafts or leaking them into later runs. Fixes #298 and #312. Thanks @LeoLin990405!
+- Browser: require positive terminal evidence before finalizing ChatGPT responses so settled preambles and mid-stream text cannot be captured as the completed answer. Thanks @StartupBros!
 
 ## 0.15.2 — 2026-07-06
 

--- a/src/browser/actions/assistantResponse.ts
+++ b/src/browser/actions/assistantResponse.ts
@@ -33,8 +33,8 @@ function readPositiveIntEnv(name: string, fallback: number): number {
 //   proofA: the finished-action bar is present for barConfirmCycles consecutive quiet cycles
 //           (debounces the transient mid-thinking action-bar flash). A debounced bar is the
 //           strongest positive signal, so it is NOT vetoed by thinking activity.
-//   proofB: a generous continuous-quiet window with NO active thinking and NO text growth —
-//           the drift-safe fallback that also recovers an answer whose action-bar selector drifted.
+//   proofB: a generous continuous-quiet window with no strong activity or changing weak sidecar
+//           evidence — the fallback that recovers an answer whose action-bar selector drifted.
 // Any text growth, a visible stop control, or active thinking resets the quiet clock, so a
 // preamble cannot reach the terminal state: it is held until the reasoning phase ends and the
 // real answer streams (then proofA/proofB fire on the real answer). Tunable via env for live
@@ -61,6 +61,8 @@ export interface TerminalGateState {
   lastChangeAt: number;
   lastDisturbanceAt: number;
   barStableCycles: number;
+  lastWeakKey: string;
+  lastWeakChangeAt: number;
   seen: boolean;
 }
 
@@ -77,6 +79,7 @@ export interface TerminalSample {
   // Strong signals prove live work (stop/shimmer/aria-busy/status/progress). Weak activity is
   // limited to a heuristic sidecar match that can linger after completion.
   strongThinkingActive: boolean;
+  thinkingKey?: string;
 }
 
 export function createTerminalGateState(now: number): TerminalGateState {
@@ -85,6 +88,8 @@ export function createTerminalGateState(now: number): TerminalGateState {
     lastChangeAt: now,
     lastDisturbanceAt: now,
     barStableCycles: 0,
+    lastWeakKey: "",
+    lastWeakChangeAt: now,
     seen: false,
   };
 }
@@ -98,7 +103,11 @@ export function classifyTurnTerminal(
 ): { state: TerminalGateState; terminal: boolean } {
   const changed = !state.seen || sample.contentKey !== state.lastKey;
   const lastChangeAt = changed ? sample.now : state.lastChangeAt;
-  const disturbed = changed || sample.stopVisible || sample.thinkingActive;
+  const weakActive = sample.thinkingActive && !sample.strongThinkingActive;
+  const weakKey = weakActive ? (sample.thinkingKey ?? "unknown-weak-activity") : "";
+  const weakChanged = weakActive && weakKey !== state.lastWeakKey;
+  const lastWeakChangeAt = weakChanged ? sample.now : state.lastWeakChangeAt;
+  const disturbed = changed || sample.stopVisible || sample.strongThinkingActive || weakChanged;
   const lastDisturbanceAt = disturbed ? sample.now : state.lastDisturbanceAt;
   // proofA debounce: weak/stale sidecar evidence may be overridden, but strong live activity
   // must reset the debounce. It also resets on ANY content change so a bar that appears while
@@ -112,6 +121,8 @@ export function classifyTurnTerminal(
     lastChangeAt,
     lastDisturbanceAt,
     barStableCycles,
+    lastWeakKey: weakKey,
+    lastWeakChangeAt,
     seen: true,
   };
 
@@ -128,10 +139,15 @@ export function classifyTurnTerminal(
       !sample.strongThinkingActive &&
       barStableCycles >= config.barConfirmCycles &&
       stableMs >= config.minStableMs;
-    // proofB — generous quiet with no active thinking; the selector-drift-safe fallback.
-    // Withheld for implausibly short captures, which must be proven by the action bar.
+    // proofB — generous quiet with no strong activity. Changing weak sidecar evidence keeps
+    // resetting the window; static weak evidence must age for at least a minute so a stale
+    // mounted panel cannot veto selector-drift recovery forever. Implausibly short captures
+    // remain action-bar-only.
+    const weakEvidenceAged =
+      !weakActive || sample.now - lastWeakChangeAt >= Math.max(config.quietMs * 5, 60_000);
     const quietProof =
-      !sample.thinkingActive &&
+      !sample.strongThinkingActive &&
+      weakEvidenceAged &&
       sample.len >= config.minAnswerLen &&
       stableMs >= config.minStableMs &&
       quietMs >= config.quietMs;
@@ -681,6 +697,7 @@ async function pollAssistantCompletion(
           barVisible,
           thinkingActive: thinkingActivity.active,
           strongThinkingActive: thinkingActivity.strong,
+          thinkingKey: thinkingActivity.key,
         },
         TERMINAL_GATE_CONFIG,
       );

--- a/src/browser/actions/assistantResponse.ts
+++ b/src/browser/actions/assistantResponse.ts
@@ -8,7 +8,7 @@ import {
   STOP_BUTTON_SELECTORS,
 } from "../constants.js";
 import { buildConversationTurnListExpression } from "../conversationTurns.js";
-import { buildThinkingActivePredicateJs, isThinkingActive } from "./thinkingStatus.js";
+import { buildThinkingActivePredicateJs, readThinkingActivity } from "./thinkingStatus.js";
 import { delay } from "../utils.js";
 import {
   logDomFailure,
@@ -74,6 +74,9 @@ export interface TerminalSample {
   stopVisible: boolean;
   barVisible: boolean;
   thinkingActive: boolean;
+  // Strong signals prove live work (stop/shimmer/aria-busy/status/progress). Weak activity is
+  // limited to a heuristic sidecar match that can linger after completion.
+  strongThinkingActive: boolean;
 }
 
 export function createTerminalGateState(now: number): TerminalGateState {
@@ -97,12 +100,13 @@ export function classifyTurnTerminal(
   const lastChangeAt = changed ? sample.now : state.lastChangeAt;
   const disturbed = changed || sample.stopVisible || sample.thinkingActive;
   const lastDisturbanceAt = disturbed ? sample.now : state.lastDisturbanceAt;
-  // proofA debounce: intentionally NOT gated on !thinkingActive, so a debounced action bar
-  // proves completion even if a stale/false-positive thinking signal lingers (a finished turn
-  // can keep a reasoning panel mounted). It resets on ANY content change so a bar that appears
-  // while the answer is still rendering (the transient-bar / first-tokens race) cannot finalize.
+  // proofA debounce: weak/stale sidecar evidence may be overridden, but strong live activity
+  // must reset the debounce. It also resets on ANY content change so a bar that appears while
+  // the answer is still rendering (the transient-bar / first-tokens race) cannot finalize.
   const barStableCycles =
-    sample.barVisible && !sample.stopVisible && !changed ? state.barStableCycles + 1 : 0;
+    sample.barVisible && !sample.stopVisible && !sample.strongThinkingActive && !changed
+      ? state.barStableCycles + 1
+      : 0;
   const next: TerminalGateState = {
     lastKey: sample.contentKey,
     lastChangeAt,
@@ -117,10 +121,11 @@ export function classifyTurnTerminal(
     const stableMs = sample.now - lastChangeAt;
     // proofA — debounced action bar AND content stable for a minimum time. The time-stability
     // requirement guards the documented race where finished-action controls surface while only
-    // the first tokens have rendered. Not vetoed by thinkingActive (a debounced+stable bar must
-    // not hang on a stale reasoning panel), but a still-changing answer keeps stableMs at zero.
+    // the first tokens have rendered. Weak sidecar evidence cannot hang a finished turn, but
+    // strong live activity vetoes this proof and restarts its debounce.
     const barProof =
       sample.barVisible &&
+      !sample.strongThinkingActive &&
       barStableCycles >= config.barConfirmCycles &&
       stableMs >= config.minStableMs;
     // proofB — generous quiet with no active thinking; the selector-drift-safe fallback.
@@ -659,10 +664,10 @@ async function pollAssistantCompletion(
       if (isGeneratedImageAssistantAnswer(normalized)) {
         return normalized;
       }
-      const [stopVisible, barVisible, thinkingActive] = await Promise.all([
+      const [stopVisible, barVisible, thinkingActivity] = await Promise.all([
         isStopButtonVisible(Runtime),
         isCompletionVisible(Runtime),
-        isThinkingActive(Runtime),
+        readThinkingActivity(Runtime),
       ]);
       const decision = classifyTurnTerminal(
         gate,
@@ -674,7 +679,8 @@ async function pollAssistantCompletion(
           contentKey: `${normalized.meta.messageId ?? normalized.meta.turnId ?? ""}::${normalized.text}`,
           stopVisible,
           barVisible,
-          thinkingActive,
+          thinkingActive: thinkingActivity.active,
+          strongThinkingActive: thinkingActivity.strong,
         },
         TERMINAL_GATE_CONFIG,
       );

--- a/src/browser/actions/assistantResponse.ts
+++ b/src/browser/actions/assistantResponse.ts
@@ -57,22 +57,33 @@ const TERMINAL_GATE_CONFIG: TerminalGateConfig = {
 };
 
 export interface TerminalGateState {
-  maxLen: number;
-  lastGrowthAt: number;
+  lastKey: string;
+  lastChangeAt: number;
   lastDisturbanceAt: number;
   barStableCycles: number;
+  seen: boolean;
 }
 
 export interface TerminalSample {
   now: number;
   len: number;
+  // A fingerprint of the current answer (its text, ideally plus turn/message identity). ANY
+  // change (not just a length increase) is treated as the turn still moving: an equal-length
+  // or shorter rewrite, or a preamble replaced by the answer, resets the stability clocks.
+  contentKey: string;
   stopVisible: boolean;
   barVisible: boolean;
   thinkingActive: boolean;
 }
 
 export function createTerminalGateState(now: number): TerminalGateState {
-  return { maxLen: 0, lastGrowthAt: now, lastDisturbanceAt: now, barStableCycles: 0 };
+  return {
+    lastKey: "",
+    lastChangeAt: now,
+    lastDisturbanceAt: now,
+    barStableCycles: 0,
+    seen: false,
+  };
 }
 
 // Pure, unit-testable per-cycle classifier. Feed it one sample every poll; when it returns
@@ -82,25 +93,36 @@ export function classifyTurnTerminal(
   sample: TerminalSample,
   config: TerminalGateConfig,
 ): { state: TerminalGateState; terminal: boolean } {
-  const grew = sample.len > state.maxLen;
-  const maxLen = grew ? sample.len : state.maxLen;
-  const lastGrowthAt = grew ? sample.now : state.lastGrowthAt;
-  const disturbed = grew || sample.stopVisible || sample.thinkingActive;
+  const changed = !state.seen || sample.contentKey !== state.lastKey;
+  const lastChangeAt = changed ? sample.now : state.lastChangeAt;
+  const disturbed = changed || sample.stopVisible || sample.thinkingActive;
   const lastDisturbanceAt = disturbed ? sample.now : state.lastDisturbanceAt;
   // proofA debounce: intentionally NOT gated on !thinkingActive, so a debounced action bar
   // proves completion even if a stale/false-positive thinking signal lingers (a finished turn
-  // can keep a reasoning panel mounted). Only proofB is vetoed by thinkingActive.
+  // can keep a reasoning panel mounted). It resets on ANY content change so a bar that appears
+  // while the answer is still rendering (the transient-bar / first-tokens race) cannot finalize.
   const barStableCycles =
-    sample.barVisible && !sample.stopVisible && !grew ? state.barStableCycles + 1 : 0;
-  const next: TerminalGateState = { maxLen, lastGrowthAt, lastDisturbanceAt, barStableCycles };
+    sample.barVisible && !sample.stopVisible && !changed ? state.barStableCycles + 1 : 0;
+  const next: TerminalGateState = {
+    lastKey: sample.contentKey,
+    lastChangeAt,
+    lastDisturbanceAt,
+    barStableCycles,
+    seen: true,
+  };
 
   let terminal = false;
   if (!sample.stopVisible && sample.len > 0) {
     const quietMs = sample.now - lastDisturbanceAt;
-    const stableMs = sample.now - lastGrowthAt;
-    // proofA — debounced action bar; bypasses the thinking veto (a present, debounced bar is
-    // stronger positive proof than any panel heuristic, and must not hang on a lingering panel).
-    const barProof = sample.barVisible && barStableCycles >= config.barConfirmCycles;
+    const stableMs = sample.now - lastChangeAt;
+    // proofA — debounced action bar AND content stable for a minimum time. The time-stability
+    // requirement guards the documented race where finished-action controls surface while only
+    // the first tokens have rendered. Not vetoed by thinkingActive (a debounced+stable bar must
+    // not hang on a stale reasoning panel), but a still-changing answer keeps stableMs at zero.
+    const barProof =
+      sample.barVisible &&
+      barStableCycles >= config.barConfirmCycles &&
+      stableMs >= config.minStableMs;
     // proofB — generous quiet with no active thinking; the selector-drift-safe fallback.
     // Withheld for implausibly short captures, which must be proven by the action bar.
     const quietProof =
@@ -645,6 +667,9 @@ async function pollAssistantCompletion(
         {
           now: Date.now(),
           len: normalized.text.length,
+          // Fingerprint = turn/message identity + the full text, so a same-length rewrite, a
+          // shorter final answer replacing a longer preamble, or a new turn all count as change.
+          contentKey: `${normalized.meta.messageId ?? normalized.meta.turnId ?? ""}::${normalized.text}`,
           stopVisible,
           barVisible,
           thinkingActive,

--- a/src/browser/actions/assistantResponse.ts
+++ b/src/browser/actions/assistantResponse.ts
@@ -666,7 +666,7 @@ async function pollAssistantCompletion(
       }
       const [stopVisible, barVisible, thinkingActivity] = await Promise.all([
         isStopButtonVisible(Runtime),
-        isCompletionVisible(Runtime),
+        isCompletionVisible(Runtime, normalized.meta, minTurnIndex),
         readThinkingActivity(Runtime),
       ]);
       const decision = classifyTurnTerminal(
@@ -737,43 +737,77 @@ function buildStopButtonVisibilityPredicateJs(fnName: string): string {
 
 export const buildStopButtonVisibilityExpressionForTest = buildStopButtonVisibilityExpression;
 
-async function isCompletionVisible(Runtime: ChromeClient["Runtime"]): Promise<boolean> {
+function buildCompletionVisibilityExpression(
+  meta: { turnId?: string | null; messageId?: string | null },
+  minTurnIndex?: number,
+): string {
+  const expectedMessageId = meta.messageId ? JSON.stringify(meta.messageId) : "null";
+  const expectedTurnId = meta.turnId ? JSON.stringify(meta.turnId) : "null";
+  const minTurnLiteral =
+    typeof minTurnIndex === "number" && Number.isFinite(minTurnIndex) && minTurnIndex >= 0
+      ? Math.floor(minTurnIndex)
+      : -1;
+  return `(() => {
+    const EXPECTED_MESSAGE_ID = ${expectedMessageId};
+    const EXPECTED_TURN_ID = ${expectedTurnId};
+    const MIN_TURN_INDEX = ${minTurnLiteral};
+    // Find the LAST assistant turn to check completion status. Must match the same logic as
+    // buildAssistantExtractor, then correlate the controls to the sampled response.
+    const ASSISTANT_SELECTOR = '${ASSISTANT_ROLE_SELECTOR}';
+    const isAssistantTurn = (node) => {
+      if (!(node instanceof HTMLElement)) return false;
+      const turnAttr = (node.getAttribute('data-turn') || node.dataset?.turn || '').toLowerCase();
+      if (turnAttr === 'assistant') return true;
+      const role = (node.getAttribute('data-message-author-role') || node.dataset?.messageAuthorRole || '').toLowerCase();
+      if (role === 'assistant') return true;
+      const testId = (node.getAttribute('data-testid') || '').toLowerCase();
+      if (testId.includes('assistant')) return true;
+      return Boolean(node.querySelector(ASSISTANT_SELECTOR) || node.querySelector('[data-testid*="assistant"]'));
+    };
+
+    const turns = ${buildConversationTurnListExpression()};
+    let lastAssistantTurn = null;
+    let lastAssistantIndex = -1;
+    for (let i = turns.length - 1; i >= 0; i--) {
+      if (isAssistantTurn(turns[i])) {
+        lastAssistantTurn = turns[i];
+        lastAssistantIndex = i;
+        break;
+      }
+    }
+    if (!lastAssistantTurn) return false;
+
+    const hasExpectedIdentity = Boolean(EXPECTED_MESSAGE_ID || EXPECTED_TURN_ID);
+    if (hasExpectedIdentity) {
+      const identityNodes = [
+        lastAssistantTurn,
+        ...Array.from(lastAssistantTurn.querySelectorAll('[data-message-id], [data-testid]')),
+      ];
+      const identityMatches = identityNodes.some((node) =>
+        (EXPECTED_MESSAGE_ID && node.getAttribute?.('data-message-id') === EXPECTED_MESSAGE_ID) ||
+        (EXPECTED_TURN_ID && node.getAttribute?.('data-testid') === EXPECTED_TURN_ID),
+      );
+      if (!identityMatches) return false;
+    } else if (MIN_TURN_INDEX < 0 || lastAssistantIndex < MIN_TURN_INDEX) {
+      // Fallback/project snapshots without an identity may use the new-turn baseline, but an
+      // uncorrelated persistent action bar from an older turn must never prove completion.
+      return false;
+    }
+
+    if (lastAssistantTurn.querySelector('${FINISHED_ACTIONS_SELECTOR}')) return true;
+    const markdowns = lastAssistantTurn.querySelectorAll('.markdown');
+    return Array.from(markdowns).some((node) => (node.textContent || '').trim() === 'Done');
+  })()`;
+}
+
+async function isCompletionVisible(
+  Runtime: ChromeClient["Runtime"],
+  meta: { turnId?: string | null; messageId?: string | null },
+  minTurnIndex?: number,
+): Promise<boolean> {
   try {
     const { result } = await Runtime.evaluate({
-      expression: `(() => {
-        // Find the LAST assistant turn to check completion status
-        // Must match the same logic as buildAssistantExtractor for consistency
-        const ASSISTANT_SELECTOR = '${ASSISTANT_ROLE_SELECTOR}';
-        const isAssistantTurn = (node) => {
-          if (!(node instanceof HTMLElement)) return false;
-          const turnAttr = (node.getAttribute('data-turn') || node.dataset?.turn || '').toLowerCase();
-          if (turnAttr === 'assistant') return true;
-          const role = (node.getAttribute('data-message-author-role') || node.dataset?.messageAuthorRole || '').toLowerCase();
-          if (role === 'assistant') return true;
-          const testId = (node.getAttribute('data-testid') || '').toLowerCase();
-          if (testId.includes('assistant')) return true;
-          return Boolean(node.querySelector(ASSISTANT_SELECTOR) || node.querySelector('[data-testid*="assistant"]'));
-        };
-
-        const turns = ${buildConversationTurnListExpression()};
-        let lastAssistantTurn = null;
-        for (let i = turns.length - 1; i >= 0; i--) {
-          if (isAssistantTurn(turns[i])) {
-            lastAssistantTurn = turns[i];
-            break;
-          }
-        }
-        if (!lastAssistantTurn) {
-          return false;
-        }
-        // Check if the last assistant turn has finished action buttons (copy, thumbs up/down, share)
-        if (lastAssistantTurn.querySelector('${FINISHED_ACTIONS_SELECTOR}')) {
-          return true;
-        }
-        // Also check for "Done" text in the last assistant turn's markdown
-        const markdowns = lastAssistantTurn.querySelectorAll('.markdown');
-        return Array.from(markdowns).some((n) => (n.textContent || '').trim() === 'Done');
-      })()`,
+      expression: buildCompletionVisibilityExpression(meta, minTurnIndex),
       returnByValue: true,
     });
     return Boolean(result?.value);
@@ -781,6 +815,8 @@ async function isCompletionVisible(Runtime: ChromeClient["Runtime"]): Promise<bo
     return false;
   }
 }
+
+export const buildCompletionVisibilityExpressionForTest = buildCompletionVisibilityExpression;
 
 function normalizeAssistantSnapshot(snapshot: AssistantSnapshot | null): {
   text: string;

--- a/src/browser/actions/assistantResponse.ts
+++ b/src/browser/actions/assistantResponse.ts
@@ -30,39 +30,24 @@ function readPositiveIntEnv(name: string, fallback: number): number {
 // Terminal-completion gate. A turn is finalized only on POSITIVE proof it is done — never on
 // the mere "stop control absent + text stable" inference, which a settled GPT-5.5 Pro preamble
 // satisfies during the brief gap before it enters its thinking/tool phase.
-//   proofA: the finished-action bar is present for barConfirmCycles consecutive quiet cycles
-//           (debounces the transient mid-thinking action-bar flash). A debounced bar is the
-//           strongest positive signal, so it is NOT vetoed by thinking activity.
-//   proofB: a generous continuous-quiet window with no strong activity or changing weak sidecar
-//           evidence — the fallback that recovers an answer whose action-bar selector drifted.
-// Any text growth, a visible stop control, or active thinking resets the quiet clock, so a
-// preamble cannot reach the terminal state: it is held until the reasoning phase ends and the
-// real answer streams (then proofA/proofB fire on the real answer). Tunable via env for live
-// calibration without a rebuild.
+// The finished-action bar must be present for barConfirmCycles consecutive stable cycles. This
+// debounces the transient mid-thinking action-bar flash, binds completion to the sampled turn,
+// and never treats elapsed quiet as proof: selector drift fails closed instead of finalizing a
+// stable preamble. Tunable via env for live calibration without a rebuild.
 export interface TerminalGateConfig {
   barConfirmCycles: number;
-  quietMs: number;
   minStableMs: number;
-  // Below this length, the quiet fallback (proofB) is NOT trusted: an implausibly short
-  // capture must be proven by the action bar (proofA), else it is refused (fail fast). This
-  // preserves the #293 guard against finalizing a 1-2 token mid-stream stub.
-  minAnswerLen: number;
 }
 
 const TERMINAL_GATE_CONFIG: TerminalGateConfig = {
   barConfirmCycles: readPositiveIntEnv("ORACLE_BAR_CONFIRM_CYCLES", 3),
-  quietMs: readPositiveIntEnv("ORACLE_TERMINAL_QUIET_MS", 12_000),
   minStableMs: readPositiveIntEnv("ORACLE_TERMINAL_MIN_STABLE_MS", 1_200),
-  minAnswerLen: MIN_CONFIDENT_ANSWER_LENGTH,
 };
 
 export interface TerminalGateState {
   lastKey: string;
   lastChangeAt: number;
-  lastDisturbanceAt: number;
   barStableCycles: number;
-  lastWeakKey: string;
-  lastWeakChangeAt: number;
   seen: boolean;
 }
 
@@ -75,21 +60,16 @@ export interface TerminalSample {
   contentKey: string;
   stopVisible: boolean;
   barVisible: boolean;
-  thinkingActive: boolean;
   // Strong signals prove live work (stop/shimmer/aria-busy/status/progress). Weak activity is
   // limited to a heuristic sidecar match that can linger after completion.
   strongThinkingActive: boolean;
-  thinkingKey?: string;
 }
 
 export function createTerminalGateState(now: number): TerminalGateState {
   return {
     lastKey: "",
     lastChangeAt: now,
-    lastDisturbanceAt: now,
     barStableCycles: 0,
-    lastWeakKey: "",
-    lastWeakChangeAt: now,
     seen: false,
   };
 }
@@ -103,12 +83,6 @@ export function classifyTurnTerminal(
 ): { state: TerminalGateState; terminal: boolean } {
   const changed = !state.seen || sample.contentKey !== state.lastKey;
   const lastChangeAt = changed ? sample.now : state.lastChangeAt;
-  const weakActive = sample.thinkingActive && !sample.strongThinkingActive;
-  const weakKey = weakActive ? (sample.thinkingKey ?? "unknown-weak-activity") : "";
-  const weakChanged = weakActive && weakKey !== state.lastWeakKey;
-  const lastWeakChangeAt = weakChanged ? sample.now : state.lastWeakChangeAt;
-  const disturbed = changed || sample.stopVisible || sample.strongThinkingActive || weakChanged;
-  const lastDisturbanceAt = disturbed ? sample.now : state.lastDisturbanceAt;
   // proofA debounce: weak/stale sidecar evidence may be overridden, but strong live activity
   // must reset the debounce. It also resets on ANY content change so a bar that appears while
   // the answer is still rendering (the transient-bar / first-tokens race) cannot finalize.
@@ -119,39 +93,22 @@ export function classifyTurnTerminal(
   const next: TerminalGateState = {
     lastKey: sample.contentKey,
     lastChangeAt,
-    lastDisturbanceAt,
     barStableCycles,
-    lastWeakKey: weakKey,
-    lastWeakChangeAt,
     seen: true,
   };
 
   let terminal = false;
   if (!sample.stopVisible && sample.len > 0) {
-    const quietMs = sample.now - lastDisturbanceAt;
     const stableMs = sample.now - lastChangeAt;
-    // proofA — debounced action bar AND content stable for a minimum time. The time-stability
+    // Debounced action bar AND content stable for a minimum time. The time-stability
     // requirement guards the documented race where finished-action controls surface while only
     // the first tokens have rendered. Weak sidecar evidence cannot hang a finished turn, but
     // strong live activity vetoes this proof and restarts its debounce.
-    const barProof =
+    terminal =
       sample.barVisible &&
       !sample.strongThinkingActive &&
       barStableCycles >= config.barConfirmCycles &&
       stableMs >= config.minStableMs;
-    // proofB — generous quiet with no strong activity. Changing weak sidecar evidence keeps
-    // resetting the window; static weak evidence must age for at least a minute so a stale
-    // mounted panel cannot veto selector-drift recovery forever. Implausibly short captures
-    // remain action-bar-only.
-    const weakEvidenceAged =
-      !weakActive || sample.now - lastWeakChangeAt >= Math.max(config.quietMs * 5, 60_000);
-    const quietProof =
-      !sample.strongThinkingActive &&
-      weakEvidenceAged &&
-      sample.len >= config.minAnswerLen &&
-      stableMs >= config.minStableMs &&
-      quietMs >= config.quietMs;
-    terminal = barProof || quietProof;
   }
   return { state: next, terminal };
 }
@@ -675,8 +632,7 @@ async function pollAssistantCompletion(
     const snapshot = await readAssistantSnapshot(Runtime, minTurnIndex, expectedConversationId);
     const normalized = normalizeAssistantSnapshot(snapshot);
     if (normalized) {
-      // Generated-image answers stream no text and mount no action bar; accept immediately
-      // (kept BEFORE the terminal gate so they never wait out the quiet window).
+      // Generated-image answers stream no text and mount no action bar; accept immediately.
       if (isGeneratedImageAssistantAnswer(normalized)) {
         return normalized;
       }
@@ -695,9 +651,7 @@ async function pollAssistantCompletion(
           contentKey: `${normalized.meta.messageId ?? normalized.meta.turnId ?? ""}::${normalized.text}`,
           stopVisible,
           barVisible,
-          thinkingActive: thinkingActivity.active,
           strongThinkingActive: thinkingActivity.strong,
-          thinkingKey: thinkingActivity.key,
         },
         TERMINAL_GATE_CONFIG,
       );
@@ -707,7 +661,7 @@ async function pollAssistantCompletion(
       }
     } else {
       // The turn disappeared/reset (navigation, re-render): restart the gate so a stale
-      // quiet streak cannot carry over onto a fresh turn.
+      // action-bar debounce cannot carry over onto a fresh turn.
       gate = createTerminalGateState(Date.now());
     }
     await delay(400);
@@ -819,9 +773,14 @@ function buildCompletionVisibilityExpression(
 
 async function isCompletionVisible(
   Runtime: ChromeClient["Runtime"],
-  meta: { turnId?: string | null; messageId?: string | null },
+  meta: {
+    turnId?: string | null;
+    messageId?: string | null;
+    completionVisible?: boolean;
+  },
   minTurnIndex?: number,
 ): Promise<boolean> {
+  if (hasScopedCompletionProof(meta)) return true;
   try {
     const { result } = await Runtime.evaluate({
       expression: buildCompletionVisibilityExpression(meta, minTurnIndex),
@@ -833,12 +792,20 @@ async function isCompletionVisible(
   }
 }
 
+export function hasScopedCompletionProof(meta: { completionVisible?: boolean }): boolean {
+  return meta.completionVisible === true;
+}
+
 export const buildCompletionVisibilityExpressionForTest = buildCompletionVisibilityExpression;
 
 function normalizeAssistantSnapshot(snapshot: AssistantSnapshot | null): {
   text: string;
   html?: string;
-  meta: { turnId?: string | null; messageId?: string | null };
+  meta: {
+    turnId?: string | null;
+    messageId?: string | null;
+    completionVisible?: boolean;
+  };
 } | null {
   const text = snapshot?.text ? cleanAssistantText(snapshot.text) : "";
   if (!text.trim()) {
@@ -857,7 +824,11 @@ function normalizeAssistantSnapshot(snapshot: AssistantSnapshot | null): {
   return {
     text,
     html: snapshot?.html ?? undefined,
-    meta: { turnId: snapshot?.turnId ?? undefined, messageId: snapshot?.messageId ?? undefined },
+    meta: {
+      turnId: snapshot?.turnId ?? undefined,
+      messageId: snapshot?.messageId ?? undefined,
+      ...(snapshot?.completionVisible === true ? { completionVisible: true } : {}),
+    },
   };
 }
 
@@ -1398,7 +1369,14 @@ function buildMarkdownFallbackExtractor(minTurnLiteral?: string): string {
       if (isUserEcho(text)) continue;
       const html = node.innerHTML ?? '';
       const turnIndex = resolveTurnIndex(node);
-      return { text, html, messageId: null, turnId: null, turnIndex };
+      return {
+        text,
+        html,
+        messageId: null,
+        turnId: null,
+        turnIndex,
+        completionVisible: actionMarkdowns.includes(node),
+      };
     }
     return null;
   })`;
@@ -1584,6 +1562,7 @@ interface AssistantSnapshot {
   messageId?: string | null;
   turnId?: string | null;
   turnIndex?: number | null;
+  completionVisible?: boolean;
 }
 
 const LANGUAGE_TAGS = new Set(

--- a/src/browser/actions/assistantResponse.ts
+++ b/src/browser/actions/assistantResponse.ts
@@ -87,10 +87,11 @@ export function classifyTurnTerminal(
   const lastGrowthAt = grew ? sample.now : state.lastGrowthAt;
   const disturbed = grew || sample.stopVisible || sample.thinkingActive;
   const lastDisturbanceAt = disturbed ? sample.now : state.lastDisturbanceAt;
+  // proofA debounce: intentionally NOT gated on !thinkingActive, so a debounced action bar
+  // proves completion even if a stale/false-positive thinking signal lingers (a finished turn
+  // can keep a reasoning panel mounted). Only proofB is vetoed by thinkingActive.
   const barStableCycles =
-    sample.barVisible && !sample.stopVisible && !sample.thinkingActive && !grew
-      ? state.barStableCycles + 1
-      : 0;
+    sample.barVisible && !sample.stopVisible && !grew ? state.barStableCycles + 1 : 0;
   const next: TerminalGateState = { maxLen, lastGrowthAt, lastDisturbanceAt, barStableCycles };
 
   let terminal = false;
@@ -350,7 +351,13 @@ export async function waitForAssistantResponse(
     );
   }
 
-  return candidate;
+  // Budget already exhausted before we could confirm: refuse rather than fall through and ship
+  // an unconfirmed capture. A settled preamble that arrived near the deadline must not be
+  // finalized just because there was no time left to prove it terminal.
+  await logDomFailure(Runtime, logger, "assistant-response-unconfirmed");
+  throw new Error(
+    "assistant-response could not be confirmed complete before the deadline; refusing to finalize a possibly-incomplete capture",
+  );
 }
 
 export async function readAssistantSnapshot(
@@ -473,7 +480,10 @@ async function recoverAssistantResponse(
       await logConversationSnapshot(Runtime, logger).catch(() => undefined);
       return null;
     }
-    return recovered;
+    // No confirmation time left: refuse rather than return the unconfirmed recovered snapshot
+    // (returning it raw would reopen the recovered-long-preamble leak this gate closes).
+    await logConversationSnapshot(Runtime, logger).catch(() => undefined);
+    return null;
   }
   await logConversationSnapshot(Runtime, logger).catch(() => undefined);
   return null;

--- a/src/browser/actions/assistantResponse.ts
+++ b/src/browser/actions/assistantResponse.ts
@@ -8,6 +8,7 @@ import {
   STOP_BUTTON_SELECTORS,
 } from "../constants.js";
 import { buildConversationTurnListExpression } from "../conversationTurns.js";
+import { buildThinkingActivePredicateJs, isThinkingActive } from "./thinkingStatus.js";
 import { delay } from "../utils.js";
 import {
   logDomFailure,
@@ -18,21 +19,97 @@ import { buildClickDispatcher } from "./domEvents.js";
 
 const ASSISTANT_POLL_TIMEOUT_ERROR = "assistant-response-watchdog-timeout";
 const STOP_CONTROL_SELECTOR = STOP_BUTTON_SELECTORS.join(", ");
+// Still used by the in-page settle heuristic's length buckets (see buildResponseObserverExpression).
 const MIN_CONFIDENT_ANSWER_LENGTH = 16;
 
-function isImplausiblyShortAnswer(candidateLength: number): boolean {
-  return candidateLength > 0 && candidateLength < MIN_CONFIDENT_ANSWER_LENGTH;
+function readPositiveIntEnv(name: string, fallback: number): number {
+  const raw = Number(process.env[name]);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : fallback;
 }
 
-export function shouldConfirmAssistantCompletion(args: {
-  candidateLength: number;
+// Terminal-completion gate. A turn is finalized only on POSITIVE proof it is done — never on
+// the mere "stop control absent + text stable" inference, which a settled GPT-5.5 Pro preamble
+// satisfies during the brief gap before it enters its thinking/tool phase.
+//   proofA: the finished-action bar is present for barConfirmCycles consecutive quiet cycles
+//           (debounces the transient mid-thinking action-bar flash). A debounced bar is the
+//           strongest positive signal, so it is NOT vetoed by thinking activity.
+//   proofB: a generous continuous-quiet window with NO active thinking and NO text growth —
+//           the drift-safe fallback that also recovers an answer whose action-bar selector drifted.
+// Any text growth, a visible stop control, or active thinking resets the quiet clock, so a
+// preamble cannot reach the terminal state: it is held until the reasoning phase ends and the
+// real answer streams (then proofA/proofB fire on the real answer). Tunable via env for live
+// calibration without a rebuild.
+export interface TerminalGateConfig {
+  barConfirmCycles: number;
+  quietMs: number;
+  minStableMs: number;
+  // Below this length, the quiet fallback (proofB) is NOT trusted: an implausibly short
+  // capture must be proven by the action bar (proofA), else it is refused (fail fast). This
+  // preserves the #293 guard against finalizing a 1-2 token mid-stream stub.
+  minAnswerLen: number;
+}
+
+const TERMINAL_GATE_CONFIG: TerminalGateConfig = {
+  barConfirmCycles: readPositiveIntEnv("ORACLE_BAR_CONFIRM_CYCLES", 3),
+  quietMs: readPositiveIntEnv("ORACLE_TERMINAL_QUIET_MS", 12_000),
+  minStableMs: readPositiveIntEnv("ORACLE_TERMINAL_MIN_STABLE_MS", 1_200),
+  minAnswerLen: MIN_CONFIDENT_ANSWER_LENGTH,
+};
+
+export interface TerminalGateState {
+  maxLen: number;
+  lastGrowthAt: number;
+  lastDisturbanceAt: number;
+  barStableCycles: number;
+}
+
+export interface TerminalSample {
+  now: number;
+  len: number;
   stopVisible: boolean;
-  completionVisible: boolean;
-}): boolean {
-  if (args.stopVisible || args.completionVisible) {
-    return true;
+  barVisible: boolean;
+  thinkingActive: boolean;
+}
+
+export function createTerminalGateState(now: number): TerminalGateState {
+  return { maxLen: 0, lastGrowthAt: now, lastDisturbanceAt: now, barStableCycles: 0 };
+}
+
+// Pure, unit-testable per-cycle classifier. Feed it one sample every poll; when it returns
+// terminal:true the capture is proven complete and safe to finalize.
+export function classifyTurnTerminal(
+  state: TerminalGateState,
+  sample: TerminalSample,
+  config: TerminalGateConfig,
+): { state: TerminalGateState; terminal: boolean } {
+  const grew = sample.len > state.maxLen;
+  const maxLen = grew ? sample.len : state.maxLen;
+  const lastGrowthAt = grew ? sample.now : state.lastGrowthAt;
+  const disturbed = grew || sample.stopVisible || sample.thinkingActive;
+  const lastDisturbanceAt = disturbed ? sample.now : state.lastDisturbanceAt;
+  const barStableCycles =
+    sample.barVisible && !sample.stopVisible && !sample.thinkingActive && !grew
+      ? state.barStableCycles + 1
+      : 0;
+  const next: TerminalGateState = { maxLen, lastGrowthAt, lastDisturbanceAt, barStableCycles };
+
+  let terminal = false;
+  if (!sample.stopVisible && sample.len > 0) {
+    const quietMs = sample.now - lastDisturbanceAt;
+    const stableMs = sample.now - lastGrowthAt;
+    // proofA — debounced action bar; bypasses the thinking veto (a present, debounced bar is
+    // stronger positive proof than any panel heuristic, and must not hang on a lingering panel).
+    const barProof = sample.barVisible && barStableCycles >= config.barConfirmCycles;
+    // proofB — generous quiet with no active thinking; the selector-drift-safe fallback.
+    // Withheld for implausibly short captures, which must be proven by the action bar.
+    const quietProof =
+      !sample.thinkingActive &&
+      sample.len >= config.minAnswerLen &&
+      stableMs >= config.minStableMs &&
+      quietMs >= config.quietMs;
+    terminal = barProof || quietProof;
   }
-  return isImplausiblyShortAnswer(args.candidateLength);
+  return { state: next, terminal };
 }
 const THINKING_STATUS_LABELS = [
   "thinking",
@@ -244,48 +321,32 @@ export async function waitForAssistantResponse(
     logger("Captured assistant generated image response");
     return candidate;
   }
-  // The evaluation path can race ahead of completion. If ChatGPT is still streaming, wait for the watchdog poller.
+  // The observer/refresh path can race ahead of true completion: a settled GPT-5.5 Pro
+  // preamble (or any mid-stream capture) looks done for a moment before the reasoning/tool
+  // phase begins. Re-confirm EVERY captured text through the terminal-only poller, which
+  // finalizes only on positive proof (a debounced action bar, or a quiet window with no
+  // active thinking). We deliberately drop the old ">= candidate length" acceptance: the
+  // poller is turn-scoped (minTurnIndex), so whatever it proves terminal is the right turn,
+  // even when the real answer is shorter than a verbose preamble.
   const elapsedMs = Date.now() - start;
   const remainingMs = Math.max(0, timeoutMs - elapsedMs);
-  const candidateText = String(candidate?.text ?? "").trim();
-  const suspiciouslyShort = isImplausiblyShortAnswer(candidateText.length);
   if (remainingMs > 0) {
-    const [stopVisible, completionVisible] = await Promise.all([
-      isStopButtonVisible(Runtime),
-      isCompletionVisible(Runtime),
-    ]);
-    // Completion controls can appear briefly while Pro is still replacing its thinking UI.
-    // Confirm every capture from that transition with the stability-based watchdog; a
-    // partial first paragraph can be arbitrarily long.
-    if (
-      shouldConfirmAssistantCompletion({
-        candidateLength: candidateText.length,
-        stopVisible,
-        completionVisible,
-      })
-    ) {
-      logger(
-        stopVisible
-          ? "Assistant still generating; waiting for completion"
-          : completionVisible
-            ? "Completion controls surfaced; confirming stable assistant response"
-            : "Captured an implausibly short response; confirming it is not a mid-stream capture",
-      );
-      const completed = await pollAssistantCompletion(
-        Runtime,
-        remainingMs,
-        minTurnIndex,
-        expectedConversationId,
-      );
-      if (completed && String(completed.text ?? "").trim().length >= candidateText.length) {
-        return completed;
-      }
+    logger("Confirming the capture is terminal (not a mid-stream/preamble capture)");
+    const completed = await pollAssistantCompletion(
+      Runtime,
+      remainingMs,
+      minTurnIndex,
+      expectedConversationId,
+    );
+    if (completed) {
+      return completed;
     }
-  }
-
-  if (suspiciouslyShort) {
+    // Could not prove completion within the budget: refuse rather than finalize a possibly
+    // incomplete capture. A clean, fast failure is recoverable (retry/salvage) and never
+    // ships a preamble as if it were the answer.
+    await logDomFailure(Runtime, logger, "assistant-response-unconfirmed");
     throw new Error(
-      "assistant-response short capture could not be confirmed before timeout; refusing to finalize it",
+      "assistant-response could not be confirmed complete before timeout; refusing to finalize a possibly-incomplete capture",
     );
   }
 
@@ -392,12 +453,26 @@ async function recoverAssistantResponse(
     400,
   );
   if (recovered) {
-    if (isImplausiblyShortAnswer(recovered.text.length)) {
-      logger("Recovered an implausibly short response; waiting for completion proof");
-      const remainingMs = Math.max(0, recoveryTimeoutMs - (Date.now() - recoveryStartedAt));
-      return pollAssistantCompletion(Runtime, remainingMs, minTurnIndex, expectedConversationId);
+    // Route EVERY recovered snapshot through the terminal-only poller (not just short ones):
+    // a recovered long preamble is exactly the raw-return bug this gate exists to prevent.
+    logger("Recovered a candidate response; confirming it is terminal before finalizing");
+    const remainingMs = Math.max(0, recoveryTimeoutMs - (Date.now() - recoveryStartedAt));
+    if (remainingMs > 0) {
+      const confirmed = await pollAssistantCompletion(
+        Runtime,
+        remainingMs,
+        minTurnIndex,
+        expectedConversationId,
+      );
+      if (confirmed) {
+        logger("Recovered and confirmed assistant response via polling fallback");
+        return confirmed;
+      }
+      // Unconfirmable within budget: refuse (return null) so the caller fails fast instead
+      // of finalizing a possibly-incomplete recovered capture.
+      await logConversationSnapshot(Runtime, logger).catch(() => undefined);
+      return null;
     }
-    logger("Recovered assistant response via polling fallback");
     return recovered;
   }
   await logConversationSnapshot(Runtime, logger).catch(() => undefined);
@@ -536,9 +611,7 @@ async function pollAssistantCompletion(
   meta: { turnId?: string | null; messageId?: string | null };
 } | null> {
   const watchdogDeadline = Date.now() + timeoutMs;
-  let previousLength = 0;
-  let stableCycles = 0;
-  let lastChangeAt = Date.now();
+  let gate = createTerminalGateState(Date.now());
   while (Date.now() < watchdogDeadline) {
     // Check abort signal to stop polling when another path won the race
     if (abortSignal?.aborted) {
@@ -547,43 +620,35 @@ async function pollAssistantCompletion(
     const snapshot = await readAssistantSnapshot(Runtime, minTurnIndex, expectedConversationId);
     const normalized = normalizeAssistantSnapshot(snapshot);
     if (normalized) {
-      const currentLength = normalized.text.length;
-      if (currentLength > previousLength) {
-        previousLength = currentLength;
-        stableCycles = 0;
-        lastChangeAt = Date.now();
-      } else {
-        stableCycles += 1;
-      }
-      const [stopVisible, completionVisible] = await Promise.all([
-        isStopButtonVisible(Runtime),
-        isCompletionVisible(Runtime),
-      ]);
+      // Generated-image answers stream no text and mount no action bar; accept immediately
+      // (kept BEFORE the terminal gate so they never wait out the quiet window).
       if (isGeneratedImageAssistantAnswer(normalized)) {
         return normalized;
       }
-      const shortAnswer = isImplausiblyShortAnswer(currentLength);
-      const mediumAnswer = currentLength >= MIN_CONFIDENT_ANSWER_LENGTH && currentLength < 40;
-      const longAnswer = currentLength >= 40 && currentLength < 500;
-      // Learned: short answers need a longer stability window or they truncate.
-      // Learned: long streaming responses (esp. thinking models) can pause mid-stream;
-      // use progressively longer windows to avoid truncation (#71).
-      const completionStableTarget = shortAnswer ? 12 : mediumAnswer ? 8 : longAnswer ? 6 : 8;
-      const requiredStableCycles = shortAnswer ? 12 : mediumAnswer ? 8 : longAnswer ? 8 : 10;
-      const stableMs = Date.now() - lastChangeAt;
-      const minStableMs = shortAnswer ? 8000 : mediumAnswer ? 1200 : longAnswer ? 2000 : 3000;
-      // Require stop button to disappear before treating completion as final.
-      if (!stopVisible) {
-        const stableEnough = stableCycles >= requiredStableCycles && stableMs >= minStableMs;
-        const completionEnough =
-          completionVisible && stableCycles >= completionStableTarget && stableMs >= minStableMs;
-        if (completionEnough || (!shortAnswer && stableEnough)) {
-          return normalized;
-        }
+      const [stopVisible, barVisible, thinkingActive] = await Promise.all([
+        isStopButtonVisible(Runtime),
+        isCompletionVisible(Runtime),
+        isThinkingActive(Runtime),
+      ]);
+      const decision = classifyTurnTerminal(
+        gate,
+        {
+          now: Date.now(),
+          len: normalized.text.length,
+          stopVisible,
+          barVisible,
+          thinkingActive,
+        },
+        TERMINAL_GATE_CONFIG,
+      );
+      gate = decision.state;
+      if (decision.terminal) {
+        return normalized;
       }
     } else {
-      previousLength = 0;
-      stableCycles = 0;
+      // The turn disappeared/reset (navigation, re-render): restart the gate so a stale
+      // quiet streak cannot carry over onto a fresh turn.
+      gate = createTerminalGateState(Date.now());
     }
     await delay(400);
   }
@@ -816,6 +881,7 @@ function buildResponseObserverExpression(
       return normalized.includes('answer now') && (normalized.includes('pro thinking') || normalized.includes('chatgpt said'));
     };
     ${buildActiveThinkingStatusPredicateJs("isActiveThinkingStatus")}
+    ${buildThinkingActivePredicateJs("isThinkingActiveNow")}
 
     // Helper to detect assistant turns - must match buildAssistantExtractor logic for consistency.
     const isAssistantTurn = (node) => {
@@ -982,8 +1048,15 @@ function buildResponseObserverExpression(
         }
         const stopVisible = Boolean(document.querySelector(STOP_SELECTOR));
         const finishedVisible = isLastAssistantTurnFinished();
+        // Defense in depth (the node side re-confirms every capture): never settle on a
+        // stable-but-quiet candidate while the model is actively thinking/generating, so the
+        // observer does not hand a settled preamble to the node path during the reasoning gap.
+        const thinkingActiveNow = isThinkingActiveNow();
 
-        if (finishedVisible || (!stopVisible && stableCycles >= stableTarget)) {
+        if (
+          finishedVisible ||
+          (!stopVisible && !thinkingActiveNow && stableCycles >= stableTarget)
+        ) {
           break;
         }
       }

--- a/src/browser/actions/assistantResponse.ts
+++ b/src/browser/actions/assistantResponse.ts
@@ -154,7 +154,9 @@ const THINKING_STATUS_LABELS = [
 function matchesThinkingStatusLabel(trimmed: string): boolean {
   if (!trimmed) return false;
   if (THINKING_STATUS_LABELS.includes(trimmed)) return true;
-  if (trimmed.startsWith("thought for ") && trimmed.length <= 40) return true;
+  // includes, not startsWith: the completed summary can carry a heading prefix
+  // ("Reasoning Thought for 12s"); the length cap keeps real answers out.
+  if (trimmed.includes("thought for ") && trimmed.length <= 40) return true;
   return trimmed.startsWith("pro thinking") && trimmed.length <= 40;
 }
 
@@ -184,7 +186,7 @@ function buildActiveThinkingStatusPredicateJs(fnName: string): string {
     const labels = ${labelsLiteral};
     const matches =
       labels.includes(normalized) ||
-      (normalized.startsWith('thought for ') && normalized.length <= 40) ||
+      (normalized.includes('thought for ') && normalized.length <= 40) ||
       (normalized.startsWith('pro thinking') && normalized.length <= 40);
     return matches && isStopControlVisible();
   };`;
@@ -1197,7 +1199,7 @@ function buildAssistantExtractor(functionName: string): string {
         normalizedText === 'edit' ||
         normalizedText === 'stopped thinking' ||
         normalizedText === 'stopped thinking edit' ||
-        /^thought for \\d+(?:\\.\\d+)?\\s*(?:s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours)\\s+edit$/.test(normalizedText);
+        /^(?:reasoning\\s+|pro thinking\\s+)?thought for \\d+(?:\\.\\d+)?\\s*(?:s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours)\\s+edit$/.test(normalizedText);
       if (generatedImages.length > 0 && imageOnlyChrome) {
         const label = generatedImages.length === 1 ? 'Generated image.' : \`Generated \${generatedImages.length} images.\`;
         return { text: label, html: messageRoot?.innerHTML ?? html, messageId, turnId, turnIndex: index };

--- a/src/browser/actions/assistantResponse.ts
+++ b/src/browser/actions/assistantResponse.ts
@@ -1285,20 +1285,26 @@ function buildMarkdownFallbackExtractor(minTurnLiteral?: string): string {
       const idx = turnNodes.findIndex((turn) => turn === node || turn.contains?.(node));
       return idx >= 0 ? idx : null;
     };
+    const normalize = (value) => String(value || '').toLowerCase().replace(/\\s+/g, ' ').trim();
+    const collectLastUser = (scope) => {
+      if (!scope?.querySelectorAll) return null;
+      const userTurns = Array.from(scope.querySelectorAll('[data-message-author-role="user"], [data-turn="user"]'));
+      return userTurns[userTurns.length - 1] ?? null;
+    };
+    const lastUser = collectLastUser(root) || collectLastUser(document);
+    const userText = lastUser ? normalize(lastUser.innerText || lastUser.textContent || '') : '';
+    const isAfterCurrentUser = (node) => {
+      if (!lastUser || typeof lastUser.compareDocumentPosition !== 'function') return false;
+      // Node.DOCUMENT_POSITION_FOLLOWING = 4. Use the numeric bit so the injected expression
+      // also works in stripped browser test contexts without a global Node constructor.
+      return Boolean(lastUser.compareDocumentPosition(node) & 4);
+    };
     const isAfterMinTurn = (node) => {
       if (__minTurn === null) return true;
-      if (!hasTurns) return true;
+      if (!hasTurns) return isAfterCurrentUser(node);
       const idx = resolveTurnIndex(node);
       return idx !== null && idx >= __minTurn;
     };
-    const normalize = (value) => String(value || '').toLowerCase().replace(/\\s+/g, ' ').trim();
-    const collectUserText = (scope) => {
-      if (!scope?.querySelectorAll) return '';
-      const userTurns = Array.from(scope.querySelectorAll('[data-message-author-role="user"], [data-turn="user"]'));
-      const lastUser = userTurns[userTurns.length - 1];
-      return lastUser ? normalize(lastUser.innerText || lastUser.textContent || '') : '';
-    };
-    const userText = collectUserText(root) || collectUserText(document);
     const isUserEcho = (text) => {
       if (!userText) return false;
       const normalized = normalize(text);

--- a/src/browser/actions/thinkingStatus.ts
+++ b/src/browser/actions/thinkingStatus.ts
@@ -536,6 +536,10 @@ function buildThinkingActivityPredicateJs(fnName: string, detailed: boolean): st
       if (isCompletedSummary(text)) return false;
       return ACTIVE_LABELS.some((label) => text === label || text.startsWith(label + ' '));
     };
+    const isExactActiveLabel = (raw) => {
+      const text = norm(raw);
+      return Boolean(text) && !isCompletedSummary(text) && ACTIVE_LABELS.includes(text);
+    };
     const statusNodes = (() => {
       try {
         return Array.from(
@@ -549,7 +553,12 @@ function buildThinkingActivityPredicateJs(fnName: string, detailed: boolean): st
     })();
     for (const node of statusNodes) {
       if (!(node instanceof HTMLElement) || !isVisible(node)) continue;
-      if (isActiveLabel(node.textContent) || isActiveLabel(node.getAttribute('aria-label'))) return ${strong};
+      const testId = norm(node.getAttribute('data-testid'));
+      const verifiedThinkingChrome = testId.includes('thinking') || testId.includes('reasoning');
+      const matches = verifiedThinkingChrome
+        ? isActiveLabel(node.textContent) || isActiveLabel(node.getAttribute('aria-label'))
+        : isExactActiveLabel(node.textContent) || isExactActiveLabel(node.getAttribute('aria-label'));
+      if (matches) return ${strong};
     }
     // 5) A live progress bar (determinate or indeterminate) is active generation, even when no
     //    label or shimmer is present (some connector/tool phases surface only a progress bar).
@@ -614,7 +623,16 @@ function buildThinkingActivityPredicateJs(fnName: string, detailed: boolean): st
       if (!(node instanceof HTMLElement) || !isVisible(node)) continue;
       const rect = node.getBoundingClientRect();
       const rightSide = rect.left >= window.innerWidth * 0.35 && rect.width >= 180 && rect.height >= 120;
-      if (hasLiveProgress(node)) return ${strong};
+      const panelLabel = norm([
+        node.getAttribute?.('aria-label'),
+        node.getAttribute?.('data-testid'),
+        node.className,
+      ].filter(Boolean).join(' '));
+      const verifiedThinkingPanel =
+        panelLabel.includes('thinking') ||
+        panelLabel.includes('reasoning') ||
+        panelLabel.includes('sidecar');
+      if (hasLiveProgress(node) && verifiedThinkingPanel) return ${strong};
       // A text-only sidecar match is intentionally weak: completed turns can retain a mounted
       // reasoning panel whose shape/text heuristics still look active. The terminal gate may
       // override only this weak evidence after a stable, debounced finished-action bar.

--- a/src/browser/actions/thinkingStatus.ts
+++ b/src/browser/actions/thinkingStatus.ts
@@ -574,7 +574,15 @@ export function buildThinkingActivePredicateJs(fnName: string): string {
         return true; // role=progressbar with no value -> indeterminate -> active
       });
     };
-    if (hasLiveProgress(document)) return true;
+    // Scoped to the CURRENT assistant turn, not the whole document: unrelated page UI can keep
+    // a visible progress bar mounted indefinitely (review P1), and a document-wide veto would
+    // then hold thinkingActive true until the watchdog timeout on a completed response. The
+    // sidecar check below covers verified reasoning panels; here only the latest turn counts.
+    const turns = (() => {
+      try { return document.querySelectorAll(CONVERSATION_SELECTOR); } catch { return []; }
+    })();
+    const lastTurn = turns.length ? turns[turns.length - 1] : null;
+    if (lastTurn instanceof HTMLElement && hasLiveProgress(lastTurn)) return true;
     // 6) A visible thinking/reasoning sidecar panel (the connector/reasoning phase is often
     //    exposed ONLY through a right-side panel with no inline label). Match the existing
     //    thinking-monitor heuristic: a right-side panel that looks like thinking, or any such

--- a/src/browser/actions/thinkingStatus.ts
+++ b/src/browser/actions/thinkingStatus.ts
@@ -478,11 +478,14 @@ const ACTIVE_THINKING_LABELS = [
 // loading-shimmer skeleton, aria-busy, a visible thinking sidecar panel with live progress,
 // or a visible ACTIVE (present-tense) thinking status label. Used as a completion VETO so a
 // settled preamble is never finalized while the reasoning/tool phase is still running.
-export function buildThinkingActivePredicateJs(fnName: string): string {
+function buildThinkingActivityPredicateJs(fnName: string, detailed: boolean): string {
   const stopLiteral = JSON.stringify(STOP_BUTTON_SELECTORS.join(", "));
   const activeLabelsLiteral = JSON.stringify(ACTIVE_THINKING_LABELS);
   const conversationLiteral = JSON.stringify(CONVERSATION_TURN_SELECTOR);
   const assistantLiteral = JSON.stringify(ASSISTANT_ROLE_SELECTOR);
+  const strong = detailed ? "{ active: true, strong: true }" : "true";
+  const weak = detailed ? "{ active: true, strong: false }" : "true";
+  const idle = detailed ? "{ active: false, strong: false }" : "false";
   return `const ${fnName} = () => {
     const STOP_SELECTOR = ${stopLiteral};
     const ACTIVE_LABELS = ${activeLabelsLiteral};
@@ -508,11 +511,11 @@ export function buildThinkingActivePredicateJs(fnName: string): string {
       return Array.from(nodes).some((node) => pred(node));
     };
     // 1) Stop/interrupt control visible -> generation is active (language-independent).
-    if (some(STOP_SELECTOR, isVisible)) return true;
+    if (some(STOP_SELECTOR, isVisible)) return ${strong};
     // 2) Visible animated loading-shimmer skeleton (only mounted while streaming/thinking).
-    if (some('span.loading-shimmer, .loading-shimmer, [class*="loading-shimmer"]', isVisible)) return true;
+    if (some('span.loading-shimmer, .loading-shimmer, [class*="loading-shimmer"]', isVisible)) return ${strong};
     // 3) aria-busy live region.
-    if (some('[aria-busy="true"]', isVisible)) return true;
+    if (some('[aria-busy="true"]', isVisible)) return ${strong};
     // 4) Active (present-tense) thinking status label near a status/reasoning node.
     const norm = (value) =>
       String(value || '')
@@ -546,7 +549,7 @@ export function buildThinkingActivePredicateJs(fnName: string): string {
     })();
     for (const node of statusNodes) {
       if (!(node instanceof HTMLElement) || !isVisible(node)) continue;
-      if (isActiveLabel(node.textContent) || isActiveLabel(node.getAttribute('aria-label'))) return true;
+      if (isActiveLabel(node.textContent) || isActiveLabel(node.getAttribute('aria-label'))) return ${strong};
     }
     // 5) A live progress bar (determinate or indeterminate) is active generation, even when no
     //    label or shimmer is present (some connector/tool phases surface only a progress bar).
@@ -582,7 +585,7 @@ export function buildThinkingActivePredicateJs(fnName: string): string {
       try { return document.querySelectorAll(CONVERSATION_SELECTOR); } catch { return []; }
     })();
     const lastTurn = turns.length ? turns[turns.length - 1] : null;
-    if (lastTurn instanceof HTMLElement && hasLiveProgress(lastTurn)) return true;
+    if (lastTurn instanceof HTMLElement && hasLiveProgress(lastTurn)) return ${strong};
     // 6) A visible thinking/reasoning sidecar panel (the connector/reasoning phase is often
     //    exposed ONLY through a right-side panel with no inline label). Match the existing
     //    thinking-monitor heuristic: a right-side panel that looks like thinking, or any such
@@ -611,29 +614,55 @@ export function buildThinkingActivePredicateJs(fnName: string): string {
       if (!(node instanceof HTMLElement) || !isVisible(node)) continue;
       const rect = node.getBoundingClientRect();
       const rightSide = rect.left >= window.innerWidth * 0.35 && rect.width >= 180 && rect.height >= 120;
-      if (hasLiveProgress(node) || (rightSide && looksLikeThinking(node))) return true;
+      if (hasLiveProgress(node)) return ${strong};
+      // A text-only sidecar match is intentionally weak: completed turns can retain a mounted
+      // reasoning panel whose shape/text heuristics still look active. The terminal gate may
+      // override only this weak evidence after a stable, debounced finished-action bar.
+      if (rightSide && looksLikeThinking(node)) return ${weak};
     }
-    return false;
+    return ${idle};
   };`;
 }
 
-export async function isThinkingActive(Runtime: ChromeClient["Runtime"]): Promise<boolean> {
+export function buildThinkingActivePredicateJs(fnName: string): string {
+  return buildThinkingActivityPredicateJs(fnName, false);
+}
+
+export interface ThinkingActivity {
+  active: boolean;
+  strong: boolean;
+}
+
+export function buildThinkingActivityDetailsPredicateJs(fnName: string): string {
+  return buildThinkingActivityPredicateJs(fnName, true);
+}
+
+export async function readThinkingActivity(
+  Runtime: ChromeClient["Runtime"],
+): Promise<ThinkingActivity> {
   try {
     const { result } = await Runtime.evaluate({
       expression: `(() => {
-        ${buildThinkingActivePredicateJs("isThinkingActive")}
-        return isThinkingActive();
+        ${buildThinkingActivityDetailsPredicateJs("readThinkingActivity")}
+        return readThinkingActivity();
       })()`,
       returnByValue: true,
     });
-    return Boolean(result?.value);
+    const value = result?.value as Partial<ThinkingActivity> | undefined;
+    return { active: Boolean(value?.active), strong: Boolean(value?.strong) };
   } catch {
-    return false;
+    return { active: false, strong: false };
   }
+}
+
+export async function isThinkingActive(Runtime: ChromeClient["Runtime"]): Promise<boolean> {
+  return (await readThinkingActivity(Runtime)).active;
 }
 
 export const startThinkingStatusMonitorForTest = startThinkingStatusMonitor;
 export const readThinkingStatusForTest = readThinkingStatus;
 export const buildThinkingStatusExpressionForTest = buildThinkingStatusExpression;
 export const buildThinkingActivePredicateJsForTest = buildThinkingActivePredicateJs;
+export const buildThinkingActivityDetailsPredicateJsForTest =
+  buildThinkingActivityDetailsPredicateJs;
 export { ACTIVE_THINKING_LABELS };

--- a/src/browser/actions/thinkingStatus.ts
+++ b/src/browser/actions/thinkingStatus.ts
@@ -484,7 +484,7 @@ function buildThinkingActivityPredicateJs(fnName: string, detailed: boolean): st
   const conversationLiteral = JSON.stringify(CONVERSATION_TURN_SELECTOR);
   const assistantLiteral = JSON.stringify(ASSISTANT_ROLE_SELECTOR);
   const strong = detailed ? "{ active: true, strong: true }" : "true";
-  const weak = detailed ? "{ active: true, strong: false, key: sidecarText }" : "true";
+  const weak = detailed ? "{ active: true, strong: false }" : "true";
   const idle = detailed ? "{ active: false, strong: false }" : "false";
   return `const ${fnName} = () => {
     const STOP_SELECTOR = ${stopLiteral};
@@ -642,7 +642,6 @@ function buildThinkingActivityPredicateJs(fnName: string, detailed: boolean): st
       // A text-only sidecar match is intentionally weak: completed turns can retain a mounted
       // reasoning panel whose shape/text heuristics still look active. The terminal gate may
       // override only this weak evidence after a stable, debounced finished-action bar.
-      const sidecarText = norm(node.textContent) || norm(node.getAttribute?.('aria-label'));
       if (rightSide && looksLikeThinking(node)) return ${weak};
     }
     return ${idle};
@@ -656,7 +655,6 @@ export function buildThinkingActivePredicateJs(fnName: string): string {
 export interface ThinkingActivity {
   active: boolean;
   strong: boolean;
-  key?: string;
 }
 
 export function buildThinkingActivityDetailsPredicateJs(fnName: string): string {
@@ -675,11 +673,7 @@ export async function readThinkingActivity(
       returnByValue: true,
     });
     const value = result?.value as Partial<ThinkingActivity> | undefined;
-    return {
-      active: Boolean(value?.active),
-      strong: Boolean(value?.strong),
-      key: typeof value?.key === "string" ? value.key : undefined,
-    };
+    return { active: Boolean(value?.active), strong: Boolean(value?.strong) };
   } catch {
     return { active: false, strong: false };
   }

--- a/src/browser/actions/thinkingStatus.ts
+++ b/src/browser/actions/thinkingStatus.ts
@@ -446,6 +446,123 @@ function buildThinkingStatusExpression(): string {
   })()`;
 }
 
+// Present-tense/gerund status labels that mean the model is ACTIVELY working. The
+// past-tense "thought for Xs" summary is deliberately excluded: it persists in the DOM
+// on every completed reasoning turn (and on reattach), so treating its mere presence as
+// "still thinking" would veto completion forever and hang the call. Kept in sync with
+// THINKING_STATUS_LABELS in assistantResponse.ts (the connector phases "searching the
+// web"/"reading"/"finalizing answer" are exactly the GPT-5.5 Pro gaps that produce the
+// preamble->answer window this predicate must cover).
+const ACTIVE_THINKING_LABELS = [
+  "thinking",
+  "pro thinking",
+  "thinking longer for a better answer",
+  "reasoning",
+  "finalizing answer",
+  "finalizing",
+  "analyzing",
+  "researching",
+  "working on it",
+  "working",
+  "planning",
+  "searching the web",
+  "searching",
+  "reading",
+];
+
+// buildThinkingActivePredicateJs: a SIDE-EFFECT-FREE injected predicate `${fnName}()` that
+// returns true iff the model is ACTIVELY generating/thinking right now. Unlike
+// buildThinkingStatusExpression it never clicks a disclosure and never keys on the mere
+// PRESENCE of a reasoning container ([data-testid*="reasoning"] persists after completion);
+// it keys only on ACTIVITY signals: a visible stop/interrupt control, a visible animated
+// loading-shimmer skeleton, aria-busy, a visible thinking sidecar panel with live progress,
+// or a visible ACTIVE (present-tense) thinking status label. Used as a completion VETO so a
+// settled preamble is never finalized while the reasoning/tool phase is still running.
+export function buildThinkingActivePredicateJs(fnName: string): string {
+  const stopLiteral = JSON.stringify(STOP_BUTTON_SELECTORS.join(", "));
+  const activeLabelsLiteral = JSON.stringify(ACTIVE_THINKING_LABELS);
+  const conversationLiteral = JSON.stringify(CONVERSATION_TURN_SELECTOR);
+  const assistantLiteral = JSON.stringify(ASSISTANT_ROLE_SELECTOR);
+  return `const ${fnName} = () => {
+    const STOP_SELECTOR = ${stopLiteral};
+    const ACTIVE_LABELS = ${activeLabelsLiteral};
+    const CONVERSATION_SELECTOR = ${conversationLiteral};
+    const ASSISTANT_SELECTOR = ${assistantLiteral};
+    const isVisible = (node) => {
+      if (!(node instanceof HTMLElement)) return false;
+      const rect = node.getBoundingClientRect();
+      if (!rect || rect.width <= 0 || rect.height <= 0) return false;
+      const style = window.getComputedStyle(node);
+      if (
+        style.display === 'none' ||
+        style.visibility === 'hidden' ||
+        (style.opacity !== '' && Number(style.opacity) === 0)
+      ) {
+        return false;
+      }
+      return true;
+    };
+    const some = (selector, pred) => {
+      let nodes;
+      try { nodes = document.querySelectorAll(selector); } catch { return false; }
+      return Array.from(nodes).some((node) => pred(node));
+    };
+    // 1) Stop/interrupt control visible -> generation is active (language-independent).
+    if (some(STOP_SELECTOR, isVisible)) return true;
+    // 2) Visible animated loading-shimmer skeleton (only mounted while streaming/thinking).
+    if (some('span.loading-shimmer, .loading-shimmer, [class*="loading-shimmer"]', isVisible)) return true;
+    // 3) aria-busy live region.
+    if (some('[aria-busy="true"]', isVisible)) return true;
+    // 4) Active (present-tense) thinking status label near a status/reasoning node.
+    const norm = (value) =>
+      String(value || '')
+        .normalize('NFD')
+        .replace(/[\\u0300-\\u036f]/g, '')
+        .toLowerCase()
+        .replace(/\\s+/g, ' ')
+        .trim();
+    const isActiveLabel = (raw) => {
+      const text = norm(raw);
+      if (!text || text.length > 60) return false;
+      if (text.startsWith('thought for')) return false; // completed reasoning summary, NOT active
+      return ACTIVE_LABELS.some((label) => text === label || text.startsWith(label + ' '));
+    };
+    const statusNodes = (() => {
+      try {
+        return Array.from(
+          document.querySelectorAll(
+            '[data-testid*="thinking"], [data-testid*="reasoning"], [role="status"], [aria-live="polite"], [aria-live="assertive"]',
+          ),
+        );
+      } catch {
+        return [];
+      }
+    })();
+    for (const node of statusNodes) {
+      if (!(node instanceof HTMLElement) || !isVisible(node)) continue;
+      if (isActiveLabel(node.textContent) || isActiveLabel(node.getAttribute('aria-label'))) return true;
+    }
+    return false;
+  };`;
+}
+
+export async function isThinkingActive(Runtime: ChromeClient["Runtime"]): Promise<boolean> {
+  try {
+    const { result } = await Runtime.evaluate({
+      expression: `(() => {
+        ${buildThinkingActivePredicateJs("isThinkingActive")}
+        return isThinkingActive();
+      })()`,
+      returnByValue: true,
+    });
+    return Boolean(result?.value);
+  } catch {
+    return false;
+  }
+}
+
 export const startThinkingStatusMonitorForTest = startThinkingStatusMonitor;
 export const readThinkingStatusForTest = readThinkingStatus;
 export const buildThinkingStatusExpressionForTest = buildThinkingStatusExpression;
+export const buildThinkingActivePredicateJsForTest = buildThinkingActivePredicateJs;
+export { ACTIVE_THINKING_LABELS };

--- a/src/browser/actions/thinkingStatus.ts
+++ b/src/browser/actions/thinkingStatus.ts
@@ -512,10 +512,17 @@ function buildThinkingActivityPredicateJs(fnName: string, detailed: boolean): st
     };
     // 1) Stop/interrupt control visible -> generation is active (language-independent).
     if (some(STOP_SELECTOR, isVisible)) return ${strong};
-    // 2) Visible animated loading-shimmer skeleton (only mounted while streaming/thinking).
-    if (some('span.loading-shimmer, .loading-shimmer, [class*="loading-shimmer"]', isVisible)) return ${strong};
-    // 3) aria-busy live region.
-    if (some('[aria-busy="true"]', isVisible)) return ${strong};
+    // 2-3) Shimmer/aria-busy are checked only inside the current turn or verified thinking
+    // panel below. Page-global busy UI (history/sidebar/upload) is not model activity.
+    const hasBusyIndicator = (scope) => {
+      let nodes;
+      try {
+        nodes = scope.querySelectorAll(
+          'span.loading-shimmer, .loading-shimmer, [class*="loading-shimmer"], [aria-busy="true"]',
+        );
+      } catch { return false; }
+      return Array.from(nodes).some((node) => isVisible(node));
+    };
     // 4) Active (present-tense) thinking status label near a status/reasoning node.
     const norm = (value) =>
       String(value || '')
@@ -524,12 +531,11 @@ function buildThinkingActivityPredicateJs(fnName: string, detailed: boolean): st
         .toLowerCase()
         .replace(/\\s+/g, ' ')
         .trim();
-    // Completed reasoning summary: SHORT visible text containing "thought for " (numeric or
-    // worded duration, with or without a heading prefix like "Reasoning Thought for 12s", even
-    // when fragments concatenate without whitespace). The length cap is what keeps this from
-    // vetoing a live sidecar trace: a running trace grows far past 60 chars, while a collapsed
-    // completed summary (plus optional heading) stays short.
-    const isCompletedSummary = (text) => text.length > 0 && text.length <= 60 && text.includes('thought for ');
+    // Completed reasoning summary: the whole visible label must be a duration summary. Anchoring
+    // prevents an early live trace such as "Thought for 2s: Searching the web" from being
+    // mistaken for completion before the trace grows beyond an arbitrary length threshold.
+    const isCompletedSummary = (text) =>
+      /^(?:(?:reasoning|pro thinking)\\s*)?thought for (?:\\d+(?:\\.\\d+)?\\s*(?:s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours)(?:\\s+\\d+(?:\\.\\d+)?\\s*(?:s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours))*|(?:a|an) [a-z]+(?: [a-z]+){0,2})$/.test(text);
     const isActiveLabel = (raw) => {
       const text = norm(raw);
       if (!text || text.length > 60) return false;
@@ -594,7 +600,10 @@ function buildThinkingActivityPredicateJs(fnName: string, detailed: boolean): st
       try { return document.querySelectorAll(CONVERSATION_SELECTOR); } catch { return []; }
     })();
     const lastTurn = turns.length ? turns[turns.length - 1] : null;
-    if (lastTurn instanceof HTMLElement && hasLiveProgress(lastTurn)) return ${strong};
+    if (
+      lastTurn instanceof HTMLElement &&
+      (hasBusyIndicator(lastTurn) || hasLiveProgress(lastTurn))
+    ) return ${strong};
     // 6) A visible thinking/reasoning sidecar panel (the connector/reasoning phase is often
     //    exposed ONLY through a right-side panel with no inline label). Match the existing
     //    thinking-monitor heuristic: a right-side panel that looks like thinking, or any such
@@ -606,6 +615,7 @@ function buildThinkingActivityPredicateJs(fnName: string, detailed: boolean): st
       // is judged by its full rendered length, not by fragments of it.
       const visible = norm(node.textContent) || norm(node.getAttribute?.('aria-label'));
       if (isCompletedSummary(visible)) return false;
+      if (visible.includes('thought for ')) return true;
       const label = norm([
         node.textContent,
         node.getAttribute?.('aria-label'),
@@ -632,7 +642,7 @@ function buildThinkingActivityPredicateJs(fnName: string, detailed: boolean): st
         panelLabel.includes('thinking') ||
         panelLabel.includes('reasoning') ||
         panelLabel.includes('sidecar');
-      if (hasLiveProgress(node) && verifiedThinkingPanel) return ${strong};
+      if ((hasBusyIndicator(node) || hasLiveProgress(node)) && verifiedThinkingPanel) return ${strong};
       // A text-only sidecar match is intentionally weak: completed turns can retain a mounted
       // reasoning panel whose shape/text heuristics still look active. The terminal gate may
       // override only this weak evidence after a stable, debounced finished-action bar.

--- a/src/browser/actions/thinkingStatus.ts
+++ b/src/browser/actions/thinkingStatus.ts
@@ -521,10 +521,16 @@ export function buildThinkingActivePredicateJs(fnName: string): string {
         .toLowerCase()
         .replace(/\\s+/g, ' ')
         .trim();
+    // Completed reasoning summary: SHORT visible text containing "thought for " (numeric or
+    // worded duration, with or without a heading prefix like "Reasoning Thought for 12s", even
+    // when fragments concatenate without whitespace). The length cap is what keeps this from
+    // vetoing a live sidecar trace: a running trace grows far past 60 chars, while a collapsed
+    // completed summary (plus optional heading) stays short.
+    const isCompletedSummary = (text) => text.length > 0 && text.length <= 60 && text.includes('thought for ');
     const isActiveLabel = (raw) => {
       const text = norm(raw);
       if (!text || text.length > 60) return false;
-      if (text.startsWith('thought for')) return false; // completed reasoning summary, NOT active
+      if (isCompletedSummary(text)) return false;
       return ACTIVE_LABELS.some((label) => text === label || text.startsWith(label + ' '));
     };
     const statusNodes = (() => {
@@ -575,12 +581,16 @@ export function buildThinkingActivePredicateJs(fnName: string): string {
     //    container that carries a live progress bar. Presence alone is NOT enough (a collapsed
     //    reasoning summary persists post-completion); require the thinking cue or live progress.
     const looksLikeThinking = (node) => {
+      // Judge completion on the panel's VISIBLE text only: data-testid values like
+      // "reasoning-panel" would otherwise taint the completed-summary check, and a live trace
+      // is judged by its full rendered length, not by fragments of it.
+      const visible = norm(node.textContent) || norm(node.getAttribute?.('aria-label'));
+      if (isCompletedSummary(visible)) return false;
       const label = norm([
         node.textContent,
         node.getAttribute?.('aria-label'),
         node.getAttribute?.('data-testid'),
       ].filter(Boolean).join(' '));
-      if (label.startsWith('thought for')) return false;
       return label.includes('thinking') || label.includes('reasoning') || label.includes('pro thinking');
     };
     let panels;

--- a/src/browser/actions/thinkingStatus.ts
+++ b/src/browser/actions/thinkingStatus.ts
@@ -542,6 +542,47 @@ export function buildThinkingActivePredicateJs(fnName: string): string {
       if (!(node instanceof HTMLElement) || !isVisible(node)) continue;
       if (isActiveLabel(node.textContent) || isActiveLabel(node.getAttribute('aria-label'))) return true;
     }
+    // 5) A live progress bar (determinate or indeterminate) is active generation, even when no
+    //    label or shimmer is present (some connector/tool phases surface only a progress bar).
+    const hasLiveProgress = (scope) => {
+      let nodes;
+      try {
+        nodes = scope.querySelectorAll('progress, [role="progressbar"], [aria-valuenow], [data-testid*="progress"]');
+      } catch { return false; }
+      return Array.from(nodes).some((n) => {
+        if (!(n instanceof HTMLElement) || !isVisible(n)) return false;
+        if (n.getAttribute('aria-valuenow') != null) return true;
+        if (n instanceof HTMLProgressElement) return true;
+        return String(n.getAttribute('role') || '').toLowerCase() === 'progressbar';
+      });
+    };
+    if (hasLiveProgress(document)) return true;
+    // 6) A visible thinking/reasoning sidecar panel (the connector/reasoning phase is often
+    //    exposed ONLY through a right-side panel with no inline label). Match the existing
+    //    thinking-monitor heuristic: a right-side panel that looks like thinking, or any such
+    //    container that carries a live progress bar. Presence alone is NOT enough (a collapsed
+    //    reasoning summary persists post-completion); require the thinking cue or live progress.
+    const looksLikeThinking = (node) => {
+      const label = norm([
+        node.textContent,
+        node.getAttribute?.('aria-label'),
+        node.getAttribute?.('data-testid'),
+      ].filter(Boolean).join(' '));
+      if (label.startsWith('thought for')) return false;
+      return label.includes('thinking') || label.includes('reasoning') || label.includes('pro thinking');
+    };
+    let panels;
+    try {
+      panels = document.querySelectorAll(
+        'aside, [role="complementary"], [role="dialog"], [data-testid*="thinking"], [data-testid*="reasoning"], [class*="sidecar"], [class*="sidebar"]',
+      );
+    } catch { panels = []; }
+    for (const node of Array.from(panels)) {
+      if (!(node instanceof HTMLElement) || !isVisible(node)) continue;
+      const rect = node.getBoundingClientRect();
+      const rightSide = rect.left >= window.innerWidth * 0.35 && rect.width >= 180 && rect.height >= 120;
+      if (hasLiveProgress(node) || (rightSide && looksLikeThinking(node))) return true;
+    }
     return false;
   };`;
 }

--- a/src/browser/actions/thinkingStatus.ts
+++ b/src/browser/actions/thinkingStatus.ts
@@ -484,7 +484,7 @@ function buildThinkingActivityPredicateJs(fnName: string, detailed: boolean): st
   const conversationLiteral = JSON.stringify(CONVERSATION_TURN_SELECTOR);
   const assistantLiteral = JSON.stringify(ASSISTANT_ROLE_SELECTOR);
   const strong = detailed ? "{ active: true, strong: true }" : "true";
-  const weak = detailed ? "{ active: true, strong: false }" : "true";
+  const weak = detailed ? "{ active: true, strong: false, key: sidecarText }" : "true";
   const idle = detailed ? "{ active: false, strong: false }" : "false";
   return `const ${fnName} = () => {
     const STOP_SELECTOR = ${stopLiteral};
@@ -542,15 +542,11 @@ function buildThinkingActivityPredicateJs(fnName: string, detailed: boolean): st
       if (isCompletedSummary(text)) return false;
       return ACTIVE_LABELS.some((label) => text === label || text.startsWith(label + ' '));
     };
-    const isExactActiveLabel = (raw) => {
-      const text = norm(raw);
-      return Boolean(text) && !isCompletedSummary(text) && ACTIVE_LABELS.includes(text);
-    };
     const statusNodes = (() => {
       try {
         return Array.from(
           document.querySelectorAll(
-            '[data-testid*="thinking"], [data-testid*="reasoning"], [role="status"], [aria-live="polite"], [aria-live="assertive"]',
+            '[data-testid*="thinking"], [data-testid*="reasoning"]',
           ),
         );
       } catch {
@@ -561,9 +557,9 @@ function buildThinkingActivityPredicateJs(fnName: string, detailed: boolean): st
       if (!(node instanceof HTMLElement) || !isVisible(node)) continue;
       const testId = norm(node.getAttribute('data-testid'));
       const verifiedThinkingChrome = testId.includes('thinking') || testId.includes('reasoning');
-      const matches = verifiedThinkingChrome
-        ? isActiveLabel(node.textContent) || isActiveLabel(node.getAttribute('aria-label'))
-        : isExactActiveLabel(node.textContent) || isExactActiveLabel(node.getAttribute('aria-label'));
+      const matches =
+        verifiedThinkingChrome &&
+        (isActiveLabel(node.textContent) || isActiveLabel(node.getAttribute('aria-label')));
       if (matches) return ${strong};
     }
     // 5) A live progress bar (determinate or indeterminate) is active generation, even when no
@@ -646,6 +642,7 @@ function buildThinkingActivityPredicateJs(fnName: string, detailed: boolean): st
       // A text-only sidecar match is intentionally weak: completed turns can retain a mounted
       // reasoning panel whose shape/text heuristics still look active. The terminal gate may
       // override only this weak evidence after a stable, debounced finished-action bar.
+      const sidecarText = norm(node.textContent) || norm(node.getAttribute?.('aria-label'));
       if (rightSide && looksLikeThinking(node)) return ${weak};
     }
     return ${idle};
@@ -659,6 +656,7 @@ export function buildThinkingActivePredicateJs(fnName: string): string {
 export interface ThinkingActivity {
   active: boolean;
   strong: boolean;
+  key?: string;
 }
 
 export function buildThinkingActivityDetailsPredicateJs(fnName: string): string {
@@ -677,7 +675,11 @@ export async function readThinkingActivity(
       returnByValue: true,
     });
     const value = result?.value as Partial<ThinkingActivity> | undefined;
-    return { active: Boolean(value?.active), strong: Boolean(value?.strong) };
+    return {
+      active: Boolean(value?.active),
+      strong: Boolean(value?.strong),
+      key: typeof value?.key === "string" ? value.key : undefined,
+    };
   } catch {
     return { active: false, strong: false };
   }

--- a/src/browser/actions/thinkingStatus.ts
+++ b/src/browser/actions/thinkingStatus.ts
@@ -546,14 +546,26 @@ export function buildThinkingActivePredicateJs(fnName: string): string {
     //    label or shimmer is present (some connector/tool phases surface only a progress bar).
     const hasLiveProgress = (scope) => {
       let nodes;
+      // Only genuine progress indicators — NOT generic [aria-valuenow] range widgets (sliders,
+      // spinbuttons), which are not liveness signals and would falsely veto completion forever.
       try {
-        nodes = scope.querySelectorAll('progress, [role="progressbar"], [aria-valuenow], [data-testid*="progress"]');
+        nodes = scope.querySelectorAll('progress, [role="progressbar"]');
       } catch { return false; }
       return Array.from(nodes).some((n) => {
         if (!(n instanceof HTMLElement) || !isVisible(n)) return false;
-        if (n.getAttribute('aria-valuenow') != null) return true;
-        if (n instanceof HTMLProgressElement) return true;
-        return String(n.getAttribute('role') || '').toLowerCase() === 'progressbar';
+        if (n instanceof HTMLProgressElement) {
+          // Determinate <progress> is active only while it has not reached its max.
+          if (Number.isFinite(n.value) && Number.isFinite(n.max) && n.max > 0) return n.value < n.max;
+          return true; // indeterminate
+        }
+        const rawNow = n.getAttribute('aria-valuenow');
+        if (rawNow != null) {
+          const now = Number(rawNow);
+          const rawMax = n.getAttribute('aria-valuemax');
+          const max = rawMax != null && Number.isFinite(Number(rawMax)) ? Number(rawMax) : 100;
+          return Number.isFinite(now) ? now < max : true;
+        }
+        return true; // role=progressbar with no value -> indeterminate -> active
       });
     };
     if (hasLiveProgress(document)) return true;

--- a/src/browser/actions/thinkingStatus.ts
+++ b/src/browser/actions/thinkingStatus.ts
@@ -535,7 +535,7 @@ function buildThinkingActivityPredicateJs(fnName: string, detailed: boolean): st
     // prevents an early live trace such as "Thought for 2s: Searching the web" from being
     // mistaken for completion before the trace grows beyond an arbitrary length threshold.
     const isCompletedSummary = (text) =>
-      /^(?:(?:reasoning|pro thinking)\\s*)?thought for (?:\\d+(?:\\.\\d+)?\\s*(?:s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours)(?:\\s+\\d+(?:\\.\\d+)?\\s*(?:s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours))*|(?:a|an) [a-z]+(?: [a-z]+){0,2})$/.test(text);
+      /^(?:(?:reasoning|pro thinking)\\s*)?thought for (?:\\d+(?:\\.\\d+)?\\s*(?:s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours)(?:\\s+\\d+(?:\\.\\d+)?\\s*(?:s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours))*|(?:a|an) [a-z]+(?: [a-z]+){0,2})(?: edit)?$/.test(text);
     const isActiveLabel = (raw) => {
       const text = norm(raw);
       if (!text || text.length > 60) return false;

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -602,7 +602,7 @@ export function isImageOnlyUiChromeText(text: string): boolean {
     normalized === "edit" ||
     normalized === "stopped thinking" ||
     normalized === "stopped thinking edit" ||
-    /^thought for \d+(?:\.\d+)?\s*(?:s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours)\s+edit$/.test(
+    /^(?:reasoning\s+|pro thinking\s+)?thought for \d+(?:\.\d+)?\s*(?:s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours)\s+edit$/.test(
       normalized,
     )
   );

--- a/tests/browser/assistantResponseStatus.test.ts
+++ b/tests/browser/assistantResponseStatus.test.ts
@@ -158,6 +158,9 @@ describe("classifyTurnTerminal", () => {
       const sample: TerminalSample = {
         now,
         len: partial.len,
+        // Default fingerprint = the length, so a changing length reads as "still moving"; tests
+        // that need an equal-length rewrite pass an explicit contentKey.
+        contentKey: partial.contentKey ?? String(partial.len),
         stopVisible: partial.stopVisible ?? false,
         barVisible: partial.barVisible ?? false,
         thinkingActive: partial.thinkingActive ?? false,
@@ -224,6 +227,31 @@ describe("classifyTurnTerminal", () => {
     expect(out.at(-1)).toBe(true);
   });
 
+  test("proofA does NOT finalize a transient bar while the answer is still rendering", () => {
+    // Repo history: finished-action controls can surface while only the first tokens exist.
+    // The bar is present the whole time, but the text keeps changing, so proofA must not fire.
+    const out = runGate([
+      { len: 4, barVisible: true },
+      { len: 8, barVisible: true },
+      { len: 12, barVisible: true },
+      { len: 40, barVisible: true },
+      { len: 90, barVisible: true },
+    ]);
+    expect(out.some(Boolean)).toBe(false);
+  });
+
+  test("any content change (even equal length) resets the stability clocks", () => {
+    // An equal-length rewrite (preamble replaced by an answer of the same length) must reset:
+    // length-only tracking would have treated it as stable and could finalize mid-rewrite.
+    const out = runGate([
+      { len: 200, barVisible: true, contentKey: "preamble-aaaaaaaaaaaaaaaaaaaa" },
+      { len: 200, barVisible: true, contentKey: "answer-bbbbbbbbbbbbbbbbbbbbbb" }, // same len, new text
+      { len: 200, barVisible: true, contentKey: "answer-bbbbbbbbbbbbbbbbbbbbbb" },
+    ]);
+    // The rewrite at sample 1 resets the debounce; only ~1 stable cycle follows -> not terminal.
+    expect(out.some(Boolean)).toBe(false);
+  });
+
   test("proofB: a bar-drifted answer finalizes after the quiet window with no thinking", () => {
     const samples: Array<Partial<TerminalSample> & { len: number }> = [
       { len: 800, stopVisible: true },
@@ -276,15 +304,19 @@ describe("classifyTurnTerminal", () => {
 
 describe("thinking-active completion veto", () => {
   class FakeEl {
+    public rect = { left: 0, top: 0, width: 120, height: 40 };
     constructor(
       public textContent = "",
       private attrs: Record<string, string> = {},
     ) {}
     getBoundingClientRect() {
-      return { width: 120, height: 40 };
+      return this.rect;
     }
     getAttribute(name: string): string | null {
       return this.attrs[name] ?? null;
+    }
+    querySelectorAll() {
+      return [];
     }
   }
 
@@ -293,14 +325,21 @@ describe("thinking-active completion veto", () => {
     shimmer?: boolean;
     ariaBusy?: boolean;
     statusText?: string;
+    progress?: boolean;
+    panel?: FakeEl;
   }): boolean {
     const predicate = buildThinkingActivePredicateJsForTest("isThinkingActive");
     const statusNodes = opts.statusText != null ? [new FakeEl(opts.statusText)] : [];
+    const progressNodes = opts.progress
+      ? [new FakeEl("", { "aria-valuenow": "40", role: "progressbar" })]
+      : [];
+    const panelNodes = opts.panel ? [opts.panel] : [];
     const context = createContext({
       Array,
       Number,
       String,
       HTMLElement: FakeEl,
+      HTMLProgressElement: class {},
       document: {
         querySelectorAll: (selector: string) => {
           if (selector.includes("stop") || selector.includes('aria-label*="stop"')) {
@@ -308,6 +347,19 @@ describe("thinking-active completion veto", () => {
           }
           if (selector.includes("loading-shimmer")) return opts.shimmer ? [new FakeEl()] : [];
           if (selector.includes("aria-busy")) return opts.ariaBusy ? [new FakeEl()] : [];
+          if (selector.includes("progressbar") || selector.includes("aria-valuenow")) {
+            return progressNodes;
+          }
+          // The panel selector carries "aside"/"complementary"/"sidecar"; the status selector
+          // does not, so match panels first to disambiguate (both mention thinking/reasoning).
+          if (
+            selector.includes("aside") ||
+            selector.includes("complementary") ||
+            selector.includes("sidecar") ||
+            selector.includes("sidebar")
+          ) {
+            return panelNodes;
+          }
           if (
             selector.includes("thinking") ||
             selector.includes("reasoning") ||
@@ -351,6 +403,22 @@ describe("thinking-active completion veto", () => {
     // The headline hang the design must avoid: this summary lingers in the DOM on every
     // finished Pro turn and on reattach. A presence-based veto would hang forever here.
     expect(evalThinkingActive({ statusText: "Thought for 12s" })).toBe(false);
+  });
+
+  test("fires on a live progress bar as the sole liveness signal (progress-only sidecar)", () => {
+    expect(evalThinkingActive({ progress: true })).toBe(true);
+  });
+
+  test("fires on a right-side reasoning sidecar panel with no inline label", () => {
+    const panel = new FakeEl("Reasoning");
+    panel.rect = { left: 1000, top: 100, width: 380, height: 400 }; // right side, large
+    expect(evalThinkingActive({ panel })).toBe(true);
+  });
+
+  test("does NOT fire on a completed 'Thought for Xs' sidecar (past-tense, not active)", () => {
+    const panel = new FakeEl("Thought for 12s");
+    panel.rect = { left: 1000, top: 100, width: 380, height: 400 };
+    expect(evalThinkingActive({ panel })).toBe(false);
   });
 
   test("does NOT fire on an idle DOM (finished, no controls)", () => {

--- a/tests/browser/assistantResponseStatus.test.ts
+++ b/tests/browser/assistantResponseStatus.test.ts
@@ -342,9 +342,11 @@ describe("thinking-active completion veto", () => {
     getAttribute(name: string): string | null {
       return this.attrs[name] ?? null;
     }
-    querySelectorAll() {
+    querySelectorAll(selector: string) {
+      if (selector.includes("progress")) return this.children;
       return [];
     }
+    public children: FakeEl[] = [];
   }
 
   function evalThinkingActive(opts: {
@@ -355,6 +357,7 @@ describe("thinking-active completion veto", () => {
     progress?: boolean;
     progressNow?: number;
     progressMax?: number;
+    unrelatedProgress?: boolean;
     panel?: FakeEl;
   }): boolean {
     const predicate = buildThinkingActivePredicateJsForTest("isThinkingActive");
@@ -369,6 +372,11 @@ describe("thinking-active completion veto", () => {
         : { "aria-valuenow": "40", role: "progressbar" };
     const progressNodes =
       opts.progress || opts.progressNow != null ? [new FakeEl("", progressAttrs)] : [];
+    // Progress is scoped to the CURRENT assistant turn (review P1): the harness models the
+    // turn container; unrelatedProgress mounts a live bar OUTSIDE any turn, which must not veto.
+    const turn = new FakeEl("turn");
+    turn.children = progressNodes;
+    const turnNodes = [turn];
     const panelNodes = opts.panel ? [opts.panel] : [];
     const context = createContext({
       Array,
@@ -384,7 +392,12 @@ describe("thinking-active completion veto", () => {
           if (selector.includes("loading-shimmer")) return opts.shimmer ? [new FakeEl()] : [];
           if (selector.includes("aria-busy")) return opts.ariaBusy ? [new FakeEl()] : [];
           if (selector.includes("progressbar") || selector.includes("aria-valuenow")) {
-            return progressNodes;
+            // Only an UNRELATED page-wide bar is ever visible at document level now; the
+            // turn-scoped bars are reached through the turn node's own querySelectorAll.
+            return opts.unrelatedProgress ? [new FakeEl("", progressAttrs)] : [];
+          }
+          if (selector.includes("conversation-turn") || selector.includes("data-turn")) {
+            return turnNodes;
           }
           // The panel selector carries "aside"/"complementary"/"sidecar"; the status selector
           // does not, so match panels first to disambiguate (both mention thinking/reasoning).
@@ -444,13 +457,19 @@ describe("thinking-active completion veto", () => {
     },
   );
 
-  test("fires on a live progress bar as the sole liveness signal (progress-only sidecar)", () => {
+  test("fires on a live progress bar inside the current assistant turn", () => {
     expect(evalThinkingActive({ progress: true })).toBe(true);
   });
 
   test("does NOT fire on a completed progress bar (value at max)", () => {
     // A finished connector bar must not veto completion forever.
     expect(evalThinkingActive({ progressNow: 100, progressMax: 100 })).toBe(false);
+  });
+
+  test("does NOT fire on an unrelated progress bar outside the assistant turn", () => {
+    // Review P1: unrelated page UI can keep a visible progress bar mounted indefinitely; a
+    // document-wide veto would then hold a completed response until the watchdog timeout.
+    expect(evalThinkingActive({ unrelatedProgress: true })).toBe(false);
   });
 
   test("fires on a right-side reasoning sidecar panel with no inline label", () => {

--- a/tests/browser/assistantResponseStatus.test.ts
+++ b/tests/browser/assistantResponseStatus.test.ts
@@ -210,7 +210,7 @@ describe("classifyTurnTerminal", () => {
     expect(out.at(-1)).toBe(true);
   });
 
-  test("proofA still fires even if a stale thinking panel lingers", () => {
+  test("proofA fires even if a stale thinking panel lingers (bar bypasses the veto)", () => {
     const out = runGate([
       { len: 800, stopVisible: true },
       { len: 800, barVisible: true, thinkingActive: true },
@@ -218,10 +218,10 @@ describe("classifyTurnTerminal", () => {
       { len: 800, barVisible: true, thinkingActive: true },
       { len: 800, barVisible: true, thinkingActive: true },
     ]);
-    // barVisible && !stop && !thinking is required to increment; thinkingActive blocks the
-    // debounce, so proofA does NOT fire here — the veto holds. (Documents that a lingering
-    // ACTIVE panel defers to the quiet fallback; a *completed* turn reports thinking=false.)
-    expect(out.some(Boolean)).toBe(false);
+    // The debounce increments on barVisible && !stop && !grew (NOT gated on thinking), so a
+    // debounced action bar proves completion even if a false-positive or stale thinking signal
+    // lingers. This avoids hanging a finished turn whose reasoning panel is still mounted.
+    expect(out.at(-1)).toBe(true);
   });
 
   test("proofB: a bar-drifted answer finalizes after the quiet window with no thinking", () => {

--- a/tests/browser/assistantResponseStatus.test.ts
+++ b/tests/browser/assistantResponseStatus.test.ts
@@ -4,9 +4,13 @@ import {
   buildActiveThinkingStatusPredicateJsForTest,
   buildAssistantSnapshotExpressionForTest,
   buildStopButtonVisibilityExpressionForTest,
+  classifyTurnTerminal,
+  createTerminalGateState,
   matchesThinkingStatusLabelForTest,
-  shouldConfirmAssistantCompletion,
+  type TerminalGateConfig,
+  type TerminalSample,
 } from "../../src/browser/actions/assistantResponse.js";
+import { buildThinkingActivePredicateJsForTest } from "../../src/browser/actions/thinkingStatus.js";
 import { STOP_BUTTON_SELECTORS } from "../../src/browser/constants.js";
 
 function evaluatePredicate(text: string, generating: boolean): boolean {
@@ -132,73 +136,224 @@ describe("assistant thinking-status capture", () => {
   });
 });
 
-describe("shouldConfirmAssistantCompletion", () => {
-  test("confirms while the stop button is visible", () => {
-    expect(
-      shouldConfirmAssistantCompletion({
-        candidateLength: 500,
-        stopVisible: true,
-        completionVisible: false,
-      }),
-    ).toBe(true);
+describe("classifyTurnTerminal", () => {
+  const config: TerminalGateConfig = {
+    barConfirmCycles: 3,
+    quietMs: 1_000,
+    minStableMs: 200,
+    minAnswerLen: 16,
+  };
+
+  // Drive the pure classifier over a sequence of samples (each 400ms apart by default),
+  // returning the per-sample terminal decisions.
+  function runGate(
+    samples: Array<Partial<TerminalSample> & { len: number }>,
+    cfg: TerminalGateConfig = config,
+    stepMs = 400,
+  ): boolean[] {
+    let now = 0;
+    let state = createTerminalGateState(now);
+    const out: boolean[] = [];
+    for (const partial of samples) {
+      const sample: TerminalSample = {
+        now,
+        len: partial.len,
+        stopVisible: partial.stopVisible ?? false,
+        barVisible: partial.barVisible ?? false,
+        thinkingActive: partial.thinkingActive ?? false,
+      };
+      const result = classifyTurnTerminal(state, sample, cfg);
+      state = result.state;
+      out.push(result.terminal);
+      now += stepMs;
+    }
+    return out;
+  }
+
+  test("never finalizes while the stop control is visible", () => {
+    const out = runGate(Array.from({ length: 20 }, () => ({ len: 400, stopVisible: true })));
+    expect(out.some(Boolean)).toBe(false);
   });
 
-  test("confirms while completion controls are visible", () => {
-    expect(
-      shouldConfirmAssistantCompletion({
-        candidateLength: 500,
-        stopVisible: false,
-        completionVisible: true,
-      }),
-    ).toBe(true);
+  test("holds a settled long preamble until the reasoning phase resolves", () => {
+    // A 150-char preamble settles (stop gone, no bar), then thinking mounts for ~4s, then the
+    // real answer streams and its action bar appears. It must NOT finalize the preamble.
+    const samples: Array<Partial<TerminalSample> & { len: number }> = [];
+    // preamble streaming
+    for (let i = 0; i < 3; i++) samples.push({ len: 50 * (i + 1), stopVisible: true });
+    // settle gap: stop gone, no bar, no thinking yet (the exact window the bug exploited)
+    for (let i = 0; i < 2; i++) samples.push({ len: 150 });
+    // thinking phase mounts (connector/reasoning)
+    for (let i = 0; i < 10; i++) samples.push({ len: 150, thinkingActive: true });
+    // real answer streams after thinking, bar appears and debounces
+    samples.push({ len: 600, stopVisible: true });
+    samples.push({ len: 900, stopVisible: true });
+    for (let i = 0; i < 5; i++) samples.push({ len: 900, barVisible: true });
+    const out = runGate(samples);
+    // No terminal:true may occur before the real answer streamed (index of first len>150).
+    const firstAnswerIdx = samples.findIndex((s) => s.len > 150);
+    const finalizedEarly = out.slice(0, firstAnswerIdx).some(Boolean);
+    expect(finalizedEarly).toBe(false);
+    // It DOES finalize once the real answer's bar debounces.
+    expect(out.some(Boolean)).toBe(true);
   });
 
-  test("confirms an implausibly short capture even when no controls are visible", () => {
-    // The thinking-UI flapping case: stop button already gone, completion
-    // controls not yet shown, a stub answer ("I") captured mid-stream.
-    expect(
-      shouldConfirmAssistantCompletion({
-        candidateLength: 1,
-        stopVisible: false,
-        completionVisible: false,
-      }),
-    ).toBe(true);
+  test("proofA: a debounced action bar finalizes (and bypasses the thinking veto)", () => {
+    const out = runGate([
+      { len: 800, stopVisible: true }, // streaming
+      { len: 800, barVisible: true }, // grew stopped; bar appears (cycle 1)
+      { len: 800, barVisible: true }, // cycle 2
+      { len: 800, barVisible: true }, // cycle 3 -> barStableCycles reaches 3
+      { len: 800, barVisible: true },
+    ]);
+    // First three post-stream cycles build the debounce; terminal by the time cycles>=3.
+    expect(out.at(-1)).toBe(true);
   });
 
-  test("trusts a long capture once controls have cleared", () => {
-    expect(
-      shouldConfirmAssistantCompletion({
-        candidateLength: 500,
-        stopVisible: false,
-        completionVisible: false,
-      }),
-    ).toBe(false);
+  test("proofA still fires even if a stale thinking panel lingers", () => {
+    const out = runGate([
+      { len: 800, stopVisible: true },
+      { len: 800, barVisible: true, thinkingActive: true },
+      { len: 800, barVisible: true, thinkingActive: true },
+      { len: 800, barVisible: true, thinkingActive: true },
+      { len: 800, barVisible: true, thinkingActive: true },
+    ]);
+    // barVisible && !stop && !thinking is required to increment; thinkingActive blocks the
+    // debounce, so proofA does NOT fire here — the veto holds. (Documents that a lingering
+    // ACTIVE panel defers to the quiet fallback; a *completed* turn reports thinking=false.)
+    expect(out.some(Boolean)).toBe(false);
   });
 
-  test("does not force confirmation for an empty capture (handled elsewhere)", () => {
-    expect(
-      shouldConfirmAssistantCompletion({
-        candidateLength: 0,
-        stopVisible: false,
-        completionVisible: false,
-      }),
-    ).toBe(false);
+  test("proofB: a bar-drifted answer finalizes after the quiet window with no thinking", () => {
+    const samples: Array<Partial<TerminalSample> & { len: number }> = [
+      { len: 800, stopVisible: true },
+    ];
+    // stop gone, no bar (selector drift), no thinking: quiet accrues at 400ms/cycle.
+    for (let i = 0; i < 8; i++) samples.push({ len: 800 });
+    const out = runGate(samples);
+    // quietMs must reach 1000ms (config) -> terminal by ~cycle 3 after streaming stopped.
+    expect(out.some(Boolean)).toBe(true);
   });
 
-  test("uses length 16 as the confidence boundary", () => {
-    expect(
-      shouldConfirmAssistantCompletion({
-        candidateLength: 15,
-        stopVisible: false,
-        completionVisible: false,
-      }),
-    ).toBe(true);
-    expect(
-      shouldConfirmAssistantCompletion({
-        candidateLength: 16,
-        stopVisible: false,
-        completionVisible: false,
-      }),
-    ).toBe(false);
+  test("proofB is withheld for an implausibly short capture (must be proven by the bar)", () => {
+    const samples: Array<Partial<TerminalSample> & { len: number }> = [{ len: 1 }];
+    for (let i = 0; i < 20; i++) samples.push({ len: 1 }); // stable "I", quiet, no bar/thinking
+    const out = runGate(samples);
+    expect(out.some(Boolean)).toBe(false);
+  });
+
+  test("a short answer still finalizes once its action bar debounces", () => {
+    const out = runGate([
+      { len: 4 },
+      { len: 4, barVisible: true },
+      { len: 4, barVisible: true },
+      { len: 4, barVisible: true },
+    ]);
+    expect(out.at(-1)).toBe(true);
+  });
+
+  test("proofB does not fire while thinking stays active", () => {
+    const samples: Array<Partial<TerminalSample> & { len: number }> = [
+      { len: 800, stopVisible: true },
+    ];
+    for (let i = 0; i < 20; i++) samples.push({ len: 800, thinkingActive: true });
+    const out = runGate(samples);
+    expect(out.some(Boolean)).toBe(false);
+  });
+
+  test("text growth resets the quiet clock (no premature finalize mid-stream)", () => {
+    // A mid-stream pause shorter than the quiet window, then more text -> not terminal at the pause.
+    const out = runGate([
+      { len: 100, stopVisible: false },
+      { len: 100 }, // 400ms quiet
+      { len: 100 }, // 800ms quiet (< 1000ms)
+      { len: 200 }, // grew -> resets quiet
+      { len: 200 },
+    ]);
+    expect(out.slice(0, 4).some(Boolean)).toBe(false);
+  });
+});
+
+describe("thinking-active completion veto", () => {
+  class FakeEl {
+    constructor(
+      public textContent = "",
+      private attrs: Record<string, string> = {},
+    ) {}
+    getBoundingClientRect() {
+      return { width: 120, height: 40 };
+    }
+    getAttribute(name: string): string | null {
+      return this.attrs[name] ?? null;
+    }
+  }
+
+  function evalThinkingActive(opts: {
+    stop?: boolean;
+    shimmer?: boolean;
+    ariaBusy?: boolean;
+    statusText?: string;
+  }): boolean {
+    const predicate = buildThinkingActivePredicateJsForTest("isThinkingActive");
+    const statusNodes = opts.statusText != null ? [new FakeEl(opts.statusText)] : [];
+    const context = createContext({
+      Array,
+      Number,
+      String,
+      HTMLElement: FakeEl,
+      document: {
+        querySelectorAll: (selector: string) => {
+          if (selector.includes("stop") || selector.includes('aria-label*="stop"')) {
+            return opts.stop ? [new FakeEl()] : [];
+          }
+          if (selector.includes("loading-shimmer")) return opts.shimmer ? [new FakeEl()] : [];
+          if (selector.includes("aria-busy")) return opts.ariaBusy ? [new FakeEl()] : [];
+          if (
+            selector.includes("thinking") ||
+            selector.includes("reasoning") ||
+            selector.includes("status") ||
+            selector.includes("aria-live")
+          ) {
+            return statusNodes;
+          }
+          return [];
+        },
+      },
+      window: {
+        getComputedStyle: () => ({ display: "block", visibility: "visible", opacity: "1" }),
+        innerHeight: 900,
+        innerWidth: 1440,
+      },
+    });
+    return new Script(`${predicate}\nisThinkingActive();`).runInContext(context) as boolean;
+  }
+
+  test("fires on a visible stop control", () => {
+    expect(evalThinkingActive({ stop: true })).toBe(true);
+  });
+
+  test("fires on a visible loading-shimmer skeleton", () => {
+    expect(evalThinkingActive({ shimmer: true })).toBe(true);
+  });
+
+  test("fires on aria-busy", () => {
+    expect(evalThinkingActive({ ariaBusy: true })).toBe(true);
+  });
+
+  test.each(["Thinking", "Pro thinking", "Searching the web", "Reading", "Finalizing answer"])(
+    "fires on active status label %j",
+    (label) => {
+      expect(evalThinkingActive({ statusText: label })).toBe(true);
+    },
+  );
+
+  test("does NOT fire on the persistent completed reasoning summary 'Thought for 12s'", () => {
+    // The headline hang the design must avoid: this summary lingers in the DOM on every
+    // finished Pro turn and on reattach. A presence-based veto would hang forever here.
+    expect(evalThinkingActive({ statusText: "Thought for 12s" })).toBe(false);
+  });
+
+  test("does NOT fire on an idle DOM (finished, no controls)", () => {
+    expect(evalThinkingActive({})).toBe(false);
   });
 });

--- a/tests/browser/assistantResponseStatus.test.ts
+++ b/tests/browser/assistantResponseStatus.test.ts
@@ -326,13 +326,22 @@ describe("thinking-active completion veto", () => {
     ariaBusy?: boolean;
     statusText?: string;
     progress?: boolean;
+    progressNow?: number;
+    progressMax?: number;
     panel?: FakeEl;
   }): boolean {
     const predicate = buildThinkingActivePredicateJsForTest("isThinkingActive");
     const statusNodes = opts.statusText != null ? [new FakeEl(opts.statusText)] : [];
-    const progressNodes = opts.progress
-      ? [new FakeEl("", { "aria-valuenow": "40", role: "progressbar" })]
-      : [];
+    const progressAttrs: Record<string, string> =
+      opts.progressNow != null
+        ? {
+            "aria-valuenow": String(opts.progressNow),
+            "aria-valuemax": String(opts.progressMax ?? 100),
+            role: "progressbar",
+          }
+        : { "aria-valuenow": "40", role: "progressbar" };
+    const progressNodes =
+      opts.progress || opts.progressNow != null ? [new FakeEl("", progressAttrs)] : [];
     const panelNodes = opts.panel ? [opts.panel] : [];
     const context = createContext({
       Array,
@@ -407,6 +416,11 @@ describe("thinking-active completion veto", () => {
 
   test("fires on a live progress bar as the sole liveness signal (progress-only sidecar)", () => {
     expect(evalThinkingActive({ progress: true })).toBe(true);
+  });
+
+  test("does NOT fire on a completed progress bar (value at max)", () => {
+    // A finished connector bar must not veto completion forever.
+    expect(evalThinkingActive({ progressNow: 100, progressMax: 100 })).toBe(false);
   });
 
   test("fires on a right-side reasoning sidecar panel with no inline label", () => {

--- a/tests/browser/assistantResponseStatus.test.ts
+++ b/tests/browser/assistantResponseStatus.test.ts
@@ -13,6 +13,18 @@ import {
 import { buildThinkingActivePredicateJsForTest } from "../../src/browser/actions/thinkingStatus.js";
 import { STOP_BUTTON_SELECTORS } from "../../src/browser/constants.js";
 
+// Completed-summary shapes the veto must treat as NOT active: bare, heading-prefixed
+// (the GPT-5.6 DOM renders "Reasoning Thought for 12s"), worded non-numeric durations,
+// and heading fragments that concatenate without whitespace (CSS-spaced siblings).
+const COMPLETED_SUMMARY_LABELS = [
+  "Thought for 12s",
+  "Reasoning Thought for 12s",
+  "Thought for a few seconds",
+  "Reasoning Thought for a moment",
+  "ReasoningThought for 12s",
+  "Thought for 1m 5s",
+];
+
 function evaluatePredicate(text: string, generating: boolean): boolean {
   const predicate = buildActiveThinkingStatusPredicateJsForTest("isActiveThinkingStatus");
   class FakeHtmlElement {
@@ -58,6 +70,21 @@ describe("assistant thinking-status capture", () => {
 
   test("does not suppress normal text while generation is active", () => {
     expect(evaluatePredicate("Thinking about the design, use Postgres.", true)).toBe(false);
+  });
+
+  test.each(["Reasoning Thought for 12s", "Thought for a few seconds"])(
+    "recognizes prefixed/worded completed summary %s as status chrome, not an answer",
+    (label) => {
+      expect(matchesThinkingStatusLabelForTest(label)).toBe(true);
+      expect(evaluatePredicate(label, true)).toBe(true);
+    },
+  );
+
+  test("does not treat a real answer mentioning 'thought for' as status chrome", () => {
+    // Longer than the 40-char status cap: must never be held back as a placeholder.
+    const answer = "I thought for a while about this tradeoff and Postgres still wins.";
+    expect(matchesThinkingStatusLabelForTest(answer)).toBe(false);
+    expect(evaluatePredicate(answer, true)).toBe(false);
   });
 
   test("uses the active-status predicate in snapshot capture", () => {
@@ -408,11 +435,14 @@ describe("thinking-active completion veto", () => {
     },
   );
 
-  test("does NOT fire on the persistent completed reasoning summary 'Thought for 12s'", () => {
-    // The headline hang the design must avoid: this summary lingers in the DOM on every
-    // finished Pro turn and on reattach. A presence-based veto would hang forever here.
-    expect(evalThinkingActive({ statusText: "Thought for 12s" })).toBe(false);
-  });
+  test.each(COMPLETED_SUMMARY_LABELS)(
+    "does NOT fire on the persistent completed reasoning summary %s",
+    (statusText) => {
+      // The headline hang the design must avoid: this summary lingers in the DOM on every
+      // finished Pro turn and on reattach. A presence-based veto would hang forever here.
+      expect(evalThinkingActive({ statusText })).toBe(false);
+    },
+  );
 
   test("fires on a live progress bar as the sole liveness signal (progress-only sidecar)", () => {
     expect(evalThinkingActive({ progress: true })).toBe(true);
@@ -429,10 +459,21 @@ describe("thinking-active completion veto", () => {
     expect(evalThinkingActive({ panel })).toBe(true);
   });
 
-  test("does NOT fire on a completed 'Thought for Xs' sidecar (past-tense, not active)", () => {
-    const panel = new FakeEl("Thought for 12s");
+  test.each(COMPLETED_SUMMARY_LABELS)("does NOT fire on completed sidecar summary %s", (text) => {
+    const panel = new FakeEl(text);
     panel.rect = { left: 1000, top: 100, width: 380, height: 400 };
     expect(evalThinkingActive({ panel })).toBe(false);
+  });
+
+  test("still fires on a live sidecar trace that embeds a completed sub-step summary", () => {
+    // A running trace accumulates sub-step summaries ("Thought for 2s") alongside live
+    // reasoning text. Only a SHORT summary-only panel means the turn is done; a long trace
+    // must keep vetoing completion even though it contains the completed phrase.
+    const panel = new FakeEl(
+      "Thought for 2s: Searching the web. Reasoning about the diff and enumerating candidate hunks to inspect next.",
+    );
+    panel.rect = { left: 1000, top: 100, width: 380, height: 400 };
+    expect(evalThinkingActive({ panel })).toBe(true);
   });
 
   test("does NOT fire on an idle DOM (finished, no controls)", () => {

--- a/tests/browser/assistantResponseStatus.test.ts
+++ b/tests/browser/assistantResponseStatus.test.ts
@@ -4,9 +4,11 @@ import {
   buildActiveThinkingStatusPredicateJsForTest,
   buildAssistantSnapshotExpressionForTest,
   buildCompletionVisibilityExpressionForTest,
+  buildMarkdownFallbackExtractorForTest,
   buildStopButtonVisibilityExpressionForTest,
   classifyTurnTerminal,
   createTerminalGateState,
+  hasScopedCompletionProof,
   matchesThinkingStatusLabelForTest,
   type TerminalGateConfig,
   type TerminalSample,
@@ -230,14 +232,22 @@ describe("completion action correlation", () => {
       false,
     );
   });
+
+  test("accepts completion controls scoped by the fallback extractor", () => {
+    expect(hasScopedCompletionProof({ completionVisible: true })).toBe(true);
+    expect(hasScopedCompletionProof({})).toBe(false);
+  });
+
+  test("fallback snapshots carry only node-scoped completion evidence", () => {
+    const expression = buildMarkdownFallbackExtractorForTest("1");
+    expect(expression).toContain("completionVisible: actionMarkdowns.includes(node)");
+  });
 });
 
 describe("classifyTurnTerminal", () => {
   const config: TerminalGateConfig = {
     barConfirmCycles: 3,
-    quietMs: 1_000,
     minStableMs: 200,
-    minAnswerLen: 16,
   };
 
   // Drive the pure classifier over a sequence of samples (each 400ms apart by default),
@@ -259,9 +269,7 @@ describe("classifyTurnTerminal", () => {
         contentKey: partial.contentKey ?? String(partial.len),
         stopVisible: partial.stopVisible ?? false,
         barVisible: partial.barVisible ?? false,
-        thinkingActive: partial.thinkingActive ?? false,
         strongThinkingActive: partial.strongThinkingActive ?? false,
-        thinkingKey: partial.thinkingKey,
       };
       const result = classifyTurnTerminal(state, sample, cfg);
       state = result.state;
@@ -285,8 +293,7 @@ describe("classifyTurnTerminal", () => {
     // settle gap: stop gone, no bar, no thinking yet (the exact window the bug exploited)
     for (let i = 0; i < 2; i++) samples.push({ len: 150 });
     // thinking phase mounts (connector/reasoning)
-    for (let i = 0; i < 10; i++)
-      samples.push({ len: 150, thinkingActive: true, strongThinkingActive: true });
+    for (let i = 0; i < 10; i++) samples.push({ len: 150, strongThinkingActive: true });
     // real answer streams after thinking, bar appears and debounces
     samples.push({ len: 600, stopVisible: true });
     samples.push({ len: 900, stopVisible: true });
@@ -315,10 +322,10 @@ describe("classifyTurnTerminal", () => {
   test("proofA fires even if weak stale-sidecar evidence lingers", () => {
     const out = runGate([
       { len: 800, stopVisible: true },
-      { len: 800, barVisible: true, thinkingActive: true },
-      { len: 800, barVisible: true, thinkingActive: true },
-      { len: 800, barVisible: true, thinkingActive: true },
-      { len: 800, barVisible: true, thinkingActive: true },
+      { len: 800, barVisible: true },
+      { len: 800, barVisible: true },
+      { len: 800, barVisible: true },
+      { len: 800, barVisible: true },
     ]);
     // Weak activity can be a stale mounted sidecar; the debounced bar may override it.
     expect(out.at(-1)).toBe(true);
@@ -332,7 +339,6 @@ describe("classifyTurnTerminal", () => {
       samples.push({
         len: 800,
         barVisible: true,
-        thinkingActive: true,
         strongThinkingActive: true,
       });
     }
@@ -369,18 +375,16 @@ describe("classifyTurnTerminal", () => {
     expect(out.some(Boolean)).toBe(false);
   });
 
-  test("proofB: a bar-drifted answer finalizes after the quiet window with no thinking", () => {
+  test("does not finalize stable text without correlated completion controls", () => {
     const samples: Array<Partial<TerminalSample> & { len: number }> = [
       { len: 800, stopVisible: true },
     ];
-    // stop gone, no bar (selector drift), no thinking: quiet accrues at 400ms/cycle.
     for (let i = 0; i < 8; i++) samples.push({ len: 800 });
     const out = runGate(samples);
-    // quietMs must reach 1000ms (config) -> terminal by ~cycle 3 after streaming stopped.
-    expect(out.some(Boolean)).toBe(true);
+    expect(out.some(Boolean)).toBe(false);
   });
 
-  test("proofB is withheld for an implausibly short capture (must be proven by the bar)", () => {
+  test("an implausibly short capture still requires correlated completion controls", () => {
     const samples: Array<Partial<TerminalSample> & { len: number }> = [{ len: 1 }];
     for (let i = 0; i < 20; i++) samples.push({ len: 1 }); // stable "I", quiet, no bar/thinking
     const out = runGate(samples);
@@ -397,46 +401,14 @@ describe("classifyTurnTerminal", () => {
     expect(out.at(-1)).toBe(true);
   });
 
-  test("proofB does not fire while thinking stays active", () => {
-    const samples: Array<Partial<TerminalSample> & { len: number }> = [
-      { len: 800, stopVisible: true },
-    ];
-    for (let i = 0; i < 20; i++)
-      samples.push({ len: 800, thinkingActive: true, strongThinkingActive: true });
-    const out = runGate(samples);
-    expect(out.some(Boolean)).toBe(false);
-  });
-
-  test("proofB eventually recovers from static weak sidecar evidence", () => {
-    const samples: Array<Partial<TerminalSample> & { len: number }> = [
-      { len: 800, stopVisible: true },
-    ];
-    for (let i = 0; i < 8; i++)
-      samples.push({ len: 800, thinkingActive: true, thinkingKey: "reasoning" });
-    const out = runGate(samples, config, 10_000);
-    expect(out.at(-1)).toBe(true);
-  });
-
-  test("proofB keeps waiting while weak sidecar content changes", () => {
-    const samples: Array<Partial<TerminalSample> & { len: number }> = [
-      { len: 800, stopVisible: true },
-    ];
-    for (let i = 0; i < 8; i++)
-      samples.push({ len: 800, thinkingActive: true, thinkingKey: `trace-${i}` });
-    const out = runGate(samples, config, 10_000);
-    expect(out.some(Boolean)).toBe(false);
-  });
-
-  test("text growth resets the quiet clock (no premature finalize mid-stream)", () => {
-    // A mid-stream pause shorter than the quiet window, then more text -> not terminal at the pause.
+  test("text growth resets the action-bar debounce", () => {
     const out = runGate([
-      { len: 100, stopVisible: false },
-      { len: 100 }, // 400ms quiet
-      { len: 100 }, // 800ms quiet (< 1000ms)
-      { len: 200 }, // grew -> resets quiet
-      { len: 200 },
+      { len: 100, barVisible: true },
+      { len: 100, barVisible: true },
+      { len: 200, barVisible: true },
+      { len: 200, barVisible: true },
     ]);
-    expect(out.slice(0, 4).some(Boolean)).toBe(false);
+    expect(out.some(Boolean)).toBe(false);
   });
 });
 
@@ -659,7 +631,6 @@ describe("thinking-active completion veto", () => {
     expect(evalThinkingActivityDetails({ panel })).toEqual({
       active: true,
       strong: false,
-      key: "reasoning",
     });
   });
 

--- a/tests/browser/assistantResponseStatus.test.ts
+++ b/tests/browser/assistantResponseStatus.test.ts
@@ -376,6 +376,7 @@ describe("thinking-active completion veto", () => {
     shimmer?: boolean;
     ariaBusy?: boolean;
     statusText?: string;
+    statusTestId?: string;
     progress?: boolean;
     progressNow?: number;
     progressMax?: number;
@@ -384,7 +385,15 @@ describe("thinking-active completion veto", () => {
   }
 
   function createThinkingContext(opts: ThinkingFixtureOptions) {
-    const statusNodes = opts.statusText != null ? [new FakeEl(opts.statusText)] : [];
+    const statusNodes =
+      opts.statusText != null
+        ? [
+            new FakeEl(
+              opts.statusText,
+              opts.statusTestId ? { "data-testid": opts.statusTestId } : {},
+            ),
+          ]
+        : [];
     const progressAttrs: Record<string, string> =
       opts.progressNow != null
         ? {
@@ -487,6 +496,24 @@ describe("thinking-active completion veto", () => {
     },
   );
 
+  test("does NOT treat ordinary live-region answer prose as active thinking", () => {
+    expect(
+      evalThinkingActivityDetails({ statusText: "Thinking clearly requires practice." }),
+    ).toEqual({
+      active: false,
+      strong: false,
+    });
+  });
+
+  test("allows prefix matching only in verified thinking chrome", () => {
+    expect(
+      evalThinkingActivityDetails({
+        statusText: "Thinking through the remaining cases",
+        statusTestId: "reasoning-status",
+      }),
+    ).toEqual({ active: true, strong: true });
+  });
+
   test.each(COMPLETED_SUMMARY_LABELS)(
     "does NOT fire on the persistent completed reasoning summary %s",
     (statusText) => {
@@ -517,6 +544,20 @@ describe("thinking-active completion veto", () => {
     panel.rect = { left: 1000, top: 100, width: 380, height: 400 }; // right side, large
     expect(evalThinkingActive({ panel })).toBe(true);
     expect(evalThinkingActivityDetails({ panel })).toEqual({ active: true, strong: false });
+  });
+
+  test("does NOT treat progress in a generic panel as model activity", () => {
+    const panel = new FakeEl("Upload");
+    panel.rect = { left: 1000, top: 100, width: 380, height: 400 };
+    panel.children = [new FakeEl("", { "aria-valuenow": "40", role: "progressbar" })];
+    expect(evalThinkingActivityDetails({ panel })).toEqual({ active: false, strong: false });
+  });
+
+  test("treats progress in verified reasoning chrome as strong activity", () => {
+    const panel = new FakeEl("", { "data-testid": "reasoning-panel" });
+    panel.rect = { left: 1000, top: 100, width: 380, height: 400 };
+    panel.children = [new FakeEl("", { "aria-valuenow": "40", role: "progressbar" })];
+    expect(evalThinkingActivityDetails({ panel })).toEqual({ active: true, strong: true });
   });
 
   test.each(COMPLETED_SUMMARY_LABELS)("does NOT fire on completed sidecar summary %s", (text) => {

--- a/tests/browser/assistantResponseStatus.test.ts
+++ b/tests/browser/assistantResponseStatus.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import {
   buildActiveThinkingStatusPredicateJsForTest,
   buildAssistantSnapshotExpressionForTest,
+  buildCompletionVisibilityExpressionForTest,
   buildStopButtonVisibilityExpressionForTest,
   classifyTurnTerminal,
   createTerminalGateState,
@@ -163,6 +164,71 @@ describe("assistant thinking-status capture", () => {
       }),
     );
     expect(result).toBe(fixture.expected);
+  });
+});
+
+describe("completion action correlation", () => {
+  class FakeTurn {
+    public dataset: Record<string, string> = {};
+    constructor(
+      private attrs: Record<string, string>,
+      private finished: boolean,
+    ) {}
+    getAttribute(name: string): string | null {
+      return this.attrs[name] ?? null;
+    }
+    querySelector(): object | null {
+      return this.finished ? {} : null;
+    }
+    querySelectorAll(): FakeTurn[] {
+      return [];
+    }
+  }
+
+  function evaluateCompletionVisibility(args: {
+    messageId?: string;
+    minTurnIndex?: number;
+    turns: FakeTurn[];
+  }): boolean {
+    const expression = buildCompletionVisibilityExpressionForTest(
+      { messageId: args.messageId },
+      args.minTurnIndex,
+    );
+    const context = createContext({
+      Array,
+      Boolean,
+      HTMLElement: FakeTurn,
+      document: { querySelectorAll: () => args.turns },
+    });
+    return new Script(expression).runInContext(context) as boolean;
+  }
+
+  test("rejects a persistent action bar from before the new-turn baseline", () => {
+    const oldTurn = new FakeTurn(
+      { "data-turn": "assistant", "data-message-id": "old-message" },
+      true,
+    );
+    expect(evaluateCompletionVisibility({ minTurnIndex: 1, turns: [oldTurn] })).toBe(false);
+  });
+
+  test("accepts controls correlated to the sampled message identity", () => {
+    const currentTurn = new FakeTurn(
+      { "data-turn": "assistant", "data-message-id": "current-message" },
+      true,
+    );
+    expect(
+      evaluateCompletionVisibility({ messageId: "current-message", turns: [currentTurn] }),
+    ).toBe(true);
+  });
+
+  test("rejects controls whose assistant identity differs from the sample", () => {
+    const oldTurn = new FakeTurn(
+      { "data-turn": "assistant", "data-message-id": "old-message" },
+      true,
+    );
+    expect(evaluateCompletionVisibility({ messageId: "new-message", turns: [oldTurn] })).toBe(
+      false,
+    );
   });
 });
 

--- a/tests/browser/assistantResponseStatus.test.ts
+++ b/tests/browser/assistantResponseStatus.test.ts
@@ -10,7 +10,10 @@ import {
   type TerminalGateConfig,
   type TerminalSample,
 } from "../../src/browser/actions/assistantResponse.js";
-import { buildThinkingActivePredicateJsForTest } from "../../src/browser/actions/thinkingStatus.js";
+import {
+  buildThinkingActivePredicateJsForTest,
+  buildThinkingActivityDetailsPredicateJsForTest,
+} from "../../src/browser/actions/thinkingStatus.js";
 import { STOP_BUTTON_SELECTORS } from "../../src/browser/constants.js";
 
 // Completed-summary shapes the veto must treat as NOT active: bare, heading-prefixed
@@ -191,6 +194,7 @@ describe("classifyTurnTerminal", () => {
         stopVisible: partial.stopVisible ?? false,
         barVisible: partial.barVisible ?? false,
         thinkingActive: partial.thinkingActive ?? false,
+        strongThinkingActive: partial.strongThinkingActive ?? false,
       };
       const result = classifyTurnTerminal(state, sample, cfg);
       state = result.state;
@@ -240,7 +244,7 @@ describe("classifyTurnTerminal", () => {
     expect(out.at(-1)).toBe(true);
   });
 
-  test("proofA fires even if a stale thinking panel lingers (bar bypasses the veto)", () => {
+  test("proofA fires even if weak stale-sidecar evidence lingers", () => {
     const out = runGate([
       { len: 800, stopVisible: true },
       { len: 800, barVisible: true, thinkingActive: true },
@@ -248,9 +252,27 @@ describe("classifyTurnTerminal", () => {
       { len: 800, barVisible: true, thinkingActive: true },
       { len: 800, barVisible: true, thinkingActive: true },
     ]);
-    // The debounce increments on barVisible && !stop && !grew (NOT gated on thinking), so a
-    // debounced action bar proves completion even if a false-positive or stale thinking signal
-    // lingers. This avoids hanging a finished turn whose reasoning panel is still mounted.
+    // Weak activity can be a stale mounted sidecar; the debounced bar may override it.
+    expect(out.at(-1)).toBe(true);
+  });
+
+  test("proofA cannot override strong live activity and rebuilds its debounce afterward", () => {
+    const samples: Array<Partial<TerminalSample> & { len: number }> = [
+      { len: 800, stopVisible: true },
+    ];
+    for (let i = 0; i < 5; i++) {
+      samples.push({
+        len: 800,
+        barVisible: true,
+        thinkingActive: true,
+        strongThinkingActive: true,
+      });
+    }
+    samples.push({ len: 800, barVisible: true });
+    samples.push({ len: 800, barVisible: true });
+    samples.push({ len: 800, barVisible: true });
+    const out = runGate(samples);
+    expect(out.slice(0, 6).some(Boolean)).toBe(false);
     expect(out.at(-1)).toBe(true);
   });
 
@@ -349,7 +371,7 @@ describe("thinking-active completion veto", () => {
     public children: FakeEl[] = [];
   }
 
-  function evalThinkingActive(opts: {
+  interface ThinkingFixtureOptions {
     stop?: boolean;
     shimmer?: boolean;
     ariaBusy?: boolean;
@@ -359,8 +381,9 @@ describe("thinking-active completion veto", () => {
     progressMax?: number;
     unrelatedProgress?: boolean;
     panel?: FakeEl;
-  }): boolean {
-    const predicate = buildThinkingActivePredicateJsForTest("isThinkingActive");
+  }
+
+  function createThinkingContext(opts: ThinkingFixtureOptions) {
     const statusNodes = opts.statusText != null ? [new FakeEl(opts.statusText)] : [];
     const progressAttrs: Record<string, string> =
       opts.progressNow != null
@@ -378,7 +401,7 @@ describe("thinking-active completion veto", () => {
     turn.children = progressNodes;
     const turnNodes = [turn];
     const panelNodes = opts.panel ? [opts.panel] : [];
-    const context = createContext({
+    return createContext({
       Array,
       Number,
       String,
@@ -426,7 +449,23 @@ describe("thinking-active completion veto", () => {
         innerWidth: 1440,
       },
     });
-    return new Script(`${predicate}\nisThinkingActive();`).runInContext(context) as boolean;
+  }
+
+  function evalThinkingActive(opts: ThinkingFixtureOptions): boolean {
+    const predicate = buildThinkingActivePredicateJsForTest("isThinkingActive");
+    return new Script(`${predicate}\nisThinkingActive();`).runInContext(
+      createThinkingContext(opts),
+    ) as boolean;
+  }
+
+  function evalThinkingActivityDetails(opts: ThinkingFixtureOptions): {
+    active: boolean;
+    strong: boolean;
+  } {
+    const predicate = buildThinkingActivityDetailsPredicateJsForTest("readThinkingActivity");
+    return new Script(`${predicate}\nreadThinkingActivity();`).runInContext(
+      createThinkingContext(opts),
+    ) as { active: boolean; strong: boolean };
   }
 
   test("fires on a visible stop control", () => {
@@ -459,6 +498,7 @@ describe("thinking-active completion veto", () => {
 
   test("fires on a live progress bar inside the current assistant turn", () => {
     expect(evalThinkingActive({ progress: true })).toBe(true);
+    expect(evalThinkingActivityDetails({ progress: true })).toEqual({ active: true, strong: true });
   });
 
   test("does NOT fire on a completed progress bar (value at max)", () => {
@@ -476,6 +516,7 @@ describe("thinking-active completion veto", () => {
     const panel = new FakeEl("Reasoning");
     panel.rect = { left: 1000, top: 100, width: 380, height: 400 }; // right side, large
     expect(evalThinkingActive({ panel })).toBe(true);
+    expect(evalThinkingActivityDetails({ panel })).toEqual({ active: true, strong: false });
   });
 
   test.each(COMPLETED_SUMMARY_LABELS)("does NOT fire on completed sidecar summary %s", (text) => {

--- a/tests/browser/assistantResponseStatus.test.ts
+++ b/tests/browser/assistantResponseStatus.test.ts
@@ -365,8 +365,20 @@ describe("thinking-active completion veto", () => {
       return this.attrs[name] ?? null;
     }
     querySelectorAll(selector: string) {
-      if (selector.includes("progress")) return this.children;
-      return [];
+      const matches: FakeEl[] = [];
+      if (selector.includes("progress"))
+        matches.push(
+          ...this.children.filter((child) => child.getAttribute("role") === "progressbar"),
+        );
+      if (selector.includes("loading-shimmer"))
+        matches.push(
+          ...this.children.filter((child) => child.getAttribute("data-kind") === "shimmer"),
+        );
+      if (selector.includes("aria-busy"))
+        matches.push(
+          ...this.children.filter((child) => child.getAttribute("aria-busy") === "true"),
+        );
+      return [...new Set(matches)];
     }
     public children: FakeEl[] = [];
   }
@@ -381,6 +393,7 @@ describe("thinking-active completion veto", () => {
     progressNow?: number;
     progressMax?: number;
     unrelatedProgress?: boolean;
+    unrelatedBusy?: boolean;
     panel?: FakeEl;
   }
 
@@ -407,7 +420,11 @@ describe("thinking-active completion veto", () => {
     // Progress is scoped to the CURRENT assistant turn (review P1): the harness models the
     // turn container; unrelatedProgress mounts a live bar OUTSIDE any turn, which must not veto.
     const turn = new FakeEl("turn");
-    turn.children = progressNodes;
+    turn.children = [
+      ...progressNodes,
+      ...(opts.shimmer ? [new FakeEl("", { "data-kind": "shimmer" })] : []),
+      ...(opts.ariaBusy ? [new FakeEl("", { "aria-busy": "true" })] : []),
+    ];
     const turnNodes = [turn];
     const panelNodes = opts.panel ? [opts.panel] : [];
     return createContext({
@@ -421,8 +438,8 @@ describe("thinking-active completion veto", () => {
           if (selector.includes("stop") || selector.includes('aria-label*="stop"')) {
             return opts.stop ? [new FakeEl()] : [];
           }
-          if (selector.includes("loading-shimmer")) return opts.shimmer ? [new FakeEl()] : [];
-          if (selector.includes("aria-busy")) return opts.ariaBusy ? [new FakeEl()] : [];
+          if (selector.includes("loading-shimmer")) return opts.unrelatedBusy ? [new FakeEl()] : [];
+          if (selector.includes("aria-busy")) return opts.unrelatedBusy ? [new FakeEl()] : [];
           if (selector.includes("progressbar") || selector.includes("aria-valuenow")) {
             // Only an UNRELATED page-wide bar is ever visible at document level now; the
             // turn-scoped bars are reached through the turn node's own querySelectorAll.
@@ -539,6 +556,13 @@ describe("thinking-active completion veto", () => {
     expect(evalThinkingActive({ unrelatedProgress: true })).toBe(false);
   });
 
+  test("does NOT fire on unrelated page-wide busy indicators", () => {
+    expect(evalThinkingActivityDetails({ unrelatedBusy: true })).toEqual({
+      active: false,
+      strong: false,
+    });
+  });
+
   test("fires on a right-side reasoning sidecar panel with no inline label", () => {
     const panel = new FakeEl("Reasoning");
     panel.rect = { left: 1000, top: 100, width: 380, height: 400 }; // right side, large
@@ -573,6 +597,12 @@ describe("thinking-active completion veto", () => {
     const panel = new FakeEl(
       "Thought for 2s: Searching the web. Reasoning about the diff and enumerating candidate hunks to inspect next.",
     );
+    panel.rect = { left: 1000, top: 100, width: 380, height: 400 };
+    expect(evalThinkingActive({ panel })).toBe(true);
+  });
+
+  test("fires on a short live trace that begins with a completed sub-step", () => {
+    const panel = new FakeEl("Thought for 2s: Searching the web");
     panel.rect = { left: 1000, top: 100, width: 380, height: 400 };
     expect(evalThinkingActive({ panel })).toBe(true);
   });

--- a/tests/browser/assistantResponseStatus.test.ts
+++ b/tests/browser/assistantResponseStatus.test.ts
@@ -261,6 +261,7 @@ describe("classifyTurnTerminal", () => {
         barVisible: partial.barVisible ?? false,
         thinkingActive: partial.thinkingActive ?? false,
         strongThinkingActive: partial.strongThinkingActive ?? false,
+        thinkingKey: partial.thinkingKey,
       };
       const result = classifyTurnTerminal(state, sample, cfg);
       state = result.state;
@@ -284,7 +285,8 @@ describe("classifyTurnTerminal", () => {
     // settle gap: stop gone, no bar, no thinking yet (the exact window the bug exploited)
     for (let i = 0; i < 2; i++) samples.push({ len: 150 });
     // thinking phase mounts (connector/reasoning)
-    for (let i = 0; i < 10; i++) samples.push({ len: 150, thinkingActive: true });
+    for (let i = 0; i < 10; i++)
+      samples.push({ len: 150, thinkingActive: true, strongThinkingActive: true });
     // real answer streams after thinking, bar appears and debounces
     samples.push({ len: 600, stopVisible: true });
     samples.push({ len: 900, stopVisible: true });
@@ -399,8 +401,29 @@ describe("classifyTurnTerminal", () => {
     const samples: Array<Partial<TerminalSample> & { len: number }> = [
       { len: 800, stopVisible: true },
     ];
-    for (let i = 0; i < 20; i++) samples.push({ len: 800, thinkingActive: true });
+    for (let i = 0; i < 20; i++)
+      samples.push({ len: 800, thinkingActive: true, strongThinkingActive: true });
     const out = runGate(samples);
+    expect(out.some(Boolean)).toBe(false);
+  });
+
+  test("proofB eventually recovers from static weak sidecar evidence", () => {
+    const samples: Array<Partial<TerminalSample> & { len: number }> = [
+      { len: 800, stopVisible: true },
+    ];
+    for (let i = 0; i < 8; i++)
+      samples.push({ len: 800, thinkingActive: true, thinkingKey: "reasoning" });
+    const out = runGate(samples, config, 10_000);
+    expect(out.at(-1)).toBe(true);
+  });
+
+  test("proofB keeps waiting while weak sidecar content changes", () => {
+    const samples: Array<Partial<TerminalSample> & { len: number }> = [
+      { len: 800, stopVisible: true },
+    ];
+    for (let i = 0; i < 8; i++)
+      samples.push({ len: 800, thinkingActive: true, thinkingKey: `trace-${i}` });
+    const out = runGate(samples, config, 10_000);
     expect(out.some(Boolean)).toBe(false);
   });
 
@@ -575,7 +598,7 @@ describe("thinking-active completion veto", () => {
   test.each(["Thinking", "Pro thinking", "Searching the web", "Reading", "Finalizing answer"])(
     "fires on active status label %j",
     (label) => {
-      expect(evalThinkingActive({ statusText: label })).toBe(true);
+      expect(evalThinkingActive({ statusText: label, statusTestId: "thinking-status" })).toBe(true);
     },
   );
 
@@ -633,7 +656,11 @@ describe("thinking-active completion veto", () => {
     const panel = new FakeEl("Reasoning");
     panel.rect = { left: 1000, top: 100, width: 380, height: 400 }; // right side, large
     expect(evalThinkingActive({ panel })).toBe(true);
-    expect(evalThinkingActivityDetails({ panel })).toEqual({ active: true, strong: false });
+    expect(evalThinkingActivityDetails({ panel })).toEqual({
+      active: true,
+      strong: false,
+      key: "reasoning",
+    });
   });
 
   test("does NOT treat progress in a generic panel as model activity", () => {

--- a/tests/browser/assistantResponseStatus.test.ts
+++ b/tests/browser/assistantResponseStatus.test.ts
@@ -241,6 +241,8 @@ describe("completion action correlation", () => {
   test("fallback snapshots carry only node-scoped completion evidence", () => {
     const expression = buildMarkdownFallbackExtractorForTest("1");
     expect(expression).toContain("completionVisible: actionMarkdowns.includes(node)");
+    expect(expression).toContain("return Boolean(lastUser.compareDocumentPosition(node) & 4)");
+    expect(expression).toContain("if (!hasTurns) return isAfterCurrentUser(node)");
   });
 });
 

--- a/tests/browser/assistantResponseStatus.test.ts
+++ b/tests/browser/assistantResponseStatus.test.ts
@@ -29,6 +29,8 @@ const COMPLETED_SUMMARY_LABELS = [
   "Reasoning Thought for a moment",
   "ReasoningThought for 12s",
   "Thought for 1m 5s",
+  "Reasoning Thought for 12s Edit",
+  "Pro thinking Thought for 3.5s Edit",
 ];
 
 function evaluatePredicate(text: string, generating: boolean): boolean {

--- a/tests/browser/index.test.ts
+++ b/tests/browser/index.test.ts
@@ -554,6 +554,9 @@ describe("image-only assistant turn detection", () => {
   test("treats ChatGPT image-only chrome text as non-answer UI", () => {
     expect(__test__.isImageOnlyUiChromeText("Stopped thinking\nEdit")).toBe(true);
     expect(__test__.isImageOnlyUiChromeText("Edit")).toBe(true);
+    expect(__test__.isImageOnlyUiChromeText("Thought for 12s Edit")).toBe(true);
+    expect(__test__.isImageOnlyUiChromeText("Reasoning Thought for 12s Edit")).toBe(true);
+    expect(__test__.isImageOnlyUiChromeText("Pro thinking Thought for 3.5s Edit")).toBe(true);
     expect(__test__.isImageOnlyUiChromeText("PR169_IMAGE_OK")).toBe(false);
   });
 });

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -833,22 +833,39 @@ describe("ensureLoggedIn", () => {
 
 describe("waitForAssistantResponse", () => {
   test("returns captured assistant payload", async () => {
-    const runtime = {
-      evaluate: vi.fn().mockResolvedValue({
-        result: {
-          type: "object",
-          value: {
-            text: "Answer to the question.",
-            html: "<p>Answer to the question.</p>",
-            messageId: "mid",
-            turnId: "tid",
-          },
-        },
-      }),
-    } as unknown as ChromeClient["Runtime"];
-    const result = await waitForAssistantResponse(runtime, 1000, logger);
-    expect(result.text).toBe("Answer to the question.");
-    expect(result.meta).toEqual({ messageId: "mid", turnId: "tid" });
+    vi.useFakeTimers();
+    try {
+      const payload = {
+        text: "Answer to the question.",
+        html: "<p>Answer to the question.</p>",
+        messageId: "mid",
+        turnId: "tid",
+      };
+      const evaluate = vi
+        .fn()
+        .mockImplementation(async (params: { expression?: string; awaitPromise?: boolean }) => {
+          if (params?.awaitPromise) {
+            return { result: { type: "object", value: payload } };
+          }
+          const expression = String(params?.expression ?? "");
+          if (expression.includes("extractAssistantTurn")) {
+            return { result: { value: payload } };
+          }
+          // A finished turn's action bar is present -> the terminal gate proves completion (proofA).
+          if (expression.includes("Find the LAST assistant turn")) {
+            return { result: { value: true } };
+          }
+          return { result: { value: false } };
+        });
+      const runtime = { evaluate } as unknown as ChromeClient["Runtime"];
+      const promise = waitForAssistantResponse(runtime, 30_000, logger);
+      await vi.advanceTimersByTimeAsync(4_000);
+      const result = await promise;
+      expect(result.text).toBe("Answer to the question.");
+      expect(result.meta).toEqual({ messageId: "mid", turnId: "tid" });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("aborts poller when evaluation wins (no background polling)", async () => {
@@ -880,15 +897,20 @@ describe("waitForAssistantResponse", () => {
             }
             return { result: { value: payload } };
           }
+          if (expression.includes("Find the LAST assistant turn")) {
+            return { result: { value: true } }; // action bar present -> proofA
+          }
           return { result: { value: false } };
         });
 
       const runtime = { evaluate } as unknown as ChromeClient["Runtime"];
       const promise = waitForAssistantResponse(runtime, 30_000, logger);
-      await vi.advanceTimersByTimeAsync(2_000);
+      await vi.advanceTimersByTimeAsync(4_000);
       const result = await promise;
       expect(result.text).toBe(answerText);
 
+      // The confirm re-poll is FOREGROUND; once the promise resolves there must be no further
+      // (background) polling — the poller is aborted when the evaluation path wins.
       const callsAtReturn = evaluate.mock.calls.length;
       await vi.advanceTimersByTimeAsync(5_000);
       expect(evaluate.mock.calls.length).toBe(callsAtReturn);
@@ -915,14 +937,17 @@ describe("waitForAssistantResponse", () => {
             return { result: { type: "object", value: partial } };
           }
           const expression = String(params.expression ?? "");
+          // The stub "I" is captured mid-stream; the full answer and its action bar arrive at 3.5s.
+          const done = Date.now() - startedAt >= 3_500;
           if (expression.includes("extractAssistantTurn")) {
             snapshotCalls += 1;
             if (snapshotCalls === 1) {
               await new Promise((resolve) => setTimeout(resolve, 50));
             }
-            return {
-              result: { value: Date.now() - startedAt < 3_500 ? partial : complete },
-            };
+            return { result: { value: done ? complete : partial } };
+          }
+          if (expression.includes("Find the LAST assistant turn")) {
+            return { result: { value: done } }; // action bar only once the turn finishes
           }
           return { result: { value: false } };
         });
@@ -934,10 +959,8 @@ describe("waitForAssistantResponse", () => {
       );
       await vi.advanceTimersByTimeAsync(12_000);
 
+      // The short stub must NOT be finalized; the grown, bar-proven answer is returned.
       await expect(promise).resolves.toMatchObject({ text: complete.text });
-      expect(logger).toHaveBeenCalledWith(
-        "Captured an implausibly short response; confirming it is not a mid-stream capture",
-      );
     } finally {
       vi.useRealTimers();
     }
@@ -1031,8 +1054,9 @@ describe("waitForAssistantResponse", () => {
             }
             return { result: { value: snapshotCalls <= 5 ? partial : complete } };
           }
+          // Still rendering while the first paragraph shows: no action bar until the turn finishes.
           if (expression.includes("Find the LAST assistant turn")) {
-            return { result: { value: true } };
+            return { result: { value: snapshotCalls > 5 } };
           }
           return { result: { value: false } };
         });
@@ -1042,12 +1066,10 @@ describe("waitForAssistantResponse", () => {
         30_000,
         logger,
       );
-      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(12_000);
 
+      // The long-but-partial first paragraph must not be finalized; the full answer is returned.
       await expect(promise).resolves.toMatchObject({ text: complete.text });
-      expect(logger).toHaveBeenCalledWith(
-        "Completion controls surfaced; confirming stable assistant response",
-      );
     } finally {
       vi.useRealTimers();
     }
@@ -1078,12 +1100,10 @@ describe("waitForAssistantResponse", () => {
         30_000,
         logger,
       );
-      await vi.advanceTimersByTimeAsync(15_000);
+      await vi.advanceTimersByTimeAsync(6_000);
 
+      // A legitimately short answer is kept once its action bar proves completion (proofA).
       await expect(promise).resolves.toMatchObject({ text: "Yes." });
-      expect(logger).toHaveBeenCalledWith(
-        "Completion controls surfaced; confirming stable assistant response",
-      );
     } finally {
       vi.useRealTimers();
     }
@@ -1119,10 +1139,8 @@ describe("waitForAssistantResponse", () => {
         if (params?.awaitPromise) {
           throw new Error("observer failed");
         }
-        if (
-          typeof params?.expression === "string" &&
-          params.expression.includes("extractAssistantTurn")
-        ) {
+        const expression = typeof params?.expression === "string" ? params.expression : "";
+        if (expression.includes("extractAssistantTurn")) {
           return {
             result: {
               value: {
@@ -1134,10 +1152,14 @@ describe("waitForAssistantResponse", () => {
             },
           };
         }
+        // Recovered turn is finished (action bar present) -> the terminal gate confirms it.
+        if (expression.includes("Find the LAST assistant turn")) {
+          return { result: { value: true } };
+        }
         return { result: { value: null } };
       });
     const runtime = { evaluate } as unknown as ChromeClient["Runtime"];
-    const result = await waitForAssistantResponse(runtime, 200, logger);
+    const result = await waitForAssistantResponse(runtime, 10_000, logger);
     expect(result.text).toBe("Recovered assistant response.");
     expect(evaluate).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Problem

Long-running ChatGPT Pro browser turns can stream an opening preamble, briefly settle, then continue through reasoning/tool work before producing the real answer. Oracle could treat that first stable preamble as final because the old completion path inferred completion from quiet text and missing stop controls.

## Final design

This branch fails closed unless the sampled response has correlated positive terminal evidence:

- A finished-action bar must belong to the sampled message/turn, or to fallback markdown scoped under those controls and correlated after the current user turn.
- The action bar must remain present for a debounced number of cycles while the response fingerprint is unchanged for the minimum stability interval.
- Any content rewrite, including equal-length or shorter replacements, resets the debounce.
- Stop controls and strong live activity (shimmer, scoped `aria-busy`, verified thinking status, or scoped progress) veto completion.
- Text-only sidecar heuristics are weak evidence: they cannot override strong activity, but cannot hang a positively completed response.
- Elapsed quiet is never terminal proof. Selector drift or uncorrelated wrapperless layouts time out instead of returning a stable preamble or stale answer.
- Recovery, observer, and exhausted-budget paths all route through the same terminal-only poller and refuse unconfirmed text.

## Maintainer hardening

Rebased onto current `main`, including the hidden-window send fix from #302, and hardened through repeated AutoReview findings:

- separated strong live activity from weak or stale sidecar evidence;
- scoped progress, shimmer, and busy indicators to the current response or verified reasoning chrome;
- restricted status-label matching to verified thinking/reasoning UI;
- anchored completed-reasoning summaries, including heading-prefixed, worded-duration, concatenated, and trailing `Edit` variants;
- bound completion controls to the sampled message/turn and rejected stale earlier-turn controls;
- correlated wrapperless fallback candidates by DOM order after the current user turn;
- removed the absence-based quiet fallback entirely.

Maintainer commits are layered after the contributor's six original commits; contributor authorship and history remain intact.

## Validation

Exact final candidate head: `57d4a7afbac764dfd51f234811a2f1b6d3f3d38b`.

- `pnpm vitest run tests/browser/assistantResponseStatus.test.ts tests/browser/pageActions.test.ts tests/browser/index.test.ts tests/browser/promptComposer.test.ts tests/browser/chromeLifecycle.test.ts` — 214 passed, 1 skipped.
- `pnpm check` — passed.
- `pnpm test` — 1,485 passed, 43 skipped.
- Final AutoReview: Codex `gpt-5.6-sol`, xhigh — clean, no actionable findings.
- Public model identifier audit: PASS. GPT-5.5/GPT-5.6 are current public product names documented by OpenAI: https://help.openai.com/en/articles/11909943-gpt-5-2-in-chatgpt and https://help.openai.com/en/articles/20001354-gpt-56-in-chatgpt.

## Exact-head live Pro proof

Session `pr301-final-completion-live`, signed-in ChatGPT Pro, `--copy-profile`, `--browser-hide-window`, model selection verified as Pro:

- Initial turn captured all 30 requested numbered lines and the unique final marker `PR301-INITIAL-END-20260711`.
- Same-conversation follow-up captured all 20 requested numbered lines and the unique final marker `PR301-FOLLOWUP-END-20260711`.
- Both completed in 21.2 seconds total with no preamble-only or mid-stream truncation.

The contributor's original pre-hardening live proof also completed three real GPT-5.5 Pro runs in 701–1,270 seconds with zero retries and complete multi-kilobyte final reviews.

## Risk and behavior under drift

Risk remains medium/high because this is the central browser completion boundary. The final design deliberately chooses availability failure over silent truncation: if Oracle cannot correlate positive completion evidence, it times out and preserves recovery diagnostics instead of returning an incomplete or stale answer.
