### PR TITLE
feat(browser): normalize ChatGPT Work sessions to Chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Browser: allow `ORACLE_BROWSER_MAX_CONCURRENT_TABS` to set the per-host shared-profile tab cap while preserving explicit config precedence and the default limit. Thanks @StartupBros!
+- Browser: detect ChatGPT's active Chat/Work mode before new browser runs, normalize Work pages and attached Work tabs to a new Chat with verified trusted input, and preserve explicit resume safety. Refs #315.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Browser: allow `ORACLE_BROWSER_MAX_CONCURRENT_TABS` to set the per-host shared-profile tab cap while preserving explicit config precedence and the default limit. Thanks @StartupBros!
-- Browser: detect ChatGPT's active Chat/Work mode before new browser runs, normalize Work pages and attached Work tabs to a new Chat with verified trusted input, and preserve explicit resume safety. Refs #315.
+- Browser: detect ChatGPT's active Chat/Work mode before new browser runs, normalize Work pages and attached Work tabs to a new Chat with verified trusted input, and preserve explicit resume safety. Fixes #315. Thanks @DragonFSKY!
 
 ### Fixed
 

--- a/src/browser/actions/navigation.ts
+++ b/src/browser/actions/navigation.ts
@@ -203,26 +203,38 @@ function buildChatModeProbeExpression(): string {
       const match = String(value || '').match(/\\/c\\/([a-zA-Z0-9-]+)/);
       return match?.[1] || null;
     };
