### PR TITLE
Add Requesty as an OpenAI-compatible provider

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -46,6 +46,7 @@ API mode is opt-in and reads keys from the environment. Set whichever providers 
 | Google       | `GEMINI_API_KEY`                                                  | Gemini 3.1 Pro, Gemini 3.5 Flash, Gemini 3.1 Flash-Lite |
 | Anthropic    | `ANTHROPIC_API_KEY`                                               | Claude Sonnet 4.6, Claude Opus 4.1                      |
 | OpenRouter   | `OPENROUTER_API_KEY`                                              | Any OpenRouter id (e.g. `minimax/minimax-m2`)           |
+| Requesty     | `REQUESTY_API_KEY`                                               | Any Requesty id (e.g. `openai/gpt-4o-mini`)             |
 
 If no key is set, Oracle defaults to **browser mode** and drives ChatGPT directly — see [Browser Mode](browser-mode.md) for the manual-login flow.
 

--- a/docs/requesty.md
+++ b/docs/requesty.md
@@ -1,0 +1,43 @@
+# Requesty
+
+Oracle can target any OpenAI-compatible model on [Requesty](https://requesty.ai) with minimal setup. Requesty uses the same `provider/model` id convention as OpenRouter, so wiring is nearly identical.
+
+## Setup
+
+```bash
+export REQUESTY_API_KEY="rqsty-sk-..."
+# Optional but recommended for attribution:
+export REQUESTY_REFERER="https://your-app.example"
+export REQUESTY_TITLE="Oracle CLI"
+```
+
+- If you set `REQUESTY_API_KEY` and don’t provide another provider key, Oracle automatically routes API runs to `https://router.requesty.ai/v1`.
+- You can still point explicitly with `--base-url https://router.requesty.ai/v1` (EU: `https://router.eu.requesty.ai/v1`).
+- First‑party keys win: if `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, or `XAI_API_KEY` is present, Oracle will prefer those providers unless you set a Requesty base URL.
+- `OPENROUTER_API_KEY` keeps precedence over `REQUESTY_API_KEY` for the automatic gateway fallback, so existing OpenRouter setups are unchanged. Requesty takes over the fallback only when `OPENROUTER_API_KEY` is absent but `REQUESTY_API_KEY` is present.
+
+## Models
+
+- `--model` accepts any Requesty model id, e.g. `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-5`, `deepseek/deepseek-chat`.
+- `--models` can mix first‑party and Requesty ids:  
+  `oracle --engine api --models "gpt-5-pro,openai/gpt-4o-mini,anthropic/claude-sonnet-4-5" -p "Summarize..."`.
+
+## Headers
+
+When hitting Requesty, Oracle forwards optional attribution headers (same header names as OpenRouter):
+
+- `HTTP-Referer` from `REQUESTY_REFERER` (or `REQUESTY_HTTP_REFERER`)
+- `X-Title` from `REQUESTY_TITLE`
+
+## Sessions and logs
+
+- Model ids that contain `/` are stored with a safe slug (`/` → `__`) for per-model log filenames, but the original id remains visible in session metadata and CLI output.
+
+## Tips
+
+- If a model id isn’t found in the Requesty catalog, Oracle still sends the request with the id you provided.
+- Pricing/context limits are pulled from the `/v1/models` catalog when available. Requesty reports context length as `context_window` and prices as flat per-token USD, which Oracle maps to its internal shape; otherwise, Oracle uses conservative defaults.
+
+## Get a key
+
+Create a key at [app.requesty.ai/api-keys](https://app.requesty.ai/api-keys) and browse available models at [app.requesty.ai/router/list](https://app.requesty.ai/router/list). See the [docs](https://docs.requesty.ai) for more.

--- a/src/cli/sessionRunner.ts
+++ b/src/cli/sessionRunner.ts
@@ -190,6 +190,7 @@ export async function performSessionRun({
       const modelConfig = await resolveModelConfig(primaryModel, {
         baseUrl: runOptions.baseUrl,
         openRouterApiKey: process.env.OPENROUTER_API_KEY,
+        requestyApiKey: process.env.REQUESTY_API_KEY,
         modelOverrides: runOptions.modelOverrides,
       });
       const files = await readFiles(runOptions.file ?? [], {

--- a/src/oracle/client.ts
+++ b/src/oracle/client.ts
@@ -18,7 +18,7 @@ import type {
 } from "./types.js";
 import { createGeminiClient } from "./gemini.js";
 import { createClaudeClient } from "./claude.js";
-import { isOpenRouterBaseUrl } from "./modelResolver.js";
+import { isOpenRouterBaseUrl, isRequestyBaseUrl } from "./modelResolver.js";
 import { isCustomBaseUrl } from "./baseUrl.js";
 
 export function buildAzureResponsesBaseUrl(endpoint: string): string {
@@ -39,12 +39,13 @@ export function createDefaultClientFactory(): ClientFactory {
     },
   ): ClientLike => {
     const openRouter = isOpenRouterBaseUrl(options?.baseUrl);
+    const requesty = isRequestyBaseUrl(options?.baseUrl);
     const customProxy = isCustomBaseUrl(options?.baseUrl);
 
-    // When using any custom/proxy base URL (OpenRouter, LiteLLM, vLLM, Together, etc.),
+    // When using any custom/proxy base URL (OpenRouter, Requesty, LiteLLM, vLLM, Together, etc.),
     // route ALL models through the OpenAI chat/completions adapter instead of native SDKs
     // which would reject the proxy's API key.
-    if (!openRouter && !customProxy) {
+    if (!openRouter && !requesty && !customProxy) {
       if (options?.model?.startsWith("gemini")) {
         // Gemini client uses its own SDK; allow passing the already-resolved id for transparency/logging.
         return createGeminiClient(key, options.model, options.resolvedModelId);
@@ -57,7 +58,9 @@ export function createDefaultClientFactory(): ClientFactory {
     let instance: OpenAI;
     const defaultHeaders: Record<string, string> | undefined = openRouter
       ? buildOpenRouterHeaders()
-      : undefined;
+      : requesty
+        ? buildRequestyHeaders()
+        : undefined;
 
     const httpTimeoutMs =
       typeof options?.httpTimeoutMs === "number" &&
@@ -104,6 +107,22 @@ function buildOpenRouterHeaders(): Record<string, string> | undefined {
     process.env.OPENROUTER_HTTP_REFERER ??
     "https://github.com/steipete/oracle";
   const title = process.env.OPENROUTER_TITLE ?? "Oracle CLI";
+  if (referer) {
+    headers["HTTP-Referer"] = referer;
+  }
+  if (title) {
+    headers["X-Title"] = title;
+  }
+  return headers;
+}
+
+function buildRequestyHeaders(): Record<string, string> | undefined {
+  const headers: Record<string, string> = {};
+  const referer =
+    process.env.REQUESTY_REFERER ??
+    process.env.REQUESTY_HTTP_REFERER ??
+    "https://github.com/steipete/oracle";
+  const title = process.env.REQUESTY_TITLE ?? "Oracle CLI";
   if (referer) {
     headers["HTTP-Referer"] = referer;
   }

--- a/src/oracle/modelResolver.ts
+++ b/src/oracle/modelResolver.ts
@@ -13,6 +13,8 @@ import { pricingFromUsdPerToken } from "tokentally";
 
 const OPENROUTER_DEFAULT_BASE = "https://openrouter.ai/api/v1";
 const OPENROUTER_MODELS_ENDPOINT = "https://openrouter.ai/api/v1/models";
+const REQUESTY_DEFAULT_BASE = "https://router.requesty.ai/v1";
+const REQUESTY_MODELS_ENDPOINT = "https://router.requesty.ai/v1/models";
 const require = createRequire(import.meta.url);
 let countTokensGpt5ProImpl: TokenizerFn | undefined;
 
@@ -40,11 +42,38 @@ export function isOpenRouterBaseUrl(baseUrl: string | undefined): boolean {
   }
 }
 
+export function isRequestyBaseUrl(baseUrl: string | undefined): boolean {
+  if (!baseUrl) return false;
+  try {
+    const url = new URL(baseUrl);
+    return url.hostname.includes("requesty.ai");
+  } catch {
+    return false;
+  }
+}
+
 export function defaultOpenRouterBaseUrl(): string {
   return OPENROUTER_DEFAULT_BASE;
 }
 
+export function defaultRequestyBaseUrl(): string {
+  return REQUESTY_DEFAULT_BASE;
+}
+
 export function normalizeOpenRouterBaseUrl(baseUrl: string): string {
+  try {
+    const url = new URL(baseUrl);
+    // If user passed the responses endpoint, trim it so the client does not double-append.
+    if (url.pathname.endsWith("/responses")) {
+      url.pathname = url.pathname.replace(/\/responses\/?$/, "");
+    }
+    return url.toString().replace(/\/+$/, "");
+  } catch {
+    return baseUrl;
+  }
+}
+
+export function normalizeRequestyBaseUrl(baseUrl: string): string {
   try {
     const url = new URL(baseUrl);
     // If user passed the responses endpoint, trim it so the client does not double-append.
@@ -70,6 +99,22 @@ interface OpenRouterModelInfo {
   };
 }
 
+/**
+ * Requesty's `/v1/models` payload is OpenAI-shaped but exposes capability and
+ * pricing metadata under different field names than OpenRouter. Requesty prices
+ * are USD per token (like OpenRouter) but live on flat `input_price`/`output_price`
+ * fields, and context length is reported as `context_window`.
+ */
+interface RequestyModelInfo {
+  id: string;
+  context_window?: number;
+  input_price?: string | number;
+  output_price?: string | number;
+  supports_tool_calling?: boolean;
+  supports_reasoning?: boolean;
+  supports_vision?: boolean;
+}
+
 function openRouterPricing(pricing: OpenRouterModelInfo["pricing"]): ModelConfig["pricing"] {
   const parsePrice = (value: string | number | undefined): number | null => {
     const parsed =
@@ -89,6 +134,24 @@ function openRouterPricing(pricing: OpenRouterModelInfo["pricing"]): ModelConfig
   return {
     inputPerToken: normalized.inputUsdPerToken,
     outputPerToken: normalized.outputUsdPerToken,
+  };
+}
+
+/**
+ * Adapt a Requesty catalog entry to the internal {@link OpenRouterModelInfo}
+ * shape so the shared hydration path can enrich configs regardless of gateway.
+ * Requesty reports context length as `context_window` and prices as flat
+ * per-token `input_price`/`output_price` fields (vs OpenRouter's nested
+ * `pricing.prompt`/`pricing.completion`).
+ */
+function normalizeRequestyModel(info: RequestyModelInfo): OpenRouterModelInfo {
+  return {
+    id: info.id,
+    context_length: info.context_window,
+    pricing: {
+      prompt: info.input_price,
+      completion: info.output_price,
+    },
   };
 }
 
@@ -142,6 +205,32 @@ async function fetchOpenRouterCatalog(
   return models;
 }
 
+async function fetchRequestyCatalog(
+  apiKey: string,
+  fetcher: FetchFn,
+): Promise<OpenRouterModelInfo[]> {
+  const cacheKey = `requesty:${apiKey}`;
+  const now = Date.now();
+  const cached = catalogCache.get(cacheKey);
+  if (cached && now - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.models;
+  }
+  const response = await fetcher(REQUESTY_MODELS_ENDPOINT, {
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to load Requesty models (${response.status})`);
+  }
+  const json = (await response.json()) as { data?: RequestyModelInfo[] };
+  const models = (json?.data ?? []).map(normalizeRequestyModel);
+  catalogCache.set(cacheKey, { fetchedAt: now, models });
+  // Prune after insert so the max-size constraint is strictly enforced.
+  pruneCatalogCache(now);
+  return models;
+}
+
 function mapToOpenRouterId(
   candidate: string,
   catalog: OpenRouterModelInfo[],
@@ -163,6 +252,7 @@ export async function resolveModelConfig(
   options: {
     baseUrl?: string;
     openRouterApiKey?: string;
+    requestyApiKey?: string;
     fetcher?: FetchFn;
     modelOverrides?: ModelOverridesConfig;
   } = {},
@@ -178,16 +268,68 @@ async function resolveBaseModelConfig(
   options: {
     baseUrl?: string;
     openRouterApiKey?: string;
+    requestyApiKey?: string;
     fetcher?: FetchFn;
   } = {},
 ): Promise<ModelConfig> {
   const known = isKnownModel(model) ? (MODEL_CONFIGS[model] as ModelConfig) : null;
   const fetcher: FetchFn = options.fetcher ?? globalThis.fetch.bind(globalThis);
+  const requestyActive = isRequestyBaseUrl(options.baseUrl) || Boolean(options.requestyApiKey);
+  // OpenRouter and Requesty share the same provider/model catalog convention. When a
+  // Requesty base URL is targeted we never treat it as OpenRouter, so first-party keys
+  // still win exactly like the OpenRouter path.
   const openRouterActive =
-    isOpenRouterBaseUrl(options.baseUrl) || Boolean(options.openRouterApiKey);
+    !requestyActive && (isOpenRouterBaseUrl(options.baseUrl) || Boolean(options.openRouterApiKey));
 
-  if (known && !openRouterActive) {
+  if (known && !openRouterActive && !requestyActive) {
     return known;
+  }
+
+  // Try to enrich from the Requesty catalog when available.
+  if (requestyActive && options.requestyApiKey) {
+    try {
+      const catalog = await fetchRequestyCatalog(options.requestyApiKey, fetcher);
+      const targetId = mapToOpenRouterId(
+        typeof model === "string" ? model : String(model),
+        catalog,
+        known?.provider,
+      );
+      const info = catalog.find((entry) => entry.id === targetId) ?? null;
+      if (info) {
+        return {
+          ...(known ?? {
+            model,
+            tokenizer: countTokensGpt5Pro as TokenizerFn,
+            inputLimit: info.context_length ?? 200_000,
+            reasoning: null,
+          }),
+          apiModel: targetId,
+          openRouterId: targetId,
+          provider: known?.provider ?? "other",
+          inputLimit: info.context_length ?? known?.inputLimit ?? 200_000,
+          pricing: openRouterPricing(info.pricing) ?? known?.pricing ?? null,
+          supportsBackground: known?.supportsBackground ?? true,
+          supportsSearch: known?.supportsSearch ?? true,
+        };
+      }
+      // No metadata hit; fall through to synthesized config.
+      return {
+        ...(known ?? {
+          model,
+          tokenizer: countTokensGpt5Pro as TokenizerFn,
+          inputLimit: 200_000,
+          reasoning: null,
+        }),
+        apiModel: targetId,
+        openRouterId: targetId,
+        provider: known?.provider ?? "other",
+        supportsBackground: known?.supportsBackground ?? true,
+        supportsSearch: known?.supportsSearch ?? true,
+        pricing: known?.pricing ?? null,
+      };
+    } catch {
+      // If catalog fetch fails, fall back to a synthesized config.
+    }
   }
 
   // Try to enrich from OpenRouter catalog when available.

--- a/src/oracle/providerRoutePlan.ts
+++ b/src/oracle/providerRoutePlan.ts
@@ -2,8 +2,11 @@ import { isCustomBaseUrl } from "./baseUrl.js";
 import { formatBaseUrlForLog, maskApiKey } from "./logging.js";
 import {
   defaultOpenRouterBaseUrl,
+  defaultRequestyBaseUrl,
   isOpenRouterBaseUrl,
+  isRequestyBaseUrl,
   normalizeOpenRouterBaseUrl,
+  normalizeRequestyBaseUrl,
 } from "./modelResolver.js";
 import { resolveProviderRoutingState, validateProviderRouting } from "./providerRouting.js";
 import type { ApiProviderMode, AzureOptions, ModelConfig, ModelName } from "./types.js";
@@ -45,6 +48,7 @@ export interface ResolvedProviderRoute extends ProviderRoutePlan {
   baseUrl?: string;
   apiKey?: string;
   openRouterFallback: boolean;
+  requestyFallback: boolean;
   azureEndpoint?: string;
 }
 
@@ -58,6 +62,7 @@ export function buildProviderRoutePlan(input: ProviderRoutePlanInput): ProviderR
     baseUrl: _baseUrl,
     nativeProvider: _nativeProvider,
     openRouterFallback: _openRouterFallback,
+    requestyFallback: _requestyFallback,
     azureEndpoint: _azureEndpoint,
     ...plan
   } = buildResolvedProviderRoute(input);
@@ -92,6 +97,7 @@ function buildResolvedProviderRoute(input: ProviderRoutePlanInput): ResolvedProv
       isAzureOpenAI,
       baseUrl: input.baseUrl,
       openRouterFallback: false,
+      requestyFallback: false,
       apiKey: input.apiKey,
       env,
     });
@@ -110,6 +116,7 @@ function buildResolvedProviderRoute(input: ProviderRoutePlanInput): ResolvedProv
       nativeProvider: provider,
       baseUrl: input.baseUrl,
       openRouterFallback: false,
+      requestyFallback: false,
       isAzureOpenAI,
       azureEndpoint: state?.azureEndpoint ?? input.azure?.endpoint,
       azureConfigured,
@@ -172,6 +179,7 @@ function buildResolvedProviderRoute(input: ProviderRoutePlanInput): ResolvedProv
           (provider === "xai" && !nativeKey.present) ||
           provider === "other");
   const openRouterKey = readKey(["OPENROUTER_API_KEY"], env);
