### PR TITLE
Discover live model inventory + data-driven picker matching (robust to new models)

### DIFF
--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -2113,6 +2113,7 @@ async function runRootCommand(options: CliOptions): Promise<void> {
       ...options,
       remoteHost: remoteHost ?? undefined,
       model: activeModel,
+      modelRequest: cliModelArg,
       browserModelLabel: resolveBrowserModelLabel(cliModelArg, activeModel),
     });
     return resolvedOptions.browserResumeConversationUrl

--- a/docs/model-discovery-proposal.md
+++ b/docs/model-discovery-proposal.md
@@ -69,10 +69,16 @@ miss, the existing `buildModelSelectionExpression` loop.
 
 Driven against a signed-in ChatGPT via the CLI running from source:
 
-- `-m "GPT-5.6 Sol"` → `Model picker (inventory): GPT-5.6 Sol` — the exact input that collapses to
-  `gpt-5.2` and fails on published 0.15.2 now resolves correctly (already-selected short-circuit).
-- `-m gpt-5.5-pro` → `Model picker (inventory): Pro GPT-5.5` — a real version switch (5.6 Sol → 5.5),
-  applied via the version submenu and verified.
+| `-m` input | result |
+|------------|--------|
+| `"GPT-5.6 Sol"` | `Model picker (inventory): GPT-5.6 Sol` — the input that collapses to `gpt-5.2` and fails on 0.15.2 |
+| `gpt-5.5-pro` | `Model picker (inventory): Pro GPT-5.5` — real version switch (5.6 Sol → 5.5) |
+| `gpt-5.4` | `Model picker (inventory): GPT-5.4` — switch; the "Leaving on July 23" note is stripped |
+| `o3` | `Model picker (inventory): o3` — a model the CLI can't name, selected purely from the live menu |
+| `gpt-9.9` (invalid) | `Model inventory: "gpt-9.9" → not-found (available: GPT-5.6 Sol, GPT-5.5, GPT-5.4, GPT-5.3, o3); using legacy picker.` |
+
+The raw `-m` value is threaded as `modelRequest` (not the CLI-inferred id), so `o3` and any
+future/unknown model resolve from the live menu instead of being pre-collapsed to `gpt-5.2`.
 
 Two DOM quirks were found and handled during live testing (both in the tests):
 - The composer pill merges version+effort for non-default versions (`5.5Pro`), so verification reads
@@ -87,8 +93,8 @@ Two DOM quirks were found and handled during live testing (both in the tests):
    opt-in flag, cached, off by default (browser users often have no API key).
 2. Once discovery is proven in the field, retire the hard-coded version ladder / testid tokens in
    `buildModelSelectionExpression` and keep it only as a deep fallback.
-3. Thread the *pre-inference* `-m` literal (today `modelRequest` is the CLI-resolved id) so a brand-new
-   version the CLI doesn't recognize still matches purely from the live menu.
+3. Consider making `not-found` a hard error (with the real candidate list) instead of a legacy
+   fallback, once discovery is trusted — clearer than the legacy engine's downstream failure.
 
 ## Notes / edge cases handled
 

--- a/docs/model-discovery-proposal.md
+++ b/docs/model-discovery-proposal.md
@@ -46,27 +46,49 @@ Because version parsing is generic, a brand-new model (gpt-5.7, gpt-6, o4) resol
 ChatGPT lists it — **zero code change**. Unavailable requests fail loud with the real candidate
 list instead of clicking a phantom.
 
-## What's in this PR (prototype, additive, zero-regression)
+## What's in this PR
+
+Discovery + data-driven match are now **wired into the live selection path** as the
+preferred route for `strategy: "select"`, with a safety net: any discovery/match/apply/verify
+failure returns null and falls through to the untouched legacy engine. Worst case is one extra
+discovery round-trip, then exactly today's behavior — so this can only improve outcomes.
 
 | File | Purpose |
 |------|---------|
 | `src/oracle/modelInventory.ts` | Types + pure `buildInventoryFromRawItems` (classify/clean/current) |
 | `src/oracle/modelMatch.ts` | Pure `matchModelToInventory` + `parseRequest` (generic version, effort synonyms) |
-| `src/browser/actions/modelInventoryScrape.ts` | `enumerateModelInventory(Runtime)` — grounded DOM scraper |
-| `tests/oracle/modelInventory.test.ts` | 6 cases incl. the real 5.6 DOM |
-| `tests/oracle/modelMatch.test.ts` | 11 cases incl. the 0.15.2 failures + a future-model case |
+| `src/browser/actions/modelInventoryScrape.ts` | `enumerateModelInventory` / `applyInventorySelection` / `readCurrentSelection` (grounded DOM ops) |
+| `src/browser/actions/modelSelection.ts` | `selectViaInventory` orchestrator, tried before the legacy engine |
+| `src/browser/types.ts`, `src/cli/browserConfig.ts`, `src/sessionManager.ts` | thread the raw `-m` request as `modelRequest` |
+| `tests/oracle/*`, `tests/browser/*` | 26 unit tests incl. the 0.15.2 failures, a future-model case, and a `new Function()` parse-check of every browser expression |
 
-`npx vitest run tests/oracle/modelInventory.test.ts tests/oracle/modelMatch.test.ts` → **17 passed**.
-Nothing is wired into the live path yet, so there is no behavior change.
+Flow: `ensureModelSelection` → `selectViaInventory` (discover → match → apply → verify) → on any
+miss, the existing `buildModelSelectionExpression` loop.
 
-## Follow-ups (separate commits)
+## Live verification (GPT-5.6 "Sol", 2026-07-12)
 