+    const isStructuredWorkBadge = (node) =>
+      node instanceof HTMLElement &&
+      node.tagName === 'SPAN' &&
+      normalize(node.textContent) === 'work' &&
+      node.childElementCount === 0 &&
+      !node.hasAttribute('dir') &&
+      node.classList.contains('shrink-0') &&
+      node.parentElement?.matches('span.flex.items-center');
 
     const pathname = typeof location?.pathname === 'string' ? location.pathname : '';
     const conversationId = conversationIdFromPath(pathname);
     if (conversationId) {
-      const activeHistoryLink = Array.from(document.querySelectorAll('a[href*="/c/"]')).find((node) => {
+      const activeHistoryLinks = Array.from(document.querySelectorAll('a[href*="/c/"]')).filter((node) => {
         try {
-          const candidatePath = new URL(node.getAttribute('href') || '', location.origin).pathname;
-          return conversationIdFromPath(candidatePath) === conversationId;
+          const candidateUrl = new URL(node.getAttribute('href') || '', location.origin);
+          return candidateUrl.origin === location.origin && conversationIdFromPath(candidateUrl.pathname) === conversationId;
         } catch {
           return false;
         }
       });
-      if (activeHistoryLink) {
-        const aria = normalize(activeHistoryLink.getAttribute('aria-label'));
-        const metadata = aria.split(',').slice(1).map((part) => part.trim());
-        const hasWorkMetadata = metadata.some((part) => part === 'work' || part.startsWith('work(') || part.startsWith('work（'));
-        const hasWorkBadge = Array.from(activeHistoryLink.querySelectorAll('*')).some(
-          (node) => normalize(node.textContent) === 'work',
+      if (activeHistoryLinks.length > 0) {
+        const hasWorkBadge = activeHistoryLinks.some((link) =>
+          Array.from(link.querySelectorAll('span')).some(isStructuredWorkBadge),
         );
-        if (hasWorkMetadata || hasWorkBadge) return { status: 'work-conversation' };
+        if (hasWorkBadge) return { status: 'work-conversation' };
+
+        const ariaLabels = activeHistoryLinks
+          .map((link) => normalize(link.getAttribute('aria-label')))
+          .filter(Boolean);
+        if (ariaLabels.length === 0 || ariaLabels.some((aria) => /,\\s*work\\s*$/.test(aria))) {
+          return { status: 'conversation-unresolved' };
+        }
         return { status: 'chat-conversation' };
       }
       return { status: 'conversation-unresolved' };
@@ -252,7 +264,8 @@ export async function ensureChatMode(
   logger: BrowserLogger,
   options: { pollMs?: number; resetWorkConversation?: () => Promise<void> } = {},
 ): Promise<"chat" | "switched" | "unavailable"> {
-  const deadline = Date.now() + Math.min(Math.max(0, timeoutMs), 10_000);
+  const verificationWindowMs = Math.min(Math.max(0, timeoutMs), 10_000);
+  let deadline = Date.now() + verificationWindowMs;
   const pollMs = Math.max(0, options.pollMs ?? 200);
   let changedFromWork = false;
   let clickedChat = false;
@@ -272,20 +285,26 @@ export async function ensureChatMode(
         await delay(pollMs);
         continue;
       }
+      if (changedFromWork) break;
       return "unavailable";
     }
     if (probe?.status === "controls-absent") {
-      if (changedFromWork && Date.now() < deadline) {
-        await delay(pollMs);
-        continue;
+      if (changedFromWork) {
+        if (Date.now() < deadline) {
+          await delay(pollMs);
+          continue;
+        }
+        break;
       }
       return "unavailable";
     }
     if (probe?.status === "work-conversation") {
-      if (options.resetWorkConversation && !changedFromWork) {
+      if (changedFromWork) break;
+      if (options.resetWorkConversation) {
         logger("ChatGPT mode: Work conversation; opening a new Chat");
         await options.resetWorkConversation();
         changedFromWork = true;
+        deadline = Date.now() + verificationWindowMs;
         await delay(pollMs);
         continue;
       }
@@ -314,6 +333,7 @@ export async function ensureChatMode(
       });
       changedFromWork = true;
       clickedChat = true;
+      deadline = Date.now() + verificationWindowMs;
       await delay(pollMs);
       continue;
     }
@@ -324,7 +344,7 @@ export async function ensureChatMode(
   await logDomFailure(Runtime, logger, "chat-mode-selection");
   throw new BrowserAutomationError(
     changedFromWork
-      ? "ChatGPT remained in Work mode after Oracle selected Chat."
+      ? "Oracle could not verify Chat mode after leaving Work."
       : "ChatGPT exposed Chat/Work controls but Oracle could not verify the active mode.",
     { stage: "chat-mode-selection", details: { changedFromWork, clickedChat } },
   );

--- a/src/browser/actions/navigation.ts
+++ b/src/browser/actions/navigation.ts
@@ -174,6 +174,166 @@ export async function navigateToPromptReadyWithFallback(
   }
 }
 
+type ChatModeProbeResult = {
+  status:
+    | "chat-selected"
+    | "chat-conversation"
+    | "work-selected"
+    | "work-conversation"
+    | "conversation-unresolved"
+    | "controls-absent"
+    | "mode-unresolved";
+  chatPoint?: { x: number; y: number };
+};
+
+function buildChatModeProbeExpression(): string {
+  return `(() => {
+    const normalize = (value) => String(value || '').toLowerCase().replace(/\\s+/g, ' ').trim();
+    const isVisible = (node) => {
+      if (!(node instanceof HTMLElement)) return false;
+      const rect = node.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) return false;
+      const style = window.getComputedStyle(node);
+      return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
+    };
+    const isSelected = (node) =>
+      node?.getAttribute?.('aria-checked') === 'true' ||
+      node?.getAttribute?.('data-state') === 'on';
+    const conversationIdFromPath = (value) => {
+      const match = String(value || '').match(/\\/c\\/([a-zA-Z0-9-]+)/);
+      return match?.[1] || null;
+    };
+
+    const pathname = typeof location?.pathname === 'string' ? location.pathname : '';
+    const conversationId = conversationIdFromPath(pathname);
+    if (conversationId) {
+      const activeHistoryLink = Array.from(document.querySelectorAll('a[href*="/c/"]')).find((node) => {
+        try {
+          const candidatePath = new URL(node.getAttribute('href') || '', location.origin).pathname;
+          return conversationIdFromPath(candidatePath) === conversationId;
+        } catch {
+          return false;
+        }
+      });
+      if (activeHistoryLink) {
+        const aria = normalize(activeHistoryLink.getAttribute('aria-label'));
+        const metadata = aria.split(',').slice(1).map((part) => part.trim());
+        const hasWorkMetadata = metadata.some((part) => part === 'work' || part.startsWith('work(') || part.startsWith('work（'));
+        const hasWorkBadge = Array.from(activeHistoryLink.querySelectorAll('*')).some(
+          (node) => normalize(node.textContent) === 'work',
+        );
+        if (hasWorkMetadata || hasWorkBadge) return { status: 'work-conversation' };
+        return { status: 'chat-conversation' };
+      }
+      return { status: 'conversation-unresolved' };
+    }
+
+    const radios = Array.from(document.querySelectorAll('button[role="radio"]')).filter(isVisible);
+    const chat = radios.find((node) => normalize(node.textContent) === 'chat');
+    const work = radios.find((node) => normalize(node.textContent) === 'work');
+    if (!chat && !work) return { status: 'controls-absent' };
+    if (!chat || !work) return { status: 'mode-unresolved' };
+    if (isSelected(chat)) return { status: 'chat-selected' };
+    if (isSelected(work)) {
+      const rect = chat.getBoundingClientRect();
+      return {
+        status: 'work-selected',
+        chatPoint: { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 },
+      };
+    }
+    return { status: 'mode-unresolved' };
+  })()`;
+}
+
+export async function ensureChatMode(
+  Runtime: ChromeClient["Runtime"],
+  Input: ChromeClient["Input"],
+  timeoutMs: number,
+  logger: BrowserLogger,
+  options: { pollMs?: number; resetWorkConversation?: () => Promise<void> } = {},
+): Promise<"chat" | "switched" | "unavailable"> {
+  const deadline = Date.now() + Math.min(Math.max(0, timeoutMs), 10_000);
+  const pollMs = Math.max(0, options.pollMs ?? 200);
+  let changedFromWork = false;
+  let clickedChat = false;
+
+  for (;;) {
+    const outcome = await Runtime.evaluate({
+      expression: buildChatModeProbeExpression(),
+      returnByValue: true,
+    });
+    const probe = outcome.result?.value as ChatModeProbeResult | undefined;
+    if (probe?.status === "chat-selected" || probe?.status === "chat-conversation") {
+      logger(changedFromWork ? "ChatGPT mode: Chat (switched from Work)" : "ChatGPT mode: Chat");
+      return changedFromWork ? "switched" : "chat";
+    }
+    if (probe?.status === "conversation-unresolved") {
+      if (Date.now() < deadline) {
+        await delay(pollMs);
+        continue;
+      }
+      return "unavailable";
+    }
+    if (probe?.status === "controls-absent") {
+      if (changedFromWork && Date.now() < deadline) {
+        await delay(pollMs);
+        continue;
+      }
+      return "unavailable";
+    }
+    if (probe?.status === "work-conversation") {
+      if (options.resetWorkConversation && !changedFromWork) {
+        logger("ChatGPT mode: Work conversation; opening a new Chat");
+        await options.resetWorkConversation();
+        changedFromWork = true;
+        await delay(pollMs);
+        continue;
+      }
+      throw new BrowserAutomationError(
+        "The selected ChatGPT tab is an existing Work conversation and cannot be resumed as an ordinary Chat conversation. Start a new Chat conversation instead.",
+        { stage: "chat-mode-selection", details: { mode: "work-conversation" } },
+      );
+    }
+    if (probe?.status === "work-selected" && !clickedChat && probe.chatPoint) {
+      logger("ChatGPT mode: Work; switching to Chat");
+      const { x, y } = probe.chatPoint;
+      await Input.dispatchMouseEvent({ type: "mouseMoved", x, y });
+      await Input.dispatchMouseEvent({
+        type: "mousePressed",
+        x,
+        y,
+        button: "left",
+        clickCount: 1,
+      });
+      await Input.dispatchMouseEvent({
+        type: "mouseReleased",
+        x,
+        y,
+        button: "left",
+        clickCount: 1,
+      });
+      changedFromWork = true;
+      clickedChat = true;
+      await delay(pollMs);
+      continue;
+    }
+    if (Date.now() >= deadline) break;
+    await delay(pollMs);
+  }
+
+  await logDomFailure(Runtime, logger, "chat-mode-selection");
+  throw new BrowserAutomationError(
+    changedFromWork
+      ? "ChatGPT remained in Work mode after Oracle selected Chat."
+      : "ChatGPT exposed Chat/Work controls but Oracle could not verify the active mode.",
+    { stage: "chat-mode-selection", details: { changedFromWork, clickedChat } },
+  );
+}
+
+export function buildChatModeProbeExpressionForTest(): string {
+  return buildChatModeProbeExpression();
+}
+
 export async function ensureNotBlocked(
   Runtime: ChromeClient["Runtime"],
   headless: boolean,

--- a/src/browser/actions/navigation.ts
+++ b/src/browser/actions/navigation.ts
@@ -215,7 +215,11 @@ function buildChatModeProbeExpression(): string {
     const pathname = typeof location?.pathname === 'string' ? location.pathname : '';
     const conversationId = conversationIdFromPath(pathname);
     if (conversationId) {
-      const activeHistoryLinks = Array.from(document.querySelectorAll('a[href*="/c/"]')).filter((node) => {
+      // Conversation messages can contain same-origin links to the current thread. Only sidebar
+      // history items use ChatGPT's renderer-owned menu-item anchor class.
+      const activeHistoryLinks = Array.from(
+        document.querySelectorAll('a.__menu-item[href*="/c/"]'),
+      ).filter((node) => {
         try {
           const candidateUrl = new URL(node.getAttribute('href') || '', location.origin);
           return candidateUrl.origin === location.origin && conversationIdFromPath(candidateUrl.pathname) === conversationId;
@@ -286,7 +290,18 @@ export async function ensureChatMode(
         continue;
       }
       if (changedFromWork) break;
-      return "unavailable";
+      if (options.resetWorkConversation) {
+        logger("ChatGPT conversation mode unresolved; opening a new Chat");
+        await options.resetWorkConversation();
+        changedFromWork = true;
+        deadline = Date.now() + verificationWindowMs;
+        await delay(pollMs);
+        continue;
+      }
+      throw new BrowserAutomationError(
+        "Oracle could not verify whether the selected ChatGPT conversation uses Chat or Work mode, so it cannot safely resume that conversation.",
+        { stage: "chat-mode-selection", details: { mode: "conversation-unresolved" } },
+      );
     }
     if (probe?.status === "controls-absent") {
       if (changedFromWork) {

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -30,6 +30,7 @@ import {
   ensureNotBlocked,
   ensureLoggedIn,
   ensurePromptReady,
+  ensureChatMode,
   waitForResumedConversationHydration,
   installJavaScriptDialogAutoDismissal,
   ensureModelSelection,
@@ -1320,6 +1321,21 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
           }),
         );
       }
+    }
+    const chatMode = await raceWithDisconnect(
+      ensureChatMode(Runtime, Input, config.inputTimeoutMs, logger, {
+        resetWorkConversation:
+          config.browserTabRef && !isResumingConversation
+            ? async () => {
+                await navigateToChatGPT(Page, Runtime, config.url, logger);
+                await ensureNotBlocked(Runtime, config.headless, logger);
+                await ensurePromptReady(Runtime, config.inputTimeoutMs, logger);
+              }
+            : undefined,
+      }),
+    );
+    if (chatMode === "switched") {
+      await raceWithDisconnect(ensurePromptReady(Runtime, config.inputTimeoutMs, logger));
     }
     logger(
       `Prompt textarea ready (initial focus, ${promptText.length.toLocaleString()} chars queued)`,
@@ -2902,6 +2918,19 @@ async function runRemoteBrowserMode(
         requirePriorTurns: true,
         expectedConversationUrl: config.resumeConversationUrl,
       });
+    }
+    const chatMode = await ensureChatMode(Runtime, Input, config.inputTimeoutMs, logger, {
+      resetWorkConversation:
+        attachedExistingTab && !config.resumeConversationUrl
+          ? async () => {
+              await navigateToChatGPT(Page, Runtime, config.url, logger);
+              await ensureNotBlocked(Runtime, config.headless, logger);
+              await ensurePromptReady(Runtime, config.inputTimeoutMs, logger);
+            }
+          : undefined,
+    });
+    if (chatMode === "switched") {
+      await ensurePromptReady(Runtime, config.inputTimeoutMs, logger);
     }
     logger(
       `Prompt textarea ready (initial focus, ${promptText.length.toLocaleString()} chars queued)`,

--- a/src/browser/pageActions.ts
+++ b/src/browser/pageActions.ts
@@ -4,6 +4,7 @@ export {
   ensureNotBlocked,
   ensureLoggedIn,
   ensurePromptReady,
+  ensureChatMode,
   waitForResumedConversationHydration,
   installJavaScriptDialogAutoDismissal,
 } from "./actions/navigation.js";

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -173,6 +173,97 @@ describe("ensurePromptReady", () => {
 });
 
 describe("ensureChatMode", () => {
+  class FakeChatModeElement {
+    readonly classList: { contains: (value: string) => boolean };
+
+    constructor(
+      readonly tagName: string,
+      readonly textContent: string,
+      classes: string[] = [],
+      readonly childElementCount = 0,
+      private readonly attributes: Record<string, string> = {},
+      readonly parentElement: FakeChatModeElement | null = null,
+    ) {
+      const tokens = new Set(classes);
+      this.classList = { contains: (value: string) => tokens.has(value) };
+    }
+
+    hasAttribute(name: string) {
+      return Object.hasOwn(this.attributes, name);
+    }
+
+    matches(selector: string) {
+      return (
+        selector === "span.flex.items-center" &&
+        this.tagName === "SPAN" &&
+        this.classList.contains("flex") &&
+        this.classList.contains("items-center")
+      );
+    }
+  }
+
+  const structuredWorkBadge = (
+    overrides: {
+      tagName?: string;
+      textContent?: string;
+      classes?: string[];
+      childElementCount?: number;
+      attributes?: Record<string, string>;
+      parentClasses?: string[];
+    } = {},
+  ) => {
+    const parent = new FakeChatModeElement(
+      "SPAN",
+      "",
+      overrides.parentClasses ?? ["flex", "items-center"],
+    );
+    return new FakeChatModeElement(
+      overrides.tagName ?? "SPAN",
+      overrides.textContent ?? "Work",
+      overrides.classes ?? ["shrink-0"],
+      overrides.childElementCount ?? 0,
+      overrides.attributes ?? {},
+      parent,
+    );
+  };
+
+  const runConversationModeProbe = (
+    pathname: string,
+    links: Array<{ href: string; ariaLabel?: string; descendants?: FakeChatModeElement[] }>,
+  ) => {
+    const expression = buildChatModeProbeExpressionForTest();
+    const historyLinks = links.map(({ href, ariaLabel = "", descendants = [] }) => ({
+      getAttribute: (name: string) => {
+        if (name === "href") return href;
+        if (name === "aria-label") return ariaLabel;
+        return null;
+      },
+      querySelectorAll: (selector: string) => (selector === "span" ? descendants : []),
+    }));
+    const document = {
+      querySelectorAll: (selector: string) => (selector === 'a[href*="/c/"]' ? historyLinks : []),
+    };
+    const evaluate = new Function(
+      "document",
+      "location",
+      "URL",
+      "HTMLElement",
+      `return ${expression};`,
+    ) as (
+      document: unknown,
+      location: unknown,
+      url: typeof URL,
+      htmlElement: typeof FakeChatModeElement,
+    ) => { status: string };
+
+    return evaluate(
+      document,
+      { origin: "https://chatgpt.com", pathname },
+      URL,
+      FakeChatModeElement,
+    );
+  };
+
   test("uses a trusted click to switch Work to Chat and verifies the result", async () => {
     const evaluate = vi
       .fn()
@@ -311,36 +402,147 @@ describe("ensureChatMode", () => {
     expect(input.dispatchMouseEvent).not.toHaveBeenCalled();
   });
 
-  test("classifies a Work conversation nested under a project URL by conversation id", () => {
-    const expression = buildChatModeProbeExpressionForTest();
-    const activeHistoryLink = {
-      getAttribute: (name: string) => {
-        if (name === "href") return "/c/project-work-thread";
-        if (name === "aria-label") return "Project task, Work";
-        return null;
-      },
-      querySelectorAll: () => [],
-    };
-    const document = {
-      querySelectorAll: (selector: string) =>
-        selector === 'a[href*="/c/"]' ? [activeHistoryLink] : [],
-    };
-    const evaluate = new Function("document", "location", "URL", `return ${expression};`) as (
-      document: unknown,
-      location: unknown,
-      url: typeof URL,
-    ) => { status: string };
+  test.each([
+    ["root", "/c/root-work-thread", "/c/root-work-thread", "Root task, Work"],
+    [
+      "project",
+      "/g/example/project/c/project-work-thread",
+      "/c/project-work-thread",
+      "Project task, chat in project Example, Work",
+    ],
+  ])(
+    "classifies a structured Work badge on a %s conversation URL",
+    (_kind, pathname, href, ariaLabel) => {
+      expect(
+        runConversationModeProbe(pathname, [
+          {
+            href,
+            ariaLabel,
+            descendants: [structuredWorkBadge()],
+          },
+        ]),
+      ).toEqual({ status: "work-conversation" });
+    },
+  );
 
+  test.each([
+    ["comma-containing title", "Plan, Work, and travel", []],
+    ["title exactly Work", "Work", [structuredWorkBadge({ attributes: { dir: "auto" } })]],
+    ["arbitrary exact-text descendant", "Work notes", [structuredWorkBadge({ classes: [] })]],
+    [
+      "near-miss badge with nested content",
+      "Work notes",
+      [structuredWorkBadge({ childElementCount: 1 })],
+    ],
+    [
+      "near-miss badge under an ordinary parent",
+      "Work notes",
+      [structuredWorkBadge({ parentClasses: ["flex"] })],
+    ],
+  ])("keeps an ordinary Chat conversation for a %s", (_caseName, ariaLabel, descendants) => {
     expect(
-      evaluate(
-        document,
+      runConversationModeProbe("/c/chat-thread", [
+        { href: "/c/chat-thread", ariaLabel, descendants },
+      ]),
+    ).toEqual({ status: "chat-conversation" });
+  });
+
+  test("treats a terminal aria Work suffix as hydration evidence rather than authority", () => {
+    expect(
+      runConversationModeProbe("/c/pending-thread", [
         {
-          origin: "https://chatgpt.com",
-          pathname: "/g/example/project/c/project-work-thread",
+          href: "/c/pending-thread",
+          ariaLabel: "Ordinary title ending, Work",
         },
-        URL,
-      ),
+      ]),
+    ).toEqual({ status: "conversation-unresolved" });
+  });
+
+  test("fails open after persistent aria-only ambiguity without resetting the conversation", async () => {
+    const runtime = {
+      evaluate: vi
+        .fn()
+        .mockResolvedValue({ result: { value: { status: "conversation-unresolved" } } }),
+    } as unknown as ChromeClient["Runtime"];
+    const input = { dispatchMouseEvent: vi.fn() } as unknown as ChromeClient["Input"];
+    const resetWorkConversation = vi.fn();
+
+    await expect(
+      ensureChatMode(runtime, input, 0, logger, { pollMs: 0, resetWorkConversation }),
+    ).resolves.toBe("unavailable");
+    expect(resetWorkConversation).not.toHaveBeenCalled();
+  });
+
+  test("aggregates responsive duplicates for the exact conversation id", () => {
+    expect(
+      runConversationModeProbe("/c/duplicate-thread", [
+        { href: "/c/duplicate-thread", ariaLabel: "Hydrated title" },
+        {
+          href: "/c/duplicate-thread",
+          ariaLabel: "Hydrated title, Work",
+          descendants: [structuredWorkBadge()],
+        },
+      ]),
     ).toEqual({ status: "work-conversation" });
+  });
+
+  test("ignores a matching conversation path from another origin", () => {
+    expect(
+      runConversationModeProbe("/c/same-thread", [
+        {
+          href: "https://example.test/c/same-thread",
+          ariaLabel: "External, Work",
+          descendants: [structuredWorkBadge()],
+        },
+        { href: "/c/same-thread", ariaLabel: "Local chat" },
+      ]),
+    ).toEqual({ status: "chat-conversation" });
+  });
+
+  test("fails closed when post-reset Chat verification remains unavailable", async () => {
+    const runtime = {
+      evaluate: vi
+        .fn()
+        .mockResolvedValueOnce({ result: { value: { status: "work-conversation" } } })
+        .mockResolvedValueOnce({ result: { value: { status: "controls-absent" } } })
+        .mockResolvedValue({ result: { value: false } }),
+    } as unknown as ChromeClient["Runtime"];
+    const input = { dispatchMouseEvent: vi.fn() } as unknown as ChromeClient["Input"];
+    const resetWorkConversation = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      ensureChatMode(runtime, input, 0, logger, { pollMs: 0, resetWorkConversation }),
+    ).rejects.toThrow(/could not verify Chat mode after leaving Work/i);
+    expect(resetWorkConversation).toHaveBeenCalledOnce();
+  });
+
+  test("allocates a fresh verification window after resetting a Work conversation", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(0);
+      const runtime = {
+        evaluate: vi
+          .fn()
+          .mockResolvedValueOnce({ result: { value: { status: "work-conversation" } } })
+          .mockResolvedValueOnce({ result: { value: { status: "conversation-unresolved" } } })
+          .mockResolvedValueOnce({ result: { value: { status: "chat-selected" } } }),
+      } as unknown as ChromeClient["Runtime"];
+      const input = { dispatchMouseEvent: vi.fn() } as unknown as ChromeClient["Input"];
+      const resetWorkConversation = vi.fn().mockImplementation(async () => {
+        vi.setSystemTime(1_000);
+      });
+
+      const result = ensureChatMode(runtime, input, 1_000, logger, {
+        pollMs: 1,
+        resetWorkConversation,
+      });
+      await vi.runAllTimersAsync();
+
+      await expect(result).resolves.toBe("switched");
+      expect(runtime.evaluate).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("scopes detection to exact mode radios and the active conversation metadata", () => {
@@ -349,7 +551,11 @@ describe("ensureChatMode", () => {
     expect(expression).toContain("normalize(node.textContent) === 'chat'");
     expect(expression).toContain("normalize(node.textContent) === 'work'");
     expect(expression).toContain('a[href*="/c/"]');
-    expect(expression).toContain("conversationIdFromPath(candidatePath) === conversationId");
+    expect(expression).toContain("candidateUrl.origin === location.origin");
+    expect(expression).toContain(
+      "conversationIdFromPath(candidateUrl.pathname) === conversationId",
+    );
+    expect(expression).toContain("node.classList.contains('shrink-0')");
     expect(expression).not.toContain("document.body.innerText");
   });
 });

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -7,6 +7,7 @@ import {
   navigateToChatGPT,
   navigateToPromptReadyWithFallback,
   ensurePromptReady,
+  ensureChatMode,
   waitForResumedConversationHydration,
   ensureNotBlocked,
   ensureLoggedIn,
@@ -17,6 +18,7 @@ import {
   isCloudflareInterstitialForTest,
   buildLoginProbeExpressionForTest,
   buildWelcomeBackAccountPickerExpressionForTest,
+  buildChatModeProbeExpressionForTest,
 } from "../../src/browser/actions/navigation.js";
 import * as attachments from "../../src/browser/actions/attachments.js";
 import * as attachmentDataTransfer from "../../src/browser/actions/attachmentDataTransfer.js";
@@ -167,6 +169,188 @@ describe("ensurePromptReady", () => {
       evaluate: vi.fn().mockResolvedValue({ result: { value: false } }),
     } as unknown as ChromeClient["Runtime"];
     await expect(ensurePromptReady(runtime, 0, logger)).rejects.toThrow(/textarea did not appear/i);
+  });
+});
+
+describe("ensureChatMode", () => {
+  test("uses a trusted click to switch Work to Chat and verifies the result", async () => {
+    const evaluate = vi
+      .fn()
+      .mockResolvedValueOnce({
+        result: { value: { status: "work-selected", chatPoint: { x: 120, y: 48 } } },
+      })
+      .mockResolvedValueOnce({ result: { value: { status: "chat-selected" } } });
+    const dispatchMouseEvent = vi.fn().mockResolvedValue(undefined);
+    const runtime = { evaluate } as unknown as ChromeClient["Runtime"];
+    const input = { dispatchMouseEvent } as unknown as ChromeClient["Input"];
+
+    await expect(ensureChatMode(runtime, input, 1_000, logger, { pollMs: 0 })).resolves.toBe(
+      "switched",
+    );
+
+    expect(dispatchMouseEvent).toHaveBeenNthCalledWith(1, {
+      type: "mouseMoved",
+      x: 120,
+      y: 48,
+    });
+    expect(dispatchMouseEvent).toHaveBeenNthCalledWith(2, {
+      type: "mousePressed",
+      x: 120,
+      y: 48,
+      button: "left",
+      clickCount: 1,
+    });
+    expect(dispatchMouseEvent).toHaveBeenNthCalledWith(3, {
+      type: "mouseReleased",
+      x: 120,
+      y: 48,
+      button: "left",
+      clickCount: 1,
+    });
+    expect(logger).toHaveBeenCalledWith("ChatGPT mode: Work; switching to Chat");
+    expect(logger).toHaveBeenCalledWith("ChatGPT mode: Chat (switched from Work)");
+    expect(String(evaluate.mock.calls[0]?.[0]?.expression)).toContain('button[role="radio"]');
+  });
+
+  test("does not click when Chat is already selected", async () => {
+    const runtime = {
+      evaluate: vi.fn().mockResolvedValue({ result: { value: { status: "chat-selected" } } }),
+    } as unknown as ChromeClient["Runtime"];
+    const input = {
+      dispatchMouseEvent: vi.fn(),
+    } as unknown as ChromeClient["Input"];
+
+    await expect(ensureChatMode(runtime, input, 0, logger)).resolves.toBe("chat");
+    expect(input.dispatchMouseEvent).not.toHaveBeenCalled();
+  });
+
+  test("keeps compatibility when the Chat/Work selector is absent", async () => {
+    const runtime = {
+      evaluate: vi.fn().mockResolvedValue({ result: { value: { status: "controls-absent" } } }),
+    } as unknown as ChromeClient["Runtime"];
+    const input = {
+      dispatchMouseEvent: vi.fn(),
+    } as unknown as ChromeClient["Input"];
+
+    await expect(ensureChatMode(runtime, input, 0, logger)).resolves.toBe("unavailable");
+    expect(input.dispatchMouseEvent).not.toHaveBeenCalled();
+  });
+
+  test("fails closed for an existing Work conversation", async () => {
+    const runtime = {
+      evaluate: vi.fn().mockResolvedValue({ result: { value: { status: "work-conversation" } } }),
+    } as unknown as ChromeClient["Runtime"];
+    const input = {
+      dispatchMouseEvent: vi.fn(),
+    } as unknown as ChromeClient["Input"];
+
+    await expect(ensureChatMode(runtime, input, 0, logger)).rejects.toThrow(
+      /existing Work conversation/i,
+    );
+    expect(input.dispatchMouseEvent).not.toHaveBeenCalled();
+  });
+
+  test("recognizes a hydrated ordinary Chat conversation", async () => {
+    const runtime = {
+      evaluate: vi.fn().mockResolvedValue({ result: { value: { status: "chat-conversation" } } }),
+    } as unknown as ChromeClient["Runtime"];
+    const input = {
+      dispatchMouseEvent: vi.fn(),
+    } as unknown as ChromeClient["Input"];
+
+    await expect(ensureChatMode(runtime, input, 0, logger)).resolves.toBe("chat");
+    expect(input.dispatchMouseEvent).not.toHaveBeenCalled();
+  });
+
+  test("waits for conversation metadata to hydrate before classifying Work", async () => {
+    const runtime = {
+      evaluate: vi
+        .fn()
+        .mockResolvedValueOnce({ result: { value: { status: "conversation-unresolved" } } })
+        .mockResolvedValueOnce({ result: { value: { status: "work-conversation" } } })
+        .mockResolvedValueOnce({ result: { value: { status: "chat-selected" } } }),
+    } as unknown as ChromeClient["Runtime"];
+    const input = {
+      dispatchMouseEvent: vi.fn(),
+    } as unknown as ChromeClient["Input"];
+    const resetWorkConversation = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      ensureChatMode(runtime, input, 1_000, logger, {
+        pollMs: 0,
+        resetWorkConversation,
+      }),
+    ).resolves.toBe("switched");
+
+    expect(resetWorkConversation).toHaveBeenCalledOnce();
+    expect(runtime.evaluate).toHaveBeenCalledTimes(3);
+  });
+
+  test("opens a new Chat when a non-resume run attaches to a Work conversation", async () => {
+    const runtime = {
+      evaluate: vi
+        .fn()
+        .mockResolvedValueOnce({ result: { value: { status: "work-conversation" } } })
+        .mockResolvedValueOnce({ result: { value: { status: "chat-selected" } } }),
+    } as unknown as ChromeClient["Runtime"];
+    const input = {
+      dispatchMouseEvent: vi.fn(),
+    } as unknown as ChromeClient["Input"];
+    const resetWorkConversation = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      ensureChatMode(runtime, input, 1_000, logger, {
+        pollMs: 0,
+        resetWorkConversation,
+      }),
+    ).resolves.toBe("switched");
+
+    expect(resetWorkConversation).toHaveBeenCalledOnce();
+    expect(logger).toHaveBeenCalledWith("ChatGPT mode: Work conversation; opening a new Chat");
+    expect(logger).toHaveBeenCalledWith("ChatGPT mode: Chat (switched from Work)");
+    expect(input.dispatchMouseEvent).not.toHaveBeenCalled();
+  });
+
+  test("classifies a Work conversation nested under a project URL by conversation id", () => {
+    const expression = buildChatModeProbeExpressionForTest();
+    const activeHistoryLink = {
+      getAttribute: (name: string) => {
+        if (name === "href") return "/c/project-work-thread";
+        if (name === "aria-label") return "Project task, Work";
+        return null;
+      },
+      querySelectorAll: () => [],
+    };
+    const document = {
+      querySelectorAll: (selector: string) =>
+        selector === 'a[href*="/c/"]' ? [activeHistoryLink] : [],
+    };
+    const evaluate = new Function("document", "location", "URL", `return ${expression};`) as (
+      document: unknown,
+      location: unknown,
+      url: typeof URL,
+    ) => { status: string };
+
+    expect(
+      evaluate(
+        document,
+        {
+          origin: "https://chatgpt.com",
+          pathname: "/g/example/project/c/project-work-thread",
+        },
+        URL,
+      ),
+    ).toEqual({ status: "work-conversation" });
+  });
+
+  test("scopes detection to exact mode radios and the active conversation metadata", () => {
+    const expression = buildChatModeProbeExpressionForTest();
+    expect(expression).toContain('button[role="radio"]');
+    expect(expression).toContain("normalize(node.textContent) === 'chat'");
+    expect(expression).toContain("normalize(node.textContent) === 'work'");
+    expect(expression).toContain('a[href*="/c/"]');
+    expect(expression).toContain("conversationIdFromPath(candidatePath) === conversationId");
+    expect(expression).not.toContain("document.body.innerText");
   });
 });
 

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -229,19 +229,30 @@ describe("ensureChatMode", () => {
 
   const runConversationModeProbe = (
     pathname: string,
-    links: Array<{ href: string; ariaLabel?: string; descendants?: FakeChatModeElement[] }>,
+    links: Array<{
+      href: string;
+      ariaLabel?: string;
+      descendants?: FakeChatModeElement[];
+      trustedHistory?: boolean;
+    }>,
   ) => {
     const expression = buildChatModeProbeExpressionForTest();
-    const historyLinks = links.map(({ href, ariaLabel = "", descendants = [] }) => ({
-      getAttribute: (name: string) => {
-        if (name === "href") return href;
-        if (name === "aria-label") return ariaLabel;
-        return null;
-      },
-      querySelectorAll: (selector: string) => (selector === "span" ? descendants : []),
-    }));
+    const historyLinks = links.map(
+      ({ href, ariaLabel = "", descendants = [], trustedHistory = true }) => ({
+        trustedHistory,
+        getAttribute: (name: string) => {
+          if (name === "href") return href;
+          if (name === "aria-label") return ariaLabel;
+          return null;
+        },
+        querySelectorAll: (selector: string) => (selector === "span" ? descendants : []),
+      }),
+    );
     const document = {
-      querySelectorAll: (selector: string) => (selector === 'a[href*="/c/"]' ? historyLinks : []),
+      querySelectorAll: (selector: string) =>
+        selector === 'a.__menu-item[href*="/c/"]'
+          ? historyLinks.filter((link) => link.trustedHistory)
+          : [],
     };
     const evaluate = new Function(
       "document",
@@ -458,19 +469,35 @@ describe("ensureChatMode", () => {
     ).toEqual({ status: "conversation-unresolved" });
   });
 
-  test("fails open after persistent aria-only ambiguity without resetting the conversation", async () => {
+  test("opens a new Chat after persistent ambiguity on a non-resume attachment", async () => {
+    const runtime = {
+      evaluate: vi
+        .fn()
+        .mockResolvedValueOnce({ result: { value: { status: "conversation-unresolved" } } })
+        .mockResolvedValueOnce({ result: { value: { status: "chat-selected" } } }),
+    } as unknown as ChromeClient["Runtime"];
+    const input = { dispatchMouseEvent: vi.fn() } as unknown as ChromeClient["Input"];
+    const resetWorkConversation = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      ensureChatMode(runtime, input, 0, logger, { pollMs: 0, resetWorkConversation }),
+    ).resolves.toBe("switched");
+    expect(resetWorkConversation).toHaveBeenCalledOnce();
+    expect(logger).toHaveBeenCalledWith("ChatGPT conversation mode unresolved; opening a new Chat");
+  });
+
+  test("fails closed after persistent ambiguity on an explicit resume", async () => {
     const runtime = {
       evaluate: vi
         .fn()
         .mockResolvedValue({ result: { value: { status: "conversation-unresolved" } } }),
     } as unknown as ChromeClient["Runtime"];
     const input = { dispatchMouseEvent: vi.fn() } as unknown as ChromeClient["Input"];
-    const resetWorkConversation = vi.fn();
 
-    await expect(
-      ensureChatMode(runtime, input, 0, logger, { pollMs: 0, resetWorkConversation }),
-    ).resolves.toBe("unavailable");
-    expect(resetWorkConversation).not.toHaveBeenCalled();
+    await expect(ensureChatMode(runtime, input, 0, logger, { pollMs: 0 })).rejects.toThrow(
+      /cannot safely resume/i,
+    );
+    expect(input.dispatchMouseEvent).not.toHaveBeenCalled();
   });
 
   test("aggregates responsive duplicates for the exact conversation id", () => {
@@ -497,6 +524,19 @@ describe("ensureChatMode", () => {
         { href: "/c/same-thread", ariaLabel: "Local chat" },
       ]),
     ).toEqual({ status: "chat-conversation" });
+  });
+
+  test("ignores an exact-id link rendered outside trusted sidebar history", () => {
+    expect(
+      runConversationModeProbe("/c/same-thread", [
+        {
+          href: "/c/same-thread",
+          ariaLabel: "User-authored link",
+          descendants: [structuredWorkBadge()],
+          trustedHistory: false,
+        },
+      ]),
+    ).toEqual({ status: "conversation-unresolved" });
   });
 
   test("fails closed when post-reset Chat verification remains unavailable", async () => {
@@ -550,7 +590,7 @@ describe("ensureChatMode", () => {
     expect(expression).toContain('button[role="radio"]');
     expect(expression).toContain("normalize(node.textContent) === 'chat'");
     expect(expression).toContain("normalize(node.textContent) === 'work'");
-    expect(expression).toContain('a[href*="/c/"]');
+    expect(expression).toContain('a.__menu-item[href*="/c/"]');
     expect(expression).toContain("candidateUrl.origin === location.origin");
     expect(expression).toContain(
       "conversationIdFromPath(candidateUrl.pathname) === conversationId",


### PR DESCRIPTION
Closes #315.

## Motivation

ChatGPT exposes separate `Chat` and `Work` modes. Both render a usable composer, so prompt readiness alone cannot prevent an ordinary Oracle browser run from selecting models or submitting in Work.

## Design

- Probe the exact visible Chat/Work radio controls before model or effort selection.
- Switch Work to Chat with trusted CDP mouse input and positively verify Chat.
- Classify attached root and project conversations by exact conversation ID using only ChatGPT's renderer-owned sidebar history anchors.
- Treat only the structured Work badge as authoritative; titles, ARIA labels, and user-authored links cannot prove Work.
- Reset confirmed or unclassifiable non-resume attachments to a new Chat while preserving the configured project/workspace URL.
- Reject confirmed or unclassifiable explicit resumes before submission.
- Allocate a fresh verification window after every switch/reset and require positive Chat evidence.
- Preserve compatibility on selector-free new-chat layouts where Oracle has not observed an existing conversation.
- Apply the shared normalization to local and remote Chrome paths.

## Validation

Current head: `77c0b197cb369683b837d28fcb3ce648537193bf`.

- `pnpm vitest run tests/browser/pageActions.test.ts tests/browser/index.test.ts` — 149 passed, 1 skipped.
- `pnpm check` — passed.
- `pnpm test` — 1,556 passed, 43 skipped.
- `pnpm build` — passed.
- `pnpm docs:check` — passed (85 flags, 6 files).
- AutoReview local maintainer diff — clean, no actionable findings (0.90 confidence).
- AutoReview full branch against `origin/main` — clean, no actionable findings (0.86 confidence).

## Exact-head signed-in browser proof

Validated with Oracle's existing persistent signed-in browser profile. No run clicked or auto-clicked ChatGPT's `Answer now` control. Browser ports, target IDs, profile paths, and conversation URLs are omitted.

- Work selected on the home page: live radios showed Work selected; Oracle logged `ChatGPT mode: Work; switching to Chat`, then `ChatGPT mode: Chat (switched from Work)`; returned `PR316_FINAL_WORK_TO_CHAT_OK` in 12.4s.
- Structured Work conversation attachment: the active trusted history anchor carried the renderer-owned Work badge; Oracle logged `Work conversation; opening a new Chat`, navigated to the Chat home, positively verified Chat, and returned `PR316_FINAL_WORK_ATTACHMENT_OK` in 12.4s.
- Title collision: a Chat created from `Plan, Work, and travel` exposed a title/ARIA label containing Work but no structured Work badge; Oracle logged `ChatGPT mode: Chat`, kept the same conversation URL, and returned `PR316_FINAL_TITLE_COLLISION_OK` in 10.6s.

Thanks @DragonFSKY for the implementation and exact-head hardening.
