### PR TITLE
fix(browser): restore prompt submission when the Chrome window is hidden (#298)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.15.3 — Unreleased
 
+### Fixed
+
+- Browser: keep hidden macOS Chrome windows rendered off-screen so trusted prompt submissions land without retaining drafts or leaking them into later runs. Fixes #298 and #312. Thanks @LeoLin990405!
+
 ## 0.15.2 — 2026-07-06
 
 ### Changed

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -720,15 +720,6 @@ async function attemptSendButton(
       typeof value.y === "number"
     ) {
       await clickTrustedPoint(Runtime, Input, value.x, value.y);
-      // Trusted input events reach only a composited window, so a hidden or
-      // occluded one swallows the click without raising anything. If the send
-      // clearly did not take, fall back to the synthetic DOM click that worked
-      // before trusted clicks were introduced. The fallback re-checks for a
-      // still-enabled send button, so a slow-but-successful send cannot be
-      // submitted twice.
-      if (!(await sendTookEffect(Runtime))) {
-        await dispatchSendButtonClick(Runtime);
-      }
       return true;
     }
     if (status === "clicked") {
@@ -753,98 +744,6 @@ async function attemptSendButton(
     );
   }
   return false;
-}
-
-// Shared predicate: a send button we are allowed to click is both visible and enabled.
-// Kept in sync with the primary send script so the fallback cannot re-send a prompt
-// that already left the composer (a submitted send leaves no enabled send button).
-const SEND_BUTTON_PREDICATE_JS = `
-  const sendSelectors = ${JSON.stringify(SEND_BUTTON_SELECTORS)};
-  const isSendVisible = (node) => {
-    if (!(node instanceof HTMLElement)) return false;
-    const rect = node.getBoundingClientRect();
-    if (rect.width <= 0 || rect.height <= 0) return false;
-    const style = window.getComputedStyle(node);
-    return style.display !== 'none' && style.visibility !== 'hidden';
-  };
-  const isSendEnabled = (node) => {
-    const style = window.getComputedStyle(node);
-    return !(
-      node.hasAttribute('disabled') ||
-      node.getAttribute('aria-disabled') === 'true' ||
-      node.getAttribute('data-disabled') === 'true' ||
-      style.pointerEvents === 'none' ||
-      style.display === 'none'
-    );
-  };
-  const findSendButton = () => {
-    const candidates = [];
-    for (const selector of sendSelectors) {
-      candidates.push(...Array.from(document.querySelectorAll(selector)));
-    }
-    return candidates.find((node) => isSendVisible(node) && isSendEnabled(node)) || null;
-  };`;
-
-const SEND_EFFECT_TIMEOUT_MS = 1_500;
-const SEND_EFFECT_POLL_MS = 100;
-
-/**
- * Did the send actually leave the composer?
- *
- * Positive signals: the composer cleared, the send button is gone/disabled, a
- * stop button appeared, or an assistant turn is rendering. Any of these means
- * ChatGPT accepted the submission; none of them means the click was swallowed.
- */
-async function sendTookEffect(Runtime: ChromeClient["Runtime"]): Promise<boolean> {
-  const expression = `(() => {
-    ${SEND_BUTTON_PREDICATE_JS}
-    const inputSelectors = ${JSON.stringify(INPUT_SELECTORS)};
-    const readValue = (node) => {
-      if (!node) return '';
-      if (node instanceof HTMLTextAreaElement) return node.value ?? '';
-      return node.innerText ?? '';
-    };
-    const inputs = inputSelectors
-      .map((selector) => document.querySelector(selector))
-      .filter((node) => Boolean(node));
-    const composerCleared =
-      inputs.length > 0 && inputs.every((node) => !String(readValue(node)).trim());
-    const sendButtonGone = findSendButton() === null;
-    const stopVisible = Boolean(document.querySelector(${JSON.stringify(STOP_BUTTON_SELECTOR)}));
-    const assistantVisible = Boolean(document.querySelector(${JSON.stringify(ASSISTANT_ROLE_SELECTOR)}));
-    return composerCleared || sendButtonGone || stopVisible || assistantVisible;
-  })()`;
-  const deadline = Date.now() + SEND_EFFECT_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    try {
-      const { result } = await Runtime.evaluate({ expression, returnByValue: true });
-      if (result?.value === true) {
-        return true;
-      }
-    } catch {
-      // ignore; keep polling until the deadline
-    }
-    await delay(SEND_EFFECT_POLL_MS);
-  }
-  return false;
-}
-
-/** Synthetic DOM click on a still-enabled send button. Returns false when none is left to click. */
-async function dispatchSendButtonClick(Runtime: ChromeClient["Runtime"]): Promise<boolean> {
-  const expression = `(() => {
-    ${buildClickDispatcher()}
-    ${SEND_BUTTON_PREDICATE_JS}
-    const button = findSendButton();
-    if (!button) return false;
-    dispatchClickSequence(button);
-    return true;
-  })()`;
-  try {
-    const { result } = await Runtime.evaluate({ expression, returnByValue: true });
-    return result?.value === true;
-  } catch {
-    return false;
-  }
 }
 
 async function clickTrustedPoint(
@@ -1084,8 +983,6 @@ function summarizeCommitProbe(probe: CommitProbeState): Record<string, unknown> 
 // biome-ignore lint/style/useNamingConvention: test-only export used in vitest suite
 export const __test__ = {
   attemptSendButton,
-  dispatchSendButtonClick,
   sendButtonTimeoutMs,
-  sendTookEffect,
   verifyPromptCommitted,
 };

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -720,6 +720,15 @@ async function attemptSendButton(
       typeof value.y === "number"
     ) {
       await clickTrustedPoint(Runtime, Input, value.x, value.y);
+      // Trusted input events reach only a composited window, so a hidden or
+      // occluded one swallows the click without raising anything. If the send
+      // clearly did not take, fall back to the synthetic DOM click that worked
+      // before trusted clicks were introduced. The fallback re-checks for a
+      // still-enabled send button, so a slow-but-successful send cannot be
+      // submitted twice.
+      if (!(await sendTookEffect(Runtime))) {
+        await dispatchSendButtonClick(Runtime);
+      }
       return true;
     }
     if (status === "clicked") {
@@ -744,6 +753,98 @@ async function attemptSendButton(
     );
   }
   return false;
+}
+
+// Shared predicate: a send button we are allowed to click is both visible and enabled.
+// Kept in sync with the primary send script so the fallback cannot re-send a prompt
+// that already left the composer (a submitted send leaves no enabled send button).
+const SEND_BUTTON_PREDICATE_JS = `
+  const sendSelectors = ${JSON.stringify(SEND_BUTTON_SELECTORS)};
+  const isSendVisible = (node) => {
+    if (!(node instanceof HTMLElement)) return false;
+    const rect = node.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return false;
+    const style = window.getComputedStyle(node);
+    return style.display !== 'none' && style.visibility !== 'hidden';
+  };
+  const isSendEnabled = (node) => {
+    const style = window.getComputedStyle(node);
+    return !(
+      node.hasAttribute('disabled') ||
+      node.getAttribute('aria-disabled') === 'true' ||
+      node.getAttribute('data-disabled') === 'true' ||
+      style.pointerEvents === 'none' ||
+      style.display === 'none'
+    );
+  };
+  const findSendButton = () => {
+    const candidates = [];
+    for (const selector of sendSelectors) {
+      candidates.push(...Array.from(document.querySelectorAll(selector)));
+    }
+    return candidates.find((node) => isSendVisible(node) && isSendEnabled(node)) || null;
+  };`;
+
+const SEND_EFFECT_TIMEOUT_MS = 1_500;
+const SEND_EFFECT_POLL_MS = 100;
+
+/**
+ * Did the send actually leave the composer?
+ *
+ * Positive signals: the composer cleared, the send button is gone/disabled, a
+ * stop button appeared, or an assistant turn is rendering. Any of these means
+ * ChatGPT accepted the submission; none of them means the click was swallowed.
+ */
+async function sendTookEffect(Runtime: ChromeClient["Runtime"]): Promise<boolean> {
+  const expression = `(() => {
+    ${SEND_BUTTON_PREDICATE_JS}
+    const inputSelectors = ${JSON.stringify(INPUT_SELECTORS)};
+    const readValue = (node) => {
+      if (!node) return '';
+      if (node instanceof HTMLTextAreaElement) return node.value ?? '';
+      return node.innerText ?? '';
+    };
+    const inputs = inputSelectors
+      .map((selector) => document.querySelector(selector))
+      .filter((node) => Boolean(node));
+    const composerCleared =
+      inputs.length > 0 && inputs.every((node) => !String(readValue(node)).trim());
+    const sendButtonGone = findSendButton() === null;
+    const stopVisible = Boolean(document.querySelector(${JSON.stringify(STOP_BUTTON_SELECTOR)}));
+    const assistantVisible = Boolean(document.querySelector(${JSON.stringify(ASSISTANT_ROLE_SELECTOR)}));
+    return composerCleared || sendButtonGone || stopVisible || assistantVisible;
+  })()`;
+  const deadline = Date.now() + SEND_EFFECT_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      const { result } = await Runtime.evaluate({ expression, returnByValue: true });
+      if (result?.value === true) {
+        return true;
+      }
+    } catch {
+      // ignore; keep polling until the deadline
+    }
+    await delay(SEND_EFFECT_POLL_MS);
+  }
+  return false;
+}
+
+/** Synthetic DOM click on a still-enabled send button. Returns false when none is left to click. */
+async function dispatchSendButtonClick(Runtime: ChromeClient["Runtime"]): Promise<boolean> {
+  const expression = `(() => {
+    ${buildClickDispatcher()}
+    ${SEND_BUTTON_PREDICATE_JS}
+    const button = findSendButton();
+    if (!button) return false;
+    dispatchClickSequence(button);
+    return true;
+  })()`;
+  try {
+    const { result } = await Runtime.evaluate({ expression, returnByValue: true });
+    return result?.value === true;
+  } catch {
+    return false;
+  }
 }
 
 async function clickTrustedPoint(
@@ -983,6 +1084,8 @@ function summarizeCommitProbe(probe: CommitProbeState): Record<string, unknown> 
 // biome-ignore lint/style/useNamingConvention: test-only export used in vitest suite
 export const __test__ = {
   attemptSendButton,
+  dispatchSendButtonClick,
   sendButtonTimeoutMs,
+  sendTookEffect,
   verifyPromptCommitted,
 };

--- a/src/browser/chromeLifecycle.ts
+++ b/src/browser/chromeLifecycle.ts
@@ -2,15 +2,11 @@ import { rm } from "node:fs/promises";
 import { readFileSync } from "node:fs";
 import os from "node:os";
 import net from "node:net";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import CDP from "chrome-remote-interface";
 import { launch, Launcher, type LaunchedChrome } from "chrome-launcher";
 import type { BrowserLogger, ResolvedBrowserConfig, ChromeClient } from "./types.js";
 import { cleanupStaleProfileState } from "./profileState.js";
 import { delay } from "./utils.js";
-
-const execFileAsync = promisify(execFile);
 
 export async function launchChrome(
   config: ResolvedBrowserConfig,
@@ -20,7 +16,11 @@ export async function launchChrome(
   const connectHost = resolveRemoteDebugHost();
   const debugBindAddress = connectHost && connectHost !== "127.0.0.1" ? "0.0.0.0" : connectHost;
   const debugPort = config.debugPort ?? parseDebugPortEnv();
-  const chromeFlags = buildChromeFlags(config.headless ?? false, debugBindAddress);
+  const chromeFlags = buildChromeFlags(
+    config.headless ?? false,
+    debugBindAddress,
+    config.hideWindow ?? false,
+  );
   const usePatchedLauncher = Boolean(connectHost && connectHost !== "127.0.0.1");
   // copy-profile reuses a copied signed-in profile whose cookies are
   // Keychain-encrypted, so it must launch with the real Keychain (not mocked):
@@ -54,6 +54,27 @@ export async function launchChrome(
   return Object.assign(launcher, { host: connectHost ?? "127.0.0.1" }) as LaunchedChrome & {
     host?: string;
   };
+}
+
+export async function positionChromeWindowOffscreen(
+  client: ChromeClient,
+  logger: BrowserLogger,
+): Promise<void> {
+  if (process.platform !== "darwin") {
+    logger("Window hiding is only supported on macOS");
+    return;
+  }
+  try {
+    const { windowId } = await client.Browser.getWindowForTarget();
+    await client.Browser.setWindowBounds({
+      windowId,
+      bounds: { left: -32_000, top: -32_000, windowState: "normal" },
+    });
+    logger("Chrome window positioned off-screen");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger(`Failed to position Chrome window off-screen: ${message}`);
+  }
 }
 
 export function registerTerminationHooks(
@@ -142,32 +163,6 @@ export function registerTerminationHooks(
       process.removeListener(signal, handleSignal);
     }
   };
-}
-
-export async function hideChromeWindow(
-  chrome: LaunchedChrome,
-  logger: BrowserLogger,
-): Promise<void> {
-  if (process.platform !== "darwin") {
-    logger("Window hiding is only supported on macOS");
-    return;
-  }
-  if (!chrome.pid) {
-    logger("Unable to hide window: missing Chrome PID");
-    return;
-  }
-  const script = `tell application "System Events"
-    try
-      set visible of (first process whose unix id is ${chrome.pid}) to false
-    end try
-  end tell`;
-  try {
-    await execFileAsync("osascript", ["-e", script]);
-    logger("Chrome window hidden (Cmd-H)");
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    logger(`Failed to hide Chrome window: ${message}`);
-  }
 }
 
 export async function connectToChrome(
@@ -630,7 +625,11 @@ function isBlankPageTarget(target: { type?: string; url?: string }): boolean {
   return url === "about:blank" || url === "chrome://newtab/" || url === "chrome://new-tab-page/";
 }
 
-function buildChromeFlags(headless: boolean, debugBindAddress?: string | null): string[] {
+function buildChromeFlags(
+  headless: boolean,
+  debugBindAddress?: string | null,
+  hideWindow = false,
+): string[] {
   const flags = [
     "--disable-background-networking",
     "--disable-background-timer-throttling",
@@ -662,9 +661,22 @@ function buildChromeFlags(headless: boolean, debugBindAddress?: string | null): 
 
   if (headless) {
     flags.push("--headless=new");
+  } else if (hideWindow && process.platform === "darwin") {
+    // Cmd-H stops macOS Chrome from compositing the page, which can swallow
+    // trusted CDP clicks and retain the prompt as a draft. Keeping the window
+    // off-screen avoids desktop disruption while preserving normal rendering.
+    flags.push("--window-position=-32000,-32000");
   }
 
   return flags;
+}
+
+export function buildChromeFlagsForTest(
+  headless: boolean,
+  debugBindAddress?: string | null,
+  hideWindow = false,
+): string[] {
+  return buildChromeFlags(headless, debugBindAddress, hideWindow);
 }
 
 function resolveChromeLaunchOptions(

--- a/src/browser/controlPlan.ts
+++ b/src/browser/controlPlan.ts
@@ -74,7 +74,7 @@ export function describeBrowserControlPlan(config: BrowserControlConfig = {}): B
   }
 
   if (config.hideWindow) {
-    guidance.push("Chrome may briefly focus while launching before Oracle hides it.");
+    guidance.push("On macOS, Oracle launches Chrome off-screen while keeping the page rendered.");
     guidance.push(
       "For the calmest shared-desktop flow, prefer --browser-attach-running or --remote-chrome.",
     );
@@ -82,7 +82,7 @@ export function describeBrowserControlPlan(config: BrowserControlConfig = {}): B
       mode: "hidden-window",
       launchesChrome: true,
       mayFocusWindow: true,
-      summary: "launch Chrome and hide the window after startup",
+      summary: "launch Chrome in hidden-window mode",
       guidance,
     };
   }

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -448,6 +448,29 @@ async function createAssistantTimeoutError(params: {
   return warningError;
 }
 
+/**
+ * Make the page behave like a focused foreground tab.
+ *
+ * The send button is activated with trusted CDP input events dispatched at
+ * viewport coordinates. Chrome delivers those only to a window that is being
+ * composited, so a hidden (`--browser-hide-window`), minimized, or occluded
+ * window swallows the click while the automation still believes it clicked.
+ * Soft-fails: focus emulation is an optimization, never a hard requirement.
+ */
+async function enableFocusEmulation(
+  client: ChromeClient,
+  logger: BrowserLogger,
+  label: string,
+): Promise<void> {
+  try {
+    await client.Emulation.setFocusEmulationEnabled({ enabled: true });
+    logger(`[browser] Focus emulation enabled for ${label}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger(`[browser] Focus emulation unavailable: ${message}`);
+  }
+}
+
 function listIgnoredRemoteChromeFlags(config: {
   attachRunning?: ResolvedBrowserConfig["attachRunning"];
   headless?: ResolvedBrowserConfig["headless"];
@@ -1153,6 +1176,10 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
       domainEnablers.push(DOM.enable());
     }
     await Promise.all(domainEnablers);
+    // The send button is clicked with trusted CDP input events at viewport
+    // coordinates, which ChatGPT silently drops when the window is hidden or
+    // occluded. Emulate focus so the page behaves like a foreground tab.
+    await enableFocusEmulation(client, logger, "local target");
     removeDialogHandler = installJavaScriptDialogAutoDismissal(Page, logger);
     if (!profileIsPreSigned) {
       await Network.clearBrowserCookies();
@@ -2836,13 +2863,7 @@ async function runRemoteBrowserMode(
     }
     await Promise.all(domainEnablers);
     removeDialogHandler = installJavaScriptDialogAutoDismissal(Page, logger);
-    try {
-      await client.Emulation.setFocusEmulationEnabled({ enabled: true });
-      logger("[browser] Focus emulation enabled for remote target");
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      logger(`[browser] Focus emulation unavailable: ${message}`);
-    }
+    await enableFocusEmulation(client, logger, "remote target");
 
     const activeConversationUrlMonitor = createConversationUrlMonitor({
       readUrl: async () => {

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -16,7 +16,7 @@ import type {
 import {
   launchChrome,
   registerTerminationHooks,
-  hideChromeWindow,
+  positionChromeWindowOffscreen,
   connectToRemoteChrome,
   connectWithNewTab,
   closeTab,
@@ -1167,15 +1167,14 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
       Promise.race([promise, disconnectPromise]);
     const { Network, Page, Runtime, Input, DOM, Target } = client;
 
-    if (!config.headless && config.hideWindow) {
-      await hideChromeWindow(chrome, logger);
-    }
-
     const domainEnablers = [Network.enable({}), Page.enable(), Runtime.enable()];
     if (DOM && typeof DOM.enable === "function") {
       domainEnablers.push(DOM.enable());
     }
     await Promise.all(domainEnablers);
+    if (!config.headless && config.hideWindow) {
+      await positionChromeWindowOffscreen(client, logger);
+    }
     // The send button is clicked with trusted CDP input events at viewport
     // coordinates, which ChatGPT silently drops when the window is hidden or
     // occluded. Emulate focus so the page behaves like a foreground tab.

--- a/src/browser/projectSourcesRunner.ts
+++ b/src/browser/projectSourcesRunner.ts
@@ -5,8 +5,8 @@ import type { LaunchedChrome } from "chrome-launcher";
 import {
   closeTab,
   connectWithNewTab,
-  hideChromeWindow,
   launchChrome,
+  positionChromeWindowOffscreen,
   registerTerminationHooks,
 } from "./chromeLifecycle.js";
 import { resolveBrowserConfig } from "./config.js";
@@ -181,14 +181,14 @@ export async function runBrowserProjectSources(
       Promise.race([promise, disconnectPromise]);
 
     const { Network, Page, Runtime, Input, DOM, Target } = client;
-    if (!config.headless && config.hideWindow) {
-      await hideChromeWindow(chrome, logger);
-    }
     const domainEnablers = [Network.enable({}), Page.enable(), Runtime.enable()];
     if (DOM && typeof DOM.enable === "function") {
       domainEnablers.push(DOM.enable());
     }
     await Promise.all(domainEnablers);
+    if (!config.headless && config.hideWindow) {
+      await positionChromeWindowOffscreen(client, logger);
+    }
     removeDialogHandler = installJavaScriptDialogAutoDismissal(Page, logger);
     if (!manualLogin) {
       await Network.clearBrowserCookies();

--- a/src/browser/reattach.ts
+++ b/src/browser/reattach.ts
@@ -15,7 +15,7 @@ import type { BrowserLogger, ChromeClient } from "./types.js";
 import {
   launchChrome,
   connectToChrome,
-  hideChromeWindow,
+  positionChromeWindowOffscreen,
   connectToRemoteChromeTarget,
   listRemoteChromeTargets,
 } from "./chromeLifecycle.js";
@@ -290,9 +290,8 @@ async function resumeBrowserSessionViaNewChrome(
     await DOM.enable();
   }
   if (!resolved.headless && resolved.hideWindow) {
-    await hideChromeWindow(chrome, logger);
+    await positionChromeWindowOffscreen(client, logger);
   }
-
   let appliedCookies = 0;
   if (!manualLogin && resolved.cookieSync) {
     appliedCookies = await syncCookies(Network, resolved.url, resolved.chromeProfile, logger, {

--- a/tests/browser/chromeLifecycle.test.ts
+++ b/tests/browser/chromeLifecycle.test.ts
@@ -123,6 +123,47 @@ describe("copied-profile launch flags", () => {
   });
 });
 
+describe("hidden-window launch flags", () => {
+  test("keeps macOS Chrome rendered in an off-screen window", async () => {
+    const { buildChromeFlagsForTest } = await import("../../src/browser/chromeLifecycle.js");
+    const flags = buildChromeFlagsForTest(false, undefined, true);
+
+    if (process.platform === "darwin") {
+      expect(flags).toContain("--window-position=-32000,-32000");
+    } else {
+      expect(flags).not.toContain("--window-position=-32000,-32000");
+    }
+  });
+
+  test("does not add a window position to headless Chrome", async () => {
+    const { buildChromeFlagsForTest } = await import("../../src/browser/chromeLifecycle.js");
+
+    expect(buildChromeFlagsForTest(true, undefined, true)).not.toContain(
+      "--window-position=-32000,-32000",
+    );
+  });
+
+  test("moves a running macOS Chrome window without minimizing it", async () => {
+    const { positionChromeWindowOffscreen } = await import("../../src/browser/chromeLifecycle.js");
+    const browser = {
+      getWindowForTarget: vi.fn().mockResolvedValue({ windowId: 7 }),
+      setWindowBounds: vi.fn().mockResolvedValue(undefined),
+    };
+    const logger = vi.fn();
+
+    await positionChromeWindowOffscreen({ Browser: browser } as never, logger as never);
+
+    if (process.platform === "darwin") {
+      expect(browser.setWindowBounds).toHaveBeenCalledWith({
+        windowId: 7,
+        bounds: { left: -32_000, top: -32_000, windowState: "normal" },
+      });
+    } else {
+      expect(browser.setWindowBounds).not.toHaveBeenCalled();
+    }
+  });
+});
+
 describe("connectWithNewTab", () => {
   beforeEach(() => {
     cdpMock.mockReset();

--- a/tests/browser/controlPlan.test.ts
+++ b/tests/browser/controlPlan.test.ts
@@ -33,7 +33,9 @@ describe("browser control plan", () => {
   });
 
   test("describes hidden and remote modes distinctly", () => {
-    expect(describeBrowserControlPlan({ hideWindow: true }).mode).toBe("hidden-window");
+    const hidden = describeBrowserControlPlan({ hideWindow: true });
+    expect(hidden.mode).toBe("hidden-window");
+    expect(hidden.guidance.join(" ")).toContain("off-screen");
     expect(
       describeBrowserControlPlan({ remoteChrome: { host: "127.0.0.1", port: 9222 } }).mode,
     ).toBe("remote-chrome");

--- a/tests/browser/promptComposer.test.ts
+++ b/tests/browser/promptComposer.test.ts
@@ -25,7 +25,7 @@ describe("promptComposer", () => {
     );
   });
 
-  test("does not treat cleared composer + stop button as committed without a new turn", async () => {
+  test("does not treat historical assistant content as committed without a new turn", async () => {
     vi.useFakeTimers();
     try {
       const runtime = {
@@ -44,7 +44,7 @@ describe("promptComposer", () => {
                 lastMatched: false,
                 hasNewTurn: false,
                 stopVisible: true,
-                assistantVisible: false,
+                assistantVisible: true,
                 composerCleared: true,
                 inConversation: false,
               },
@@ -294,99 +294,34 @@ describe("promptComposer", () => {
 
     expect(onPromptSubmitted).toHaveBeenCalledTimes(1);
   });
-});
 
-describe("trusted send-click fallback", () => {
-  test("sendTookEffect resolves true as soon as the page shows the send landed", async () => {
-    const runtime = {
-      evaluate: vi
-        .fn()
-        .mockResolvedValueOnce({ result: { value: false } })
-        .mockResolvedValueOnce({ result: { value: true } }),
-    } as unknown as { evaluate: (args: { expression: string }) => Promise<unknown> };
-
-    await expect(promptComposer.sendTookEffect(runtime as never)).resolves.toBe(true);
-  });
-
-  test("sendTookEffect resolves false when the click is swallowed", async () => {
+  test("waits for a delayed trusted click without issuing a second send", async () => {
     vi.useFakeTimers();
     try {
-      const runtime = {
-        evaluate: vi.fn().mockResolvedValue({ result: { value: false } }),
-      } as unknown as { evaluate: (args: { expression: string }) => Promise<unknown> };
-
-      const promise = promptComposer.sendTookEffect(runtime as never);
-      await vi.advanceTimersByTimeAsync(2_000);
-      await expect(promise).resolves.toBe(false);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  test("dispatchSendButtonClick reports whether an enabled send button was still there", async () => {
-    const clicked = {
-      evaluate: vi.fn().mockResolvedValue({ result: { value: true } }),
-    } as unknown as { evaluate: (args: { expression: string }) => Promise<unknown> };
-    await expect(promptComposer.dispatchSendButtonClick(clicked as never)).resolves.toBe(true);
-
-    // No enabled send button left (the prompt already submitted) -> no second send.
-    const gone = {
-      evaluate: vi.fn().mockResolvedValue({ result: { value: false } }),
-    } as unknown as { evaluate: (args: { expression: string }) => Promise<unknown> };
-    await expect(promptComposer.dispatchSendButtonClick(gone as never)).resolves.toBe(false);
-  });
-
-  test("falls back to a DOM click when the trusted click is swallowed", async () => {
-    vi.useFakeTimers();
-    try {
-      let fallbackDispatched = false;
-      const evaluate = vi.fn(async ({ expression }: { expression: string }) => {
-        if (expression.includes("button.scrollIntoView")) {
-          return { result: { value: { status: "point", x: 10, y: 20 } } };
-        }
-        if (expression.includes("dispatchClickSequence(button)")) {
-          fallbackDispatched = true;
-          return { result: { value: true } };
-        }
-        // sendTookEffect probe: the hidden window swallowed the click.
-        return { result: { value: false } };
+      const evaluate = vi.fn().mockResolvedValue({
+        result: { value: { status: "point", x: 10, y: 20 } },
       });
-      const input = { dispatchMouseEvent: vi.fn() };
+      const input = {
+        dispatchMouseEvent: vi.fn(async ({ type }: { type: string }) => {
+          if (type === "mouseReleased") {
+            await new Promise((resolve) => setTimeout(resolve, 1_000));
+          }
+        }),
+      };
 
-      const promise = promptComposer.attemptSendButton(
+      const result = promptComposer.attemptSendButton(
         { evaluate } as never,
         input as never,
         undefined,
         undefined,
       );
-      await vi.advanceTimersByTimeAsync(2_000);
-      await expect(promise).resolves.toBe(true);
-      expect(input.dispatchMouseEvent).toHaveBeenCalled();
-      expect(fallbackDispatched).toBe(true);
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      await expect(result).resolves.toBe(true);
+      expect(evaluate).toHaveBeenCalledTimes(1);
+      expect(input.dispatchMouseEvent).toHaveBeenCalledTimes(3);
     } finally {
       vi.useRealTimers();
     }
-  });
-
-  test("does not dispatch the DOM fallback when the trusted click landed", async () => {
-    let fallbackDispatched = false;
-    const evaluate = vi.fn(async ({ expression }: { expression: string }) => {
-      if (expression.includes("button.scrollIntoView")) {
-        return { result: { value: { status: "point", x: 10, y: 20 } } };
-      }
-      if (expression.includes("dispatchClickSequence(button)")) {
-        fallbackDispatched = true;
-        return { result: { value: true } };
-      }
-      // sendTookEffect probe: composer cleared, send landed.
-      return { result: { value: true } };
-    });
-    const input = { dispatchMouseEvent: vi.fn() };
-
-    await expect(
-      promptComposer.attemptSendButton({ evaluate } as never, input as never, undefined, undefined),
-    ).resolves.toBe(true);
-    expect(input.dispatchMouseEvent).toHaveBeenCalled();
-    expect(fallbackDispatched).toBe(false);
   });
 });

--- a/tests/browser/promptComposer.test.ts
+++ b/tests/browser/promptComposer.test.ts
@@ -295,3 +295,98 @@ describe("promptComposer", () => {
     expect(onPromptSubmitted).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("trusted send-click fallback", () => {
+  test("sendTookEffect resolves true as soon as the page shows the send landed", async () => {
+    const runtime = {
+      evaluate: vi
+        .fn()
+        .mockResolvedValueOnce({ result: { value: false } })
+        .mockResolvedValueOnce({ result: { value: true } }),
+    } as unknown as { evaluate: (args: { expression: string }) => Promise<unknown> };
+
+    await expect(promptComposer.sendTookEffect(runtime as never)).resolves.toBe(true);
+  });
+
+  test("sendTookEffect resolves false when the click is swallowed", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtime = {
+        evaluate: vi.fn().mockResolvedValue({ result: { value: false } }),
+      } as unknown as { evaluate: (args: { expression: string }) => Promise<unknown> };
+
+      const promise = promptComposer.sendTookEffect(runtime as never);
+      await vi.advanceTimersByTimeAsync(2_000);
+      await expect(promise).resolves.toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("dispatchSendButtonClick reports whether an enabled send button was still there", async () => {
+    const clicked = {
+      evaluate: vi.fn().mockResolvedValue({ result: { value: true } }),
+    } as unknown as { evaluate: (args: { expression: string }) => Promise<unknown> };
+    await expect(promptComposer.dispatchSendButtonClick(clicked as never)).resolves.toBe(true);
+
+    // No enabled send button left (the prompt already submitted) -> no second send.
+    const gone = {
+      evaluate: vi.fn().mockResolvedValue({ result: { value: false } }),
+    } as unknown as { evaluate: (args: { expression: string }) => Promise<unknown> };
+    await expect(promptComposer.dispatchSendButtonClick(gone as never)).resolves.toBe(false);
+  });
+
+  test("falls back to a DOM click when the trusted click is swallowed", async () => {
+    vi.useFakeTimers();
+    try {
+      let fallbackDispatched = false;
+      const evaluate = vi.fn(async ({ expression }: { expression: string }) => {
+        if (expression.includes("button.scrollIntoView")) {
+          return { result: { value: { status: "point", x: 10, y: 20 } } };
+        }
+        if (expression.includes("dispatchClickSequence(button)")) {
+          fallbackDispatched = true;
+          return { result: { value: true } };
+        }
+        // sendTookEffect probe: the hidden window swallowed the click.
+        return { result: { value: false } };
+      });
+      const input = { dispatchMouseEvent: vi.fn() };
+
+      const promise = promptComposer.attemptSendButton(
+        { evaluate } as never,
+        input as never,
+        undefined,
+        undefined,
+      );
+      await vi.advanceTimersByTimeAsync(2_000);
+      await expect(promise).resolves.toBe(true);
+      expect(input.dispatchMouseEvent).toHaveBeenCalled();
+      expect(fallbackDispatched).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("does not dispatch the DOM fallback when the trusted click landed", async () => {
+    let fallbackDispatched = false;
+    const evaluate = vi.fn(async ({ expression }: { expression: string }) => {
+      if (expression.includes("button.scrollIntoView")) {
+        return { result: { value: { status: "point", x: 10, y: 20 } } };
+      }
+      if (expression.includes("dispatchClickSequence(button)")) {
+        fallbackDispatched = true;
+        return { result: { value: true } };
+      }
+      // sendTookEffect probe: composer cleared, send landed.
+      return { result: { value: true } };
+    });
+    const input = { dispatchMouseEvent: vi.fn() };
+
+    await expect(
+      promptComposer.attemptSendButton({ evaluate } as never, input as never, undefined, undefined),
+    ).resolves.toBe(true);
+    expect(input.dispatchMouseEvent).toHaveBeenCalled();
+    expect(fallbackDispatched).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #298 and #312.

## Root cause

PR #282 moved prompt submission to trusted CDP mouse input. On macOS, `--browser-hide-window` then hid the Chrome process with Cmd-H. Hidden Chrome stopped compositing the page, swallowed the trusted click without an error, and retained the prompt as a draft. A later visible run could submit accumulated drafts together.

## Final design

- Launch hidden macOS Chrome off-screen with `--window-position=-32000,-32000`, keeping it normally rendered from startup.
- Reposition reused Chrome windows through CDP without minimizing or hiding the process.
- Keep focus emulation as a soft-failing local/remote optimization.
- Remove the proposed post-click synthetic fallback. It could mistake historical assistant content for a successful new send, or race a delayed trusted click and submit twice.
- Preserve the existing baseline-aware prompt-commit verifier as the only commit proof.
- Apply the same off-screen behavior to normal browser runs, Project Sources, and recovered sessions.

Contributor commit and authorship are preserved. The maintainer hardening commit replaces only the unsafe fallback strategy.

## Tests

- `pnpm vitest run tests/browser/chromeLifecycle.test.ts tests/browser/controlPlan.test.ts tests/browser/promptComposer.test.ts tests/browser/index.test.ts` — 84 passed.
- `pnpm check` — passed.
- `pnpm test` — 1,436 passed, 43 skipped.
- Final AutoReview — no actionable findings.

Regression coverage includes off-screen launch/repositioning, historical assistant content not proving a new commit, and a delayed trusted click remaining a single send attempt.

## Live macOS Pro proof

Exact branch tree, signed-in ChatGPT Pro, `--copy-profile`, `--browser-hide-window`, model selection verified as Pro:

1. `pr302-hidden-followup-live`: initial marker and same-conversation follow-up both returned exactly once in 22.3s.
2. `pr302-hidden-second-live`: a fresh consecutive hidden-window run returned only its marker in 10.8s.

No prompt remained in the composer, no prior marker leaked into the next run, and no duplicate/combined send occurred.

Exact head: `05b8897f4cf21beb4d9bbdf4327ae31b7e5fa919`.
