### PR TITLE
fix(browser): support GPT-5.6 unified effort picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Browser: support ChatGPT GPT-5.6's unified Intelligence picker, where the menu wraps `composer-intelligence-picker-content` and the highest effort is labeled `Pro` instead of `Pro Extended`; recognize the current Chinese effort labels (`极速5.5`, `中`, `高`, and `极高`) without prefix collisions and verify switches against React-replaced composer pills.
+- Browser: support ChatGPT GPT-5.6's unified Intelligence picker, where the menu wraps `composer-intelligence-picker-content` and the highest effort is labeled `Pro` instead of `Pro Extended`; recognize the current Chinese effort labels (`极速5.5`, `中`, `高`, and `极高`) without prefix collisions and verify switches against React-replaced composer pills. Fixes #303. Thanks @DragonFSKY!
 - Browser: keep hidden macOS Chrome windows rendered off-screen so trusted prompt submissions land without retaining drafts or leaking them into later runs. Fixes #298 and #312. Thanks @LeoLin990405!
 - Browser: require positive terminal evidence before finalizing ChatGPT responses so settled preambles and mid-stream text cannot be captured as the completed answer. Thanks @StartupBros!
 - Browser: distinguish genuine Cloudflare interstitials from healthy ChatGPT pages that carry bot-management scripts or mention generic challenge text. Thanks @StartupBros!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Browser: support ChatGPT GPT-5.6's unified Intelligence picker, where the menu wraps `composer-intelligence-picker-content` and the highest effort is labeled `Pro` instead of `Pro Extended`; recognize the current Chinese effort labels (`极速5.5`, `中`, `高`, and `极高`) without prefix collisions and verify switches against React-replaced composer pills.
 - Browser: keep hidden macOS Chrome windows rendered off-screen so trusted prompt submissions land without retaining drafts or leaking them into later runs. Fixes #298 and #312. Thanks @LeoLin990405!
 - Browser: require positive terminal evidence before finalizing ChatGPT responses so settled preambles and mid-stream text cannot be captured as the completed answer. Thanks @StartupBros!
 - Browser: distinguish genuine Cloudflare interstitials from healthy ChatGPT pages that carry bot-management scripts or mention generic challenge text. Thanks @StartupBros!