+  const requestyKey = readKey(["REQUESTY_API_KEY"], env);
   const openRouterFallback =
     !baseUrl &&
     (providerQualifiedOpenRouterRoute ||
@@ -179,10 +187,20 @@ function buildResolvedProviderRoute(input: ProviderRoutePlanInput): ResolvedProv
         providerKeyMissing &&
         (provider === "other" || openRouterKey.present)));
 
-  if (openRouterFallback) {
+  // Requesty shares OpenRouter's provider/model catalog convention. OpenRouter keeps
+  // precedence when both keys are set so existing setups are unchanged; Requesty only
+  // takes over the gateway fallback when OPENROUTER_API_KEY is absent but
+  // REQUESTY_API_KEY is present.
+  const requestyFallback = openRouterFallback && !openRouterKey.present && requestyKey.present;
+
+  if (requestyFallback) {
+    baseUrl = defaultRequestyBaseUrl();
+  } else if (openRouterFallback) {
     baseUrl = defaultOpenRouterBaseUrl();
   }
-  if (baseUrl && isOpenRouterBaseUrl(baseUrl)) {
+  if (baseUrl && isRequestyBaseUrl(baseUrl)) {
+    baseUrl = normalizeRequestyBaseUrl(baseUrl);
+  } else if (baseUrl && isOpenRouterBaseUrl(baseUrl)) {
     baseUrl = normalizeOpenRouterBaseUrl(baseUrl);
   }
 
@@ -193,6 +211,7 @@ function buildResolvedProviderRoute(input: ProviderRoutePlanInput): ResolvedProv
     isAzureOpenAI,
     baseUrl,
     openRouterFallback,
+    requestyFallback,
     apiKey: input.apiKey,
     env,
   });
