### PR TITLE
fix(browser): scope the aria-label stop fallback to the composer form (follow-up to #285)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Browser: scope the fallback stop-control selector to the composer so read-aloud, dictation, and voice controls cannot hold completed responses open until timeout. Thanks @StartupBros!
 - Browser: support ChatGPT GPT-5.6's unified Intelligence picker, where the menu wraps `composer-intelligence-picker-content` and the highest effort is labeled `Pro` instead of `Pro Extended`; recognize the current Chinese effort labels (`极速5.5`, `中`, `高`, and `极高`) without prefix collisions and verify switches against React-replaced composer pills. Fixes #303. Thanks @DragonFSKY!
 - Browser: keep hidden macOS Chrome windows rendered off-screen so trusted prompt submissions land without retaining drafts or leaking them into later runs. Fixes #298 and #312. Thanks @LeoLin990405!
 - Browser: require positive terminal evidence before finalizing ChatGPT responses so settled preambles and mid-stream text cannot be captured as the completed answer. Thanks @StartupBros!

--- a/src/browser/constants.ts
+++ b/src/browser/constants.ts
@@ -73,10 +73,14 @@ export const UPLOAD_STATUS_SELECTORS = [
 ];
 
 export const STOP_BUTTON_SELECTOR = '[data-testid="stop-button"]';
+// The aria-label fallback exists for data-testid drift, but a document-wide match makes ANY
+// visible "stop" control (read-aloud, voice/dictation) read as "still generating", which blocks
+// completion until the response timeout. Scope it to the composer form and exclude the known
+// non-generation stop controls that legitimately live there.
 export const STOP_BUTTON_SELECTORS = [
   STOP_BUTTON_SELECTOR,
   '[data-testid="composer-stop-button"]',
-  'button[aria-label*="stop" i]',
+  'form button[aria-label*="stop" i]:not([aria-label*="dictat" i]):not([aria-label*="voice" i]):not([aria-label*="read" i])',
 ];
 export const SEND_BUTTON_SELECTORS = [
   'button[data-testid="send-button"]',

--- a/tests/browser/assistantResponseStatus.test.ts
+++ b/tests/browser/assistantResponseStatus.test.ts
@@ -102,6 +102,18 @@ describe("assistant thinking-status capture", () => {
     expect(expression).toContain("const fallback = extractFallback();");
   });
 
+  test("aria-label stop fallback is scoped to the composer and excludes non-generation stops", () => {
+    // Post-merge review of #285: a document-wide button[aria-label*="stop"] match let ANY
+    // visible stop control (read-aloud, voice/dictation) hold isStopButtonVisible() true and
+    // stall completion until the response timeout. Pin the scoping + exclusions.
+    const fallback = STOP_BUTTON_SELECTORS.find((s) => s.includes('aria-label*="stop"'));
+    expect(fallback).toBeDefined();
+    expect(fallback).toMatch(/^form /);
+    expect(fallback).toContain(':not([aria-label*="dictat" i])');
+    expect(fallback).toContain(':not([aria-label*="voice" i])');
+    expect(fallback).toContain(':not([aria-label*="read" i])');
+  });
+
   test("shares all stop-control selectors with completion capture", () => {
     let observedSelector = "";
     new Script(buildStopButtonVisibilityExpressionForTest()).runInContext(

--- a/tests/browser/thinking.test.ts
+++ b/tests/browser/thinking.test.ts
@@ -154,7 +154,53 @@ function matchesSelectorList(node: FakeElement, selector: string): boolean {
     .split(",")
     .map((part) => part.trim())
     .filter(Boolean)
-    .some((part) => matchesSimpleSelector(node, part));
+    .some((part) => matchesComplexSelector(node, part));
+}
+
+// Descendant combinator support: split on whitespace OUTSIDE attribute brackets and :not()
+// parens, match the last compound on the node itself, and walk ancestors for the rest.
+function matchesComplexSelector(node: FakeElement, selector: string): boolean {
+  const compounds: string[] = [];
+  let current = "";
+  let depth = 0;
+  for (const char of selector) {
+    if (char === "[" || char === "(") depth += 1;
+    if (char === "]" || char === ")") depth -= 1;
+    if (depth === 0 && /\s/.test(char)) {
+      if (current) compounds.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  if (current) compounds.push(current);
+  if (compounds.length === 0) return false;
+  if (!matchesCompoundSelector(node, compounds[compounds.length - 1] ?? "")) return false;
+  let ancestor = node.parentElement;
+  for (let i = compounds.length - 2; i >= 0; i -= 1) {
+    let found: FakeElement | null = null;
+    while (ancestor) {
+      if (matchesCompoundSelector(ancestor, compounds[i] ?? "")) {
+        found = ancestor;
+        break;
+      }
+      ancestor = ancestor.parentElement;
+    }
+    if (!found) return false;
+    ancestor = found.parentElement;
+  }
+  return true;
+}
+
+// :not(...) support: every negated simple selector must NOT match the node.
+function matchesCompoundSelector(node: FakeElement, selector: string): boolean {
+  const negations: string[] = [];
+  const positive = selector.replace(/:not\(([^)]+)\)/g, (_match, inner: string) => {
+    negations.push(inner);
+    return "";
+  });
+  if (negations.some((negated) => matchesSimpleSelector(node, negated))) return false;
+  return matchesSimpleSelector(node, positive);
 }
 
 function matchesSimpleSelector(node: FakeElement, selector: string): boolean {
@@ -507,13 +553,35 @@ describe("thinking status browser expression", () => {
     "falls back to a visible stop control when no thinking indicator matches: %o",
     async (attrs) => {
       const document = new FakeDocument();
+      // The aria-label fallback is scoped to the composer FORM (post-#285 review): mirror the
+      // real DOM, where the generation stop control lives inside the composer form.
+      const form = new FakeElement("form", "", {});
       const composer = new FakeElement("div", "", { "data-testid": "composer-footer-actions" });
       composer.append(new FakeElement("button", "", attrs));
-      document.append(composer);
+      form.append(composer);
+      document.append(form);
 
       const result = await runThinkingStatusExpression(document);
 
       expect(result).toEqual({ message: "response streaming", source: "inline" });
+    },
+  );
+
+  test.each(["Stop reading aloud", "Stop dictation", "Stop voice mode"])(
+    "ignores non-generation stop control %j",
+    async (label) => {
+      // Post-merge review of #285: any visible page-wide "stop" control (read-aloud, voice,
+      // dictation) held the stop fallback true and stalled completion until the timeout.
+      const document = new FakeDocument();
+      const form = new FakeElement("form", "", {});
+      form.append(new FakeElement("button", "", { "aria-label": label }));
+      document.append(form);
+      const outside = new FakeElement("button", "", { "aria-label": "Stop background audio" });
+      document.append(outside);
+
+      const result = await runThinkingStatusExpression(document);
+
+      expect(result).toBeNull();
     },
   );
 


### PR DESCRIPTION
Follow-up to the post-merge review note on #285.

## Problem

The `button[aria-label*="stop" i]` fallback added in #285 matches document-wide, so any visible non-generation stop control (read-aloud, voice mode, dictation) keeps `isStopButtonVisible()` true. `pollAssistantCompletion()` only finalizes when that value goes false, so a completed browser response could stall until the response timeout.

## Fix

Scope the fallback to the composer form and exclude the known non-generation stop controls that legitimately render there: `form button[aria-label*="stop" i]:not([aria-label*="dictat" i]):not([aria-label*="voice" i]):not([aria-label*="read" i])`. The `data-testid` selectors stay primary; the fallback still covers testid drift for the real generation stop, which lives inside the composer form.

## Validation

`pnpm run typecheck`, `oxlint`, `oxfmt --check`, full browser suite (626 passing). The fake DOM in `thinking.test.ts` gained faithful descendant-combinator and `:not()` matching so the scoped selector is actually exercised; new regressions cover read-aloud/dictation/voice stops inside and outside the form.

## Real-behavior proof (redacted)

**Live CDP capture during an ACTIVE generation on a production GPT-5.6 conversation tab (2026-07-10 14:5x EDT):**

```json
{"generating":true,"testidStop":1,"oldSelectorMatches":1,"oldSelectorLabels":["Stop answering"],"newSelectorMatches":1,"newSelectorLabels":["Stop answering"],"pageWideStopLabels":["Stop answering"],"cf":{"hasAppShell":true,"hasChallengeScript":true,"bodyLen":59167,"titleIsChallenge":false},"visibleProgressBars":0}
```

The real generation stop control (`aria-label="Stop answering"`) lives inside the composer form on the live DOM: the scoped fallback matches it 1:1 with the old document-wide selector (`newSelectorMatches: 1`, same node), the `data-testid="stop-button"` primary is present, and form ancestry holds exactly as the selector assumes.

**Behavioral evidence from the fork running this change:** reviews completing after the deploy (09:04, 13:31, 14:14 EDT on 2026-07-10) all finalized normally, which requires stop-visibility to drop when generation ends; none stalled to the response timeout.
