### PR TITLE
fix(browser): stop false-flagging normal ChatGPT pages (incl. GPT-5.6 "Work" UI) as Cloudflare challenges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Browser: keep hidden macOS Chrome windows rendered off-screen so trusted prompt submissions land without retaining drafts or leaking them into later runs. Fixes #298 and #312. Thanks @LeoLin990405!
 - Browser: require positive terminal evidence before finalizing ChatGPT responses so settled preambles and mid-stream text cannot be captured as the completed answer. Thanks @StartupBros!
+- Browser: distinguish genuine Cloudflare interstitials from healthy ChatGPT pages that carry bot-management scripts or mention generic challenge text. Thanks @StartupBros!
 
 ## 0.15.2 — 2026-07-06
 

--- a/src/browser/actions/navigation.ts
+++ b/src/browser/actions/navigation.ts
@@ -595,19 +595,41 @@ async function waitForPrompt(
   return false;
 }
 
-async function isCloudflareInterstitial(Runtime: ChromeClient["Runtime"]): Promise<boolean> {
-  const { result: titleResult } = await Runtime.evaluate({
-    expression: "document.title",
-    returnByValue: true,
-  });
-  const title = typeof titleResult.value === "string" ? titleResult.value : "";
-  const challengeTitle = CLOUDFLARE_TITLE.toLowerCase();
-  if (title.toLowerCase().includes(challengeTitle)) {
-    return true;
-  }
+// A single injected predicate. The old check flagged a challenge whenever the
+// '/challenge-platform/' script was present, but Cloudflare bot-management injects that script on
+// NORMAL ChatGPT pages too (including the new GPT-5.6 "Work" UI), so it false-flagged healthy pages
+// as challenges (which then aborted the run). Require a REAL interstitial: the "Just a moment"
+// title, a Cloudflare challenge widget / verification copy, or the script on a short interstitial
+// page. Crucially, if the ChatGPT app shell rendered, it is never a challenge.
+export function buildCloudflareInterstitialExpression(): string {
+  return `(() => {
+    const title = String(document.title || '').toLowerCase();
+    if (title.includes(${JSON.stringify(CLOUDFLARE_TITLE.toLowerCase())})) return true;
+    if (title.includes('attention required') && title.includes('cloudflare')) return true;
+    // App shell present => a real ChatGPT page, never the interstitial. This alone kills the
+    // false positive on pages that merely carry the Cloudflare bot-management script.
+    const hasAppShell = Boolean(document.querySelector(
+      '#prompt-textarea, [data-testid="prompt-textarea"], [data-testid^="conversation-turn"], [data-testid="profile-button"], main form[data-type], nav a[href*="/c/"]'
+    ));
+    if (hasAppShell) return false;
+    const bodyText = String((document.body && document.body.innerText) || '')
+      .toLowerCase().replace(/\\s+/g, ' ').trim();
+    const hasChallengeWidget = Boolean(document.querySelector(
+      '#challenge-form, #challenge-running, #cf-challenge-running, [class*="cf-challenge"], iframe[src*="challenges.cloudflare.com"], iframe[src*="/cdn-cgi/challenge-platform/"]'
+    ));
+    const saysVerifying = /verify(ing)? you are human|checking your browser|needs to review the security of your connection|just a moment/.test(bodyText);
+    const hasChallengeScript = Boolean(document.querySelector(${JSON.stringify(CLOUDFLARE_SCRIPT_SELECTOR)}));
+    // A genuine interstitial is a SHORT page; the content-rich app never is. So the script only
+    // counts on a short page with no app shell.
+    return hasChallengeWidget || saysVerifying || (hasChallengeScript && bodyText.length < 600);
+  })()`;
+}
 
+export const buildCloudflareInterstitialExpressionForTest = buildCloudflareInterstitialExpression;
+
+async function isCloudflareInterstitial(Runtime: ChromeClient["Runtime"]): Promise<boolean> {
   const { result } = await Runtime.evaluate({
-    expression: `Boolean(document.querySelector('${CLOUDFLARE_SCRIPT_SELECTOR}'))`,
+    expression: buildCloudflareInterstitialExpression(),
     returnByValue: true,
   });
   return Boolean(result.value);

--- a/src/browser/actions/navigation.ts
+++ b/src/browser/actions/navigation.ts
@@ -599,8 +599,8 @@ async function waitForPrompt(
 // '/challenge-platform/' script was present, but Cloudflare bot-management injects that script on
 // NORMAL ChatGPT pages too (including the new GPT-5.6 "Work" UI), so it false-flagged healthy pages
 // as challenges (which then aborted the run). Classification by evidence strength:
-//   strong - the "Just a moment"/"Attention Required" title, a challenge widget, or the
-//            verification copy: a real interstitial, classify immediately.
+//   strong - the "Just a moment"/"Attention Required" title, a challenge widget, or
+//            verification copy on a short page: a real interstitial, classify immediately.
 //   shell  - the ChatGPT app shell rendered: never a challenge, regardless of injected scripts.
 //   weak   - only the bot-management script on a short, shell-less page. This is INFERENCE, and
 //            right after navigation it also matches a healthy SPA load mid-hydration (readyState
@@ -617,17 +617,20 @@ export function buildCloudflareVerdictExpression(): string {
     ));
     const bodyText = String((document.body && document.body.innerText) || '')
       .toLowerCase().replace(/\\s+/g, ' ').trim();
+    const isShortPage = bodyText.length < 600;
     const hasChallengeWidget = Boolean(document.querySelector(
       '#challenge-form, #challenge-running, #cf-challenge-running, [class*="cf-challenge"], iframe[src*="challenges.cloudflare.com"], iframe[src*="/cdn-cgi/challenge-platform/"]'
     ));
     const saysVerifying = /verify(ing)? you are human|checking your browser|needs to review the security of your connection|just a moment/.test(bodyText);
     const hasChallengeScript = Boolean(document.querySelector(${JSON.stringify(CLOUDFLARE_SCRIPT_SELECTOR)}));
     return {
-      strong: !hasAppShell && (titleSaysChallenge || hasChallengeWidget || saysVerifying),
+      strong:
+        !hasAppShell &&
+        (titleSaysChallenge || hasChallengeWidget || (isShortPage && saysVerifying)),
       shell: hasAppShell,
       // A genuine interstitial is a SHORT page; the content-rich app never is. So the script
       // only counts on a short page with no app shell.
-      weak: !hasAppShell && hasChallengeScript && bodyText.length < 600,
+      weak: !hasAppShell && hasChallengeScript && isShortPage,
     };
   })()`;
 }

--- a/src/browser/actions/navigation.ts
+++ b/src/browser/actions/navigation.ts
@@ -595,23 +595,26 @@ async function waitForPrompt(
   return false;
 }
 
-// A single injected predicate. The old check flagged a challenge whenever the
+// A single injected verdict. The old check flagged a challenge whenever the
 // '/challenge-platform/' script was present, but Cloudflare bot-management injects that script on
 // NORMAL ChatGPT pages too (including the new GPT-5.6 "Work" UI), so it false-flagged healthy pages
-// as challenges (which then aborted the run). Require a REAL interstitial: the "Just a moment"
-// title, a Cloudflare challenge widget / verification copy, or the script on a short interstitial
-// page. Crucially, if the ChatGPT app shell rendered, it is never a challenge.
-export function buildCloudflareInterstitialExpression(): string {
+// as challenges (which then aborted the run). Classification by evidence strength:
+//   strong - the "Just a moment"/"Attention Required" title, a challenge widget, or the
+//            verification copy: a real interstitial, classify immediately.
+//   shell  - the ChatGPT app shell rendered: never a challenge, regardless of injected scripts.
+//   weak   - only the bot-management script on a short, shell-less page. This is INFERENCE, and
+//            right after navigation it also matches a healthy SPA load mid-hydration (readyState
+//            fires before React renders the shell), so weak evidence must PERSIST through a
+//            hydration grace window before it counts (see isCloudflareInterstitial).
+export function buildCloudflareVerdictExpression(): string {
   return `(() => {
     const title = String(document.title || '').toLowerCase();
-    if (title.includes(${JSON.stringify(CLOUDFLARE_TITLE.toLowerCase())})) return true;
-    if (title.includes('attention required') && title.includes('cloudflare')) return true;
-    // App shell present => a real ChatGPT page, never the interstitial. This alone kills the
-    // false positive on pages that merely carry the Cloudflare bot-management script.
+    const titleSaysChallenge =
+      title.includes(${JSON.stringify(CLOUDFLARE_TITLE.toLowerCase())}) ||
+      (title.includes('attention required') && title.includes('cloudflare'));
     const hasAppShell = Boolean(document.querySelector(
       '#prompt-textarea, [data-testid="prompt-textarea"], [data-testid^="conversation-turn"], [data-testid="profile-button"], main form[data-type], nav a[href*="/c/"]'
     ));
-    if (hasAppShell) return false;
     const bodyText = String((document.body && document.body.innerText) || '')
       .toLowerCase().replace(/\\s+/g, ' ').trim();
     const hasChallengeWidget = Boolean(document.querySelector(
@@ -619,21 +622,53 @@ export function buildCloudflareInterstitialExpression(): string {
     ));
     const saysVerifying = /verify(ing)? you are human|checking your browser|needs to review the security of your connection|just a moment/.test(bodyText);
     const hasChallengeScript = Boolean(document.querySelector(${JSON.stringify(CLOUDFLARE_SCRIPT_SELECTOR)}));
-    // A genuine interstitial is a SHORT page; the content-rich app never is. So the script only
-    // counts on a short page with no app shell.
-    return hasChallengeWidget || saysVerifying || (hasChallengeScript && bodyText.length < 600);
+    return {
+      strong: !hasAppShell && (titleSaysChallenge || hasChallengeWidget || saysVerifying),
+      shell: hasAppShell,
+      // A genuine interstitial is a SHORT page; the content-rich app never is. So the script
+      // only counts on a short page with no app shell.
+      weak: !hasAppShell && hasChallengeScript && bodyText.length < 600,
+    };
   })()`;
 }
 
-export const buildCloudflareInterstitialExpressionForTest = buildCloudflareInterstitialExpression;
-
-async function isCloudflareInterstitial(Runtime: ChromeClient["Runtime"]): Promise<boolean> {
-  const { result } = await Runtime.evaluate({
-    expression: buildCloudflareInterstitialExpression(),
-    returnByValue: true,
-  });
-  return Boolean(result.value);
+// Boolean composition kept for tests/back-compat: what an instantaneous classifier would say.
+export function buildCloudflareInterstitialExpression(): string {
+  return `(() => { const v = ${buildCloudflareVerdictExpression()}; return v.strong || v.weak; })()`;
 }
+
+export const buildCloudflareInterstitialExpressionForTest = buildCloudflareInterstitialExpression;
+export const buildCloudflareVerdictExpressionForTest = buildCloudflareVerdictExpression;
+
+type CloudflareVerdict = { strong?: boolean; shell?: boolean; weak?: boolean };
+
+// Weak (script-only) evidence must persist through a hydration grace window: callers run this
+// right after navigation, when a healthy SPA load can briefly look exactly like the weak case
+// (script present, shell not yet rendered, short body). A real interstitial never grows an app
+// shell, so waiting converts the race into a correct answer at the cost of a few seconds only
+// on genuinely ambiguous pages. Strong evidence still classifies immediately.
+const CLOUDFLARE_HYDRATION_GRACE_MS = 12_000;
+
+async function isCloudflareInterstitial(
+  Runtime: ChromeClient["Runtime"],
+  graceMs: number = CLOUDFLARE_HYDRATION_GRACE_MS,
+): Promise<boolean> {
+  const deadline = Date.now() + Math.max(0, graceMs);
+  for (;;) {
+    const { result } = await Runtime.evaluate({
+      expression: buildCloudflareVerdictExpression(),
+      returnByValue: true,
+    });
+    const verdict = (result?.value ?? {}) as CloudflareVerdict;
+    if (verdict.strong) return true;
+    if (verdict.shell) return false;
+    if (!verdict.weak) return false;
+    if (Date.now() >= deadline) return true;
+    await delay(500);
+  }
+}
+
+export const isCloudflareInterstitialForTest = isCloudflareInterstitial;
 
 async function isChatGptAccountSecurityBlock(Runtime: ChromeClient["Runtime"]): Promise<boolean> {
   try {

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -11,7 +11,9 @@ import {
   ensureNotBlocked,
   ensureLoggedIn,
 } from "../../src/browser/pageActions.js";
+import { createContext, Script } from "node:vm";
 import {
+  buildCloudflareInterstitialExpressionForTest,
   buildLoginProbeExpressionForTest,
   buildWelcomeBackAccountPickerExpressionForTest,
 } from "../../src/browser/actions/navigation.js";
@@ -256,26 +258,24 @@ describe("waitForResumedConversationHydration", () => {
 
 describe("ensureNotBlocked", () => {
   test("throws descriptive error when cloudflare detected", async () => {
+    // The detector is now a single boolean-returning injected predicate.
     const runtime = {
-      evaluate: vi.fn().mockResolvedValue({ result: { value: "Just a moment..." } }),
+      evaluate: vi.fn().mockResolvedValue({ result: { value: true } }),
     } as unknown as ChromeClient["Runtime"];
     await expect(ensureNotBlocked(runtime, true, logger)).rejects.toThrow(/headless mode/i);
     expect(logger).toHaveBeenCalledWith("Cloudflare anti-bot page detected");
   });
 
-  test("passes through when title clean", async () => {
+  test("passes through when not a challenge (e.g. a normal page carrying the CF script)", async () => {
     const runtime = {
-      evaluate: vi
-        .fn()
-        .mockResolvedValueOnce({ result: { value: "ChatGPT" } })
-        .mockResolvedValueOnce({ result: { value: false } }),
+      evaluate: vi.fn().mockResolvedValue({ result: { value: false } }),
     } as unknown as ChromeClient["Runtime"];
     await expect(ensureNotBlocked(runtime, false, logger)).resolves.toBeUndefined();
   });
 
   test("throws structured browser error when headful cloudflare is detected", async () => {
     const runtime = {
-      evaluate: vi.fn().mockResolvedValue({ result: { value: "Just a moment..." } }),
+      evaluate: vi.fn().mockResolvedValue({ result: { value: true } }),
     } as unknown as ChromeClient["Runtime"];
     try {
       await ensureNotBlocked(runtime, false, logger);
@@ -293,15 +293,85 @@ describe("ensureNotBlocked", () => {
     const runtime = {
       evaluate: vi
         .fn()
-        .mockResolvedValueOnce({ result: { value: "ChatGPT" } })
-        .mockResolvedValueOnce({ result: { value: false } })
-        .mockResolvedValueOnce({ result: { value: true } }),
+        .mockResolvedValueOnce({ result: { value: false } }) // not a Cloudflare interstitial
+        .mockResolvedValueOnce({ result: { value: true } }), // account security block
     } as unknown as ChromeClient["Runtime"];
 
     await expect(ensureNotBlocked(runtime, false, logger)).rejects.toMatchObject({
       details: { stage: "chatgpt-account-blocked" },
     });
     expect(logger).toHaveBeenCalledWith("ChatGPT account security block detected");
+  });
+});
+
+describe("cloudflare interstitial detection (DOM logic)", () => {
+  function evalCloudflare(opts: {
+    title?: string;
+    bodyText?: string;
+    appShell?: boolean;
+    widget?: boolean;
+    script?: boolean;
+  }): boolean {
+    const expr = buildCloudflareInterstitialExpressionForTest();
+    const context = createContext({
+      String,
+      Boolean,
+      document: {
+        title: opts.title ?? "",
+        body: { innerText: opts.bodyText ?? "" },
+        querySelector: (selector: string) => {
+          const s = String(selector);
+          if (
+            s.includes("prompt-textarea") ||
+            s.includes("conversation-turn") ||
+            s.includes("profile-button") ||
+            s.includes("form[data-type]") ||
+            s.includes('href*="/c/"')
+          ) {
+            return opts.appShell ? {} : null;
+          }
+          if (
+            s.includes("challenge-form") ||
+            s.includes("cf-challenge") ||
+            s.includes("challenges.cloudflare.com") ||
+            s.includes("cdn-cgi/challenge-platform")
+          ) {
+            return opts.widget ? {} : null;
+          }
+          if (s.includes("challenge-platform")) {
+            return opts.script ? {} : null; // the bot-management script
+          }
+          return null;
+        },
+      },
+    });
+    return new Script(expr).runInContext(context) as boolean;
+  }
+
+  test("does NOT flag a normal app page that merely carries the CF bot-management script", () => {
+    // The regression: the new GPT-5.6 "Work" UI (app shell present) + the challenge-platform
+    // script was wrongly detected as a Cloudflare challenge.
+    expect(evalCloudflare({ title: "ChatGPT", appShell: true, script: true })).toBe(false);
+  });
+
+  test("does NOT flag a content-rich page even without a recognized app shell", () => {
+    expect(
+      evalCloudflare({ title: "", appShell: false, script: true, bodyText: "x".repeat(1200) }),
+    ).toBe(false);
+  });
+
+  test("flags the real interstitial by title", () => {
+    expect(evalCloudflare({ title: "Just a moment..." })).toBe(true);
+  });
+
+  test("flags a real challenge widget with no app shell", () => {
+    expect(evalCloudflare({ title: "", appShell: false, widget: true })).toBe(true);
+  });
+
+  test("flags a short interstitial page carrying the script", () => {
+    expect(
+      evalCloudflare({ title: "", appShell: false, script: true, bodyText: "just a moment" }),
+    ).toBe(true);
   });
 });
 

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -397,6 +397,17 @@ describe("cloudflare interstitial detection (DOM logic)", () => {
     ).toBe(false);
   });
 
+  test("does NOT treat generic challenge copy as strong evidence on a content-rich page", () => {
+    expect(
+      evalCloudflare({
+        title: "ChatGPT",
+        appShell: false,
+        script: true,
+        bodyText: `A normal long-form answer says just a moment in passing. ${"x".repeat(1200)}`,
+      }),
+    ).toBe(false);
+  });
+
   test("flags the real interstitial by title", () => {
     expect(evalCloudflare({ title: "Just a moment..." })).toBe(true);
   });

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -14,6 +14,7 @@ import {
 import { createContext, Script } from "node:vm";
 import {
   buildCloudflareInterstitialExpressionForTest,
+  isCloudflareInterstitialForTest,
   buildLoginProbeExpressionForTest,
   buildWelcomeBackAccountPickerExpressionForTest,
 } from "../../src/browser/actions/navigation.js";
@@ -256,11 +257,44 @@ describe("waitForResumedConversationHydration", () => {
   });
 });
 
+describe("isCloudflareInterstitial hydration grace", () => {
+  const verdicts = (...values: unknown[]) => {
+    const fn = vi.fn();
+    for (const value of values) fn.mockResolvedValueOnce({ result: { value } });
+    fn.mockResolvedValue({ result: { value: values[values.length - 1] } });
+    return { evaluate: fn } as unknown as ChromeClient["Runtime"];
+  };
+
+  test("weak-only evidence that resolves into the app shell is NOT a challenge", async () => {
+    // The post-navigation race: bot-management script present, React shell not yet hydrated,
+    // short body. The shell appearing during the grace window must clear the classification.
+    const runtime = verdicts({ weak: true }, { weak: true }, { shell: true });
+    await expect(isCloudflareInterstitialForTest(runtime, 5_000)).resolves.toBe(false);
+  });
+
+  test("weak-only evidence that persists through the grace window IS a challenge", async () => {
+    const runtime = verdicts({ weak: true });
+    await expect(isCloudflareInterstitialForTest(runtime, 1_200)).resolves.toBe(true);
+  });
+
+  test("strong evidence classifies immediately without waiting", async () => {
+    const runtime = verdicts({ strong: true });
+    const started = Date.now();
+    await expect(isCloudflareInterstitialForTest(runtime, 60_000)).resolves.toBe(true);
+    expect(Date.now() - started).toBeLessThan(2_000);
+  });
+
+  test("no evidence at all returns false immediately", async () => {
+    const runtime = verdicts({});
+    await expect(isCloudflareInterstitialForTest(runtime, 60_000)).resolves.toBe(false);
+  });
+});
+
 describe("ensureNotBlocked", () => {
   test("throws descriptive error when cloudflare detected", async () => {
-    // The detector is now a single boolean-returning injected predicate.
+    // The detector evaluates a verdict object; strong evidence classifies immediately.
     const runtime = {
-      evaluate: vi.fn().mockResolvedValue({ result: { value: true } }),
+      evaluate: vi.fn().mockResolvedValue({ result: { value: { strong: true } } }),
     } as unknown as ChromeClient["Runtime"];
     await expect(ensureNotBlocked(runtime, true, logger)).rejects.toThrow(/headless mode/i);
     expect(logger).toHaveBeenCalledWith("Cloudflare anti-bot page detected");
@@ -268,14 +302,17 @@ describe("ensureNotBlocked", () => {
 
   test("passes through when not a challenge (e.g. a normal page carrying the CF script)", async () => {
     const runtime = {
-      evaluate: vi.fn().mockResolvedValue({ result: { value: false } }),
+      evaluate: vi
+        .fn()
+        .mockResolvedValueOnce({ result: { value: { shell: true } } }) // challenge verdict: app shell
+        .mockResolvedValue({ result: { value: false } }), // account security block probe
     } as unknown as ChromeClient["Runtime"];
     await expect(ensureNotBlocked(runtime, false, logger)).resolves.toBeUndefined();
   });
 
   test("throws structured browser error when headful cloudflare is detected", async () => {
     const runtime = {
-      evaluate: vi.fn().mockResolvedValue({ result: { value: true } }),
+      evaluate: vi.fn().mockResolvedValue({ result: { value: { strong: true } } }),
     } as unknown as ChromeClient["Runtime"];
     try {
       await ensureNotBlocked(runtime, false, logger);
@@ -293,7 +330,7 @@ describe("ensureNotBlocked", () => {
     const runtime = {
       evaluate: vi
         .fn()
-        .mockResolvedValueOnce({ result: { value: false } }) // not a Cloudflare interstitial
+        .mockResolvedValueOnce({ result: { value: { shell: true } } }) // not a Cloudflare interstitial
         .mockResolvedValueOnce({ result: { value: true } }), // account security block
     } as unknown as ChromeClient["Runtime"];
 


### PR DESCRIPTION
## Problem

The old detector treated any `script[src*="/challenge-platform/"]` as proof of a Cloudflare interstitial. Cloudflare bot-management injects that script on healthy ChatGPT pages, including current GPT-5.6 UI. The proposed positive-evidence detector still had one false-positive edge: generic body text such as “just a moment” was immediate strong evidence even on a content-rich shell-less page.

## Final design

- A recognized ChatGPT app shell wins immediately, regardless of bot-management scripts.
- Challenge titles and actual challenge widgets remain immediate strong evidence.
- Verification body copy is strong only on a short, shell-less page.
- Script-only evidence is weak, requires a short shell-less page, and must persist through a bounded hydration grace window.
- Content-rich shell-less pages do not become challenges merely because they carry the script or mention generic challenge text.

Rebased onto current `main`; contributor commits and authorship are preserved. The maintainer commit adds the content-rich generic-text regression and changelog entry.

## Validation

Exact final head: `465124882b62e1e932d49262ed6c3131949e14d0`.

- `pnpm vitest run tests/browser/pageActions.test.ts tests/browser/assistantResponseStatus.test.ts tests/browser/index.test.ts` — 199 passed, 1 skipped.
- `pnpm check` — passed.
- `pnpm test` — 1,495 passed, 43 skipped.
- Final AutoReview — no actionable findings.

## Exact-head live proof

- Healthy signed-in ChatGPT Pro page: `pr308-final-healthy-live` returned exactly `PR308-FINAL-HEALTHY-20260711` in 9.4s; no false Cloudflare abort.
- Genuine live Cloudflare response: `https://wafactions.lusostreams.com/` returned HTTP 403 from `server: cloudflare`, title `Attention Required! | Cloudflare`, and a 770-character content-rich body. The exact built classifier returned `{ strong: true, shell: false, weak: false }`, proving title-based genuine detection still wins without relying on the short-page body heuristic.

Fresh exact-head CI is running.