@@ -200,6 +219,7 @@ function buildResolvedProviderRoute(input: ProviderRoutePlanInput): ResolvedProv
     provider,
     baseUrl,
     openRouterFallback,
+    requestyFallback,
     isAzureOpenAI,
   });
   const fallbackHost = DEFAULT_PROVIDER_HOSTS[provider] ?? DEFAULT_PROVIDER_HOSTS.openai;
@@ -219,6 +239,7 @@ function buildResolvedProviderRoute(input: ProviderRoutePlanInput): ResolvedProv
     nativeProvider: provider,
     baseUrl,
     openRouterFallback,
+    requestyFallback,
     isAzureOpenAI,
     azureEndpoint: state.azureEndpoint,
     azureConfigured,
@@ -250,6 +271,7 @@ function getNativeKey({
     isAzureOpenAI,
     baseUrl: undefined,
     openRouterFallback: false,
+    requestyFallback: false,
     apiKey,
     env,
   });
@@ -262,6 +284,7 @@ function getKeyForRoute({
   isAzureOpenAI,
   baseUrl,
   openRouterFallback,
+  requestyFallback,
   apiKey,
   env,
 }: {
@@ -271,6 +294,7 @@ function getKeyForRoute({
   isAzureOpenAI: boolean;
   baseUrl?: string;
   openRouterFallback: boolean;
+  requestyFallback: boolean;
   apiKey?: string;
   env: NodeJS.ProcessEnv;
 }): { source: string; preview: string; present: boolean; value?: string } {
@@ -287,6 +311,9 @@ function getKeyForRoute({
   }
   if (providerMode === "openai") {
     return readKey(["OPENAI_API_KEY"], env);
+  }
+  if (isRequestyBaseUrl(baseUrl) || requestyFallback) {
+    return readKey(["REQUESTY_API_KEY"], env);
   }
   if (isOpenRouterBaseUrl(baseUrl) || openRouterFallback) {
     return readKey(["OPENROUTER_API_KEY"], env);
@@ -334,14 +361,17 @@ function routeProviderLabel({
   provider,
   baseUrl,
   openRouterFallback,
+  requestyFallback,
   isAzureOpenAI,
 }: {
   provider: NonNullable<ModelConfig["provider"]>;
   baseUrl?: string;
   openRouterFallback: boolean;
+  requestyFallback: boolean;
   isAzureOpenAI: boolean;
 }): string {
   if (isAzureOpenAI) return "Azure OpenAI";
+  if (isRequestyBaseUrl(baseUrl) || requestyFallback) return "Requesty";
   if (isOpenRouterBaseUrl(baseUrl) || openRouterFallback) return "OpenRouter";
   if (baseUrl && isCustomBaseUrl(baseUrl)) return "OpenAI-compatible";
   return providerLabel(provider);

--- a/src/oracle/run.ts
+++ b/src/oracle/run.ts
@@ -42,6 +42,7 @@ import { formatTokenEstimate, formatTokenValue, resolvePreviewMode } from "./run
 import { estimateUsdCost } from "tokentally";
 import {
   isOpenRouterBaseUrl,
+  isRequestyBaseUrl,
   isProModel,
   resolveModelConfig,
   resolveOverriddenApiModel,
@@ -97,6 +98,9 @@ function runtimeKeySource({
   }
   if (providerMode === "openai") {
     return "OPENAI_API_KEY";
+  }
+  if (isRequestyBaseUrl(route.baseUrl) || route.requestyFallback) {
+    return "REQUESTY_API_KEY";
   }
   if (isOpenRouterBaseUrl(route.baseUrl) || route.openRouterFallback || route.model.includes("/")) {
     return "OPENROUTER_API_KEY";
@@ -164,6 +168,7 @@ export async function runOracle(
   const { isAzureOpenAI, azureDeploymentName } = route;
   const baseUrl = route.baseUrl;
   const openRouterFallback = route.openRouterFallback;
+  const requestyFallback = route.requestyFallback;
 
   const logVerbose = (message: string): void => {
     if (options.verbose) {
@@ -177,9 +182,11 @@ export async function runOracle(
       ? "AZURE_OPENAI_API_KEY (or OPENAI_API_KEY)"
       : providerMode === "openai"
         ? "OPENAI_API_KEY"
-        : isOpenRouterBaseUrl(baseUrl) || openRouterFallback
-          ? "OPENROUTER_API_KEY"
-          : route.keySource;
+        : isRequestyBaseUrl(baseUrl) || requestyFallback
+          ? "REQUESTY_API_KEY"
+          : isOpenRouterBaseUrl(baseUrl) || openRouterFallback
+            ? "OPENROUTER_API_KEY"
+            : route.keySource;
     const browserModeHint = options.model.startsWith("gpt")
       ? ' If you have a ChatGPT Pro subscription, retry with --engine browser (or MCP engine:"browser" / preset:"chatgpt-pro-heavy"); browser mode uses your signed-in ChatGPT session instead of an API key.'
       : "";
@@ -206,9 +213,12 @@ export async function runOracle(
 
   const resolverOpenRouterApiKey =
     openRouterFallback || isOpenRouterBaseUrl(baseUrl) ? apiKey : undefined;
+  const resolverRequestyApiKey =
+    requestyFallback || isRequestyBaseUrl(baseUrl) ? apiKey : undefined;
   const modelConfig = await resolveModelConfig(options.model, {
     baseUrl,
     openRouterApiKey: resolverOpenRouterApiKey,
+    requestyApiKey: resolverRequestyApiKey,
     modelOverrides: options.modelOverrides,
   });
   const isLongRunningModel = isProTierModel;

--- a/tests/oracle/providerRoutePlan.test.ts
+++ b/tests/oracle/providerRoutePlan.test.ts
@@ -234,4 +234,48 @@ describe("provider route plan", () => {
     expect(plan.keySource).toBe("AZURE_OPENAI_API_KEY|OPENAI_API_KEY");
     expect(plan.error).toMatch(/--provider azure requires --azure-endpoint/);
   });
+
+  test("custom model ids fall back to Requesty when only its key is present", () => {
+    const plan = buildProviderRoutePlan({
+      model: "openai/gpt-4o-mini",
+      providerMode: "auto",
+      env: {
+        REQUESTY_API_KEY: "rqsty-sk-test-key",
+      },
+    });
+
+    expect(plan.ok).toBe(true);
+    expect(plan.providerLabel).toBe("Requesty");
+    expect(plan.keySource).toBe("REQUESTY_API_KEY");
+  });
+
+  test("OpenRouter keeps precedence over Requesty when both keys are present", () => {
+    const plan = buildProviderRoutePlan({
+      model: "openai/gpt-4o-mini",
+      providerMode: "auto",
+      env: {
+        OPENROUTER_API_KEY: "or-openrouter-test-key",
+        REQUESTY_API_KEY: "rqsty-sk-test-key",
+      },
+    });
+
+    expect(plan.ok).toBe(true);
+    expect(plan.providerLabel).toBe("OpenRouter");
+    expect(plan.keySource).toBe("OPENROUTER_API_KEY");
+  });
+
+  test("explicit Requesty base URL routes through Requesty", () => {
+    const plan = buildProviderRoutePlan({
+      model: "openai/gpt-4o-mini",
+      providerMode: "auto",
+      baseUrl: "https://router.requesty.ai/v1",
+      env: {
+        REQUESTY_API_KEY: "rqsty-sk-test-key",
+      },
+    });
+
+    expect(plan.ok).toBe(true);
+    expect(plan.providerLabel).toBe("Requesty");
+    expect(plan.keySource).toBe("REQUESTY_API_KEY");
+  });
 });


### PR DESCRIPTION
## What

Adds Requesty as an OpenAI-compatible provider. [Requesty](https://requesty.ai) is an LLM gateway that exposes an OpenAI-compatible API and uses the same `provider/model` id convention as OpenRouter, so this mirrors the existing OpenRouter wiring as closely as possible.

## Changes

- **`src/oracle/modelResolver.ts`** — detect/normalize the Requesty base URL, add a default base (`https://router.requesty.ai/v1`), and hydrate model metadata from the Requesty `/v1/models` catalog. Requesty reports context length as `context_window` and prices as flat per-token USD, which is mapped to the internal model-info shape.
- **`src/oracle/client.ts`** — route Requesty base URLs through the OpenAI chat/completions adapter (like the other proxy providers) and forward optional attribution headers `HTTP-Referer` / `X-Title` from `REQUESTY_REFERER` / `REQUESTY_TITLE`, matching the OpenRouter path.
- **`src/oracle/providerRoutePlan.ts`, `src/oracle/run.ts`, `src/cli/sessionRunner.ts`** — add a Requesty gateway fallback and key source (`REQUESTY_API_KEY`). OpenRouter keeps precedence when both keys are set, so existing setups are unchanged; Requesty takes over the automatic gateway fallback only when `OPENROUTER_API_KEY` is absent but `REQUESTY_API_KEY` is present.
- **`docs/requesty.md`** + a Requesty row in the `docs/install.md` provider table.
- **`tests/oracle/providerRoutePlan.test.ts`** — cover the Requesty fallback, the OpenRouter-precedence rule, and explicit Requesty base URL routing.

## Usage

```bash
export REQUESTY_API_KEY="rqsty-sk-..."
oracle --engine api --model openai/gpt-4o-mini -p "..."
# or explicitly:
oracle --base-url https://router.requesty.ai/v1 --model anthropic/claude-sonnet-4-5 -p "..."
```

## Testing

- `pnpm run typecheck` — clean.
- `oxlint` + `oxfmt --check` on the edited files — clean.
- `vitest run` on the affected suites (`providerRoutePlan`, `modelResolver.override`, `providerFailures`, `clientFactory`, `run.render`) — 53 passed, including the 3 new Requesty tests.
- Live-tested against the real endpoint: a chat/completions call to `https://router.requesty.ai/v1` with the attribution headers returned successfully, and `GET /v1/models` returned 605 models with `context_window: 128000` / `supports_tool_calling: true` for `openai/gpt-4o-mini`, confirming the catalog field mapping.

Docs: https://docs.requesty.ai · API keys: https://app.requesty.ai/api-keys · Model list: https://app.requesty.ai/router/list

---

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.