-1. Wire discovery+match into `ensureModelSelection` for `strategy: "select"`, with **fallback to the
-   existing `buildModelSelectionExpression`** when discovery fails (keeps all current cases safe).
-2. Optional LLM fallback for ambiguous/not-found: send the enumerated options (as an **enum
+Driven against a signed-in ChatGPT via the CLI running from source:
+
+- `-m "GPT-5.6 Sol"` → `Model picker (inventory): GPT-5.6 Sol` — the exact input that collapses to
+  `gpt-5.2` and fails on published 0.15.2 now resolves correctly (already-selected short-circuit).
+- `-m gpt-5.5-pro` → `Model picker (inventory): Pro GPT-5.5` — a real version switch (5.6 Sol → 5.5),
+  applied via the version submenu and verified.
+
+Two DOM quirks were found and handled during live testing (both in the tests):
+- The composer pill merges version+effort for non-default versions (`5.5Pro`), so verification reads
+  the top-menu **version-trigger label** + **checked effort radio**, not the pill.
+- After a switch, a **spurious empty** `aria-haspopup="menu"` item can precede the real version
+  trigger — trigger detection now requires version-like text.
+
+## Follow-ups (separate commits/PRs)
+
+1. Optional LLM fallback for `ambiguous` / `not-found`: send the enumerated options (as an **enum
    constraint** so it can't hallucinate) to a cheap model; gated behind API-key availability or an
    opt-in flag, cached, off by default (browser users often have no API key).
-3. Retire the hard-coded version ladder / testid tokens once discovery is the default path.
+2. Once discovery is proven in the field, retire the hard-coded version ladder / testid tokens in
+   `buildModelSelectionExpression` and keep it only as a deep fallback.
+3. Thread the *pre-inference* `-m` literal (today `modelRequest` is the CLI-resolved id) so a brand-new
+   version the CLI doesn't recognize still matches purely from the live menu.
 
 ## Notes / edge cases handled
 

--- a/docs/model-discovery-proposal.md
+++ b/docs/model-discovery-proposal.md
@@ -1,0 +1,76 @@
+# Robust model selection via live inventory discovery
+
+## Problem
+
+Browser-mode model selection is hard-coded in three layers:
+
+1. `cli/options.ts` `inferModelFromLabel` — text → known model id
+2. `cli/browserConfig.ts` `BROWSER_MODEL_LABELS` — model id → UI label
+3. `browser/actions/modelSelection.ts` `scoreOption` — a per-version ladder
+   (`desiredVersion`, `versionFromLabel`, `if (desiredVersion === '5-6' …)`, per-version
+   `includes` guards, testid tokens `model-switcher-gpt-5-5` …)
+
+Every new ChatGPT model requires editing all three. GPT-5.6 "Sol" landed in `main` as
+~10 hand-added `'5-6'` tokens across `modelSelection.ts`. On the *published* 0.15.2 (no 5.6
+tokens), `-m "GPT-5.6 Sol"` silently collapses to `gpt-5.2` and fails:
+
+```
+[retry] Unable to find model option matching "GPT-5.2" in the model switcher.
+Available: Instant5.5, Medium, High, Extra High, Pro, GPT-5.6 Sol.
+```
+
+## Evidence (captured live, 2026-07-12)
+
+The GPT-5.6-era picker **dropped every `data-testid`** and is now a clean
+version × effort matrix keyed on `role` + text + `aria-checked`. Full capture and selectors
+in `DOM-FINDINGS.md`; raw dump in `model-menu-dom.json`. Structure:
+
+- trigger `button.__composer-pill[aria-haspopup="menu"]` (text = current effort)
+- top menu `[role="menuitemradio"]` efforts + one `[role="menuitem"][aria-haspopup="menu"]`
+  version trigger
+- version submenu `[role="menuitemradio"]` version options
+- current selection = `aria-checked="true"`
+
+## Approach: Discover → Match → Apply → Verify
+
+Invert the flow: read what the picker *actually offers*, then match against it — instead of
+precomputing a rigid target from a hard-coded ladder.
+
+- **Discover** — `enumerateModelInventory()` scrapes the live menu (incl. version submenu)
+  into a structured `ModelInventory` (`versions`, `efforts`, current markers).
+- **Match** — `matchModelToInventory(request, inventory)` parses the request generically
+  (any version number, effort synonyms) and resolves it against the live options.
+- **Apply/Verify** — click the chosen option(s), verify via the resulting label.
+
+Because version parsing is generic, a brand-new model (gpt-5.7, gpt-6, o4) resolves the moment
+ChatGPT lists it — **zero code change**. Unavailable requests fail loud with the real candidate
+list instead of clicking a phantom.
+
+## What's in this PR (prototype, additive, zero-regression)
+
+| File | Purpose |
+|------|---------|
+| `src/oracle/modelInventory.ts` | Types + pure `buildInventoryFromRawItems` (classify/clean/current) |
+| `src/oracle/modelMatch.ts` | Pure `matchModelToInventory` + `parseRequest` (generic version, effort synonyms) |
+| `src/browser/actions/modelInventoryScrape.ts` | `enumerateModelInventory(Runtime)` — grounded DOM scraper |
+| `tests/oracle/modelInventory.test.ts` | 6 cases incl. the real 5.6 DOM |
+| `tests/oracle/modelMatch.test.ts` | 11 cases incl. the 0.15.2 failures + a future-model case |
+
+`npx vitest run tests/oracle/modelInventory.test.ts tests/oracle/modelMatch.test.ts` → **17 passed**.
+Nothing is wired into the live path yet, so there is no behavior change.
+
+## Follow-ups (separate commits)
+
+1. Wire discovery+match into `ensureModelSelection` for `strategy: "select"`, with **fallback to the
+   existing `buildModelSelectionExpression`** when discovery fails (keeps all current cases safe).
+2. Optional LLM fallback for ambiguous/not-found: send the enumerated options (as an **enum
+   constraint** so it can't hallucinate) to a cheap model; gated behind API-key availability or an
+   opt-in flag, cached, off by default (browser users often have no API key).
+3. Retire the hard-coded version ladder / testid tokens once discovery is the default path.
+
+## Notes / edge cases handled
+
+- Text noise: `"Instant5.5"` → `Instant`, `"GPT-5.4Leaving on July 23"` → `GPT-5.4`.
+- `o3` classified as a version, never mangled to effort `o`.
+- Version-agnostic `-m Pro` keeps the current version, switches only the effort (today's behavior).
+- Bare `thinking` (no level) → flagged `ambiguous` (a natural LLM-fallback trigger).

--- a/src/browser/actions/modelInventoryScrape.ts
+++ b/src/browser/actions/modelInventoryScrape.ts
@@ -1,0 +1,143 @@
+// Discovery: read the ChatGPT model picker's *actual* options from the live DOM
+// and turn them into a ModelInventory. This is the browser-side counterpart to the
+// pure classifier in ../../oracle/modelInventory.ts.
+//
+// Grounded in a real GPT-5.6 "Sol" era capture (see DOM-FINDINGS.md):
+//   - trigger:  button.__composer-pill[aria-haspopup="menu"] (text = current effort)
+//   - top menu: [role="menuitemradio"] efforts + one [role="menuitem"][aria-haspopup="menu"]
+//               version trigger (text = current version)
+//   - submenu:  [role="menuitemradio"] version options
+//   - current:  aria-checked="true" / data-state="checked"
+//   - NOTE: this UI dropped every data-testid, so selection is role + text + aria only.
+//
+// The expression is evaluated inside the ChatGPT tab; keep it self-contained.
+
+import {
+  buildInventoryFromRawItems,
+  type ModelInventory,
+  type RawMenuItem,
+} from "../../oracle/modelInventory.js";
+
+export const INVENTORY_TRIGGER_SELECTOR =
+  '[data-testid="model-switcher-dropdown-button"], button.__composer-pill[aria-haspopup="menu"]';
+export const INVENTORY_MENU_SELECTOR = '[role="menu"], [data-radix-collection-root]';
+export const INVENTORY_ITEM_SELECTOR =
+  '[role="menuitemradio"], [role="menuitem"], [role="option"], [role="radio"]';
+
+/** Minimal shape of the CDP Runtime domain we depend on (keeps us decoupled from CRI types). */
+export interface RuntimeLike {
+  evaluate(params: {
+    expression: string;
+    awaitPromise?: boolean;
+    returnByValue?: boolean;
+  }): Promise<{ result?: { value?: unknown }; exceptionDetails?: unknown }>;
+}
+
+/**
+ * Build the browser expression that opens the picker (including the version
+ * submenu) and returns RawMenuItem[]. Read-only: it opens submenus to read them
+ * but never commits a selection, and closes the menu before returning.
+ */
+export function buildInventoryScrapeExpression(): string {
+  return `(async () => {
+    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+    const TRIGGER = ${JSON.stringify(INVENTORY_TRIGGER_SELECTOR)};
+    const MENU = ${JSON.stringify(INVENTORY_MENU_SELECTOR)};
+    const ITEM = ${JSON.stringify(INVENTORY_ITEM_SELECTOR)};
+
+    const fire = (el, type, pointer) => {
+      try {
+        const common = { bubbles: true, cancelable: true, view: window };
+        const ev = pointer && 'PointerEvent' in window
+          ? new PointerEvent(type, { ...common, pointerId: 1, pointerType: 'mouse' })
+          : new MouseEvent(type, common);
+        el.dispatchEvent(ev);
+      } catch (e) {}
+    };
+    const openClick = (el) => {
+      try { el.scrollIntoView({ block: 'center' }); } catch (e) {}
+      try { el.focus(); } catch (e) {}
+      ['pointerover', 'pointerenter', 'pointerdown', 'mousedown', 'pointerup', 'mouseup', 'click']
+        .forEach((t) => fire(el, t, t.startsWith('pointer')));
+    };
+    const hover = (el) => {
+      ['pointerover', 'pointerenter', 'mouseover', 'mouseenter', 'pointermove', 'mousemove']
+        .forEach((t) => fire(el, t, t.startsWith('pointer')));
+      try { el.focus(); } catch (e) {}
+    };
+    const menus = () => Array.from(document.querySelectorAll(MENU));
+    const collect = (scope) => menus().flatMap((m) =>
+      Array.from(m.querySelectorAll(ITEM)).map((n) => ({
+        text: (n.textContent || '').replace(/\\s+/g, ' ').trim(),
+        role: n.getAttribute('role'),
+        ariaChecked: n.getAttribute('aria-checked'),
+        ariaHaspopup: n.getAttribute('aria-haspopup'),
+        dataState: n.getAttribute('data-state'),
+        scope,
+      })).filter((x) => x.text),
+    );
+
+    const trigger = document.querySelector(TRIGGER);
+    if (!trigger) return { error: 'trigger-not-found', items: [] };
+
+    // Open the top menu and wait for the portal to mount.
+    openClick(trigger);
+    for (let i = 0; i < 25 && menus().length === 0; i++) {
+      if (i === 10) openClick(trigger);
+      await sleep(200);
+    }
+    if (menus().length === 0) return { error: 'menu-did-not-open', items: [] };
+
+    const top = collect('top');
+
+    // Open the version submenu: the item that opens a nested menu.
+    const menuNodes = menus().flatMap((m) => Array.from(m.querySelectorAll(ITEM)));
+    const versionTrigger = menuNodes.find(
+      (n) => n.getAttribute('aria-haspopup') === 'menu' ||
+        (n.getAttribute('data-has-submenu') !== null && /gpt|sol|o\\d/i.test(n.textContent || '')),
+    );
+    let submenu = [];
+    if (versionTrigger) {
+      const before = menus().length;
+      hover(versionTrigger);
+      openClick(versionTrigger);
+      for (let i = 0; i < 20 && menus().length <= before; i++) await sleep(100);
+      submenu = collect('submenu');
+    }
+
+    // Close the menu (best-effort) so discovery leaves no UI open.
+    try {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', keyCode: 27, which: 27, bubbles: true }));
+    } catch (e) {}
+
+    // De-dupe: top-menu items also appear once the submenu is open. Prefer scope tags.
+    const seen = new Set();
+    const items = [...top, ...submenu].filter((it) => {
+      const k = it.scope + '|' + it.text;
+      if (seen.has(k)) return false;
+      seen.add(k);
+      return true;
+    });
+    return { items };
+  })()`;
+}
+
+/**
+ * Read the live model inventory from an open ChatGPT tab.
+ * Returns a parsed ModelInventory; throws only on evaluation failure.
+ */
+export async function enumerateModelInventory(Runtime: RuntimeLike): Promise<ModelInventory> {
+  const out = await Runtime.evaluate({
+    expression: buildInventoryScrapeExpression(),
+    awaitPromise: true,
+    returnByValue: true,
+  });
+  const value = (out.result?.value ?? {}) as { items?: RawMenuItem[]; error?: string };
+  const items = Array.isArray(value.items) ? value.items : [];
+  return buildInventoryFromRawItems(items);
+}
+
+/** Exposed for a future live/integration test (kept out of unit coverage). */
+export function buildInventoryScrapeExpressionForTest(): string {
+  return buildInventoryScrapeExpression();
+}

--- a/src/browser/actions/modelInventoryScrape.ts
+++ b/src/browser/actions/modelInventoryScrape.ts
@@ -77,7 +77,12 @@ export function buildInventoryScrapeExpression(): string {
       })).filter((x) => x.text),
     );
 
-    const trigger = document.querySelector(TRIGGER);
+    // Wait for the composer pill to mount (cold pages take ~1-4s).
+    let trigger = document.querySelector(TRIGGER);
+    for (let i = 0; i < 40 && !trigger; i++) {
+      await sleep(200);
+      trigger = document.querySelector(TRIGGER);
+    }
     if (!trigger) return { error: 'trigger-not-found', items: [] };
 
     // Open the top menu and wait for the portal to mount.
@@ -88,13 +93,16 @@ export function buildInventoryScrapeExpression(): string {
     }
     if (menus().length === 0) return { error: 'menu-did-not-open', items: [] };
 
+
     const top = collect('top');
 
-    // Open the version submenu: the item that opens a nested menu.
+    // Open the version submenu: the item that opens a nested menu AND names a version
+    // (a spurious empty aria-haspopup item can precede the real version trigger).
     const menuNodes = menus().flatMap((m) => Array.from(m.querySelectorAll(ITEM)));
+    const isVer = (t) => /gpt[-\\s]?\\d|(^|[^a-z])o\\d|\\bsol\\b/i.test(t || '');
     const versionTrigger = menuNodes.find(
-      (n) => n.getAttribute('aria-haspopup') === 'menu' ||
-        (n.getAttribute('data-has-submenu') !== null && /gpt|sol|o\\d/i.test(n.textContent || '')),
+      (n) => (n.getAttribute('aria-haspopup') === 'menu' || n.getAttribute('data-has-submenu') !== null) &&
+        isVer(n.textContent),
     );
     let submenu = [];
     if (versionTrigger) {
@@ -141,3 +149,216 @@ export async function enumerateModelInventory(Runtime: RuntimeLike): Promise<Mod
 export function buildInventoryScrapeExpressionForTest(): string {
   return buildInventoryScrapeExpression();
 }
+
+// ── Apply ────────────────────────────────────────────────────────────────────
+// Click a specific version and/or effort by their exact live DOM text (as read
+// during discovery). Version is a submenu selection; effort is top-level. Either
+// may be null (leave that axis on its current value).
+
+export interface ApplyResult {
+  ok: boolean;
+  error?: string;
+  currentVersion?: string | null;
+  currentEffort?: string | null;
+  actions?: string[];
+}
+
+/**
+ * Browser expression that applies a version/effort selection by exact text.
+ * `targetVersion` / `targetEffort` are the raw DOM texts from the inventory
+ * (e.g. "GPT-5.6 Sol", "Pro"), or null to leave that axis unchanged.
+ */
+export function buildApplySelectionExpression(
+  targetVersion: string | null,
+  targetEffort: string | null,
+): string {
+  return `(async () => {
+    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+    const norm = (s) => (s || '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').replace(/\\s+/g, ' ').trim();
+    const TARGET_VERSION = ${JSON.stringify(targetVersion)};
+    const TARGET_EFFORT = ${JSON.stringify(targetEffort)};
+    const TRIGGER = ${JSON.stringify(INVENTORY_TRIGGER_SELECTOR)};
+    const MENU = ${JSON.stringify(INVENTORY_MENU_SELECTOR)};
+    const ITEM = ${JSON.stringify(INVENTORY_ITEM_SELECTOR)};
+
+    const fire = (el, type, pointer) => {
+      try {
+        const common = { bubbles: true, cancelable: true, view: window };
+        const ev = pointer && 'PointerEvent' in window
+          ? new PointerEvent(type, { ...common, pointerId: 1, pointerType: 'mouse' })
+          : new MouseEvent(type, common);
+        el.dispatchEvent(ev);
+      } catch (e) {}
+    };
+    const openClick = (el) => {
+      try { el.scrollIntoView({ block: 'center' }); } catch (e) {}
+      try { el.focus(); } catch (e) {}
+      ['pointerover', 'pointerenter', 'pointerdown', 'mousedown', 'pointerup', 'mouseup', 'click']
+        .forEach((t) => fire(el, t, t.startsWith('pointer')));
+    };
+    const hover = (el) => {
+      ['pointerover', 'pointerenter', 'mouseover', 'mouseenter', 'pointermove', 'mousemove']
+        .forEach((t) => fire(el, t, t.startsWith('pointer')));
+      try { el.focus(); } catch (e) {}
+    };
+    const menus = () => Array.from(document.querySelectorAll(MENU));
+    const items = () => menus().flatMap((m) => Array.from(m.querySelectorAll(ITEM)));
+    const trigger = () => document.querySelector(TRIGGER);
+    const isChecked = (n) => n.getAttribute('aria-checked') === 'true' || (n.getAttribute('data-state') || '') === 'checked';
+    const isVersionText = (t) => /gpt[-\\s]?\\d|(^|[^a-z])o\\d|\\bsol\\b/i.test(t || '');
+    const openMenu = async () => {
+      let t = trigger();
+      for (let i = 0; i < 40 && !t; i++) {
+        await sleep(200);
+        t = trigger();
+      }
+      if (!t) return false;
+      if (menus().length === 0) {
+        openClick(t);
+        for (let i = 0; i < 20 && menus().length === 0; i++) {
+          if (i === 10) openClick(t);
+          await sleep(150);
+        }
+      }
+      return menus().length > 0;
+    };
+    const actions = [];
+
+    if (!(await openMenu())) return { ok: false, error: 'menu-open-failed', actions };
+
+    // Effort (top-level menuitemradio)
+    if (TARGET_EFFORT) {
+      const want = norm(TARGET_EFFORT);
+      const it = items().find(
+        (n) => n.getAttribute('role') === 'menuitemradio' && !isVersionText(n.textContent) &&
+          (norm(n.textContent) === want || norm(n.textContent).startsWith(want)),
+      );
+      if (!it) return { ok: false, error: 'effort-not-found', actions };
+      if (isChecked(it)) actions.push('effort-already:' + want);
+      else { openClick(it); actions.push('effort:' + want); await sleep(700); }
+    }
+
+    // Version (open submenu, click radio)
+    if (TARGET_VERSION) {
+      const want = norm(TARGET_VERSION);
+      await openMenu();
+      const verTrigger = items().find((n) => n.getAttribute('aria-haspopup') === 'menu' && isVersionText(n.textContent));
+      if (verTrigger && norm(verTrigger.textContent).startsWith(want)) {
+        actions.push('version-already:' + want);
+      } else if (verTrigger) {
+        const before = menus().length;
+        hover(verTrigger);
+        openClick(verTrigger);
+        for (let i = 0; i < 20 && menus().length <= before; i++) await sleep(100);
+        const opt = items().find(
+          (n) => n.getAttribute('role') === 'menuitemradio' &&
+            (norm(n.textContent) === want || norm(n.textContent).startsWith(want)),
+        );
+        if (!opt) return { ok: false, error: 'version-not-found', actions };
+        if (isChecked(opt)) actions.push('version-already:' + want);
+        else { openClick(opt); actions.push('version:' + want); await sleep(700); }
+      } else {
+        return { ok: false, error: 'version-trigger-not-found', actions };
+      }
+    }
+
+    // Snapshot resulting selection (trigger pill = effort, version trigger = version).
+    await openMenu();
+    const verTrigger = items().find((n) => n.getAttribute('aria-haspopup') === 'menu' && isVersionText(n.textContent));
+    const currentVersion = (verTrigger?.textContent || '').replace(/\\s+/g, ' ').trim();
+    const currentEffort = (trigger()?.textContent || '').replace(/\\s+/g, ' ').trim();
+    try {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', keyCode: 27, which: 27, bubbles: true }));
+    } catch (e) {}
+
+    return { ok: true, currentVersion, currentEffort, actions };
+  })()`;
+}
+
+/** Apply a version/effort selection by exact text; returns the resulting state. */
+export async function applyInventorySelection(
+  Runtime: RuntimeLike,
+  targetVersion: string | null,
+  targetEffort: string | null,
+): Promise<ApplyResult> {
+  const out = await Runtime.evaluate({
+    expression: buildApplySelectionExpression(targetVersion, targetEffort),
+    awaitPromise: true,
+    returnByValue: true,
+  });
+  const value = out.result?.value as ApplyResult | undefined;
+  return value ?? { ok: false, error: "no-result" };
+}
+
+// ── Read current selection ───────────────────────────────────────────────────
+// Robustly read the active version/effort from the TOP menu only (no submenu):
+// the version-trigger item's label always reflects the current version, and the
+// checked effort radio (or composer pill) reflects the current effort. Used to
+// verify a selection without the flaky submenu re-open.
+
+export interface CurrentSelection {
+  ok: boolean;
+  version?: string | null;
+  effort?: string | null;
+}
+
+export function buildReadCurrentSelectionExpression(): string {
+  return `(async () => {
+    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+    const clean = (s) => (s || '').replace(/\\s+/g, ' ').trim();
+    const TRIGGER = ${JSON.stringify(INVENTORY_TRIGGER_SELECTOR)};
+    const MENU = ${JSON.stringify(INVENTORY_MENU_SELECTOR)};
+    const ITEM = ${JSON.stringify(INVENTORY_ITEM_SELECTOR)};
+    const isVersionText = (t) => /gpt[-\\s]?\\d|(^|[^a-z])o\\d|\\bsol\\b/i.test(t || '');
+    const fire = (el, type, pointer) => {
+      try {
+        const common = { bubbles: true, cancelable: true, view: window };
+        const ev = pointer && 'PointerEvent' in window
+          ? new PointerEvent(type, { ...common, pointerId: 1, pointerType: 'mouse' })
+          : new MouseEvent(type, common);
+        el.dispatchEvent(ev);
+      } catch (e) {}
+    };
+    const openClick = (el) => {
+      try { el.focus(); } catch (e) {}
+      ['pointerover', 'pointerenter', 'pointerdown', 'mousedown', 'pointerup', 'mouseup', 'click']
+        .forEach((t) => fire(el, t, t.startsWith('pointer')));
+    };
+    const menus = () => Array.from(document.querySelectorAll(MENU));
+    const items = () => menus().flatMap((m) => Array.from(m.querySelectorAll(ITEM)));
+    const trigger = () => document.querySelector(TRIGGER);
+    const isChecked = (n) => n.getAttribute('aria-checked') === 'true' || (n.getAttribute('data-state') || '') === 'checked';
+
+    let t = trigger();
+    for (let i = 0; i < 40 && !t; i++) { await sleep(200); t = trigger(); }
+    if (!t) return { ok: false };
+    const pill = clean(t.textContent);
+    if (menus().length === 0) {
+      openClick(t);
+      for (let i = 0; i < 20 && menus().length === 0; i++) { if (i === 10) openClick(t); await sleep(150); }
+    }
+    const its = items();
+    const verTrigger = its.find((n) => n.getAttribute('aria-haspopup') === 'menu' && isVersionText(n.textContent));
+    const checkedEffort = its.find(
+      (n) => n.getAttribute('role') === 'menuitemradio' && isChecked(n) && !isVersionText(n.textContent),
+    );
+    const version = clean(verTrigger?.textContent || '');
+    const effort = clean(checkedEffort?.textContent || pill);
+    try {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', keyCode: 27, which: 27, bubbles: true }));
+    } catch (e) {}
+    return { ok: true, version, effort };
+  })()`;
+}
+
+/** Read the active version/effort from the top menu (robust, no submenu). */
+export async function readCurrentSelection(Runtime: RuntimeLike): Promise<CurrentSelection> {
+  const out = await Runtime.evaluate({
+    expression: buildReadCurrentSelectionExpression(),
+    awaitPromise: true,
+    returnByValue: true,
+  });
+  const value = out.result?.value as CurrentSelection | undefined;
+  return value ?? { ok: false };
+}
+

--- a/src/browser/actions/modelSelection.ts
+++ b/src/browser/actions/modelSelection.ts
@@ -9,6 +9,9 @@ import {
 import { logDomFailure } from "../domDebug.js";
 import { buildClickDispatcher } from "./domEvents.js";
 import { delay } from "../utils.js";
+import { enumerateModelInventory, applyInventorySelection, readCurrentSelection } from "./modelInventoryScrape.js";
+import { matchModelToInventory } from "../../oracle/modelMatch.js";
+import { normalizeText } from "../../oracle/modelInventory.js";
 
 const LEGACY_PRO_VERSION_WORD_TOKENS = ["5 4", "5 2", "5 1", "5 0", "gpt 5 pro"] as const;
 const LEGACY_PRO_VERSION_COMPACT_TOKENS = ["gpt54", "gpt52", "gpt51", "gpt50"] as const;
@@ -36,8 +39,24 @@ export async function ensureModelSelection(
   desiredModel: string,
   logger: BrowserLogger,
   strategy: BrowserModelStrategy = "select",
-  options: { buttonWaitMs?: number; buttonPollMs?: number } = {},
+  options: { buttonWaitMs?: number; buttonPollMs?: number; modelRequest?: string } = {},
 ): Promise<BrowserModelSelectionEvidence> {
+  // Preferred path: read the picker's live options and match the raw request
+  // against them (robust to new models / UI changes). Any failure returns null
+  // and falls through to the legacy label-scoring engine below — so this can
+  // only improve outcomes, never regress them.
+  if (strategy === "select" && options.modelRequest) {
+    const viaInventory = await selectViaInventory(Runtime, options.modelRequest, logger).catch(
+      (err: unknown) => {
+        logger(
+          `Inventory selection error (${err instanceof Error ? err.message : String(err)}); using legacy picker.`,
+        );
+        return null;
+      },
+    );
+    if (viaInventory) return viaInventory;
+  }
+
   const buttonWaitMs = options.buttonWaitMs ?? MODEL_BUTTON_WAIT_MS;
   const buttonPollMs = options.buttonPollMs ?? MODEL_BUTTON_POLL_MS;
   const deadline = Date.now() + Math.max(0, buttonWaitMs);
@@ -102,6 +121,98 @@ export async function ensureModelSelection(
       );
     }
   }
+}
+
+/**
+ * Data-driven selection: discover the live picker options, match the raw request
+ * against them, apply, and verify. Returns evidence on success, or null to fall
+ * back to the legacy engine (empty inventory, unmatched request, apply/verify
+ * failure). Never throws — errors surface as null via the caller's catch.
+ */
+async function selectViaInventory(
+  Runtime: ChromeClient["Runtime"],
+  modelRequest: string,
+  logger: BrowserLogger,
+): Promise<BrowserModelSelectionEvidence | null> {
+  const inventory = await enumerateModelInventory(Runtime);
+  if (inventory.versions.length === 0 && inventory.efforts.length === 0) {
+    logger("Model inventory: picker not readable yet; using legacy picker.");
+    return null; // discovery didn't find a picker we understand → legacy path
+  }
+
+  const match = matchModelToInventory(modelRequest, inventory);
+  if (match.status !== "matched") {
+    const hint = match.candidates.length ? ` (available: ${match.candidates.join(", ")})` : "";
+    logger(`Model inventory: "${modelRequest}" → ${match.status}${hint}; using legacy picker.`);
+    return null;
+  }
+
+  const wantVersion = match.version ?? null;
+  const wantEffort = match.effort ?? null;
+  const sameVersion =
+    !wantVersion ||
+    (inventory.currentVersion != null &&
+      normalizeText(inventory.currentVersion.text) === normalizeText(wantVersion.text));
+  const sameEffort =
+    !wantEffort ||
+    (inventory.currentEffort != null &&
+      normalizeText(inventory.currentEffort.text) === normalizeText(wantEffort.text));
+
+  let currentVersion = inventory.currentVersion?.text ?? null;
+  let currentEffort = inventory.currentEffort?.text ?? null;
+  let switched = false;
+
+  if (!(sameVersion && sameEffort)) {
+    const applied = await applyInventorySelection(
+      Runtime,
+      wantVersion?.raw ?? null,
+      wantEffort?.raw ?? null,
+    );
+    if (!applied.ok) {
+      logger(`Model inventory apply failed (${applied.error ?? "unknown"}); using legacy picker.`);
+      return null;
+    }
+    switched = (applied.actions ?? []).some(
+      (a) => a.startsWith("effort:") || a.startsWith("version:"),
+    );
+    // Verify from the top menu (version-trigger label + checked effort). This avoids
+    // re-opening the version submenu, which is flaky, and beats the composer pill
+    // (which merges version+effort for non-default versions, e.g. "5.5Pro").
+    const after = await readCurrentSelection(Runtime);
+    currentVersion = after.version ?? applied.currentVersion ?? currentVersion;
+    currentEffort = after.effort ?? applied.currentEffort ?? currentEffort;
+  }
+
+  // Verify the live state now reflects the request.
+  const versionOk = !wantVersion || labelsAgree(currentVersion, wantVersion.text);
+  const effortOk = !wantEffort || labelsAgree(currentEffort, wantEffort.text);
+  if (!versionOk || !effortOk) {
+    logger(
+      `Model inventory verify mismatch (version="${currentVersion}", effort="${currentEffort}"); using legacy picker.`,
+    );
+    return null;
+  }
+
+  const label =
+    [wantEffort?.text, wantVersion?.text].filter(Boolean).join(" ") || currentEffort || modelRequest;
+  logger(`Model picker (inventory): ${label}`);
+  return {
+    requestedModel: modelRequest,
+    resolvedLabel: label,
+    strategy: "select",
+    status: switched ? "switched" : "already-selected",
+    verified: true,
+    source: "chatgpt-model-picker",
+    capturedAt: new Date().toISOString(),
+  };
+}
+
+/** True when two labels refer to the same option (tolerant of subscripts/notes). */
+function labelsAgree(observed: string | null, want: string): boolean {
+  const a = normalizeText(observed ?? "");
+  const b = normalizeText(want);
+  if (!a || !b) return false;
+  return a === b || a.includes(b) || b.includes(a);
 }
 
 function assertResolvedModelSelection(desiredModel: string, resolvedLabel: string): void {

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1397,7 +1397,10 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
     if (config.desiredModel && modelStrategy !== "ignore" && !isResumingConversation) {
       modelSelectionEvidence = await raceWithDisconnect(
         withRetries(
-          () => ensureModelSelection(Runtime, config.desiredModel as string, logger, modelStrategy),
+          () =>
+            ensureModelSelection(Runtime, config.desiredModel as string, logger, modelStrategy, {
+              modelRequest: config.modelRequest ?? undefined,
+            }),
           {
             retries: 2,
             delayMs: 300,
@@ -2951,7 +2954,10 @@ async function runRemoteBrowserMode(
     const modelStrategy = config.modelStrategy ?? DEFAULT_MODEL_STRATEGY;
     if (config.desiredModel && modelStrategy !== "ignore" && !config.resumeConversationUrl) {
       modelSelectionEvidence = await withRetries(
-        () => ensureModelSelection(Runtime, config.desiredModel as string, logger, modelStrategy),
+        () =>
+          ensureModelSelection(Runtime, config.desiredModel as string, logger, modelStrategy, {
+            modelRequest: config.modelRequest ?? undefined,
+          }),
         {
           retries: 2,
           delayMs: 300,

--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -99,6 +99,8 @@ export interface BrowserAutomationConfig {
   keepBrowser?: boolean;
   hideWindow?: boolean;
   desiredModel?: string | null;
+  /** Raw `-m` request, matched against the live picker inventory. */
+  modelRequest?: string | null;
   modelStrategy?: BrowserModelStrategy;
   debug?: boolean;
   allowCookieErrors?: boolean;
@@ -192,6 +194,7 @@ export type ResolvedBrowserConfig = Required<
     | "chromePath"
     | "chromeCookiePath"
     | "desiredModel"
+    | "modelRequest"
     | "remoteChrome"
     | "remoteChromeBrowserWSEndpoint"
     | "remoteChromeProfileRoot"
@@ -208,6 +211,7 @@ export type ResolvedBrowserConfig = Required<
   attachRunning?: boolean;
   browserTabRef?: string | null;
   desiredModel?: string | null;
+  modelRequest?: string | null;
   modelStrategy?: BrowserModelStrategy;
   thinkingTime?: ThinkingTimeLevel;
   debugPort?: number | null;

--- a/src/cli/browserConfig.ts
+++ b/src/cli/browserConfig.ts
@@ -90,6 +90,8 @@ export interface BrowserFlagOptions {
   browserPort?: number;
   browserDebugPort?: number;
   model: ModelName;
+  /** Raw `-m` value before CLI inference; matched against the live picker inventory. */
+  modelRequest?: string;
   verbose?: boolean;
 }
 
@@ -250,7 +252,7 @@ export async function buildBrowserConfig(
     copyProfileSource: options.copyProfile ?? undefined,
     hideWindow: options.browserHideWindow ? true : undefined,
     desiredModel,
-    modelRequest: options.model,
+    modelRequest: options.modelRequest?.trim() || options.model,
     modelStrategy,
     debug: options.verbose ? true : undefined,
     // Allow cookie failures by default so runs can continue without Chrome/Keychain secrets.

--- a/src/cli/browserConfig.ts
+++ b/src/cli/browserConfig.ts
@@ -250,6 +250,7 @@ export async function buildBrowserConfig(
     copyProfileSource: options.copyProfile ?? undefined,
     hideWindow: options.browserHideWindow ? true : undefined,
     desiredModel,
+    modelRequest: options.model,
     modelStrategy,
     debug: options.verbose ? true : undefined,
     // Allow cookie failures by default so runs can continue without Chrome/Keychain secrets.

--- a/src/oracle/modelInventory.ts
+++ b/src/oracle/modelInventory.ts
@@ -1,0 +1,133 @@
+// Model inventory: a data-driven snapshot of what the ChatGPT model picker
+// *actually* offers right now, plus pure helpers to build it from scraped DOM.
+//
+// Why this exists: the picker UI changes shape whenever OpenAI ships a model
+// (GPT-5.6 "Sol" dropped every `data-testid` and moved to a version×effort
+// matrix). Hard-coding a version ladder (5-0…5-6) means editing ~10 call sites
+// per launch. Instead we read the live options and match against them, so a new
+// version works with zero code changes.
+//
+// The DOM scraping lives in ../browser/actions/modelInventoryScrape.ts and only
+// produces RawMenuItem[]. Everything here is pure and unit-tested.
+
+/** One raw item as scraped from a picker menu, before classification. */
+export interface RawMenuItem {
+  /** Visible text, possibly noisy (e.g. "Instant5.5", "GPT-5.4Leaving on July 23"). */
+  text: string;
+  role?: string | null;
+  /** "true" when this option is the current selection. */
+  ariaChecked?: string | null;
+  /** "menu" when the item opens a submenu (the version trigger). */
+  ariaHaspopup?: string | null;
+  /** "checked" | "unchecked" | "open" | "closed" | null. */
+  dataState?: string | null;
+  /** Which menu this came from: the top intelligence menu or the version submenu. */
+  scope?: "top" | "submenu";
+}
+
+/** A normalized, selectable option in the picker. */
+export interface InvOption {
+  /** Cleaned display label, e.g. "GPT-5.6 Sol", "Pro". Used for clicking + matching. */
+  text: string;
+  /** Original noisy DOM text, retained so the click layer can find the exact node. */
+  raw: string;
+  /** True if this option is currently selected. */
+  current: boolean;
+}
+
+/** The live picker state: which versions and efforts exist, and what's active. */
+export interface ModelInventory {
+  versions: InvOption[];
+  efforts: InvOption[];
+  currentVersion?: InvOption;
+  currentEffort?: InvOption;
+}
+
+/** Lowercase alnum-collapsed form used for stable comparisons. */
+export function normalizeText(value: string): string {
+  return (value ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * A menu item names a model *version* (as opposed to an effort/intelligence
+ * level) when its text looks like a version id, or when it opens a submenu.
+ * Deliberately generic: matches gpt-5.6, gpt 6, o3, o4-mini, etc. — no fixed list.
+ */
+export function looksLikeVersion(text: string, ariaHaspopup?: string | null): boolean {
+  if (ariaHaspopup === "menu") return true;
+  const t = text.toLowerCase();
+  return (
+    /\bgpt[-\s]?\d/.test(t) || // gpt-5.6, gpt 6
+    /(^|[^a-z])o\d/.test(t) || // o3, o4-mini
+    /\bsol\b/.test(t) // codename that trails a version (GPT-5.6 Sol)
+  );
+}
+
+/** Strip a trailing deprecation note like "Leaving on July 23". */
+function stripDeprecationNote(text: string): string {
+  return text.replace(/\s*leaving on .*$/i, "").trim();
+}
+
+/** Clean a version label: collapse whitespace, drop deprecation notes. Keep numbers. */
+export function cleanVersionLabel(text: string): string {
+  return stripDeprecationNote(text.replace(/\s+/g, " ").trim());
+}
+
+/**
+ * Clean an effort label: drop a trailing version subscript that the UI glues on,
+ * e.g. "Instant5.5" -> "Instant". Never applied to version labels (would eat "o3").
+ */
+export function cleanEffortLabel(text: string): string {
+  const collapsed = stripDeprecationNote(text.replace(/\s+/g, " ").trim());
+  // A letter (optionally spaced) immediately followed by a trailing version number.
+  return collapsed.replace(/([A-Za-z])\s*\d+(?:\.\d+)?$/, "$1").trim();
+}
+
+function isChecked(item: RawMenuItem): boolean {
+  return item.ariaChecked === "true" || item.dataState === "checked";
+}
+
+/**
+ * Build a ModelInventory from scraped raw items. Pure and deterministic.
+ * De-dupes versions/efforts by normalized label (the current version appears
+ * both as the top-menu trigger and as a checked radio in the submenu).
+ */
+export function buildInventoryFromRawItems(raw: RawMenuItem[]): ModelInventory {
+  const versions: InvOption[] = [];
+  const efforts: InvOption[] = [];
+  const versionByKey = new Map<string, InvOption>();
+  const effortByKey = new Map<string, InvOption>();
+
+  for (const item of raw) {
+    const rawText = (item.text ?? "").trim();
+    if (!rawText) continue;
+
+    const version = looksLikeVersion(rawText, item.ariaHaspopup);
+    const label = version ? cleanVersionLabel(rawText) : cleanEffortLabel(rawText);
+    const key = normalizeText(label);
+    if (!key) continue;
+
+    const target = version ? versionByKey : effortByKey;
+    const list = version ? versions : efforts;
+    const existing = target.get(key);
+    if (existing) {
+      // Same option seen twice (trigger + submenu radio): keep current=true if either was.
+      if (isChecked(item)) existing.current = true;
+      continue;
+    }
+    const opt: InvOption = { text: label, raw: rawText, current: isChecked(item) };
+    target.set(key, opt);
+    list.push(opt);
+  }
+
+  return {
+    versions,
+    efforts,
+    currentVersion: versions.find((v) => v.current),
+    currentEffort: efforts.find((e) => e.current),
+  };
+}

--- a/src/oracle/modelMatch.ts
+++ b/src/oracle/modelMatch.ts
@@ -1,0 +1,167 @@
+// Data-driven matcher: map a user's requested model string to the options that
+// the ChatGPT picker actually offers (a ModelInventory). Pure and unit-tested.
+//
+// This replaces the hard-coded version ladder in modelSelection.ts. A request is
+// parsed into an optional {version, effort}; each part is resolved against the
+// live inventory. Because version parsing is generic (any number), a brand-new
+// model (gpt-5.7, gpt-6, o4) resolves the moment ChatGPT lists it — no new code.
+
+import type { InvOption, ModelInventory } from "./modelInventory.js";
+import { normalizeText } from "./modelInventory.js";
+
+/** Canonical effort levels, aligned with the live picker + thinkingTime aliases. */
+export type EffortKey = "instant" | "medium" | "high" | "extra-high" | "pro";
+
+export interface ParsedRequest {
+  raw: string;
+  /** Numeric version core, e.g. "5.6", "6", or "o3". Undefined = version-agnostic. */
+  versionKey?: string;
+  family?: "gpt" | "o" | "gemini" | "claude";
+  effort?: EffortKey;
+  /** Bare "thinking" with no explicit level — ambiguous effort intent. */
+  bareThinking?: boolean;
+}
+
+export type MatchResult =
+  | {
+      status: "matched";
+      version?: InvOption;
+      effort?: InvOption;
+      confidence: number;
+      reason: string;
+    }
+  | {
+      status: "not-found" | "ambiguous";
+      reason: string;
+      /** Human-readable list of what IS available, for a helpful error. */
+      candidates: string[];
+    };
+
+/** Extract the comparable version core from any label or request fragment. */
+export function versionKeyOf(text: string): string {
+  const t = text.toLowerCase();
+  const gpt = t.match(/gpt[-\s]?(\d+(?:\.\d+)?)/);
+  if (gpt) return gpt[1];
+  const o = t.match(/(?:^|[^a-z])(o\d+(?:-[a-z]+)?)/);
+  if (o) return o[1];
+  const bare = t.match(/(?:^|\s)(\d+(?:\.\d+)?)(?:\s|$)/);
+  if (bare) return bare[1];
+  return normalizeText(text);
+}
+
+/** Canonicalize an effort label/word to an EffortKey, or undefined if not one. */
+export function effortKeyOf(text: string): EffortKey | undefined {
+  const t = normalizeText(text);
+  if (/\bpro\b/.test(t)) return "pro";
+  if (/\binstant\b|\blight\b|\blow\b|\bfast\b/.test(t)) return "instant";
+  if (/\bextra high\b|\bxhigh\b|\bextrahigh\b|\bheavy\b/.test(t)) return "extra-high";
+  if (/\bhigh\b|\bextended\b/.test(t)) return "high";
+  if (/\bmedium\b|\bstandard\b/.test(t)) return "medium";
+  return undefined;
+}
+
+/** Parse a raw `-m` value into version + effort intent. */
+export function parseRequest(request: string): ParsedRequest {
+  // Keep dots for version extraction ("5.6" must not collapse to "5 6").
+  const r = request.toLowerCase().trim();
+  const parsed: ParsedRequest = { raw: request };
+
+  // Version core (dot-preserving)
+  const gpt = r.match(/gpt[-\s]?(\d+(?:\.\d+)?)/);
+  const o = r.match(/(?:^|[^a-z])(o\d+(?:[-\s][a-z]+)?)/);
+  const bare = r.match(/(?:^|\s)(\d+(?:\.\d+)?)(?:\s|$)/);
+  if (gpt) parsed.versionKey = gpt[1];
+  else if (o) {
+    parsed.versionKey = o[1].replace(/\s+/g, "-");
+    parsed.family = "o";
+  } else if (bare) parsed.versionKey = bare[1];
+
+  // Family
+  if (/\bgemini\b/.test(r)) parsed.family = "gemini";
+  else if (/\bclaude\b/.test(r)) parsed.family = "claude";
+  else if (!parsed.family && (/\bgpt\b/.test(r) || parsed.versionKey)) parsed.family = "gpt";
+
+  // Effort (effortKeyOf normalizes internally, dots don't matter here)
+  const effort = effortKeyOf(request);
+  if (effort) parsed.effort = effort;
+  else if (/\bthinking\b/.test(r)) parsed.bareThinking = true;
+
+  return parsed;
+}
+
+function listVersions(inv: ModelInventory): string[] {
+  return inv.versions.map((v) => v.text);
+}
+function listEfforts(inv: ModelInventory): string[] {
+  return inv.efforts.map((e) => e.text);
+}
+
+/**
+ * Resolve a requested model against the live inventory.
+ *
+ * - Missing version → keep current version (version-agnostic, e.g. "-m Pro").
+ * - Missing effort → keep current effort.
+ * - Requested part not offered → `not-found` with the real candidate list
+ *   (so the caller can print a useful error instead of clicking a phantom).
+ */
+export function matchModelToInventory(
+  request: string,
+  inv: ModelInventory,
+): MatchResult {
+  const parsed = parseRequest(request);
+
+  let version: InvOption | undefined;
+  if (parsed.versionKey) {
+    version = inv.versions.find((v) => versionKeyOf(v.text) === parsed.versionKey);
+    if (!version) {
+      return {
+        status: "not-found",
+        reason: `Requested version "${parsed.versionKey}" is not offered by ChatGPT right now.`,
+        candidates: listVersions(inv),
+      };
+    }
+  }
+
+  let effort: InvOption | undefined;
+  if (parsed.effort) {
+    effort = inv.efforts.find((e) => effortKeyOf(e.text) === parsed.effort);
+    if (!effort) {
+      return {
+        status: "not-found",
+        reason: `Requested effort "${parsed.effort}" is not offered for the selected model.`,
+        candidates: listEfforts(inv),
+      };
+    }
+  }
+
+  if (!version && !effort) {
+    // Nothing actionable parsed out of the request.
+    if (parsed.bareThinking) {
+      return {
+        status: "ambiguous",
+        reason: `"thinking" has no explicit level; choose one of the effort options.`,
+        candidates: listEfforts(inv),
+      };
+    }
+    return {
+      status: "ambiguous",
+      reason: `Could not map "${request}" to a version or effort.`,
+      candidates: [...listVersions(inv), ...listEfforts(inv)],
+    };
+  }
+
+  // Confidence: full when every requested part resolved exactly; version-only or
+  // effort-only requests are still high-confidence (the other axis stays current).
+  const confidence = version && effort ? 1 : 0.9;
+  const parts = [
+    version ? `version=${version.text}` : "version=(keep current)",
+    effort ? `effort=${effort.text}` : "effort=(keep current)",
+  ];
+  return {
+    status: "matched",
+    version,
+    effort,
+    confidence,
+    reason: `Matched ${request} → ${parts.join(", ")}.`,
+  };
+}

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -65,6 +65,7 @@ export interface BrowserSessionConfig {
   keepBrowser?: boolean;
   hideWindow?: boolean;
   desiredModel?: string | null;
+  modelRequest?: string | null;
   modelStrategy?: BrowserModelStrategy;
   debug?: boolean;
   allowCookieErrors?: boolean;

--- a/tests/browser/modelInventoryScrape.test.ts
+++ b/tests/browser/modelInventoryScrape.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "vitest";
+import {
+  applyInventorySelection,
+  buildApplySelectionExpression,
+  buildInventoryScrapeExpression,
+  buildReadCurrentSelectionExpression,
+  enumerateModelInventory,
+  readCurrentSelection,
+  type RuntimeLike,
+} from "../../src/browser/actions/modelInventoryScrape.js";
+
+/** A RuntimeLike that returns a canned Runtime.evaluate value. */
+const mockRuntime = (value: unknown): RuntimeLike => ({
+  evaluate: async () => ({ result: { value } }),
+});
+
+describe("browser expressions parse as valid JS", () => {
+  // Catches template-literal escaping bugs (\\d, \\s, JSON interpolation) without a browser.
+  test("scrape expression is a syntactically valid IIFE", () => {
+    const expr = buildInventoryScrapeExpression();
+    expect(expr.startsWith("(async () =>")).toBe(true);
+    expect(() => new Function(`return ${expr}`)).not.toThrow();
+  });
+
+  test("apply expression embeds targets and parses", () => {
+    const expr = buildApplySelectionExpression("GPT-5.6 Sol", "Pro");
+    expect(expr).toContain(JSON.stringify("GPT-5.6 Sol"));
+    expect(expr).toContain(JSON.stringify("Pro"));
+    expect(() => new Function(`return ${expr}`)).not.toThrow();
+  });
+
+  test("apply expression handles null axes", () => {
+    expect(() => new Function(`return ${buildApplySelectionExpression(null, "Pro")}`)).not.toThrow();
+    expect(() => new Function(`return ${buildApplySelectionExpression("o3", null)}`)).not.toThrow();
+  });
+
+  test("read-current-selection expression parses", () => {
+    const expr = buildReadCurrentSelectionExpression();
+    expect(expr.startsWith("(async () =>")).toBe(true);
+    expect(() => new Function(`return ${expr}`)).not.toThrow();
+  });
+});
+
+describe("readCurrentSelection (mock Runtime)", () => {
+  test("passes through the read result", async () => {
+    const res = await readCurrentSelection(mockRuntime({ ok: true, version: "GPT-5.5", effort: "Pro" }));
+    expect(res.ok).toBe(true);
+    expect(res.version).toBe("GPT-5.5");
+    expect(res.effort).toBe("Pro");
+  });
+});
+
+describe("enumerateModelInventory (mock Runtime)", () => {
+  test("parses scraped items into a structured inventory", async () => {
+    const inv = await enumerateModelInventory(
+      mockRuntime({
+        items: [
+          { text: "Pro", role: "menuitemradio", ariaChecked: "true", scope: "top" },
+          { text: "Instant5.5", role: "menuitemradio", scope: "top" },
+          { text: "GPT-5.6 Sol", role: "menuitemradio", ariaChecked: "true", scope: "submenu" },
+          { text: "GPT-5.5", role: "menuitemradio", scope: "submenu" },
+        ],
+      }),
+    );
+    expect(inv.versions.map((v) => v.text)).toEqual(["GPT-5.6 Sol", "GPT-5.5"]);
+    expect(inv.efforts.map((e) => e.text)).toEqual(["Pro", "Instant"]);
+    expect(inv.currentVersion?.text).toBe("GPT-5.6 Sol");
+    expect(inv.currentEffort?.text).toBe("Pro");
+  });
+
+  test("empty/failed scrape yields an empty inventory (caller falls back)", async () => {
+    const inv = await enumerateModelInventory(mockRuntime({ error: "trigger-not-found", items: [] }));
+    expect(inv.versions).toHaveLength(0);
+    expect(inv.efforts).toHaveLength(0);
+  });
+});
+
+describe("applyInventorySelection (mock Runtime)", () => {
+  test("passes through the apply result", async () => {
+    const res = await applyInventorySelection(
+      mockRuntime({ ok: true, currentVersion: "GPT-5.5", currentEffort: "Pro", actions: ["version:gpt 5 5"] }),
+      "GPT-5.5",
+      "Pro",
+    );
+    expect(res.ok).toBe(true);
+    expect(res.currentVersion).toBe("GPT-5.5");
+  });
+
+  test("missing result is reported as a failure", async () => {
+    const res = await applyInventorySelection(mockRuntime(undefined), "GPT-5.5", null);
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe("no-result");
+  });
+});

--- a/tests/oracle/modelInventory.test.ts
+++ b/tests/oracle/modelInventory.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildInventoryFromRawItems,
+  cleanEffortLabel,
+  cleanVersionLabel,
+  looksLikeVersion,
+  type RawMenuItem,
+} from "../../src/oracle/modelInventory.js";
+
+// Verbatim from a live GPT-5.6 "Sol" era picker, captured via CDP on 2026-07-12.
+// Top intelligence menu + the opened version submenu. Note: no data-testids.
+const REAL_RAW: RawMenuItem[] = [
+  { text: "Instant5.5", role: "menuitemradio", ariaChecked: "false", scope: "top" },
+  { text: "Medium", role: "menuitemradio", ariaChecked: "false", scope: "top" },
+  { text: "High", role: "menuitemradio", ariaChecked: "false", scope: "top" },
+  { text: "Extra High", role: "menuitemradio", ariaChecked: "false", scope: "top" },
+  { text: "Pro", role: "menuitemradio", ariaChecked: "true", dataState: "checked", scope: "top" },
+  { text: "GPT-5.6 Sol", role: "menuitem", ariaHaspopup: "menu", scope: "top" },
+  // version submenu
+  { text: "GPT-5.6 Sol", role: "menuitemradio", ariaChecked: "true", dataState: "checked", scope: "submenu" },
+  { text: "GPT-5.5", role: "menuitemradio", ariaChecked: "false", scope: "submenu" },
+  { text: "GPT-5.4Leaving on July 23", role: "menuitemradio", ariaChecked: "false", scope: "submenu" },
+  { text: "GPT-5.3", role: "menuitemradio", ariaChecked: "false", scope: "submenu" },
+  { text: "o3", role: "menuitemradio", ariaChecked: "false", scope: "submenu" },
+];
+
+describe("label cleaning", () => {
+  test("strips glued version subscript from effort labels", () => {
+    expect(cleanEffortLabel("Instant5.5")).toBe("Instant");
+    expect(cleanEffortLabel("Extra High")).toBe("Extra High");
+    expect(cleanEffortLabel("Pro")).toBe("Pro");
+  });
+
+  test("strips deprecation note but keeps version numbers", () => {
+    expect(cleanVersionLabel("GPT-5.4Leaving on July 23")).toBe("GPT-5.4");
+    expect(cleanVersionLabel("GPT-5.6 Sol")).toBe("GPT-5.6 Sol");
+  });
+
+  test("classifies versions vs efforts (o3 is a version, not effort 'o')", () => {
+    expect(looksLikeVersion("GPT-5.6 Sol")).toBe(true);
+    expect(looksLikeVersion("o3")).toBe(true);
+    expect(looksLikeVersion("GPT-5.6 Sol", "menu")).toBe(true);
+    expect(looksLikeVersion("Extra High")).toBe(false);
+    expect(looksLikeVersion("Pro")).toBe(false);
+    // o3 is a version, so it's cleaned as one (never subjected to effort-subscript stripping).
+    expect(cleanVersionLabel("o3")).toBe("o3");
+  });
+});
+
+describe("buildInventoryFromRawItems (real DOM)", () => {
+  const inv = buildInventoryFromRawItems(REAL_RAW);
+
+  test("extracts the version list, de-duping the trigger+submenu entry", () => {
+    expect(inv.versions.map((v) => v.text)).toEqual([
+      "GPT-5.6 Sol",
+      "GPT-5.5",
+      "GPT-5.4",
+      "GPT-5.3",
+      "o3",
+    ]);
+  });
+
+  test("extracts the effort list", () => {
+    expect(inv.efforts.map((e) => e.text)).toEqual([
+      "Instant",
+      "Medium",
+      "High",
+      "Extra High",
+      "Pro",
+    ]);
+  });
+
+  test("reads current selection from aria-checked (5.6 Sol · Pro)", () => {
+    expect(inv.currentVersion?.text).toBe("GPT-5.6 Sol");
+    expect(inv.currentEffort?.text).toBe("Pro");
+  });
+});

--- a/tests/oracle/modelMatch.test.ts
+++ b/tests/oracle/modelMatch.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "vitest";
+import { buildInventoryFromRawItems, type RawMenuItem } from "../../src/oracle/modelInventory.js";
+import { matchModelToInventory, parseRequest } from "../../src/oracle/modelMatch.js";
+
+// Live GPT-5.6 "Sol" inventory (see modelInventory.test.ts for provenance).
+const SOL_RAW: RawMenuItem[] = [
+  { text: "Instant5.5", role: "menuitemradio", scope: "top" },
+  { text: "Medium", role: "menuitemradio", scope: "top" },
+  { text: "High", role: "menuitemradio", scope: "top" },
+  { text: "Extra High", role: "menuitemradio", scope: "top" },
+  { text: "Pro", role: "menuitemradio", ariaChecked: "true", scope: "top" },
+  { text: "GPT-5.6 Sol", role: "menuitem", ariaHaspopup: "menu", scope: "top" },
+  { text: "GPT-5.6 Sol", role: "menuitemradio", ariaChecked: "true", scope: "submenu" },
+  { text: "GPT-5.5", role: "menuitemradio", scope: "submenu" },
+  { text: "GPT-5.4Leaving on July 23", role: "menuitemradio", scope: "submenu" },
+  { text: "GPT-5.3", role: "menuitemradio", scope: "submenu" },
+  { text: "o3", role: "menuitemradio", scope: "submenu" },
+];
+const SOL = buildInventoryFromRawItems(SOL_RAW);
+
+describe("parseRequest", () => {
+  test("splits version and effort", () => {
+    expect(parseRequest("gpt-5.6-pro")).toMatchObject({ versionKey: "5.6", effort: "pro" });
+    expect(parseRequest("gpt-5.6-sol")).toMatchObject({ versionKey: "5.6" });
+    expect(parseRequest("GPT-5.6 Sol")).toMatchObject({ versionKey: "5.6" });
+    expect(parseRequest("5.5 thinking")).toMatchObject({ versionKey: "5.5", bareThinking: true });
+    expect(parseRequest("o3")).toMatchObject({ versionKey: "o3", family: "o" });
+    expect(parseRequest("Pro")).toMatchObject({ effort: "pro" });
+    expect(parseRequest("Pro").versionKey).toBeUndefined();
+  });
+
+  test("effort synonyms canonicalize", () => {
+    expect(parseRequest("gpt-5.6 xhigh").effort).toBe("extra-high");
+    expect(parseRequest("gpt-5.6 heavy").effort).toBe("extra-high");
+    expect(parseRequest("gpt-5.6 standard").effort).toBe("medium");
+    expect(parseRequest("gpt-5.6 extended").effort).toBe("high");
+    expect(parseRequest("gpt-5.6 instant").effort).toBe("instant");
+  });
+});
+
+describe("matchModelToInventory — the cases oracle 0.15.2 got wrong", () => {
+  test("gpt-5.6-sol resolves to the real version (was: collapsed to GPT-5.2)", () => {
+    const r = matchModelToInventory("gpt-5.6-sol", SOL);
+    expect(r.status).toBe("matched");
+    if (r.status === "matched") expect(r.version?.text).toBe("GPT-5.6 Sol");
+  });
+
+  test("gpt-5.6-pro resolves version 5.6 + effort Pro", () => {
+    const r = matchModelToInventory("gpt-5.6-pro", SOL);
+    expect(r.status).toBe("matched");
+    if (r.status === "matched") {
+      expect(r.version?.text).toBe("GPT-5.6 Sol");
+      expect(r.effort?.text).toBe("Pro");
+      expect(r.confidence).toBe(1);
+    }
+  });
+
+  test('literal UI label "GPT-5.6 Sol" resolves', () => {
+    const r = matchModelToInventory("GPT-5.6 Sol", SOL);
+    expect(r.status).toBe("matched");
+    if (r.status === "matched") expect(r.version?.text).toBe("GPT-5.6 Sol");
+  });
+
+  test("o3 resolves to the o3 version, not effort", () => {
+    const r = matchModelToInventory("o3", SOL);
+    expect(r.status).toBe("matched");
+    if (r.status === "matched") expect(r.version?.text).toBe("o3");
+  });
+});
+
+describe("matchModelToInventory — robustness properties", () => {
+  test("version-agnostic '-m Pro' keeps current version, switches effort", () => {
+    const r = matchModelToInventory("Pro", SOL);
+    expect(r.status).toBe("matched");
+    if (r.status === "matched") {
+      expect(r.version).toBeUndefined();
+      expect(r.effort?.text).toBe("Pro");
+    }
+  });
+
+  test("a FUTURE model works with zero code change IF ChatGPT lists it", () => {
+    // Same picker, but ChatGPT has added GPT-5.7 to the version submenu.
+    const future = buildInventoryFromRawItems([
+      ...SOL_RAW,
+      { text: "GPT-5.7", role: "menuitemradio", scope: "submenu" },
+    ]);
+    const r = matchModelToInventory("gpt-5.7-pro", future);
+    expect(r.status).toBe("matched");
+    if (r.status === "matched") {
+      expect(r.version?.text).toBe("GPT-5.7");
+      expect(r.effort?.text).toBe("Pro");
+    }
+  });
+
+  test("unavailable version fails LOUD with real candidates (was: silent GPT-5.2)", () => {
+    const r = matchModelToInventory("gpt-9.9", SOL);
+    expect(r.status).toBe("not-found");
+    if (r.status !== "matched") {
+      expect(r.candidates).toContain("GPT-5.6 Sol");
+      expect(r.candidates).not.toContain("GPT-5.2");
+    }
+  });
+
+  test("unavailable effort fails loud with real effort candidates", () => {
+    const bare = buildInventoryFromRawItems([
+      { text: "GPT-5.6 Sol", role: "menuitemradio", ariaChecked: "true", scope: "submenu" },
+      { text: "Instant", role: "menuitemradio", scope: "top" },
+      { text: "Pro", role: "menuitemradio", scope: "top" },
+    ]);
+    const r = matchModelToInventory("gpt-5.6 medium", bare);
+    expect(r.status).toBe("not-found");
+    if (r.status !== "matched") expect(r.candidates).toEqual(["Instant", "Pro"]);
+  });
+
+  test("bare 'thinking' with no level is flagged ambiguous (candidate for LLM fallback)", () => {
+    const r = matchModelToInventory("thinking", SOL);
+    expect(r.status).toBe("ambiguous");
+  });
+});


### PR DESCRIPTION
## Problem

Browser-mode model selection is hard-coded in three layers:

1. `cli/options.ts` `inferModelFromLabel` — text → known model id
2. `cli/browserConfig.ts` `BROWSER_MODEL_LABELS` — model id → UI label
3. `browser/actions/modelSelection.ts` `scoreOption` — a per-version ladder (`desiredVersion`, `versionFromLabel`, per-version `includes` guards, `data-testid` tokens)

Every new ChatGPT model needs edits in all three. GPT-5.6 "Sol" landed in `main` as ~10 hand-added `'5-6'` tokens. On published `0.15.2` (no 5.6 tokens), `-m "GPT-5.6 Sol"` silently collapses to `gpt-5.2` and fails:

```
[retry] Unable to find model option matching "GPT-5.2" in the model switcher.
Available: Instant5.5, Medium, High, Extra High, Pro, GPT-5.6 Sol.
```

Notably, a live capture shows the GPT-5.6-era picker **dropped every `data-testid`** — it's now a clean version × effort matrix keyed on `role` + text + `aria-checked`, which is exactly what makes runtime discovery reliable.

## Approach — Discover → Match → Apply → Verify

Read what the picker **actually offers**, then match against it, instead of precomputing a rigid target from a hard-coded ladder:

- **Discover** (`enumerateModelInventory`) — scrape the live menu (incl. the version submenu) into a structured `ModelInventory` (`versions`, `efforts`, current markers).
- **Match** (`matchModelToInventory`) — parse the request generically (any version number, effort synonyms) and resolve it against the live options.
- **Apply / Verify** — click the chosen option(s) by exact text; verify from the top-menu labels.

Because version parsing is generic, a brand-new model (`gpt-5.7`, `o4`, …) resolves the moment ChatGPT lists it — **no code change**. Unavailable requests fail loud with the real candidate list.

**Zero-regression:** the inventory path runs first for `strategy: "select"`; on any discovery/match/apply/verify miss it returns `null` and falls through to the untouched legacy `buildModelSelectionExpression`. Worst case is one extra discovery round-trip, then exactly today's behavior.

## Live verification (against a signed-in ChatGPT, GPT-5.6 "Sol", 2026-07)

| `-m` input | result |
|---|---|
| `"GPT-5.6 Sol"` | `Model picker (inventory): GPT-5.6 Sol` — the input that fails on 0.15.2 |
| `gpt-5.5-pro` | `Model picker (inventory): Pro GPT-5.5` — real version switch (5.6 Sol → 5.5) |
| `gpt-5.4` | `Model picker (inventory): GPT-5.4` — switch; "Leaving on July 23" note stripped |
| `o3` | `Model picker (inventory): o3` — a model the CLI can't name, selected from the live menu |
| `gpt-9.9` (invalid) | `Model inventory: "gpt-9.9" → not-found (available: GPT-5.6 Sol, GPT-5.5, GPT-5.4, GPT-5.3, o3); using legacy picker.` |

The raw `-m` value is threaded as `modelRequest` (not the CLI-inferred id), so `o3` / future models resolve from the live menu instead of being pre-collapsed to `gpt-5.2`.

Two DOM quirks found + handled during live testing (covered by tests):
- The composer pill merges version+effort for non-default versions (`5.5Pro`), so verification reads the top-menu **version-trigger label** + **checked effort radio**, not the pill.
- After a switch, a **spurious empty** `aria-haspopup="menu"` item can precede the real version trigger — trigger detection now requires version-like text.

## Tests

- 26 new unit tests, incl. the 0.15.2 failure cases, a **future-model** case, and a `new Function()` parse-check of every generated browser expression.
- Pure classifier/matcher extracted to `src/oracle/` (unit-tested); browser DOM ops in `src/browser/actions/modelInventoryScrape.ts`.
- `tsc --noEmit` clean; existing `browserConfig` / `browserDefaults` tests still pass.

## Scope / follow-ups (separate PRs)

- Optional **LLM fallback** for `ambiguous` / `not-found`, with the enumerated options as an **enum constraint** (can't hallucinate), gated behind API-key availability / opt-in, cached, off by default.
- Once discovery is proven in the field, retire the hard-coded version ladder and keep it only as a deep fallback.

Happy to adjust the direction — this is intentionally additive and behind a fallback so it can land incrementally. See `docs/model-discovery-proposal.md` for the full design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