--- a/src/browser/actions/thinkingTime.ts
+++ b/src/browser/actions/thinkingTime.ts
@@ -187,6 +187,9 @@ function buildThinkingTimeExpression(
   const modelButtonLiteral = JSON.stringify(MODEL_BUTTON_SELECTOR);
   const targetLevelLiteral = JSON.stringify(level.toLowerCase());
   const targetModelKindLiteral = JSON.stringify(inferThinkingTargetModelKind(desiredModel));
+  const targetIsGpt56ModelLiteral = JSON.stringify(
+    /(?:^|[^0-9])5[._ -]6(?:[^0-9]|$)/i.test(desiredModel ?? ""),
+  );
 
   return `(async () => {
     ${buildClickDispatcher()}
@@ -196,13 +199,14 @@ function buildThinkingTimeExpression(
     const MODEL_BUTTON_SELECTOR = ${modelButtonLiteral};
     const TARGET_LEVEL = ${targetLevelLiteral};
     const TARGET_MODEL_KIND = ${targetModelKindLiteral};
+    const TARGET_IS_GPT56_MODEL = ${targetIsGpt56ModelLiteral};
 
     // Bilingual matchers: English level token + observed Chinese variants.
     const LEVEL_TOKENS = {
-      light: ['light', 'instant', '轻'],
-      standard: ['standard', 'medium', '标准'],
-      extended: ['extended', 'high', '扩展', '深度', '加强'],
-      heavy: ['heavy', 'extra high', '重度', '加重', '高'],
+      light: ['light', 'instant', '轻', '极速'],
+      standard: ['standard', 'medium', '标准', '中'],
+      extended: ['extended', 'high', '扩展', '深度', '加强', '高'],
+      heavy: ['heavy', 'extra high', '重度', '加重', '极高'],
     };
     const targetTokens = LEVEL_TOKENS[TARGET_LEVEL] || [TARGET_LEVEL];
 
@@ -230,6 +234,13 @@ function buildThinkingTimeExpression(
         if (!token) return false;
         if (token === 'high') return hasToken(t, 'high') && !hasToken(t, 'extra');
         if (token === 'extra high') return hasToken(t, 'extra') && hasToken(t, 'high');
+        if (token === '极速') {
+          const suffix = t.slice(token.length);
+          return t === token || hasToken(t, token) || /^[0-9]/.test(suffix);
+        }
+        if (['中', '高', '极高'].includes(token)) {
+          return t === token || hasToken(t, token);
+        }
         return t === token || hasToken(t, token) || t.includes(token);
       });
     };
@@ -398,6 +409,9 @@ function buildThinkingTimeExpression(
       if (menu?.getAttribute?.('data-testid') === 'composer-intelligence-picker-content') {
         return true;
       }
+      if (menu?.querySelector?.(INTELLIGENCE_MENU_SELECTOR)) {
+        return true;
+      }
       const label = menu?.querySelector?.('.__menu-label, [class*="menu-label"]');
       return normalize(label?.textContent ?? '').includes('intelligence');
     };
@@ -411,6 +425,21 @@ function buildThinkingTimeExpression(
       const items = Array.from(menu.querySelectorAll(MENU_ITEM_SELECTOR));
       const modelKind = modelKindOverride || effectiveTargetModelKind();
       if (modelKind === 'pro') {
+        // GPT-5.6's unified Intelligence picker exposes Pro as the highest
+        // effort radio directly. It no longer has a nested "Pro Extended"
+        // row, so preserve the legacy request semantics by selecting Pro.
+        if (
+          TARGET_LEVEL === 'extended' &&
+          isIntelligenceEffortMenu(menu) &&
+          !document.querySelector(PRO_EFFORT_TRIGGER_SELECTOR)
+        ) {
+          for (const item of items) {
+            const itemText = normalize(
+              (item.textContent ?? '') + ' ' + (item.getAttribute?.('aria-label') ?? ''),
+            );
+            if (itemText === 'pro') return item;
+          }
+        }
         for (const item of items) {
           const itemText = normalize(
             (item.textContent ?? '') + ' ' + (item.getAttribute?.('aria-label') ?? ''),
@@ -431,7 +460,7 @@ function buildThinkingTimeExpression(
         const itemText = normalize(
           (item.textContent ?? '') + ' ' + (item.getAttribute?.('aria-label') ?? ''),
         );
-        if (modelKind && modelKind !== 'pro' && hasToken(itemText, 'pro')) {
+        if (modelKind !== 'pro' && hasToken(itemText, 'pro')) {
           continue;
         }
         if (
@@ -439,6 +468,16 @@ function buildThinkingTimeExpression(
           matchesLevel(item.getAttribute?.('aria-label') ?? '')
         ) {
           return item;
+        }
+      }
+      if (TARGET_LEVEL === 'heavy') {
+        // Older Chinese layouts used bare 高 for the highest effort. Keep it
+        // only as a second-pass exact fallback so a current 高 row can never
+        // win before the primary 极高 row.
+        for (const item of items) {
+          const itemText = normalize(item.textContent ?? '');
+          const ariaLabel = normalize(item.getAttribute?.('aria-label') ?? '');
+          if (itemText === '高' || ariaLabel === '高') return item;
         }
       }
       return null;
@@ -454,6 +493,7 @@ function buildThinkingTimeExpression(
     const isEffortMenu = (menu) => {
       if (!isVisible(menu)) return false;
       if (menu.getAttribute?.('data-testid') === 'composer-intelligence-picker-content') return true;
+      if (menu.querySelector?.(INTELLIGENCE_MENU_SELECTOR)) return true;
       const label = menu.querySelector?.('.__menu-label, [class*="menu-label"]');
       const labelText = normalize(label?.textContent ?? '');
       return (
@@ -514,8 +554,16 @@ function buildThinkingTimeExpression(
       }
       return null;
     };
+    const freshComposerTrigger = (trigger) => {
+      if (!trigger?.matches?.('button.__composer-pill')) return null;
+      // React can replace the composer pill after an effort click. Keep using
+      // the captured node while it is live, but re-query once it is detached so
+      // verification does not read its stale pre-click label.
+      if (trigger.isConnected !== false) return trigger;
+      return findComposerEffortPill() || findModelButton() || trigger;
+    };
     const currentProEffortPillMatchesTarget = (trigger, modelKindOverride = null) => {
-      const button = trigger?.matches?.('button.__composer-pill') ? trigger : findModelButton();
+      const button = freshComposerTrigger(trigger) || findModelButton();
       if ((modelKindOverride || TARGET_MODEL_KIND || modelKindFromNode(button)) !== 'pro') {
         return false;
       }
@@ -530,7 +578,7 @@ function buildThinkingTimeExpression(
     };
     const currentEffortPillMatchesTarget = (trigger, modelKindOverride = null) => {
       if (currentProEffortPillMatchesTarget(trigger, modelKindOverride)) return true;
-      const button = trigger?.matches?.('button.__composer-pill') ? trigger : findModelButton();
+      const button = freshComposerTrigger(trigger) || findModelButton();
       if ((modelKindOverride || TARGET_MODEL_KIND || modelKindFromNode(button)) === 'pro') {
         return false;
       }
@@ -563,8 +611,9 @@ function buildThinkingTimeExpression(
         return { status: 'switched', label };
       }
 
-      if (!refreshed && trigger && trigger.getAttribute?.('aria-expanded') !== 'true') {
-        dispatchClickSequence(trigger);
+      const reopenTrigger = freshComposerTrigger(trigger) || trigger;
+      if (!refreshed && reopenTrigger?.getAttribute?.('aria-expanded') !== 'true') {
+        dispatchClickSequence(reopenTrigger);
         await sleep(INITIAL_WAIT_MS);
       }
       const deadline = performance.now() + 2000;
@@ -620,6 +669,7 @@ function buildThinkingTimeExpression(
     ];
     const findComposerEffortPill = () => {
       const seen = new Set();
+      let gpt56Fallback = null;
       for (const selector of COMPOSER_EFFORT_PILL_SELECTORS) {
         for (const button of document.querySelectorAll(selector)) {
           if (seen.has(button) || !isVisible(button)) continue;
@@ -638,9 +688,16 @@ function buildThinkingTimeExpression(
           ) {
             return button;
           }
+          if (
+            TARGET_IS_GPT56_MODEL &&
+            button.matches?.('button.__composer-pill') &&
+            normalize(button.textContent ?? '') === 'pro'
+          ) {
+            gpt56Fallback ||= button;
+          }
         }
       }
-      return null;
+      return gpt56Fallback;
     };
     let composerEffortPill = findComposerEffortPill();
     let modelBtn = findModelButton();
@@ -698,7 +755,9 @@ function buildThinkingTimeExpression(
     }
     if (composerEffortPill) {
       if (attemptedModelButton && attemptedModelButton !== composerEffortPill) closeOpenMenus();
-      const composerModelKind = TARGET_MODEL_KIND || modelKindFromNode(composerEffortPill);
+      const composerModelKind =
+        TARGET_MODEL_KIND ||
+        (TARGET_IS_GPT56_MODEL ? 'versioned' : modelKindFromNode(composerEffortPill));
       if (composerEffortPill.getAttribute?.('aria-expanded') !== 'true') {
         dispatchClickSequence(composerEffortPill);
         await sleep(INITIAL_WAIT_MS);

--- a/tests/browser/thinkingTime.test.ts
+++ b/tests/browser/thinkingTime.test.ts
@@ -333,6 +333,343 @@ describe("browser thinking-time selection expression", () => {
     expect(expression).toContain("composer-intelligence-picker-content");
     expect(expression).toContain("matchesProExtended");
     expect(expression).toContain("INTELLIGENCE_WAIT_MS");
+    expect(expression).toContain("menu?.querySelector?.(INTELLIGENCE_MENU_SELECTOR)");
+    expect(expression).toContain("itemText === 'pro'");
+    expect(expression).toContain("!document.querySelector(PRO_EFFORT_TRIGGER_SELECTOR)");
+  });
+
+  it("accepts checked Pro in GPT-5.6's wrapped Intelligence menu", async () => {
+    class FakeEventTarget {
+      dispatchEvent(_event: unknown): boolean {
+        return true;
+      }
+    }
+    class FakeElement extends FakeEventTarget {
+      constructor(
+        public textContent: string,
+        private readonly attributes: Readonly<Record<string, string>> = {},
+        private readonly children: FakeElement[] = [],
+        private readonly nestedIntelligence: FakeElement | null = null,
+      ) {
+        super();
+      }
+      getAttribute(name: string): string | null {
+        return this.attributes[name] ?? null;
+      }
+      querySelector(selector: string): FakeElement | null {
+        if (selector.includes("composer-intelligence-picker-content")) {
+          return this.nestedIntelligence;
+        }
+        return null;
+      }
+      querySelectorAll(_selector: string): FakeElement[] {
+        return this.children;
+      }
+      closest(_selector: string): FakeElement | null {
+        return null;
+      }
+      matches(selector: string): boolean {
+        return (
+          selector.includes("__composer-pill") &&
+          this.attributes.class?.includes("__composer-pill") === true
+        );
+      }
+      focus(): void {}
+      getBoundingClientRect(): { width: number; height: number } {
+        return { width: 144, height: 36 };
+      }
+    }
+    class FakeMouseEvent {
+      constructor(
+        public readonly type: string,
+        public readonly init?: unknown,
+      ) {}
+    }
+
+    const proRadio = new FakeElement("Pro", {
+      role: "menuitemradio",
+      "aria-checked": "true",
+      "data-state": "checked",
+    });
+    const effortItems = [
+      new FakeElement("极速5.5", { role: "menuitemradio", "aria-checked": "false" }),
+      new FakeElement("中", { role: "menuitemradio", "aria-checked": "false" }),
+      new FakeElement("高", { role: "menuitemradio", "aria-checked": "false" }),
+      new FakeElement("极高", { role: "menuitemradio", "aria-checked": "false" }),
+      proRadio,
+      new FakeElement("GPT-5.6 Sol", { role: "menuitem", "aria-haspopup": "menu" }),
+    ];
+    const intelligenceGroup = new FakeElement(
+      "智能 极速5.5 中 高 极高 Pro GPT-5.6 Sol",
+      { "data-testid": "composer-intelligence-picker-content", role: "group" },
+      effortItems,
+    );
+    const outerMenu = new FakeElement(
+      intelligenceGroup.textContent,
+      { role: "menu" },
+      effortItems,
+      intelligenceGroup,
+    );
+    const modelButton = new FakeElement("Pro", {
+      class: "__composer-pill",
+      "aria-expanded": "true",
+      "aria-haspopup": "menu",
+    });
+    const documentStub = {
+      body: new FakeElement(""),
+      querySelector: (selector: string) => {
+        if (selector.includes("composer-intelligence-pro-thinking-effort-trigger")) return null;
+        if (selector.includes("composer-intelligence-picker-content")) return intelligenceGroup;
+        if (
+          selector.includes("model-switcher-dropdown-button") ||
+          selector.includes("__composer-pill")
+        ) {
+          return modelButton;
+        }
+        return null;
+      },
+      querySelectorAll: (selector: string) => {
+        if (selector.includes("__composer-pill")) return [modelButton];
+        if (selector.includes('role="menu"') || selector.includes("data-radix")) {
+          return [outerMenu];
+        }
+        return [];
+      },
+      dispatchEvent: () => true,
+    };
+    let now = 0;
+    const performanceStub = { now: () => (now += 100) };
+    const expression = buildThinkingTimeExpressionForTest("extended", "gpt-5.5-pro");
+    const evaluate = new Function(
+      "document",
+      "performance",
+      "setTimeout",
+      "window",
+      "EventTarget",
+      "PointerEvent",
+      "MouseEvent",
+      "HTMLElement",
+      `return ${expression};`,
+    ) as (
+      document: unknown,
+      performance: unknown,
+      setTimeout: unknown,
+      window: unknown,
+      EventTarget: unknown,
+      PointerEvent: unknown,
+      MouseEvent: unknown,
+      HTMLElement: unknown,
+    ) => Promise<unknown>;
+
+    await expect(
+      evaluate(
+        documentStub,
+        performanceStub,
+        (callback: () => void) => callback(),
+        { PointerEvent: FakeMouseEvent, MouseEvent: FakeMouseEvent, Event: FakeMouseEvent },
+        FakeEventTarget,
+        FakeMouseEvent,
+        FakeMouseEvent,
+        FakeElement,
+      ),
+    ).resolves.toEqual({ status: "already-selected", label: "Pro" });
+  });
+
+  it("selects exact Chinese Intelligence tiers without prefix collisions", async () => {
+    class FakeEventTarget {
+      dispatchEvent(_event: unknown): boolean {
+        return true;
+      }
+    }
+    class FakeElement extends FakeEventTarget {
+      constructor(
+        public textContent: string,
+        private readonly attributes: Record<string, string> = {},
+        private readonly children: FakeElement[] = [],
+        private readonly nestedIntelligence: FakeElement | null = null,
+        private readonly onDispatch?: () => void,
+      ) {
+        super();
+      }
+      getAttribute(name: string): string | null {
+        return this.attributes[name] ?? null;
+      }
+      setAttribute(name: string, value: string): void {
+        this.attributes[name] = value;
+      }
+      querySelector(selector: string): FakeElement | null {
+        if (selector.includes("composer-intelligence-picker-content")) {
+          return this.nestedIntelligence;
+        }
+        return null;
+      }
+      querySelectorAll(_selector: string): FakeElement[] {
+        return this.children;
+      }
+      closest(_selector: string): FakeElement | null {
+        return null;
+      }
+      matches(selector: string): boolean {
+        return (
+          selector.includes("__composer-pill") &&
+          this.attributes.class?.includes("__composer-pill") === true
+        );
+      }
+      focus(): void {}
+      getBoundingClientRect(): { width: number; height: number } {
+        return { width: 144, height: 36 };
+      }
+      override dispatchEvent(event: unknown): boolean {
+        this.onDispatch?.();
+        return super.dispatchEvent(event);
+      }
+    }
+    class FakeMouseEvent {
+      constructor(
+        public readonly type: string,
+        public readonly init?: unknown,
+      ) {}
+    }
+
+    const cases: Array<{
+      level: "light" | "standard" | "extended" | "heavy";
+      label: string;
+      reverseAmbiguousPair?: boolean;
+      omitExtraHigh?: boolean;
+    }> = [
+      { level: "light", label: "极速5.5" },
+      { level: "standard", label: "中" },
+      { level: "extended", label: "高", reverseAmbiguousPair: true },
+      { level: "heavy", label: "极高" },
+      { level: "heavy", label: "极高", reverseAmbiguousPair: true },
+      { level: "heavy", label: "高", omitExtraHigh: true },
+    ];
+
+    for (const testCase of cases) {
+      let clickedLabel: string | null = null;
+      let unrelatedPillClicks = 0;
+      const proRadio = new FakeElement("Pro 深度模式", {
+        role: "menuitemradio",
+        "aria-checked": "true",
+        "data-state": "checked",
+      });
+      const makeRadio = (label: string) => {
+        const radio = new FakeElement(
+          label,
+          { role: "menuitemradio", "aria-checked": "false", "data-state": "unchecked" },
+          [],
+          null,
+          () => {
+            clickedLabel = label;
+            radio.setAttribute("aria-checked", "true");
+            radio.setAttribute("data-state", "checked");
+            proRadio.setAttribute("aria-checked", "false");
+            proRadio.setAttribute("data-state", "unchecked");
+          },
+        );
+        return radio;
+      };
+      const instant = makeRadio("极速5.5");
+      const medium = makeRadio("中");
+      const high = makeRadio("高");
+      const extraHigh = makeRadio("极高");
+      const ambiguousPair = testCase.omitExtraHigh
+        ? [high]
+        : testCase.reverseAmbiguousPair
+          ? [extraHigh, high]
+          : [high, extraHigh];
+      const orderedEfforts = [instant, medium, ...ambiguousPair];
+      const effortItems = [
+        ...orderedEfforts,
+        proRadio,
+        new FakeElement("GPT-5.6 Sol", { role: "menuitem", "aria-haspopup": "menu" }),
+      ];
+      const intelligenceGroup = new FakeElement(
+        `智能 ${orderedEfforts.map((item) => item.textContent).join(" ")} Pro 深度模式 GPT-5.6 Sol`,
+        { "data-testid": "composer-intelligence-picker-content", role: "group" },
+        effortItems,
+      );
+      const outerMenu = new FakeElement(
+        intelligenceGroup.textContent,
+        { role: "menu" },
+        effortItems,
+        intelligenceGroup,
+      );
+      const modelButton = new FakeElement("Pro", {
+        class: "__composer-pill",
+        "aria-expanded": "true",
+        "aria-haspopup": "menu",
+      });
+      const unrelatedPill = new FakeElement(
+        "Canvas",
+        { class: "__composer-pill" },
+        [],
+        null,
+        () => {
+          unrelatedPillClicks += 1;
+        },
+      );
+      const documentStub = {
+        body: new FakeElement(""),
+        querySelector: (selector: string) => {
+          if (selector.includes("composer-intelligence-pro-thinking-effort-trigger")) return null;
+          if (selector.includes("composer-intelligence-picker-content")) return intelligenceGroup;
+          if (
+            selector.includes("model-switcher-dropdown-button") ||
+            selector.includes("__composer-pill")
+          ) {
+            return modelButton;
+          }
+          return null;
+        },
+        querySelectorAll: (selector: string) => {
+          if (selector.includes("__composer-pill")) return [unrelatedPill, modelButton];
+          if (selector.includes('role="menu"') || selector.includes("data-radix")) {
+            return [outerMenu];
+          }
+          return [];
+        },
+        dispatchEvent: () => true,
+      };
+      let now = 0;
+      const performanceStub = { now: () => (now += 100) };
+      const expression = buildThinkingTimeExpressionForTest(testCase.level, "GPT-5.6 Sol");
+      const evaluate = new Function(
+        "document",
+        "performance",
+        "setTimeout",
+        "window",
+        "EventTarget",
+        "PointerEvent",
+        "MouseEvent",
+        "HTMLElement",
+        `return ${expression};`,
+      ) as (
+        document: unknown,
+        performance: unknown,
+        setTimeout: unknown,
+        window: unknown,
+        EventTarget: unknown,
+        PointerEvent: unknown,
+        MouseEvent: unknown,
+        HTMLElement: unknown,
+      ) => Promise<unknown>;
+
+      await expect(
+        evaluate(
+          documentStub,
+          performanceStub,
+          (callback: () => void) => callback(),
+          { PointerEvent: FakeMouseEvent, MouseEvent: FakeMouseEvent, Event: FakeMouseEvent },
+          FakeEventTarget,
+          FakeMouseEvent,
+          FakeMouseEvent,
+          FakeElement,
+        ),
+      ).resolves.toEqual({ status: "switched", label: testCase.label });
+      expect(clickedLabel).toBe(testCase.label);
+      expect(unrelatedPillClicks).toBe(0);
+    }
   });
 
   it("selects Extended from the current standalone Pro composer pill", async () => {
@@ -1699,13 +2036,15 @@ describe("browser thinking-time selection expression", () => {
     ).resolves.toEqual({ status: "switched", label: "High" });
   });
 
-  it("verifies non-Pro Intelligence selection from the composer pill when the menu closes", async () => {
+  it("verifies non-Pro Intelligence selection from a replacement pill when the menu closes", async () => {
     class FakeEventTarget {
       dispatchEvent(_event: unknown): boolean {
         return true;
       }
     }
     class FakeElement extends FakeEventTarget {
+      public isConnected = true;
+
       constructor(
         public textContent: string,
         private readonly attributes: Record<string, string> = {},
@@ -1754,7 +2093,7 @@ describe("browser thinking-time selection expression", () => {
     }
 
     let intelligenceMenuOpen = true;
-    const modelButton = new FakeElement("Extra High", {
+    let modelButton = new FakeElement("Extra High", {
       class: "__composer-pill",
       "aria-expanded": "true",
     });
@@ -1763,8 +2102,12 @@ describe("browser thinking-time selection expression", () => {
       { role: "menuitemradio", "aria-checked": "false", "data-state": "unchecked" },
       [],
       () => {
-        modelButton.textContent = "Instant";
-        modelButton.setAttribute("aria-expanded", "false");
+        if (!intelligenceMenuOpen) return;
+        modelButton.isConnected = false;
+        modelButton = new FakeElement("Instant", {
+          class: "__composer-pill",
+          "aria-expanded": "false",
+        });
         intelligenceMenuOpen = false;
       },
     );


### PR DESCRIPTION
## Summary

- recognize GPT-5.6's outer effort menu when it wraps `composer-intelligence-picker-content`
- map the legacy Pro Extended request to the unified picker's checked `Pro` radio only when the legacy Pro effort trigger is absent, preserving the older nested path and fail-closed behavior
- select the current Chinese Intelligence labels exactly: `light -> 极速5.5`, `standard -> 中`, `extended -> 高`, and `heavy -> 极高`, without matching `高` inside `极高`
- preserve older Chinese layouts by accepting bare `高` for `heavy` only as a second-pass fallback when no primary heavy label is present
- re-query a composer effort pill after React replaces the clicked node, so a successful switch is verified instead of reported as `selection-unverified`
- treat GPT-5.6 as a versioned Intelligence target so a current `Pro` pill does not force ordinary effort requests into Pro semantics; unrelated composer pills such as Canvas remain excluded

Fixes #303.

## Root cause

The GPT-5.6 UI moved effort radios into a wrapped unified Intelligence menu, renamed the top effort to `Pro`, and replaces the composer pill after a selection. The previous selector only recognized the inner menu, expected the legacy Pro submenu, used older Chinese aliases, and verified against the detached pre-click pill.

## Tests

- `pnpm vitest run tests/browser/thinkingTime.test.ts` (27 passed)
- `pnpm check`
- `env -u ANTHROPIC_BASE_URL pnpm vitest run --exclude tests/browser/profileCopy.test.ts` (142 files / 1,415 tests passed; the excluded test requires system `rsync`, which is not installed in this environment)
- live browser smoke on both configured signed-in ChatGPT Pro profiles through local AdsPower
  - both profiles still confirm the unified `Pro` path and submit successfully
  - Chinese UI: `light -> 极速5.5`, `standard -> 中`, `extended -> 高`, and `heavy -> 极高`
  - all four runs submitted and returned their exact smoke markers; the post-selection runs no longer report `selection-unverified`
  - combined with #306, `--model gpt-5.6 --browser-thinking-time extended` recorded `resolved=GPT-5.6 Sol`, confirmed `Thinking time: 高`, and returned `ORACLE_GPT56_ZH_EVIDENCE_FIXED_OK`

## Inspectable live-browser evidence

Validated against commit `19a57b158575599f8a4e2af4271a33f50bbf9e33`.

No run clicked or auto-clicked ChatGPT's "Answer now" control. Profile identifiers, local paths, debugging ports, browser target IDs, authentication data, and conversation URLs are redacted. The behavior lines below are verbatim terminal excerpts apart from those redacted fields.

```text
$ git rev-parse HEAD
19a57b158575599f8a4e2af4271a33f50bbf9e33
```

### Unified Pro picker

```sh
ORACLE_HOME_DIR=<redacted> node ./dist/scripts/run-cli.js -- \
  --engine browser --model gpt-5.5-pro \
  --remote-chrome <redacted-host:port> --browser-tab <redacted-target-id> \
  --browser-thinking-time extended --browser-archive never --verbose \
  --prompt 'Reply exactly ORACLE_PR304_PRO_OK.'
```

```text
Login check passed (sessionStatus=200, sessionAuthenticated=true, backendStatus=n/a, domLoginCta=false, appAuthenticated=true)
Prompt textarea ready (initial focus, 34 chars queued)
Model picker: Pro
Prompt textarea ready (after model switch, 34 chars queued)
[browser] Thinking time: Pro (already selected)
Clicked send button
[browser] conversation url (post-submit) = <redacted>
Waiting for ChatGPT response
Completion controls surfaced; confirming stable assistant response
Remote session complete • 17.2s total
[browser] Model selection evidence: requested=Pro; resolved=Pro; status=switched; strategy=select; verified=yes.
Answer:
ORACLE_PR304_PRO_OK

$ grep -c 'selection-unverified' <redacted-output.log>
0
```

### Chinese exact effort selection (`heavy -> 极高`)

```sh
ORACLE_HOME_DIR=<redacted> node ./dist/scripts/run-cli.js -- \
  --engine browser --model gpt-5.5 \
  --remote-chrome <redacted-host:port> --browser-tab <redacted-target-id> \
  --browser-thinking-time heavy --browser-archive never --verbose \
  --prompt 'Reply exactly ORACLE_PR304_ZH_HEAVY_OK.'
```

```text
Login check passed (sessionStatus=200, sessionAuthenticated=true, backendStatus=n/a, domLoginCta=false, appAuthenticated=true)
Prompt textarea ready (initial focus, 39 chars queued)
Model picker: 极速
Prompt textarea ready (after model switch, 39 chars queued)
[browser] Thinking time: 极高
Clicked send button
[browser] conversation url (post-submit) = <redacted>
Waiting for ChatGPT response
Completion controls surfaced; confirming stable assistant response
Remote session complete • 32.1s total
[browser] Model selection evidence: requested=Thinking 5.5; resolved=极速; status=already-selected; strategy=select; verified=yes.
Answer:
ORACLE_PR304_ZH_HEAVY_OK

$ grep -c 'selection-unverified' <redacted-output.log>
0
```

The current profiles expose the unified picker. The legacy nested picker path is covered by the focused regression tests because that older live layout is no longer available on these profiles.
