### PR TITLE
feat(codex): add security findings workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Codex Cloud: add explicit `oracle codex finding --action ...` commands for trusted Create PR, Chat, Close, Adjust, and copy actions while keeping `oracle codex findings` read-only.
 
+### Fixed
+
+- Codex Cloud: scope finding actions to the detail panel, verify action-specific UI outcomes, enforce `--repo` consistently, and replace repository-specific evidence filtering with configurable include/exclude path policies.
+
 ## 0.16.0 — 2026-07-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.16.1 — Unreleased
 
+### Added
+
+- Codex Cloud: add explicit `oracle codex finding --action ...` commands for trusted Create PR, Chat, Close, Adjust, and copy actions while keeping `oracle codex findings` read-only.
+
 ## 0.16.0 — 2026-07-12
 
 ### Added

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -1024,7 +1024,7 @@ addProjectSourcesCommonOptions(
 
 const codexCommand = program
   .command("codex")
-  .description("Read-only access to ChatGPT Codex Cloud (security findings).");
+  .description("Access ChatGPT Codex Cloud security findings and explicit finding actions.");
 
 function addCodexCommonOptions(command: Command): Command {
   return command
@@ -1053,6 +1053,12 @@ function addCodexCommonOptions(command: Command): Command {
     .option("--browser-keep-browser", "Keep Chrome running after completion.", false)
     .option("--browser-hide-window", "Hide Chrome window after launch on macOS.", false)
     .option("--browser-allow-cookie-errors", "Continue when cookie sync fails.", false)
+    .option("--repo <owner/name>", "Restrict findings to one repository.")
+    .option(
+      "--modal-only",
+      "Restrict Harp findings to evidence paths shipped by the Modal runtime; excludes frontend, local, tests, and evals.",
+      false,
+    )
     .option("--json", "Print structured JSON.", false)
     .option("-v, --verbose", "Enable verbose browser logging.", false);
 }
@@ -1067,6 +1073,33 @@ addCodexCommonOptions(
       "Show detail sections for a single finding (32-hex id) instead of the list.",
     )
     .option("--limit <n>", "Max number of findings to return (default: all).", parseIntOption),
+).action(async function (this: Command) {
+  const { runCodexFindingsCliCommand } = await import("../src/cli/codexFindings.js");
+  await runCodexFindingsCliCommand(this.optsWithGlobals());
+});
+
+addCodexCommonOptions(
+  codexCommand
+    .command("finding")
+    .description("Inspect or explicitly act on one Codex Cloud security finding.")
+    .requiredOption("--finding <id>", "Finding selection id (32 hexadecimal characters).")
+    .addOption(
+      new Option(
+        "--action <action>",
+        "Action: create-pr|chat|close|adjust|copy-content|copy-link|copy-patch|copy-git-apply.",
+      ).choices([
+        "create-pr",
+        "chat",
+        "close",
+        "adjust",
+        "copy-content",
+        "copy-link",
+        "copy-patch",
+        "copy-git-apply",
+      ]),
+    )
+    .option("--text <text>", "Text for the chat action.")
+    .option("--confirm", "Confirm a mutating action (create-pr|chat|close|adjust).", false),
 ).action(async function (this: Command) {
   const { runCodexFindingsCliCommand } = await import("../src/cli/codexFindings.js");
   await runCodexFindingsCliCommand(this.optsWithGlobals());

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -1047,6 +1047,10 @@ function addCodexCommonOptions(command: Command): Command {
     .option("--browser-chrome-profile <profile>", "Chrome profile name for cookie sync.")
     .option("--browser-chrome-path <path>", "Chrome/Chromium executable path.")
     .option("--browser-cookie-path <path>", "Explicit Chrome cookie DB path.")
+    .option(
+      "--copy-profile <dir>",
+      "Copy a signed-in Chrome user-data directory into a throwaway browser profile.",
+    )
     .option("--browser-inline-cookies <json>", "Inline ChatGPT cookies JSON.")
     .option("--browser-inline-cookies-file <path>", "File containing ChatGPT cookies JSON.")
     .option("--browser-no-cookie-sync", "Skip copying cookies from Chrome.")

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -1022,6 +1022,56 @@ addProjectSourcesCommonOptions(
   await runProjectSourcesCliCommand("add", this.optsWithGlobals());
 });
 
+const codexCommand = program
+  .command("codex")
+  .description("Read-only access to ChatGPT Codex Cloud (security findings).");
+
+function addCodexCommonOptions(command: Command): Command {
+  return command
+    .option(
+      "--chatgpt-url <url>",
+      "Codex Cloud findings URL (default https://chatgpt.com/codex/cloud/security/findings; or browser.chatgptUrl config).",
+    )
+    .addOption(
+      new Option("--browser-manual-login", "Reuse a persistent signed-in Chrome profile.").default(
+        undefined,
+      ),
+    )
+    .option("--browser-manual-login-profile-dir <path>", "Persistent Chrome profile directory.")
+    .option("--browser-timeout <duration>", "Overall browser timeout (e.g. 10m, 1h).")
+    .option("--browser-input-timeout <duration>", "Timeout waiting for the findings UI.")
+    .option("--browser-profile-lock-timeout <duration>", "Timeout waiting for profile launch lock.")
+    .option("--browser-reuse-wait <duration>", "Wait for an existing shared Chrome to appear.")
+    .option("--browser-max-concurrent-tabs <n>", "Concurrent tabs allowed for the shared profile.")
+    .option("--browser-cookie-wait <duration>", "Wait before retrying cookie sync.")
+    .option("--browser-chrome-profile <profile>", "Chrome profile name for cookie sync.")
+    .option("--browser-chrome-path <path>", "Chrome/Chromium executable path.")
+    .option("--browser-cookie-path <path>", "Explicit Chrome cookie DB path.")
+    .option("--browser-inline-cookies <json>", "Inline ChatGPT cookies JSON.")
+    .option("--browser-inline-cookies-file <path>", "File containing ChatGPT cookies JSON.")
+    .option("--browser-no-cookie-sync", "Skip copying cookies from Chrome.")
+    .option("--browser-keep-browser", "Keep Chrome running after completion.", false)
+    .option("--browser-hide-window", "Hide Chrome window after launch on macOS.", false)
+    .option("--browser-allow-cookie-errors", "Continue when cookie sync fails.", false)
+    .option("--json", "Print structured JSON.", false)
+    .option("-v, --verbose", "Enable verbose browser logging.", false);
+}
+
+addCodexCommonOptions(
+  codexCommand
+    .command("findings")
+    .description("List Codex Cloud security findings (read-only), or show one finding's detail.")
+    .option("--severity <sev>", "Filter list results by severity (critical|high|medium|low).")
+    .option(
+      "--finding <id>",
+      "Show detail sections for a single finding (32-hex id) instead of the list.",
+    )
+    .option("--limit <n>", "Max number of findings to return (default: all).", parseIntOption),
+).action(async function (this: Command) {
+  const { runCodexFindingsCliCommand } = await import("../src/cli/codexFindings.js");
+  await runCodexFindingsCliCommand(this.optsWithGlobals());
+});
+
 const bridgeCommand = program
   .command("bridge")
   .description("Bridge a Windows-hosted ChatGPT session to Linux clients.");

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -1054,11 +1054,6 @@ function addCodexCommonOptions(command: Command): Command {
     .option("--browser-hide-window", "Hide Chrome window after launch on macOS.", false)
     .option("--browser-allow-cookie-errors", "Continue when cookie sync fails.", false)
     .option("--repo <owner/name>", "Restrict findings to one repository.")
-    .option(
-      "--modal-only",
-      "Restrict Harp findings to evidence paths shipped by the Modal runtime; excludes frontend, local, tests, and evals.",
-      false,
-    )
     .option("--json", "Print structured JSON.", false)
     .option("-v, --verbose", "Enable verbose browser logging.", false);
 }
@@ -1099,6 +1094,18 @@ addCodexCommonOptions(
       ]),
     )
     .option("--text <text>", "Text for the chat action.")
+    .option(
+      "--evidence-prefix <paths...>",
+      "Require action evidence paths to match one of these repository-relative prefixes.",
+      collectTextValues,
+      [],
+    )
+    .option(
+      "--exclude-evidence <paths...>",
+      "Reject action evidence paths matching one of these repository-relative prefixes.",
+      collectTextValues,
+      [],
+    )
     .option("--confirm", "Confirm a mutating action (create-pr|chat|close|adjust).", false),
 ).action(async function (this: Command) {
   const { runCodexFindingsCliCommand } = await import("../src/cli/codexFindings.js");

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@steipete/oracle",
   "version": "0.16.0",
-  "description": "CLI wrapper around OpenAI Responses API with GPT-5.6 Sol, GPT-5.6, GPT-5.5 Pro, GPT-5.5, GPT-5.4, GPT-5.2, GPT-5.1, and GPT-5.1 Codex high reasoning modes. Adds a read-only `oracle codex findings` command to list and inspect ChatGPT Codex Cloud security findings.",
+  "description": "CLI wrapper around OpenAI Responses API with GPT-5.6 Sol, GPT-5.6, GPT-5.5 Pro, GPT-5.5, GPT-5.4, GPT-5.2, GPT-5.1, and GPT-5.1 Codex high reasoning modes.",
   "keywords": [],
   "homepage": "https://askoracle.sh",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@steipete/oracle",
   "version": "0.16.0",
-  "description": "CLI wrapper around OpenAI Responses API with GPT-5.6 Sol, GPT-5.6, GPT-5.5 Pro, GPT-5.5, GPT-5.4, GPT-5.2, GPT-5.1, and GPT-5.1 Codex high reasoning modes.",
+  "description": "CLI wrapper around OpenAI Responses API with GPT-5.6 Sol, GPT-5.6, GPT-5.5 Pro, GPT-5.5, GPT-5.4, GPT-5.2, GPT-5.1, and GPT-5.1 Codex high reasoning modes. Adds a read-only `oracle codex findings` command to list and inspect ChatGPT Codex Cloud security findings.",
   "keywords": [],
   "homepage": "https://askoracle.sh",
   "bugs": {

--- a/src/browser/actions/codexFindings.ts
+++ b/src/browser/actions/codexFindings.ts
@@ -1,0 +1,332 @@
+import type { BrowserLogger, ChromeClient } from "../types.js";
+import type {
+  CodexFinding,
+  CodexFindingDetail,
+  CodexFindingDetailSection,
+  CodexFindingsPageCounter,
+} from "../../codex/types.js";
+import {
+  parseFindingItem,
+  parseFindingsCounter,
+  type RawFindingItem,
+} from "../../codex/findings.js";
+import { delay } from "../utils.js";
+
+type Runtime = ChromeClient["Runtime"];
+
+export interface FindingsPage {
+  items: CodexFinding[];
+  counter?: CodexFindingsPageCounter;
+  hasNext: boolean;
+  hasPrev: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// LIST — the findings list is SSR'd into the page and rendered as `li > button`
+// rows (no href). We read them from the DOM in the main world. Pagination is a
+// plain `.click()` on the Next-page control (verified to advance the list).
+// The click helper is deny-list guarded so it can only ever hit Prev/Next.
+// ---------------------------------------------------------------------------
+
+export function buildFindingsReadyExpression(): string {
+  return `(() => {
+    const visible = (node) => {
+      if (!(node instanceof HTMLElement)) return false;
+      const rect = node.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) return false;
+      const style = window.getComputedStyle(node);
+      return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
+    };
+    const rows = [...document.querySelectorAll('li > button')].filter((b) => visible(b));
+    if (rows.length > 0) return { ready: true };
+    const empty = [...document.querySelectorAll('main *')].some(
+      (e) => /no findings/i.test(e.textContent || '') && visible(e),
+    );
+    if (empty) return { ready: true, empty: true };
+    if (!document.querySelector('main')) return { ready: false, reason: 'findings main container not mounted yet' };
+    return { ready: false, reason: 'no finding rows visible yet' };
+  })()`;
+}
+
+export function buildFindingsPageExpression(): string {
+  return `(() => {
+    try {
+      const disabled = (b) => !b || b.disabled || b.getAttribute('aria-disabled') === 'true';
+      const rows = [...document.querySelectorAll('li > button')];
+      const items = rows.map((b) => {
+        const sev = b.closest('li').querySelector('[aria-label*="severity" i]');
+        return {
+          innerText: b.innerText || '',
+          severityLabel: sev ? (sev.getAttribute('aria-label') || sev.textContent || null) : null,
+        };
+      });
+      const counterEl = [...document.querySelectorAll('*')]
+        .map((e) => e.textContent || '')
+        .find((t) => /\\d[\\d,]*\\s*[-–—]\\s*\\d[\\d,]*\\s+of\\s+\\d[\\d,]*/.test(t));
+      const counterText = counterEl
+        ? counterEl.match(/\\d[\\d,]*\\s*[-–—]\\s*\\d[\\d,]*\\s+of\\s+\\d[\\d,]*/)[0]
+        : null;
+      const next = document.querySelector('button[aria-label="Next page"]');
+      const prev = document.querySelector('button[aria-label="Previous page"]');
+      return { ok: true, page: { items, counterText, hasNext: !disabled(next), hasPrev: !disabled(prev) } };
+    } catch (e) {
+      return { ok: false, error: String((e && e.message) || e) };
+    }
+  })()`;
+}
+
+// Deny-list of mutating actions; the pagination click refuses any target whose accessible name
+// matches, and only ever resolves the exact Prev/Next aria-labels.
+export function buildPaginationClickExpression(label: "Next page" | "Previous page"): string {
+  const deny =
+    "create\\\\s*pr|open\\\\s*pr|patch|report|chat|adjust|feedback|thumbs|revert|apply|merge|commit|comment|resolve|dismiss|submit|close";
+  return `(() => {
+    const DENY = /${deny}/i;
+    const b = document.querySelector('button[aria-label=${JSON.stringify(label)}]');
+    if (!b) return { ok: false, disabled: true };
+    if (b.disabled || b.getAttribute('aria-disabled') === 'true') return { ok: false, disabled: true };
+    const name = (b.getAttribute('aria-label') || b.textContent || '').trim();
+    if (name !== ${JSON.stringify(label)} || DENY.test(name)) return { ok: false, reason: 'refused: unexpected button label ' + name };
+    b.scrollIntoView({ block: 'center' });
+    b.click();
+    return { ok: true };
+  })()`;
+}
+
+export async function waitForFindingsReady(
+  runtime: Runtime,
+  timeoutMs: number,
+  logger: BrowserLogger,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastReason = "unknown";
+  while (Date.now() < deadline) {
+    const outcome = await runtime
+      .evaluate({ expression: buildFindingsReadyExpression(), returnByValue: true })
+      .catch((error) => ({
+        result: {
+          value: { ready: false, reason: error instanceof Error ? error.message : String(error) },
+        },
+      }));
+    const value = outcome.result?.value as { ready?: boolean; reason?: string } | undefined;
+    if (value?.ready === true) {
+      return;
+    }
+    lastReason = value?.reason ?? lastReason;
+    await delay(250);
+  }
+  logger(`Findings list did not become ready before timeout (${lastReason})`);
+  throw new Error("Findings list did not become ready before timeout.");
+}
+
+export async function readFindingsPage(runtime: Runtime): Promise<FindingsPage> {
+  const outcome = await runtime.evaluate({
+    expression: buildFindingsPageExpression(),
+    returnByValue: true,
+  });
+  const value = outcome.result?.value as
+    | {
+        ok?: boolean;
+        error?: string;
+        page?: {
+          items: RawFindingItem[];
+          counterText: string | null;
+          hasNext: boolean;
+          hasPrev: boolean;
+        };
+      }
+    | undefined;
+  if (!value?.ok || !value.page) {
+    throw new Error(value?.error ?? "Unable to read the findings list.");
+  }
+  const page = value.page;
+  return {
+    items: page.items.map((raw, index) => parseFindingItem(raw, index)),
+    counter: parseFindingsCounter(page.counterText) ?? undefined,
+    hasNext: page.hasNext,
+    hasPrev: page.hasPrev,
+  };
+}
+
+// Poll until the list settles (debounced), mirroring the project-sources settle idiom.
+export async function waitForFindingsPageSettled(
+  runtime: Runtime,
+  timeoutMs: number,
+  logger: BrowserLogger,
+): Promise<FindingsPage> {
+  const deadline = Date.now() + Math.min(timeoutMs, 30_000);
+  const startedAt = Date.now();
+  let previousKey: string | null = null;
+  let stableSince = Date.now();
+  let latest = await readFindingsPage(runtime);
+  while (Date.now() < deadline) {
+    latest = await readFindingsPage(runtime);
+    const key = `${latest.counter?.from}-${latest.counter?.to}/${latest.counter?.total}\n${latest.items
+      .map((i) => i.id)
+      .join("\n")}`;
+    if (key !== previousKey) {
+      previousKey = key;
+      stableSince = Date.now();
+    }
+    const stableForMs = Date.now() - stableSince;
+    const observedForMs = Date.now() - startedAt;
+    if (observedForMs >= 1500 && stableForMs >= 500) {
+      return latest;
+    }
+    await delay(250);
+  }
+  logger("Findings list did not settle before timeout; returning latest snapshot.");
+  return latest;
+}
+
+// Returns false when there is no next page or the visible range did not advance.
+export async function goToNextFindingsPage(
+  runtime: Runtime,
+  timeoutMs: number,
+  logger: BrowserLogger,
+): Promise<boolean> {
+  const before = await readFindingsPage(runtime);
+  if (!before.hasNext) {
+    return false;
+  }
+  const outcome = await runtime.evaluate({
+    expression: buildPaginationClickExpression("Next page"),
+    returnByValue: true,
+  });
+  const value = outcome.result?.value as
+    | { ok?: boolean; disabled?: boolean; reason?: string }
+    | undefined;
+  if (!value?.ok) {
+    if (value?.reason) {
+      logger(`[debug] Next-page click refused: ${value.reason}`);
+    }
+    return false;
+  }
+  const after = await waitForFindingsPageSettled(runtime, timeoutMs, logger);
+  const advanced = (after.counter?.from ?? 0) > (before.counter?.from ?? 0);
+  return advanced;
+}
+
+// ---------------------------------------------------------------------------
+// DETAIL — direct-URL nav then DOM reads only. No click, no mutation.
+// ---------------------------------------------------------------------------
+
+export function buildFindingDetailReadyExpression(): string {
+  return `(() => {
+    const visible = (node) => {
+      if (!(node instanceof HTMLElement)) return false;
+      const rect = node.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) return false;
+      const style = window.getComputedStyle(node);
+      return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
+    };
+    const IDS = ['summary', 'validation', 'evidence', 'attack-path'];
+    const ready = IDS.some((id) => {
+      const a = document.querySelector('a[href="#' + id + '"]');
+      const c = a ? a.closest('section, div') : document.getElementById(id);
+      return visible(a) || visible(c);
+    });
+    if (ready) return { ready: true };
+    if (!document.querySelector('main')) return { ready: false, reason: 'detail main container not mounted yet' };
+    return { ready: false, reason: 'no section anchor visible yet' };
+  })()`;
+}
+
+export function buildFindingDetailExpression(): string {
+  return `(() => {
+    const normalize = (v) => String(v || '').replace(/\\s+/g, ' ').trim();
+    const main = document.querySelector('main');
+    if (!(main instanceof HTMLElement)) return { ok: false, error: 'Finding detail main container not found.' };
+    const SECTIONS = [
+      { id: 'summary', heading: 'Summary' }, { id: 'validation', heading: 'Validation' },
+      { id: 'evidence', heading: 'Evidence' }, { id: 'attack-path', heading: 'Attack path' },
+    ];
+    const sections = [];
+    for (const spec of SECTIONS) {
+      const a = document.querySelector('a[href="#' + spec.id + '"]');
+      const c = a ? a.closest('section, div') : document.getElementById(spec.id);
+      const text = c instanceof HTMLElement ? normalize(c.innerText) : '';
+      if (text) sections.push({ id: spec.id, heading: spec.heading, text });
+    }
+    const h = main.querySelector('h1, h2');
+    const title = h instanceof HTMLElement ? normalize(h.innerText) : '';
+    const repo = [...main.querySelectorAll('a[href*="/commit/"]')]
+      .map((a) => a.getAttribute('href')).find((x) => typeof x === 'string' && x.length > 0) || null;
+    const files = [...new Set(
+      [...document.querySelectorAll('a[href*="/blob/"]')]
+        .map((a) => a.getAttribute('href')).filter((x) => typeof x === 'string' && x.length > 0)
+    )];
+    const validationArtifact = [...document.querySelectorAll('a')]
+      .map((a) => a.getAttribute('href'))
+      .find((x) => typeof x === 'string' && /oaiusercontent\\.com\\/files\\//u.test(x)) || null;
+    if (sections.length === 0 && !title) return { ok: false, error: 'Finding detail has no readable sections or title yet.' };
+    return { ok: true, detail: { title, repo, sections, files, validationArtifact } };
+  })()`;
+}
+
+export async function waitForFindingDetailReady(
+  runtime: Runtime,
+  timeoutMs: number,
+  logger: BrowserLogger,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastReason = "unknown";
+  while (Date.now() < deadline) {
+    const outcome = await runtime
+      .evaluate({ expression: buildFindingDetailReadyExpression(), returnByValue: true })
+      .catch((error) => ({
+        result: {
+          value: { ready: false, reason: error instanceof Error ? error.message : String(error) },
+        },
+      }));
+    const value = outcome.result?.value as { ready?: boolean; reason?: string } | undefined;
+    if (value?.ready === true) {
+      return;
+    }
+    lastReason = value?.reason ?? lastReason;
+    await delay(250);
+  }
+  logger(`Finding detail did not become ready before timeout (${lastReason})`);
+  throw new Error("Finding detail did not become ready before timeout.");
+}
+
+export async function readFindingDetail(
+  runtime: Runtime,
+  findingId: string,
+): Promise<CodexFindingDetail> {
+  const outcome = await runtime.evaluate({
+    expression: buildFindingDetailExpression(),
+    returnByValue: true,
+  });
+  const value = outcome.result?.value as
+    | {
+        ok?: boolean;
+        error?: string;
+        detail?: {
+          title: string;
+          repo: string | null;
+          sections: CodexFindingDetailSection[];
+          files: string[];
+          validationArtifact: string | null;
+        };
+      }
+    | undefined;
+  if (!value?.ok || !value.detail) {
+    throw new Error(value?.error ?? "Unable to read the finding detail.");
+  }
+  const detail = value.detail;
+  return {
+    finding: {
+      id: findingId,
+      selectionId: findingId,
+      title: detail.title,
+      severity: "unknown",
+      index: 0,
+    },
+    title: detail.title,
+    repo: detail.repo,
+    sections: Array.isArray(detail.sections) ? detail.sections : [],
+    files: Array.isArray(detail.files) ? detail.files : [],
+    validationArtifact: detail.validationArtifact ?? null,
+  };
+}

--- a/src/browser/actions/codexFindings.ts
+++ b/src/browser/actions/codexFindings.ts
@@ -1,5 +1,6 @@
 import type { BrowserLogger, ChromeClient } from "../types.js";
 import type {
+  CodexFindingAction,
   CodexFinding,
   CodexFindingDetail,
   CodexFindingDetailSection,
@@ -13,12 +14,20 @@ import {
 import { delay } from "../utils.js";
 
 type Runtime = ChromeClient["Runtime"];
+type Input = ChromeClient["Input"];
 
 export interface FindingsPage {
   items: CodexFinding[];
   counter?: CodexFindingsPageCounter;
   hasNext: boolean;
   hasPrev: boolean;
+}
+
+export interface FindingActionResult {
+  status: string;
+  message?: string;
+  url?: string;
+  text?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -328,5 +337,226 @@ export async function readFindingDetail(
     sections: Array.isArray(detail.sections) ? detail.sections : [],
     files: Array.isArray(detail.files) ? detail.files : [],
     validationArtifact: detail.validationArtifact ?? null,
+  };
+}
+
+function actionButtonName(action: CodexFindingAction | "submit"): string {
+  switch (action) {
+    case "create-pr":
+      return "Create PR";
+    case "chat":
+      return "Chat";
+    case "close":
+      return "Close";
+    case "adjust":
+      return "Adjust";
+    case "copy-content":
+      return "Copy finding content";
+    case "copy-link":
+      return "Copy finding link";
+    case "copy-patch":
+    case "copy-git-apply":
+      return "Open git action menu";
+    case "submit":
+      return "Submit";
+  }
+}
+
+export function buildFindingActionTargetExpression(action: CodexFindingAction): string {
+  return buildButtonTargetExpression(actionButtonName(action));
+}
+
+function buildButtonTargetExpression(name: string): string {
+  return `(() => {
+    const wanted = ${JSON.stringify(name)};
+    const visible = (node) => {
+      if (!(node instanceof HTMLElement)) return false;
+      const rect = node.getBoundingClientRect();
+      const style = window.getComputedStyle(node);
+      return rect.width > 0 && rect.height > 0 && style.display !== 'none' && style.visibility !== 'hidden';
+    };
+    const nodes = [...document.querySelectorAll('button')];
+    const button = nodes.find((node) => {
+      const label = (node.getAttribute('aria-label') || node.innerText || '').trim();
+      return label === wanted && visible(node) && !node.disabled && node.getAttribute('aria-disabled') !== 'true';
+    });
+    if (!button) return { ok: false, reason: 'button not found: ' + wanted };
+    button.scrollIntoView({ block: 'center', inline: 'center' });
+    const rect = button.getBoundingClientRect();
+    return { ok: true, x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  })()`;
+}
+
+function buildNamedButtonTargetExpression(name: string): string {
+  return buildButtonTargetExpression(name);
+}
+
+async function clickTrustedPoint(
+  runtime: Runtime,
+  input: Input,
+  x: number,
+  y: number,
+): Promise<void> {
+  if (input && typeof input.dispatchMouseEvent === "function") {
+    await input.dispatchMouseEvent({ type: "mouseMoved", x, y });
+    await input.dispatchMouseEvent({ type: "mousePressed", x, y, button: "left", clickCount: 1 });
+    await input.dispatchMouseEvent({ type: "mouseReleased", x, y, button: "left", clickCount: 1 });
+    return;
+  }
+  throw new Error("Trusted browser input is unavailable; refusing to trigger a finding action.");
+}
+
+async function clickFindingActionButton(
+  runtime: Runtime,
+  input: Input,
+  action: CodexFindingAction,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let reason = "button not found";
+  while (Date.now() < deadline) {
+    const value = (
+      await runtime.evaluate({
+        expression: buildFindingActionTargetExpression(action),
+        returnByValue: true,
+      })
+    ).result?.value as { ok?: boolean; x?: number; y?: number; reason?: string } | undefined;
+    if (value?.ok && typeof value.x === "number" && typeof value.y === "number") {
+      await clickTrustedPoint(runtime, input, value.x, value.y);
+      return;
+    }
+    reason = value?.reason ?? reason;
+    await delay(250);
+  }
+  throw new Error(`Finding action ${action} was not ready: ${reason}`);
+}
+
+async function clickNamedButton(
+  runtime: Runtime,
+  input: Input,
+  name: string,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let reason = "button not found";
+  while (Date.now() < deadline) {
+    const value = (
+      await runtime.evaluate({
+        expression: buildNamedButtonTargetExpression(name),
+        returnByValue: true,
+      })
+    ).result?.value as { ok?: boolean; x?: number; y?: number; reason?: string } | undefined;
+    if (value?.ok && typeof value.x === "number" && typeof value.y === "number") {
+      await clickTrustedPoint(runtime, input, value.x, value.y);
+      return;
+    }
+    reason = value?.reason ?? reason;
+    await delay(250);
+  }
+  throw new Error(`Finding button ${name} was not ready: ${reason}`);
+}
+
+async function openGitActionMenu(runtime: Runtime, input: Input, timeoutMs: number): Promise<void> {
+  await clickNamedButton(runtime, input, "Open git action menu", timeoutMs);
+}
+
+async function fillFindingChat(runtime: Runtime, text: string): Promise<void> {
+  const expression = `(() => {
+    const input = document.querySelector('textarea[placeholder="Ask a question or add context (optional)"]');
+    if (!(input instanceof HTMLTextAreaElement)) return false;
+    const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+    setter?.call(input, ${JSON.stringify(text)});
+    input.dispatchEvent(new InputEvent('input', { bubbles: true, data: ${JSON.stringify(text)}, inputType: 'insertText' }));
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    return true;
+  })()`;
+  const value = (await runtime.evaluate({ expression, returnByValue: true })).result?.value;
+  if (value !== true) throw new Error("Finding chat composer was not found.");
+}
+
+export async function executeFindingAction(
+  runtime: Runtime,
+  input: Input,
+  action: CodexFindingAction,
+  actionText: string | undefined,
+  timeoutMs: number,
+  logger: BrowserLogger,
+): Promise<FindingActionResult> {
+  if (action === "create-pr") {
+    await openGitActionMenu(runtime, input, timeoutMs);
+    const existing = (
+      await runtime.evaluate({
+        expression: `(() => {
+        const item = [...document.querySelectorAll('[role="menuitem"]')].find((el) => (el.innerText || '').trim() === 'View PR');
+        if (!(item instanceof HTMLElement)) return null;
+        const link = item.closest('a')?.href || item.querySelector('a')?.href || null;
+        return { link };
+      })()`,
+        returnByValue: true,
+      })
+    ).result?.value as { link?: string | null } | null | undefined;
+    if (existing) {
+      await input.dispatchKeyEvent({ type: "keyDown", key: "Escape", code: "Escape" });
+      await input.dispatchKeyEvent({ type: "keyUp", key: "Escape", code: "Escape" });
+      return {
+        status: "existing-pr",
+        message: "A PR already exists for this finding.",
+        url: existing.link ?? undefined,
+      };
+    }
+    await input.dispatchKeyEvent({ type: "keyDown", key: "Escape", code: "Escape" });
+    await input.dispatchKeyEvent({ type: "keyUp", key: "Escape", code: "Escape" });
+  }
+  await clickFindingActionButton(runtime, input, action, timeoutMs);
+  if (action === "chat") {
+    if (!actionText?.trim()) throw new Error("chat requires --text");
+    await fillFindingChat(runtime, actionText);
+    await clickNamedButton(runtime, input, "Submit", timeoutMs);
+  }
+  if (action === "copy-patch" || action === "copy-git-apply") {
+    const menuText = action === "copy-patch" ? "Copy patch" : "Copy git apply";
+    const expression = `(() => {
+      const wanted = ${JSON.stringify(menuText)};
+      const node = [...document.querySelectorAll('[role="menuitem"]')].find((el) => (el.innerText || '').trim() === wanted);
+      if (!(node instanceof HTMLElement)) return null;
+      const rect = node.getBoundingClientRect();
+      return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+    })()`;
+    const value = (await runtime.evaluate({ expression, returnByValue: true })).result?.value as
+      | { x?: number; y?: number }
+      | null
+      | undefined;
+    if (!value || typeof value.x !== "number" || typeof value.y !== "number") {
+      throw new Error(`Finding git menu item was not found: ${menuText}`);
+    }
+    await clickTrustedPoint(runtime, input, value.x, value.y);
+  }
+  const deadline = Date.now() + Math.min(timeoutMs, 30_000);
+  let state:
+    | { url?: string; text?: string; pr?: string | null; dialog?: string | null }
+    | undefined;
+  while (Date.now() < deadline) {
+    state = (
+      await runtime.evaluate({
+        expression: `(() => ({
+          url: location.href,
+          text: document.querySelector('main')?.innerText?.slice(0, 2000) || '',
+          pr: [...document.querySelectorAll('a[href*="/pull/"]')].map((a) => a.href)[0] || null,
+          dialog: document.querySelector('[role="dialog"]')?.innerText || null,
+        }))()`,
+        returnByValue: true,
+      })
+    ).result?.value as
+      | { url?: string; text?: string; pr?: string | null; dialog?: string | null }
+      | undefined;
+    if (action !== "create-pr" || state?.pr || state?.dialog) break;
+    await delay(250);
+  }
+  logger(`[codex] finding action completed: ${action}`);
+  return {
+    status: "ok",
+    message: state?.dialog ?? (action === "create-pr" && state?.pr ? "PR created" : undefined),
+    url: state?.pr ?? state?.url,
+    text: state?.text,
   };
 }

--- a/src/browser/actions/codexFindings.ts
+++ b/src/browser/actions/codexFindings.ts
@@ -375,9 +375,15 @@ function buildButtonTargetExpression(name: string): string {
       const style = window.getComputedStyle(node);
       return rect.width > 0 && rect.height > 0 && style.display !== 'none' && style.visibility !== 'hidden';
     };
-    const nodes = [...document.querySelectorAll('button')];
+    const labelFor = (node) => (node.getAttribute('aria-label') || node.innerText || '').trim();
+    const panel = [...document.querySelectorAll('section')].find((section) =>
+      section.querySelector('a[href="#summary"]') &&
+      [...section.querySelectorAll('button')].some((node) => labelFor(node) === wanted && visible(node)),
+    );
+    if (!panel) return { ok: false, reason: 'finding action panel not found' };
+    const nodes = [...panel.querySelectorAll('button')];
     const button = nodes.find((node) => {
-      const label = (node.getAttribute('aria-label') || node.innerText || '').trim();
+      const label = labelFor(node);
       return label === wanted && visible(node) && !node.disabled && node.getAttribute('aria-disabled') !== 'true';
     });
     if (!button) return { ok: false, reason: 'button not found: ' + wanted };
@@ -385,6 +391,92 @@ function buildButtonTargetExpression(name: string): string {
     const rect = button.getBoundingClientRect();
     return { ok: true, x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
   })()`;
+}
+
+function buildFindingActionStateExpression(): string {
+  return `(() => {
+    const panel = [...document.querySelectorAll('section')].find((section) =>
+      section.querySelector('a[href="#summary"]') &&
+      section.querySelector('button'),
+    );
+    const panelText = panel?.innerText || '';
+    const labels = panel ? [...panel.querySelectorAll('button')].map((node) =>
+      (node.getAttribute('aria-label') || node.innerText || '').trim(),
+    ) : [];
+    const liveText = [...document.querySelectorAll('[role="alert"], [role="status"], [aria-live]')]
+      .map((node) => node.innerText || node.textContent || '')
+      .join('\\n');
+    const menuOpen = document.querySelector('[role="menu"], [data-radix-popper-content-wrapper]') !== null;
+    const dialogText = [...document.querySelectorAll('[role="dialog"]')]
+      .map((node) => node.innerText || '')
+      .join('\\n');
+    return {
+      panelText,
+      liveText,
+      dialogText,
+      menuOpen,
+      hasClose: labels.includes('Close'),
+      hasSubmit: labels.includes('Submit'),
+      pr: [...document.querySelectorAll('a[href*="/pull/"]')].map((a) => a.href)[0] || null,
+    };
+  })()`;
+}
+
+type FindingActionState = {
+  panelText?: string;
+  liveText?: string;
+  dialogText?: string;
+  menuOpen?: boolean;
+  hasClose?: boolean;
+  hasSubmit?: boolean;
+  pr?: string | null;
+};
+
+async function readFindingActionState(runtime: Runtime): Promise<FindingActionState> {
+  const evaluated = await runtime.evaluate({
+    expression: buildFindingActionStateExpression(),
+    returnByValue: true,
+  });
+  const value = evaluated.result?.value as FindingActionState | undefined;
+  if (!value) {
+    const description =
+      evaluated.exceptionDetails?.exception?.description ??
+      evaluated.exceptionDetails?.text ??
+      "no state returned";
+    throw new Error(`Unable to read finding action panel state: ${description}`);
+  }
+  return value;
+}
+
+async function waitForFindingActionPostcondition(
+  runtime: Runtime,
+  action: CodexFindingAction,
+  before: FindingActionState,
+  timeoutMs: number,
+): Promise<FindingActionState> {
+  const deadline = Date.now() + Math.min(timeoutMs, 30_000);
+  let state = await readFindingActionState(runtime);
+  while (Date.now() < deadline) {
+    const liveChanged = state.liveText !== before.liveText;
+    const panelChanged = state.panelText !== before.panelText;
+    const copied = /copied|clipboard/iu.test(state.liveText ?? "");
+    const complete =
+      action === "copy-content" || action === "copy-link"
+        ? copied
+        : action === "copy-patch" || action === "copy-git-apply"
+          ? state.menuOpen === false
+          : action === "chat"
+            ? state.hasSubmit === false || panelChanged || liveChanged
+            : action === "close"
+              ? state.hasClose === false || /closed/iu.test(state.panelText ?? "") || panelChanged
+              : action === "adjust"
+                ? Boolean(state.dialogText) || panelChanged || liveChanged
+                : Boolean(state.pr) || Boolean(state.dialogText);
+    if (complete) return state;
+    await delay(250);
+    state = await readFindingActionState(runtime);
+  }
+  throw new Error(`Finding action ${action} did not produce its expected UI result.`);
 }
 
 function buildNamedButtonTargetExpression(name: string): string {
@@ -482,6 +574,7 @@ export async function executeFindingAction(
   timeoutMs: number,
   logger: BrowserLogger,
 ): Promise<FindingActionResult> {
+  const before = await readFindingActionState(runtime);
   if (action === "create-pr") {
     await openGitActionMenu(runtime, input, timeoutMs);
     const existing = (
@@ -531,32 +624,12 @@ export async function executeFindingAction(
     }
     await clickTrustedPoint(runtime, input, value.x, value.y);
   }
-  const deadline = Date.now() + Math.min(timeoutMs, 30_000);
-  let state:
-    | { url?: string; text?: string; pr?: string | null; dialog?: string | null }
-    | undefined;
-  while (Date.now() < deadline) {
-    state = (
-      await runtime.evaluate({
-        expression: `(() => ({
-          url: location.href,
-          text: document.querySelector('main')?.innerText?.slice(0, 2000) || '',
-          pr: [...document.querySelectorAll('a[href*="/pull/"]')].map((a) => a.href)[0] || null,
-          dialog: document.querySelector('[role="dialog"]')?.innerText || null,
-        }))()`,
-        returnByValue: true,
-      })
-    ).result?.value as
-      | { url?: string; text?: string; pr?: string | null; dialog?: string | null }
-      | undefined;
-    if (action !== "create-pr" || state?.pr || state?.dialog) break;
-    await delay(250);
-  }
+  const state = await waitForFindingActionPostcondition(runtime, action, before, timeoutMs);
   logger(`[codex] finding action completed: ${action}`);
   return {
     status: "ok",
-    message: state?.dialog ?? (action === "create-pr" && state?.pr ? "PR created" : undefined),
-    url: state?.pr ?? state?.url,
-    text: state?.text,
+    message: state.dialogText ?? (action === "create-pr" && state.pr ? "PR created" : undefined),
+    url: state.pr ?? undefined,
+    text: state.panelText,
   };
 }

--- a/src/browser/codexFindingsRunner.ts
+++ b/src/browser/codexFindingsRunner.ts
@@ -55,12 +55,12 @@ import { normalizeCodexFindingsUrl, buildFindingDetailUrl } from "../codex/url.j
 import {
   aggregateFindingPages,
   githubRepoFromUrl,
-  isModalRuntimeEvidence,
+  isEvidencePathAllowed,
   shouldStopPaging,
 } from "../codex/findings.js";
 import type {
   CodexFinding,
-  CodexFindingsPageCounter,
+  CodexFindingDetail,
   CodexFindingsRequest,
   CodexFindingsResult,
 } from "../codex/types.js";
@@ -215,6 +215,7 @@ export async function runBrowserCodexFindings(
       const detail = await raceWithDisconnect(
         readFindingDetail(Runtime, requireFindingId(request.findingId)),
       );
+      assertFindingScope(detail, request);
       completed = true;
       return {
         status: "ok",
@@ -236,20 +237,7 @@ export async function runBrowserCodexFindings(
       await raceWithDisconnect(navigateToChatGPT(Page, Runtime, detailUrl, logger));
       await raceWithDisconnect(waitForFindingDetailReady(Runtime, config.inputTimeoutMs, logger));
       const detail = await raceWithDisconnect(readFindingDetail(Runtime, findingId));
-      const expectedRepo = request.repo ?? (request.modalOnly ? "umgbhalla/harp" : undefined);
-      if (expectedRepo && githubRepoFromUrl(detail.repo ?? "") !== expectedRepo) {
-        throw new Error(
-          `Finding ${findingId} belongs to ${githubRepoFromUrl(detail.repo ?? "") ?? "an unknown repository"}, not ${expectedRepo}.`,
-        );
-      }
-      if (
-        request.modalOnly &&
-        (detail.files.length === 0 || detail.files.some((file) => !isModalRuntimeEvidence(file)))
-      ) {
-        throw new Error(
-          `Finding ${findingId} is not Modal-runtime-only; refusing action because its evidence includes frontend, local-only, test, eval, or unknown paths.`,
-        );
-      }
+      assertFindingScope(detail, request);
       const actionResult: FindingActionResult = await raceWithDisconnect(
         executeFindingAction(
           Runtime,
@@ -280,7 +268,6 @@ export async function runBrowserCodexFindings(
     const limit =
       typeof request.limit === "number" && request.limit >= 0 ? request.limit : undefined;
     const pages: CodexFinding[][] = [];
-    let counter: CodexFindingsPageCounter | undefined;
     let pagesVisited = 0;
     // Hard cap so a mis-reporting counter can never loop forever.
     const maxPages = 100;
@@ -289,10 +276,9 @@ export async function runBrowserCodexFindings(
         waitForFindingsPageSettled(Runtime, config.inputTimeoutMs, logger),
       );
       pages.push(page.items);
-      counter = page.counter;
       pagesVisited += 1;
       const collected = aggregateFindingPages(pages).length;
-      if (!request.repo && !request.modalOnly && limit !== undefined && collected >= limit) {
+      if (!request.repo && limit !== undefined && collected >= limit) {
         break;
       }
       if (shouldStopPaging(page.counter, pagesVisited)) {
@@ -306,13 +292,11 @@ export async function runBrowserCodexFindings(
       }
     }
     let findings = aggregateFindingPages(pages);
-    if (request.repo || request.modalOnly) {
-      const expectedRepo = request.repo ?? "umgbhalla/harp";
-      findings = findings.filter((finding) => finding.repo === expectedRepo);
-    }
+    if (request.repo) findings = findings.filter((finding) => finding.repo === request.repo);
     if (request.severity) {
       findings = findings.filter((f) => f.severity === request.severity);
     }
+    const filteredTotal = findings.length;
     if (limit !== undefined) {
       findings = findings.slice(0, limit);
     }
@@ -323,10 +307,10 @@ export async function runBrowserCodexFindings(
       operation: "list",
       findingsUrl,
       findings,
-      counter: counter ?? {
+      counter: {
         from: findings.length ? 1 : 0,
         to: findings.length,
-        total: findings.length,
+        total: filteredTotal,
       },
       warnings,
       tookMs: Date.now() - startedAt,
@@ -403,6 +387,25 @@ export async function runBrowserCodexFindings(
     if (cleanupProfileLock) {
       await cleanupProfileLock.release().catch(() => undefined);
     }
+  }
+}
+
+function assertFindingScope(detail: CodexFindingDetail, request: CodexFindingsRequest): void {
+  if (request.repo && githubRepoFromUrl(detail.repo ?? "") !== request.repo) {
+    throw new Error(
+      `Finding belongs to ${githubRepoFromUrl(detail.repo ?? "") ?? "an unknown repository"}, not ${request.repo}.`,
+    );
+  }
+  const includePrefixes = request.evidencePrefixes ?? [];
+  const excludePrefixes = request.evidenceExcludes ?? [];
+  if (includePrefixes.length === 0 && excludePrefixes.length === 0) return;
+  if (
+    detail.files.length === 0 ||
+    detail.files.some((file) => !isEvidencePathAllowed(file, { includePrefixes, excludePrefixes }))
+  ) {
+    throw new Error(
+      "Finding evidence does not satisfy the requested path policy; refusing to continue.",
+    );
   }
 }
 

--- a/src/browser/codexFindingsRunner.ts
+++ b/src/browser/codexFindingsRunner.ts
@@ -34,6 +34,7 @@ import {
   writeDevToolsActivePort,
   type ProfileRunLock,
 } from "./profileState.js";
+import { copyChromeProfile } from "./profileCopy.js";
 import { CHATGPT_URL } from "./constants.js";
 import { delay } from "./utils.js";
 import {
@@ -94,6 +95,7 @@ export async function runBrowserCodexFindings(
   }
 
   const manualLogin = Boolean(config.manualLogin);
+  const usingCopiedProfile = Boolean(config.copyProfileSource);
   const manualProfileDir = config.manualLoginProfileDir
     ? path.resolve(config.manualLoginProfileDir)
     : defaultManualLoginProfileDir();
@@ -105,6 +107,16 @@ export async function runBrowserCodexFindings(
     await mkdir(userDataDir, { recursive: true });
     logger(`Manual login mode enabled; reusing persistent profile at ${userDataDir}`);
     await assertManualLoginProfileReadyForRun({ userDataDir, keepBrowser: effectiveKeepBrowser });
+  } else if (config.copyProfileSource) {
+    const copiedProfileDirectory = await copyChromeProfile(
+      config.copyProfileSource,
+      userDataDir,
+      config.chromeProfile,
+    );
+    config = { ...config, chromeProfile: copiedProfileDirectory };
+    logger(
+      `Seeded temporary Chrome profile ${copiedProfileDirectory} from ${config.copyProfileSource} (copy-profile mode; signed-in session reused without manual login)`,
+    );
   } else {
     logger(`Created temporary Chrome profile at ${userDataDir}`);
   }
@@ -183,7 +195,7 @@ export async function runBrowserCodexFindings(
       await positionChromeWindowOffscreen(client, logger);
     }
     removeDialogHandler = installJavaScriptDialogAutoDismissal(Page, logger);
-    if (!manualLogin) {
+    if (!manualLogin && !usingCopiedProfile) {
       await Network.clearBrowserCookies();
     }
 
@@ -191,6 +203,7 @@ export async function runBrowserCodexFindings(
       config,
       network: Network,
       manualLogin,
+      usingCopiedProfile,
       logger,
     });
     await clearStaleChatGptConversationCookies(Network, Target, logger);
@@ -383,6 +396,8 @@ export async function runBrowserCodexFindings(
         // best effort
       }
       logger(`Chrome left running on port ${chrome.port} with profile ${userDataDir}`);
+    } else if (!manualLogin) {
+      await rm(userDataDir, { recursive: true, force: true }).catch(() => undefined);
     }
     if (cleanupProfileLock) {
       await cleanupProfileLock.release().catch(() => undefined);
@@ -413,13 +428,19 @@ async function applyCodexFindingsCookies({
   config,
   network,
   manualLogin,
+  usingCopiedProfile,
   logger,
 }: {
   config: ResolvedBrowserConfig;
   network: ChromeClient["Network"];
   manualLogin: boolean;
+  usingCopiedProfile: boolean;
   logger: BrowserLogger;
 }): Promise<number> {
+  if (usingCopiedProfile) {
+    logger("Using the signed-in copied Chrome profile; skipping cookie sync.");
+    return 0;
+  }
   const manualLoginCookieSync = manualLogin && Boolean(config.manualLoginCookieSync);
   const cookieSyncEnabled = config.cookieSync && (!manualLogin || manualLoginCookieSync);
   if (!cookieSyncEnabled) {

--- a/src/browser/codexFindingsRunner.ts
+++ b/src/browser/codexFindingsRunner.ts
@@ -43,14 +43,21 @@ import {
   resolveManualLoginWaitMs,
 } from "./manualLoginProfile.js";
 import {
+  executeFindingAction,
   goToNextFindingsPage,
   readFindingDetail,
   waitForFindingDetailReady,
   waitForFindingsPageSettled,
   waitForFindingsReady,
 } from "./actions/codexFindings.js";
+import type { FindingActionResult } from "./actions/codexFindings.js";
 import { normalizeCodexFindingsUrl, buildFindingDetailUrl } from "../codex/url.js";
-import { aggregateFindingPages, shouldStopPaging } from "../codex/findings.js";
+import {
+  aggregateFindingPages,
+  githubRepoFromUrl,
+  isModalRuntimeEvidence,
+  shouldStopPaging,
+} from "../codex/findings.js";
 import type {
   CodexFinding,
   CodexFindingsPageCounter,
@@ -170,9 +177,7 @@ export async function runBrowserCodexFindings(
     const raceWithDisconnect = <T>(promise: Promise<T>): Promise<T> =>
       Promise.race([promise, disconnectPromise]);
 
-    // READ-ONLY: no Input, no DOM domain — the tool cannot emit a trusted event, so no
-    // mutating Radix action (Create PR / Submit / Close / Adjust / feedback) is reachable.
-    const { Network, Page, Runtime, Target } = client;
+    const { Network, Page, Runtime, Input, Target } = client;
     await Promise.all([Network.enable({}), Page.enable(), Runtime.enable()]);
     if (!config.headless && config.hideWindow) {
       await positionChromeWindowOffscreen(client, logger);
@@ -221,6 +226,52 @@ export async function runBrowserCodexFindings(
       };
     }
 
+    if (request.operation === "action") {
+      const findingId = requireFindingId(request.findingId);
+      if (!request.action) throw new Error("codex finding action requires an action.");
+      if (["create-pr", "chat", "close", "adjust"].includes(request.action) && !request.confirm) {
+        throw new Error(`Refusing mutating finding action ${request.action} without --confirm.`);
+      }
+      const detailUrl = buildFindingDetailUrl(findingsUrl, findingId);
+      await raceWithDisconnect(navigateToChatGPT(Page, Runtime, detailUrl, logger));
+      await raceWithDisconnect(waitForFindingDetailReady(Runtime, config.inputTimeoutMs, logger));
+      const detail = await raceWithDisconnect(readFindingDetail(Runtime, findingId));
+      const expectedRepo = request.repo ?? (request.modalOnly ? "umgbhalla/harp" : undefined);
+      if (expectedRepo && githubRepoFromUrl(detail.repo ?? "") !== expectedRepo) {
+        throw new Error(
+          `Finding ${findingId} belongs to ${githubRepoFromUrl(detail.repo ?? "") ?? "an unknown repository"}, not ${expectedRepo}.`,
+        );
+      }
+      if (
+        request.modalOnly &&
+        (detail.files.length === 0 || detail.files.some((file) => !isModalRuntimeEvidence(file)))
+      ) {
+        throw new Error(
+          `Finding ${findingId} is not Modal-runtime-only; refusing action because its evidence includes frontend, local-only, test, eval, or unknown paths.`,
+        );
+      }
+      const actionResult: FindingActionResult = await raceWithDisconnect(
+        executeFindingAction(
+          Runtime,
+          Input,
+          request.action,
+          request.actionText,
+          config.inputTimeoutMs,
+          logger,
+        ),
+      );
+      completed = true;
+      return {
+        status: "ok",
+        operation: "action",
+        findingsUrl: detailUrl,
+        action: request.action,
+        actionResult,
+        warnings,
+        tookMs: Date.now() - startedAt,
+      };
+    }
+
     // LIST: the findings list is SSR'd + rendered as `li > button` rows; scrape the DOM and
     // page through with a plain Next-page click (verified to advance). No trusted Input needed.
     await raceWithDisconnect(navigateToChatGPT(Page, Runtime, findingsUrl, logger));
@@ -241,7 +292,7 @@ export async function runBrowserCodexFindings(
       counter = page.counter;
       pagesVisited += 1;
       const collected = aggregateFindingPages(pages).length;
-      if (limit !== undefined && collected >= limit) {
+      if (!request.repo && !request.modalOnly && limit !== undefined && collected >= limit) {
         break;
       }
       if (shouldStopPaging(page.counter, pagesVisited)) {
@@ -255,6 +306,10 @@ export async function runBrowserCodexFindings(
       }
     }
     let findings = aggregateFindingPages(pages);
+    if (request.repo || request.modalOnly) {
+      const expectedRepo = request.repo ?? "umgbhalla/harp";
+      findings = findings.filter((finding) => finding.repo === expectedRepo);
+    }
     if (request.severity) {
       findings = findings.filter((f) => f.severity === request.severity);
     }

--- a/src/browser/codexFindingsRunner.ts
+++ b/src/browser/codexFindingsRunner.ts
@@ -1,0 +1,544 @@
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { LaunchedChrome } from "chrome-launcher";
+import {
+  closeTab,
+  connectWithNewTab,
+  launchChrome,
+  positionChromeWindowOffscreen,
+  registerTerminationHooks,
+} from "./chromeLifecycle.js";
+import { resolveBrowserConfig } from "./config.js";
+import { clearStaleChatGptConversationCookies, syncCookies } from "./cookies.js";
+import {
+  installJavaScriptDialogAutoDismissal,
+  navigateToChatGPT,
+  ensureLoggedIn,
+} from "./pageActions.js";
+import type { BrowserLogger, ChromeClient, ResolvedBrowserConfig } from "./types.js";
+import {
+  acquireBrowserTabLease,
+  hasOtherActiveBrowserTabLeases,
+  type BrowserTabLease,
+} from "./tabLeaseRegistry.js";
+import {
+  acquireProfileRunLock,
+  cleanupStaleProfileState,
+  findRunningChromeDebugTargetForProfile,
+  readChromePid,
+  readDevToolsPort,
+  shouldCleanupManualLoginProfileState,
+  verifyDevToolsReachable,
+  writeChromePid,
+  writeDevToolsActivePort,
+  type ProfileRunLock,
+} from "./profileState.js";
+import { CHATGPT_URL } from "./constants.js";
+import { delay } from "./utils.js";
+import {
+  assertManualLoginProfileReadyForRun,
+  defaultManualLoginProfileDir,
+  formatManualLoginSetupCommand,
+  resolveManualLoginWaitMs,
+} from "./manualLoginProfile.js";
+import {
+  goToNextFindingsPage,
+  readFindingDetail,
+  waitForFindingDetailReady,
+  waitForFindingsPageSettled,
+  waitForFindingsReady,
+} from "./actions/codexFindings.js";
+import { normalizeCodexFindingsUrl, buildFindingDetailUrl } from "../codex/url.js";
+import { aggregateFindingPages, shouldStopPaging } from "../codex/findings.js";
+import type {
+  CodexFinding,
+  CodexFindingsPageCounter,
+  CodexFindingsRequest,
+  CodexFindingsResult,
+} from "../codex/types.js";
+
+type BrowserChrome = LaunchedChrome & { host?: string };
+
+function requireFindingId(findingId: string | undefined): string {
+  if (!findingId?.trim()) {
+    throw new Error("codex findings --finding <id> is required to show a finding's detail.");
+  }
+  return findingId.trim();
+}
+
+export async function runBrowserCodexFindings(
+  request: CodexFindingsRequest,
+): Promise<CodexFindingsResult> {
+  const startedAt = Date.now();
+  const logger: BrowserLogger = ((message: string) => request.log?.(message)) as BrowserLogger;
+  const findingsUrl = normalizeCodexFindingsUrl(request.chatgptUrl);
+  const warnings: string[] = [];
+
+  let config = resolveBrowserConfig({
+    ...request.config,
+    url: findingsUrl,
+    chatgptUrl: findingsUrl,
+  });
+  if (config.remoteChrome) {
+    throw new Error(
+      "codex findings uses local browser automation only. Run it on the signed-in browser host.",
+    );
+  }
+
+  const manualLogin = Boolean(config.manualLogin);
+  const manualProfileDir = config.manualLoginProfileDir
+    ? path.resolve(config.manualLoginProfileDir)
+    : defaultManualLoginProfileDir();
+  const userDataDir = manualLogin
+    ? manualProfileDir
+    : await mkdtemp(path.join(os.tmpdir(), "oracle-codex-findings-"));
+  const effectiveKeepBrowser = Boolean(config.keepBrowser);
+  if (manualLogin) {
+    await mkdir(userDataDir, { recursive: true });
+    logger(`Manual login mode enabled; reusing persistent profile at ${userDataDir}`);
+    await assertManualLoginProfileReadyForRun({ userDataDir, keepBrowser: effectiveKeepBrowser });
+  } else {
+    logger(`Created temporary Chrome profile at ${userDataDir}`);
+  }
+
+  let tabLease: BrowserTabLease | null = null;
+  if (manualLogin) {
+    tabLease = await acquireBrowserTabLease(userDataDir, {
+      maxConcurrentTabs: config.maxConcurrentTabs,
+      timeoutMs: config.timeoutMs,
+      logger,
+      sessionId: "codex-findings",
+    });
+  }
+
+  let chrome: BrowserChrome | null = null;
+  let reusedChrome: LaunchedChrome | null = null;
+  let client: ChromeClient | null = null;
+  let isolatedTargetId: string | null = null;
+  let removeTerminationHooks: (() => void) | null = null;
+  let removeDialogHandler: (() => void) | null = null;
+  let connectionClosedUnexpectedly = false;
+  let completed = false;
+
+  try {
+    const acquired = manualLogin
+      ? await acquireManualLoginChromeForCodexFindings(userDataDir, config, logger)
+      : {
+          chrome: await launchChrome({ ...config, remoteChrome: null }, userDataDir, logger),
+          reusedChrome: null,
+        };
+    chrome = acquired.chrome;
+    reusedChrome = acquired.reusedChrome;
+    const chromeHost = chrome.host ?? "127.0.0.1";
+    if (tabLease) {
+      await tabLease.update({ chromeHost, chromePort: chrome.port });
+    }
+
+    removeTerminationHooks = registerTerminationHooks(
+      chrome,
+      userDataDir,
+      effectiveKeepBrowser,
+      logger,
+      { isInFlight: () => !completed, preserveUserDataDir: manualLogin },
+    );
+
+    const strictTabIsolation = Boolean(manualLogin && reusedChrome);
+    const devtoolsRetries = manualLogin ? 6 : 0;
+    const connection = await connectWithNewTab(chrome.port, logger, "about:blank", chromeHost, {
+      fallbackToDefault: !strictTabIsolation,
+      retries: devtoolsRetries,
+      retryDelayMs: 500,
+    });
+    client = connection.client;
+    isolatedTargetId = connection.targetId ?? null;
+    if (tabLease && isolatedTargetId) {
+      await tabLease.update({
+        chromeHost,
+        chromePort: chrome.port,
+        chromeTargetId: isolatedTargetId,
+        tabUrl: findingsUrl,
+      });
+    }
+
+    const disconnectPromise = new Promise<never>((_, reject) => {
+      client?.on("disconnect", () => {
+        connectionClosedUnexpectedly = true;
+        reject(new Error("Chrome window closed before codex findings finished."));
+      });
+    });
+    const raceWithDisconnect = <T>(promise: Promise<T>): Promise<T> =>
+      Promise.race([promise, disconnectPromise]);
+
+    // READ-ONLY: no Input, no DOM domain — the tool cannot emit a trusted event, so no
+    // mutating Radix action (Create PR / Submit / Close / Adjust / feedback) is reachable.
+    const { Network, Page, Runtime, Target } = client;
+    await Promise.all([Network.enable({}), Page.enable(), Runtime.enable()]);
+    if (!config.headless && config.hideWindow) {
+      await positionChromeWindowOffscreen(client, logger);
+    }
+    removeDialogHandler = installJavaScriptDialogAutoDismissal(Page, logger);
+    if (!manualLogin) {
+      await Network.clearBrowserCookies();
+    }
+
+    const appliedCookies = await applyCodexFindingsCookies({
+      config,
+      network: Network,
+      manualLogin,
+      logger,
+    });
+    await clearStaleChatGptConversationCookies(Network, Target, logger);
+
+    await raceWithDisconnect(navigateToChatGPT(Page, Runtime, CHATGPT_URL, logger));
+    await raceWithDisconnect(
+      waitForCodexFindingsLogin({
+        runtime: Runtime,
+        logger,
+        appliedCookies,
+        manualLogin,
+        timeoutMs: config.timeoutMs,
+        profileDir: userDataDir,
+        keepBrowser: effectiveKeepBrowser,
+      }),
+    );
+
+    if (request.operation === "detail") {
+      const detailUrl = buildFindingDetailUrl(findingsUrl, requireFindingId(request.findingId));
+      await raceWithDisconnect(navigateToChatGPT(Page, Runtime, detailUrl, logger));
+      await raceWithDisconnect(waitForFindingDetailReady(Runtime, config.inputTimeoutMs, logger));
+      const detail = await raceWithDisconnect(
+        readFindingDetail(Runtime, requireFindingId(request.findingId)),
+      );
+      completed = true;
+      return {
+        status: "ok",
+        operation: "detail",
+        findingsUrl: detailUrl,
+        detail,
+        warnings,
+        tookMs: Date.now() - startedAt,
+      };
+    }
+
+    // LIST: the findings list is SSR'd + rendered as `li > button` rows; scrape the DOM and
+    // page through with a plain Next-page click (verified to advance). No trusted Input needed.
+    await raceWithDisconnect(navigateToChatGPT(Page, Runtime, findingsUrl, logger));
+    await raceWithDisconnect(waitForFindingsReady(Runtime, config.inputTimeoutMs, logger));
+
+    const limit =
+      typeof request.limit === "number" && request.limit >= 0 ? request.limit : undefined;
+    const pages: CodexFinding[][] = [];
+    let counter: CodexFindingsPageCounter | undefined;
+    let pagesVisited = 0;
+    // Hard cap so a mis-reporting counter can never loop forever.
+    const maxPages = 100;
+    while (pagesVisited < maxPages) {
+      const page = await raceWithDisconnect(
+        waitForFindingsPageSettled(Runtime, config.inputTimeoutMs, logger),
+      );
+      pages.push(page.items);
+      counter = page.counter;
+      pagesVisited += 1;
+      const collected = aggregateFindingPages(pages).length;
+      if (limit !== undefined && collected >= limit) {
+        break;
+      }
+      if (shouldStopPaging(page.counter, pagesVisited)) {
+        break;
+      }
+      const advanced = await raceWithDisconnect(
+        goToNextFindingsPage(Runtime, config.inputTimeoutMs, logger),
+      );
+      if (!advanced) {
+        break;
+      }
+    }
+    let findings = aggregateFindingPages(pages);
+    if (request.severity) {
+      findings = findings.filter((f) => f.severity === request.severity);
+    }
+    if (limit !== undefined) {
+      findings = findings.slice(0, limit);
+    }
+    findings = findings.map((f: CodexFinding, i: number) => ({ ...f, index: i }));
+    completed = true;
+    return {
+      status: "ok",
+      operation: "list",
+      findingsUrl,
+      findings,
+      counter: counter ?? {
+        from: findings.length ? 1 : 0,
+        to: findings.length,
+        total: findings.length,
+      },
+      warnings,
+      tookMs: Date.now() - startedAt,
+    };
+  } finally {
+    removeDialogHandler?.();
+    removeTerminationHooks?.();
+    const chromeHost = chrome?.host ?? "127.0.0.1";
+    try {
+      await client?.close();
+    } catch {
+      // ignore close failures
+    }
+    if (completed && isolatedTargetId && chrome?.port) {
+      await closeTab(chrome.port, isolatedTargetId, logger, chromeHost).catch(() => undefined);
+    }
+
+    let keepBrowserOpen = effectiveKeepBrowser;
+    let cleanupProfileLock: ProfileRunLock | null = null;
+    if (!keepBrowserOpen && manualLogin && tabLease) {
+      const cleanupLockTimeoutMs = Math.max(0, config.profileLockTimeoutMs ?? 0);
+      if (cleanupLockTimeoutMs > 0) {
+        cleanupProfileLock = await acquireProfileRunLock(userDataDir, {
+          timeoutMs: cleanupLockTimeoutMs,
+          logger,
+          sessionId: "codex-findings",
+        }).catch(() => null);
+      }
+      keepBrowserOpen = await hasOtherActiveBrowserTabLeases(userDataDir, tabLease.id).catch(
+        () => false,
+      );
+      if (keepBrowserOpen) {
+        logger("[browser] Other ChatGPT tab leases still active; leaving shared Chrome running.");
+      } else if (reusedChrome && !connectionClosedUnexpectedly) {
+        keepBrowserOpen = true;
+        logger("[browser] Reused shared Chrome; leaving browser process running.");
+      }
+    }
+    if (tabLease) {
+      const handle = tabLease;
+      tabLease = null;
+      await handle.release().catch(() => undefined);
+    }
+    if (!keepBrowserOpen && chrome) {
+      if (!connectionClosedUnexpectedly) {
+        try {
+          await chrome.kill();
+        } catch {
+          // ignore kill failures
+        }
+      }
+      if (manualLogin) {
+        const shouldCleanup = await shouldCleanupManualLoginProfileState(
+          userDataDir,
+          logger.verbose ? logger : undefined,
+          { connectionClosedUnexpectedly, host: chrome.host ?? "127.0.0.1" },
+        );
+        if (shouldCleanup) {
+          await cleanupStaleProfileState(userDataDir, logger, { lockRemovalMode: "never" }).catch(
+            () => undefined,
+          );
+        }
+      } else {
+        await rm(userDataDir, { recursive: true, force: true }).catch(() => undefined);
+      }
+    } else if (chrome) {
+      try {
+        chrome.process?.unref();
+      } catch {
+        // best effort
+      }
+      logger(`Chrome left running on port ${chrome.port} with profile ${userDataDir}`);
+    }
+    if (cleanupProfileLock) {
+      await cleanupProfileLock.release().catch(() => undefined);
+    }
+  }
+}
+
+async function applyCodexFindingsCookies({
+  config,
+  network,
+  manualLogin,
+  logger,
+}: {
+  config: ResolvedBrowserConfig;
+  network: ChromeClient["Network"];
+  manualLogin: boolean;
+  logger: BrowserLogger;
+}): Promise<number> {
+  const manualLoginCookieSync = manualLogin && Boolean(config.manualLoginCookieSync);
+  const cookieSyncEnabled = config.cookieSync && (!manualLogin || manualLoginCookieSync);
+  if (!cookieSyncEnabled) {
+    logger(
+      manualLogin
+        ? "Skipping Chrome cookie sync (--browser-manual-login enabled); reuse the opened profile after signing in."
+        : "Skipping Chrome cookie sync (--browser-no-cookie-sync)",
+    );
+    return 0;
+  }
+  const cookieCount = await syncCookies(network, config.url, config.chromeProfile, logger, {
+    allowErrors: config.allowCookieErrors ?? false,
+    filterNames: config.cookieNames ?? undefined,
+    inlineCookies: config.inlineCookies ?? undefined,
+    cookiePath: config.chromeCookiePath ?? undefined,
+    waitMs: config.cookieSyncWaitMs ?? 0,
+  });
+  logger(
+    cookieCount > 0
+      ? config.inlineCookies
+        ? `Applied ${cookieCount} inline cookies`
+        : `Copied ${cookieCount} cookies from Chrome profile ${config.chromeProfile ?? "Default"}`
+      : "No Chrome cookies found; continuing without session reuse",
+  );
+  return cookieCount;
+}
+
+async function waitForCodexFindingsLogin({
+  runtime,
+  logger,
+  appliedCookies,
+  manualLogin,
+  timeoutMs,
+  profileDir,
+  keepBrowser,
+}: {
+  runtime: ChromeClient["Runtime"];
+  logger: BrowserLogger;
+  appliedCookies: number;
+  manualLogin: boolean;
+  timeoutMs: number;
+  profileDir?: string;
+  keepBrowser?: boolean;
+}): Promise<void> {
+  if (!manualLogin) {
+    await ensureLoggedIn(runtime, logger, { appliedCookies });
+    return;
+  }
+  const waitMs = resolveManualLoginWaitMs(timeoutMs, Boolean(keepBrowser));
+  const deadline = Date.now() + waitMs;
+  let lastNotice = 0;
+  while (Date.now() < deadline) {
+    try {
+      await ensureLoggedIn(runtime, logger, { appliedCookies });
+      return;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const retryable =
+        message.toLowerCase().includes("login button") ||
+        message.toLowerCase().includes("session not detected");
+      if (!retryable) {
+        throw error;
+      }
+      const now = Date.now();
+      if (now - lastNotice > 5000) {
+        logger(
+          "Manual login mode: please sign into chatgpt.com in the opened Chrome window; waiting for session to appear...",
+        );
+        lastNotice = now;
+      }
+      await delay(1000);
+    }
+  }
+  const setupCommand = formatManualLoginSetupCommand(profileDir ?? defaultManualLoginProfileDir());
+  throw new Error(
+    "Manual login mode timed out waiting for ChatGPT session. " +
+      `Browser mode is using Oracle's private Chrome profile at ${profileDir ?? "(default profile)"}, not your normal Chrome profile. ` +
+      `Run first-time setup, sign in there, then retry: ${setupCommand}`,
+  );
+}
+
+async function acquireManualLoginChromeForCodexFindings(
+  userDataDir: string,
+  config: ResolvedBrowserConfig,
+  logger: BrowserLogger,
+): Promise<{ chrome: BrowserChrome; reusedChrome: LaunchedChrome | null }> {
+  const lockTimeoutMs = Math.max(0, config.profileLockTimeoutMs ?? 0);
+  let launchLock: ProfileRunLock | null = null;
+  if (lockTimeoutMs > 0) {
+    launchLock = await acquireProfileRunLock(userDataDir, {
+      timeoutMs: lockTimeoutMs,
+      logger,
+      sessionId: "codex-findings",
+    });
+  }
+  try {
+    const reusedChrome = await maybeReuseCodexFindingsChrome(userDataDir, logger, {
+      waitForPortMs: config.reuseChromeWaitMs,
+    });
+    const chrome =
+      reusedChrome ?? (await launchChrome({ ...config, remoteChrome: null }, userDataDir, logger));
+    if (chrome.port) {
+      await writeDevToolsActivePort(userDataDir, chrome.port);
+      if (!reusedChrome && chrome.pid) {
+        await writeChromePid(userDataDir, chrome.pid);
+      }
+    }
+    return { chrome, reusedChrome };
+  } finally {
+    await launchLock?.release().catch(() => undefined);
+  }
+}
+
+async function maybeReuseCodexFindingsChrome(
+  userDataDir: string,
+  logger: BrowserLogger,
+  options: { waitForPortMs?: number; probe?: typeof verifyDevToolsReachable } = {},
+): Promise<LaunchedChrome | null> {
+  const waitForPortMs = Math.max(0, options.waitForPortMs ?? 0);
+  let port = await readDevToolsPort(userDataDir);
+  if (!port && waitForPortMs > 0) {
+    const deadline = Date.now() + waitForPortMs;
+    logger(`Waiting up to ${Math.round(waitForPortMs / 1000)}s for shared Chrome to appear...`);
+    while (!port && Date.now() < deadline) {
+      await delay(250);
+      port = await readDevToolsPort(userDataDir);
+    }
+  }
+  let pid = await readChromePid(userDataDir);
+  if (!port) {
+    const discovered = await findRunningChromeDebugTargetForProfile(userDataDir);
+    if (!discovered) {
+      if (pid) {
+        logger(
+          `No reachable Chrome DevTools target found for ${userDataDir}; clearing stale profile state before launching new Chrome.`,
+        );
+        await cleanupStaleProfileState(userDataDir, logger, {
+          lockRemovalMode: "if_oracle_pid_dead",
+        });
+      }
+      return null;
+    }
+    const probe = await (options.probe ?? verifyDevToolsReachable)({ port: discovered.port });
+    if (!probe.ok) {
+      logger(
+        `Discovered Chrome for ${userDataDir} on port ${discovered.port} but it was unreachable (${probe.error}); launching new Chrome.`,
+      );
+      await cleanupStaleProfileState(userDataDir, logger, {
+        lockRemovalMode: "if_oracle_pid_dead",
+      });
+      return null;
+    }
+    await writeDevToolsActivePort(userDataDir, discovered.port);
+    await writeChromePid(userDataDir, discovered.pid);
+    logger(
+      `Discovered running Chrome for ${userDataDir}; reusing (DevTools port ${discovered.port}, pid ${discovered.pid})`,
+    );
+    return {
+      port: discovered.port,
+      pid: discovered.pid,
+      kill: async () => {},
+      process: undefined,
+    } as unknown as LaunchedChrome;
+  }
+  const probe = await (options.probe ?? verifyDevToolsReachable)({ port });
+  if (!probe.ok) {
+    logger(
+      `Recorded Chrome DevTools port ${port} is stale (${probe.error}); launching new Chrome.`,
+    );
+    await cleanupStaleProfileState(userDataDir, logger, { lockRemovalMode: "if_oracle_pid_dead" });
+    return null;
+  }
+  logger(`Reusing running Chrome on port ${port} with profile ${userDataDir}`);
+  return {
+    port,
+    pid: pid ?? undefined,
+    kill: async () => {},
+    process: undefined,
+  } as unknown as LaunchedChrome;
+}

--- a/src/browser/constants.ts
+++ b/src/browser/constants.ts
@@ -1,6 +1,7 @@
 import type { BrowserModelStrategy } from "./types.js";
 
 export const CHATGPT_URL = "https://chatgpt.com/";
+export const CODEX_FINDINGS_URL = "https://chatgpt.com/codex/cloud/security/findings";
 export const DEFAULT_MODEL_TARGET = "Pro";
 export const DEFAULT_MODEL_STRATEGY: BrowserModelStrategy = "select";
 export const COOKIE_URLS = [

--- a/src/cli/codexFindings.ts
+++ b/src/cli/codexFindings.ts
@@ -15,7 +15,8 @@ export interface CodexFindingsCliOptions extends Partial<BrowserFlagOptions> {
   text?: string;
   confirm?: boolean;
   repo?: string;
-  modalOnly?: boolean;
+  evidencePrefix?: string[];
+  excludeEvidence?: string[];
   limit?: number;
   json?: boolean;
   verbose?: boolean;
@@ -38,7 +39,8 @@ export async function runCodexFindingsCliCommand(options: CodexFindingsCliOption
     actionText: options.text,
     confirm: options.confirm,
     repo: options.repo,
-    modalOnly: options.modalOnly,
+    evidencePrefixes: options.evidencePrefix,
+    evidenceExcludes: options.excludeEvidence,
     severity: options.severity,
     limit: options.limit,
     config: browserConfig,

--- a/src/cli/codexFindings.ts
+++ b/src/cli/codexFindings.ts
@@ -1,0 +1,154 @@
+import chalk from "chalk";
+import type { BrowserSessionConfig } from "../sessionStore.js";
+import type { BrowserFlagOptions } from "./browserConfig.js";
+import { buildBrowserConfig } from "./browserConfig.js";
+import { loadUserConfig } from "../config.js";
+import { runBrowserCodexFindings } from "../browser/codexFindingsRunner.js";
+import { normalizeCodexFindingsUrl } from "../codex/url.js";
+import type { CodexFindingsResult } from "../codex/types.js";
+
+export interface CodexFindingsCliOptions extends Partial<BrowserFlagOptions> {
+  chatgptUrl?: string;
+  severity?: string;
+  finding?: string;
+  limit?: number;
+  json?: boolean;
+  verbose?: boolean;
+}
+
+export async function runCodexFindingsCliCommand(options: CodexFindingsCliOptions): Promise<void> {
+  const { config: userConfig } = await loadUserConfig();
+  const configuredUrl = userConfig.browser?.chatgptUrl ?? userConfig.browser?.url;
+  const findingsUrl = normalizeCodexFindingsUrl(options.chatgptUrl ?? configuredUrl ?? "");
+  const browserConfig = await buildCodexFindingsBrowserConfig({
+    options,
+    findingsUrl,
+    configuredBrowser: userConfig.browser ?? {},
+  });
+  const result = await runBrowserCodexFindings({
+    operation: options.finding ? "detail" : "list",
+    chatgptUrl: findingsUrl,
+    findingId: options.finding,
+    severity: options.severity,
+    limit: options.limit,
+    config: browserConfig,
+    log: (message) => {
+      if (options.verbose || !message.startsWith("[debug]")) {
+        console.log(chalk.dim(message));
+      }
+    },
+  });
+  printCodexFindingsResult(result, Boolean(options.json));
+}
+
+export async function buildCodexFindingsBrowserConfig({
+  options,
+  findingsUrl,
+  configuredBrowser,
+}: {
+  options: CodexFindingsCliOptions;
+  findingsUrl: string;
+  configuredBrowser: BrowserSessionConfig;
+}): Promise<BrowserSessionConfig> {
+  const flagConfig = removeUndefined(
+    await buildBrowserConfig({
+      ...options,
+      model: "gpt-5.5-pro",
+      chatgptUrl: findingsUrl,
+    }),
+  );
+  const envProfileDir = process.env.ORACLE_BROWSER_PROFILE_DIR?.trim();
+  const manualLogin =
+    flagConfig.manualLogin ?? configuredBrowser.manualLogin ?? (envProfileDir ? true : undefined);
+  const manualLoginProfileDir =
+    manualLogin === true
+      ? (flagConfig.manualLoginProfileDir ??
+        configuredBrowser.manualLoginProfileDir ??
+        envProfileDir ??
+        null)
+      : null;
+  return {
+    ...configuredBrowser,
+    ...flagConfig,
+    url: findingsUrl,
+    chatgptUrl: findingsUrl,
+    // Default (no manual-login): sync cookies from the active Chrome profile so any signed-in
+    // profile works without extra setup.
+    cookieSync: manualLogin
+      ? false
+      : (flagConfig.cookieSync ?? configuredBrowser.cookieSync ?? true),
+    manualLogin,
+    manualLoginProfileDir,
+    desiredModel: null,
+    modelStrategy: "ignore",
+    researchMode: "off",
+  };
+}
+
+function removeUndefined<T extends object>(value: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).filter(([, entry]) => entry !== undefined),
+  ) as Partial<T>;
+}
+
+function printCodexFindingsResult(result: CodexFindingsResult, json: boolean): void {
+  if (json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  if (result.operation === "detail" && result.detail) {
+    const d = result.detail;
+    console.log(chalk.bold(d.title || "(untitled finding)"));
+    if (d.repo) console.log(chalk.dim(d.repo));
+    for (const section of d.sections) {
+      console.log("");
+      console.log(chalk.bold(`# ${section.heading}`));
+      console.log(section.text);
+    }
+    if (d.files.length > 0) {
+      console.log("");
+      console.log(chalk.bold("# Evidence files"));
+      for (const file of d.files) console.log(`  ${file}`);
+    }
+    if (d.validationArtifact) {
+      console.log("");
+      console.log(chalk.bold("# Validation artifact (signed, expires soon)"));
+      console.log(`  ${d.validationArtifact}`);
+    }
+    return;
+  }
+  const findings = result.findings ?? [];
+  const counter = result.counter;
+  console.log(
+    chalk.bold(
+      counter
+        ? `Codex findings ${counter.from}-${counter.to} of ${counter.total}`
+        : "Codex findings",
+    ),
+  );
+  if (findings.length === 0) {
+    console.log(chalk.dim("No findings."));
+    return;
+  }
+  for (const finding of findings) {
+    const idLabel = finding.selectionId ?? finding.id;
+    console.log(`${chalk.dim(idLabel)}  ${sevLabel(finding.severity)}  ${finding.title}`);
+    if (finding.repo) console.log(chalk.dim(`    ${finding.repo}`));
+  }
+}
+
+function sevLabel(severity: string): string {
+  const pad = severity.toUpperCase().padEnd(8);
+  switch (severity) {
+    case "critical":
+      return chalk.red.bold(pad);
+    case "high":
+      return chalk.red(pad);
+    case "medium":
+      return chalk.yellow(pad);
+    case "low":
+      return chalk.blue(pad);
+    default:
+      return chalk.dim(pad);
+  }
+}

--- a/src/cli/codexFindings.ts
+++ b/src/cli/codexFindings.ts
@@ -5,12 +5,17 @@ import { buildBrowserConfig } from "./browserConfig.js";
 import { loadUserConfig } from "../config.js";
 import { runBrowserCodexFindings } from "../browser/codexFindingsRunner.js";
 import { normalizeCodexFindingsUrl } from "../codex/url.js";
-import type { CodexFindingsResult } from "../codex/types.js";
+import type { CodexFindingAction, CodexFindingsResult } from "../codex/types.js";
 
 export interface CodexFindingsCliOptions extends Partial<BrowserFlagOptions> {
   chatgptUrl?: string;
   severity?: string;
   finding?: string;
+  action?: CodexFindingAction;
+  text?: string;
+  confirm?: boolean;
+  repo?: string;
+  modalOnly?: boolean;
   limit?: number;
   json?: boolean;
   verbose?: boolean;
@@ -26,9 +31,14 @@ export async function runCodexFindingsCliCommand(options: CodexFindingsCliOption
     configuredBrowser: userConfig.browser ?? {},
   });
   const result = await runBrowserCodexFindings({
-    operation: options.finding ? "detail" : "list",
+    operation: options.action ? "action" : options.finding ? "detail" : "list",
     chatgptUrl: findingsUrl,
     findingId: options.finding,
+    action: options.action,
+    actionText: options.text,
+    confirm: options.confirm,
+    repo: options.repo,
+    modalOnly: options.modalOnly,
     severity: options.severity,
     limit: options.limit,
     config: browserConfig,
@@ -115,6 +125,13 @@ function printCodexFindingsResult(result: CodexFindingsResult, json: boolean): v
       console.log(chalk.bold("# Validation artifact (signed, expires soon)"));
       console.log(`  ${d.validationArtifact}`);
     }
+    return;
+  }
+  if (result.operation === "action" && result.actionResult) {
+    console.log(chalk.bold(`Finding action: ${result.action ?? "unknown"}`));
+    console.log(result.actionResult.message ?? result.actionResult.status);
+    if (result.actionResult.url) console.log(result.actionResult.url);
+    if (result.actionResult.text) console.log(result.actionResult.text);
     return;
   }
   const findings = result.findings ?? [];

--- a/src/codex/findings.ts
+++ b/src/codex/findings.ts
@@ -1,0 +1,70 @@
+import type { CodexFinding, CodexFindingSeverity, CodexFindingsPageCounter } from "./types.js";
+
+const SEVERITIES: CodexFindingSeverity[] = ["critical", "high", "medium", "low"];
+const COUNTER_RE = /(\d[\d,]*)\s*[-–—]\s*(\d[\d,]*)\s+of\s+(\d[\d,]*)/u;
+
+export function parseSeverity(label: unknown): CodexFindingSeverity {
+  const lower = String(label ?? "")
+    .trim()
+    .toLowerCase();
+  return (
+    SEVERITIES.find((s) => lower === s || lower.startsWith(s) || lower.includes(s)) ?? "unknown"
+  );
+}
+
+export function parseFindingsCounter(
+  text: string | null | undefined,
+): CodexFindingsPageCounter | null {
+  if (!text) {
+    return null;
+  }
+  const match = COUNTER_RE.exec(text);
+  if (!match) {
+    return null;
+  }
+  const num = (raw: string) => Number.parseInt(raw.replace(/,/gu, ""), 10);
+  return { from: num(match[1]), to: num(match[2]), total: num(match[3]) };
+}
+
+// Raw list item captured from the page DOM.
+export interface RawFindingItem {
+  innerText: string; // `{title}\n{repo}\n·\nCommitted Nd ago`
+  severityLabel: string | null; // e.g. "High severity" (from the item's severity icon)
+}
+
+export function parseFindingItem(raw: RawFindingItem, index: number): CodexFinding {
+  const lines = raw.innerText
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && line !== "·");
+  const title = lines[0] ?? "(untitled finding)";
+  const repo = lines.find((line) => /\//u.test(line) && !/^committed/iu.test(line));
+  const status = lines.find((line) => /^committed/iu.test(line));
+  const severity = parseSeverity(raw.severityLabel ?? "");
+  const id = `${title}|${repo ?? ""}`;
+  return { id, title, severity, repo, status, index };
+}
+
+// Dedupe by id across pages (page boundaries can overlap) and re-index sequentially.
+export function aggregateFindingPages(pages: CodexFinding[][]): CodexFinding[] {
+  const byId = new Map<string, CodexFinding>();
+  for (const page of pages) {
+    for (const finding of page) {
+      if (!byId.has(finding.id)) {
+        byId.set(finding.id, finding);
+      }
+    }
+  }
+  return Array.from(byId.values()).map((finding, index) => ({ ...finding, index }));
+}
+
+// Stop paging when the counter is unparseable (loud/safe) or the last visible row is the total.
+export function shouldStopPaging(
+  counter: CodexFindingsPageCounter | undefined,
+  pagesVisited: number,
+): boolean {
+  if (!counter) {
+    return true;
+  }
+  return pagesVisited >= 1 && counter.to >= counter.total;
+}

--- a/src/codex/findings.ts
+++ b/src/codex/findings.ts
@@ -68,3 +68,23 @@ export function shouldStopPaging(
   }
   return pagesVisited >= 1 && counter.to >= counter.total;
 }
+
+const MODAL_RUNTIME_ROOTS = ["harp/", "deploy.sh", "pyproject.toml"] as const;
+const NON_MODAL_PATHS = new Set(["harp/sandbox_local.py", "harp/serve_local.py"]);
+
+export function modalEvidencePath(url: string): string | null {
+  const match = /\/blob\/[a-f0-9]{7,64}\/(.+?)(?:#|$)/iu.exec(url);
+  return match?.[1] ?? null;
+}
+
+export function isModalRuntimeEvidence(url: string): boolean {
+  const path = modalEvidencePath(url);
+  if (!path || NON_MODAL_PATHS.has(path) || path.startsWith("harp/evals/")) return false;
+  if (path.startsWith("tests/") || path.startsWith("tests_harp/")) return false;
+  return MODAL_RUNTIME_ROOTS.some((root) => path === root || path.startsWith(root));
+}
+
+export function githubRepoFromUrl(url: string): string | null {
+  const match = /^https:\/\/github\.com\/([^/]+\/[^/]+)\/(?:commit|blob)\//u.exec(url);
+  return match?.[1] ?? null;
+}

--- a/src/codex/findings.ts
+++ b/src/codex/findings.ts
@@ -38,7 +38,9 @@ export function parseFindingItem(raw: RawFindingItem, index: number): CodexFindi
     .map((line) => line.trim())
     .filter((line) => line.length > 0 && line !== "·");
   const title = lines[0] ?? "(untitled finding)";
-  const repo = lines.find((line) => /\//u.test(line) && !/^committed/iu.test(line));
+  // Finding titles can contain path-like text (for example `/work`). Only treat a
+  // standalone owner/name line as repository metadata.
+  const repo = lines.find((line) => /^[^/\s]+\/[^/\s]+$/u.test(line));
   const status = lines.find((line) => /^committed/iu.test(line));
   const severity = parseSeverity(raw.severityLabel ?? "");
   const id = `${title}|${repo ?? ""}`;
@@ -69,19 +71,31 @@ export function shouldStopPaging(
   return pagesVisited >= 1 && counter.to >= counter.total;
 }
 
-const MODAL_RUNTIME_ROOTS = ["harp/", "deploy.sh", "pyproject.toml"] as const;
-const NON_MODAL_PATHS = new Set(["harp/sandbox_local.py", "harp/serve_local.py"]);
-
-export function modalEvidencePath(url: string): string | null {
+export function evidencePath(url: string): string | null {
   const match = /\/blob\/[a-f0-9]{7,64}\/(.+?)(?:#|$)/iu.exec(url);
   return match?.[1] ?? null;
 }
 
-export function isModalRuntimeEvidence(url: string): boolean {
-  const path = modalEvidencePath(url);
-  if (!path || NON_MODAL_PATHS.has(path) || path.startsWith("harp/evals/")) return false;
-  if (path.startsWith("tests/") || path.startsWith("tests_harp/")) return false;
-  return MODAL_RUNTIME_ROOTS.some((root) => path === root || path.startsWith(root));
+function matchesEvidencePrefix(path: string, prefix: string): boolean {
+  const normalized = prefix.trim().replace(/^\/+|\/+$/gu, "");
+  if (!normalized) return false;
+  return path === normalized || path.startsWith(`${normalized}/`);
+}
+
+export function isEvidencePathAllowed(
+  url: string,
+  {
+    includePrefixes = [],
+    excludePrefixes = [],
+  }: { includePrefixes?: string[]; excludePrefixes?: string[] } = {},
+): boolean {
+  const path = evidencePath(url);
+  if (!path) return false;
+  if (excludePrefixes.some((prefix) => matchesEvidencePrefix(path, prefix))) return false;
+  return (
+    includePrefixes.length === 0 ||
+    includePrefixes.some((prefix) => matchesEvidencePrefix(path, prefix))
+  );
 }
 
 export function githubRepoFromUrl(url: string): string | null {

--- a/src/codex/types.ts
+++ b/src/codex/types.ts
@@ -1,0 +1,58 @@
+import type { BrowserAutomationConfig } from "../browser/types.js";
+
+export type CodexFindingsOperation = "list" | "detail";
+export type CodexFindingSeverity = "critical" | "high" | "medium" | "low" | "unknown";
+export type CodexFindingDetailSectionId = "summary" | "validation" | "evidence" | "attack-path";
+
+export interface CodexFinding {
+  id: string; // = selectionId when present, else `${title}|${repo ?? ""}`
+  selectionId?: string; // 32-char hex from the loader payload; feeds --finding + detail URL
+  title: string;
+  severity: CodexFindingSeverity;
+  repo?: string; // parsed from payload, NEVER hardcoded
+  status?: string;
+  detailHref?: string;
+  index: number; // 0-based position after client-side severity filter + limit
+}
+
+export interface CodexFindingsPageCounter {
+  from: number;
+  to: number;
+  total: number;
+}
+
+export interface CodexFindingDetailSection {
+  id: CodexFindingDetailSectionId;
+  heading: string;
+  text: string; // normalized innerText of the section (read-only)
+}
+
+export interface CodexFindingDetail {
+  finding: CodexFinding; // finding.id/selectionId stamped from request.findingId
+  title: string; // main h1/h2 text
+  repo: string | null; // github commit permalink, parsed (never hardcoded)
+  sections: CodexFindingDetailSection[];
+  files: string[]; // github /blob/ evidence permalinks, deduped
+  validationArtifact: string | null; // signed oaiusercontent SAS link (captured, NEVER fetched)
+}
+
+export interface CodexFindingsRequest {
+  operation: CodexFindingsOperation;
+  chatgptUrl: string; // already normalized by caller; runner re-normalizes
+  findingId?: string; // 32-hex; required when operation === "detail"
+  severity?: CodexFindingSeverity | string; // optional client-side filter
+  limit?: number; // max findings returned (client cap); default = all
+  config?: BrowserAutomationConfig;
+  log?: (message: string) => void;
+}
+
+export interface CodexFindingsResult {
+  status: "ok";
+  operation: CodexFindingsOperation;
+  findingsUrl: string; // detail mode: the resolved detail URL
+  findings?: CodexFinding[]; // list mode: mapped from loader, filtered + capped
+  counter?: CodexFindingsPageCounter; // {from, to: findings.length, total: loader total}
+  detail?: CodexFindingDetail; // detail mode
+  warnings: string[];
+  tookMs: number;
+}

--- a/src/codex/types.ts
+++ b/src/codex/types.ts
@@ -54,7 +54,8 @@ export interface CodexFindingsRequest {
   confirm?: boolean;
   severity?: CodexFindingSeverity | string; // optional client-side filter
   repo?: string;
-  modalOnly?: boolean;
+  evidencePrefixes?: string[];
+  evidenceExcludes?: string[];
   limit?: number; // max findings returned (client cap); default = all
   config?: BrowserAutomationConfig;
   log?: (message: string) => void;

--- a/src/codex/types.ts
+++ b/src/codex/types.ts
@@ -1,6 +1,15 @@
 import type { BrowserAutomationConfig } from "../browser/types.js";
 
-export type CodexFindingsOperation = "list" | "detail";
+export type CodexFindingsOperation = "list" | "detail" | "action";
+export type CodexFindingAction =
+  | "create-pr"
+  | "chat"
+  | "close"
+  | "adjust"
+  | "copy-content"
+  | "copy-link"
+  | "copy-patch"
+  | "copy-git-apply";
 export type CodexFindingSeverity = "critical" | "high" | "medium" | "low" | "unknown";
 export type CodexFindingDetailSectionId = "summary" | "validation" | "evidence" | "attack-path";
 
@@ -40,7 +49,12 @@ export interface CodexFindingsRequest {
   operation: CodexFindingsOperation;
   chatgptUrl: string; // already normalized by caller; runner re-normalizes
   findingId?: string; // 32-hex; required when operation === "detail"
+  action?: CodexFindingAction;
+  actionText?: string;
+  confirm?: boolean;
   severity?: CodexFindingSeverity | string; // optional client-side filter
+  repo?: string;
+  modalOnly?: boolean;
   limit?: number; // max findings returned (client cap); default = all
   config?: BrowserAutomationConfig;
   log?: (message: string) => void;
@@ -53,6 +67,8 @@ export interface CodexFindingsResult {
   findings?: CodexFinding[]; // list mode: mapped from loader, filtered + capped
   counter?: CodexFindingsPageCounter; // {from, to: findings.length, total: loader total}
   detail?: CodexFindingDetail; // detail mode
+  action?: CodexFindingAction;
+  actionResult?: { status: string; message?: string; url?: string; text?: string };
   warnings: string[];
   tookMs: number;
 }

--- a/src/codex/url.ts
+++ b/src/codex/url.ts
@@ -1,0 +1,66 @@
+import { CODEX_FINDINGS_URL } from "../browser/constants.js";
+
+const FINDING_ID_RE = /^[0-9a-f]{32}$/u;
+const FINDINGS_PATH_PREFIX = "/codex/cloud/security/findings";
+
+// RR v7 route-module ids for the security findings list. Only used as a fallback when the
+// unscoped `.data` fetch fails; these are app-structure names, not a repo/account/id.
+export const CODEX_LIST_ROUTES = "routes/codex.cloud.security,routes/codex.cloud.security.$tab";
+
+function parseChatGptUrl(rawUrl: string): URL {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch (error) {
+    throw new Error(
+      `Invalid Codex findings URL: ${rawUrl} (${error instanceof Error ? error.message : String(error)})`,
+    );
+  }
+  const hostname = url.hostname.toLowerCase();
+  if (hostname !== "chatgpt.com" && hostname !== "chat.openai.com") {
+    throw new Error(`Codex findings require a ChatGPT URL, received: ${rawUrl}`);
+  }
+  if (!url.pathname.startsWith(FINDINGS_PATH_PREFIX)) {
+    throw new Error(`Codex findings require a ${FINDINGS_PATH_PREFIX} URL, received: ${rawUrl}`);
+  }
+  return url;
+}
+
+export function normalizeCodexFindingsUrl(rawUrl: string): string {
+  if (!rawUrl.trim()) {
+    return CODEX_FINDINGS_URL;
+  }
+  const url = parseChatGptUrl(rawUrl);
+  // Preserve only a user-supplied `sev` filter; never inject a scanId/selectionId.
+  const sev = url.searchParams.get("sev");
+  url.search = "";
+  if (sev !== null) {
+    url.searchParams.set("sev", sev);
+  }
+  return url.toString();
+}
+
+export function buildFindingDetailUrl(baseUrl: string, id: string): string {
+  const findingId = id.trim().toLowerCase();
+  if (!FINDING_ID_RE.test(findingId)) {
+    throw new Error(
+      `--finding must be a 32-character hex finding id, received: ${JSON.stringify(id)}`,
+    );
+  }
+  const url = new URL(normalizeCodexFindingsUrl(baseUrl));
+  url.pathname = `${url.pathname.replace(/\/+$/u, "")}/${findingId}`;
+  url.search = "";
+  url.searchParams.set("sev", ""); // matches observed ?sev= ; no scanId/selectionId injected
+  return url.toString();
+}
+
+export function buildFindingsDataUrl(baseUrl: string, opts?: { routes?: string }): string {
+  const url = new URL(normalizeCodexFindingsUrl(baseUrl));
+  url.pathname = `${url.pathname.replace(/\/+$/u, "")}.data`; // suffix-only; cannot smuggle host/scheme
+  url.search = "";
+  url.searchParams.set("sev", "");
+  if (opts?.routes) {
+    url.searchParams.set("_routes", opts.routes);
+  }
+  return url.toString();
+}

--- a/tests/codex/findings.test.ts
+++ b/tests/codex/findings.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   aggregateFindingPages,
+  githubRepoFromUrl,
+  isModalRuntimeEvidence,
   parseFindingItem,
   parseFindingsCounter,
   parseSeverity,
@@ -117,5 +119,32 @@ describe("buildFindingDetailUrl / buildFindingsDataUrl", () => {
   });
   it("suffixes .data (kept for parity, unused by list)", () => {
     expect(buildFindingsDataUrl(CODEX_FINDINGS_URL)).toBe(`${CODEX_FINDINGS_URL}.data?sev=`);
+  });
+});
+
+describe("Modal runtime finding scope", () => {
+  it("recognizes Harp Modal evidence and rejects local/frontend surfaces", () => {
+    expect(
+      isModalRuntimeEvidence(
+        "https://github.com/umgbhalla/harp/blob/abcdef1/harp/serve_modal.py#L1-L10",
+      ),
+    ).toBe(true);
+    expect(
+      isModalRuntimeEvidence(
+        "https://github.com/umgbhalla/harp/blob/abcdef1/harp/sandbox_local.py#L1-L10",
+      ),
+    ).toBe(false);
+    expect(
+      isModalRuntimeEvidence(
+        "https://github.com/umgbhalla/harp/blob/abcdef1/apps/web/app/page.tsx#L1-L10",
+      ),
+    ).toBe(false);
+  });
+
+  it("extracts the repository from report evidence links", () => {
+    expect(githubRepoFromUrl("https://github.com/umgbhalla/harp/commit/abcdef1234567890")).toBe(
+      "umgbhalla/harp",
+    );
+    expect(githubRepoFromUrl("https://example.com/nope")).toBeNull();
   });
 });

--- a/tests/codex/findings.test.ts
+++ b/tests/codex/findings.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+  aggregateFindingPages,
+  parseFindingItem,
+  parseFindingsCounter,
+  parseSeverity,
+  shouldStopPaging,
+} from "../../src/codex/findings.js";
+import {
+  buildFindingDetailUrl,
+  buildFindingsDataUrl,
+  normalizeCodexFindingsUrl,
+} from "../../src/codex/url.js";
+import { CODEX_FINDINGS_URL } from "../../src/browser/constants.js";
+
+const ID_A = "ec67666608e481919bfa195fe60fa36e";
+
+describe("parseSeverity", () => {
+  it("normalizes severity labels (incl. 'High severity')", () => {
+    expect(parseSeverity("High severity")).toBe("high");
+    expect(parseSeverity("CRITICAL")).toBe("critical");
+    expect(parseSeverity("Medium")).toBe("medium");
+  });
+  it("falls back to unknown", () => {
+    expect(parseSeverity("n/a")).toBe("unknown");
+    expect(parseSeverity(undefined)).toBe("unknown");
+  });
+});
+
+describe("parseFindingsCounter", () => {
+  it("parses 'N-M of T' with commas and en-dash", () => {
+    expect(parseFindingsCounter("1-20 of 120")).toEqual({ from: 1, to: 20, total: 120 });
+    expect(parseFindingsCounter("21-40 of 120")).toEqual({ from: 21, to: 40, total: 120 });
+    expect(parseFindingsCounter("1–20 of 1,137")).toEqual({ from: 1, to: 20, total: 1137 });
+  });
+  it("returns null for garbage/empty", () => {
+    expect(parseFindingsCounter("garbage")).toBeNull();
+    expect(parseFindingsCounter(null)).toBeNull();
+  });
+});
+
+describe("parseFindingItem", () => {
+  it("splits the row innerText and reads severity from the icon label", () => {
+    const finding = parseFindingItem(
+      {
+        innerText: "Background bash can leak host files\numgbhalla/harp\n·\nCommitted 1d ago",
+        severityLabel: "High severity",
+      },
+      0,
+    );
+    expect(finding).toMatchObject({
+      title: "Background bash can leak host files",
+      repo: "umgbhalla/harp",
+      status: "Committed 1d ago",
+      severity: "high",
+      index: 0,
+    });
+    expect(finding.id).toBe("Background bash can leak host files|umgbhalla/harp");
+  });
+  it("defaults severity to unknown when no icon label", () => {
+    const finding = parseFindingItem({ innerText: "Some title\nacme/x", severityLabel: null }, 3);
+    expect(finding.severity).toBe("unknown");
+    expect(finding.repo).toBe("acme/x");
+  });
+});
+
+describe("aggregateFindingPages", () => {
+  it("dedupes overlapping rows across pages and re-indexes", () => {
+    const p1 = [
+      parseFindingItem({ innerText: "A\nr/a", severityLabel: "High severity" }, 0),
+      parseFindingItem({ innerText: "B\nr/b", severityLabel: "Low severity" }, 1),
+    ];
+    const p2 = [
+      parseFindingItem({ innerText: "B\nr/b", severityLabel: "Low severity" }, 0),
+      parseFindingItem({ innerText: "C\nr/c", severityLabel: "Critical severity" }, 1),
+    ];
+    const merged = aggregateFindingPages([p1, p2]);
+    expect(merged.map((f) => f.title)).toEqual(["A", "B", "C"]);
+    expect(merged.map((f) => f.index)).toEqual([0, 1, 2]);
+  });
+});
+
+describe("shouldStopPaging", () => {
+  it("stops on unparseable counter or last page", () => {
+    expect(shouldStopPaging(undefined, 1)).toBe(true);
+    expect(shouldStopPaging({ from: 21, to: 40, total: 40 }, 2)).toBe(true);
+  });
+  it("continues while more rows remain", () => {
+    expect(shouldStopPaging({ from: 1, to: 20, total: 120 }, 1)).toBe(false);
+  });
+});
+
+describe("normalizeCodexFindingsUrl", () => {
+  it("defaults when empty and keeps sev", () => {
+    expect(normalizeCodexFindingsUrl("")).toBe(CODEX_FINDINGS_URL);
+    expect(normalizeCodexFindingsUrl(`${CODEX_FINDINGS_URL}?sev=high`)).toBe(
+      `${CODEX_FINDINGS_URL}?sev=high`,
+    );
+  });
+  it("rejects non-findings path and foreign host", () => {
+    expect(() => normalizeCodexFindingsUrl("https://chatgpt.com/c/abc")).toThrow();
+    expect(() =>
+      normalizeCodexFindingsUrl("https://example.com/codex/cloud/security/findings"),
+    ).toThrow();
+  });
+});
+
+describe("buildFindingDetailUrl / buildFindingsDataUrl", () => {
+  it("appends a validated 32-hex id", () => {
+    expect(buildFindingDetailUrl(CODEX_FINDINGS_URL, ID_A)).toBe(
+      `${CODEX_FINDINGS_URL}/${ID_A}?sev=`,
+    );
+  });
+  it("rejects a non-hex id (blocks traversal/injection)", () => {
+    expect(() => buildFindingDetailUrl(CODEX_FINDINGS_URL, "../../evil")).toThrow();
+    expect(() => buildFindingDetailUrl(CODEX_FINDINGS_URL, "short")).toThrow();
+  });
+  it("suffixes .data (kept for parity, unused by list)", () => {
+    expect(buildFindingsDataUrl(CODEX_FINDINGS_URL)).toBe(`${CODEX_FINDINGS_URL}.data?sev=`);
+  });
+});

--- a/tests/codex/findings.test.ts
+++ b/tests/codex/findings.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   aggregateFindingPages,
+  evidencePath,
   githubRepoFromUrl,
-  isModalRuntimeEvidence,
+  isEvidencePathAllowed,
   parseFindingItem,
   parseFindingsCounter,
   parseSeverity,
@@ -64,6 +65,16 @@ describe("parseFindingItem", () => {
     expect(finding.severity).toBe("unknown");
     expect(finding.repo).toBe("acme/x");
   });
+  it("does not mistake path-like title text for repository metadata", () => {
+    const finding = parseFindingItem(
+      {
+        innerText: "Scoped memories leak through tenant-wide /work files\nCommitted 1d ago",
+        severityLabel: "High severity",
+      },
+      0,
+    );
+    expect(finding.repo).toBeUndefined();
+  });
 });
 
 describe("aggregateFindingPages", () => {
@@ -122,23 +133,16 @@ describe("buildFindingDetailUrl / buildFindingsDataUrl", () => {
   });
 });
 
-describe("Modal runtime finding scope", () => {
-  it("recognizes Harp Modal evidence and rejects local/frontend surfaces", () => {
+describe("Evidence path scope", () => {
+  it("matches configured prefixes and exclusions without repository assumptions", () => {
+    const runtime = "https://github.com/acme/project/blob/abcdef1/src/runtime.py#L1-L10";
+    const frontend = "https://github.com/acme/project/blob/abcdef1/apps/web/page.tsx#L1-L10";
+    expect(evidencePath(runtime)).toBe("src/runtime.py");
+    expect(isEvidencePathAllowed(runtime, { includePrefixes: ["src/"] })).toBe(true);
     expect(
-      isModalRuntimeEvidence(
-        "https://github.com/umgbhalla/harp/blob/abcdef1/harp/serve_modal.py#L1-L10",
-      ),
-    ).toBe(true);
-    expect(
-      isModalRuntimeEvidence(
-        "https://github.com/umgbhalla/harp/blob/abcdef1/harp/sandbox_local.py#L1-L10",
-      ),
+      isEvidencePathAllowed(runtime, { includePrefixes: ["src/"], excludePrefixes: ["src/"] }),
     ).toBe(false);
-    expect(
-      isModalRuntimeEvidence(
-        "https://github.com/umgbhalla/harp/blob/abcdef1/apps/web/app/page.tsx#L1-L10",
-      ),
-    ).toBe(false);
+    expect(isEvidencePathAllowed(frontend, { includePrefixes: ["src/"] })).toBe(false);
   });
 
   it("extracts the repository from report evidence links", () => {


### PR DESCRIPTION
## Motivation

Oracle previously had no Codex Cloud security-findings workflow. This PR adds the complete path from discovery to action: it can enumerate findings, open a selected finding, extract the report and evidence needed to understand it, and then invoke the finding’s supported detail-panel actions from the CLI.

The first part is deliberately read-only. It turns the authenticated findings surface into structured CLI output instead of forcing an operator to navigate the web UI, while preserving the report sections and evidence links that explain why a finding exists. The second part adds the operational step that was missing before: an explicit finding action command that can create a PR, start a finding chat, close or adjust a finding, and copy the available patch or report material.

## Design

### Discovery and report extraction

- `oracle codex findings` enumerates the paginated findings surface, reports severity and repository metadata, supports severity/limit filtering, and can emit JSON.
- `oracle codex findings --finding <selection-id>` opens one finding and extracts its title, repository/commit reference, Summary, Validation, Evidence, and Attack-path analysis sections.
- Detail extraction also returns deduplicated GitHub evidence links and the signed validation-artifact URL without fetching or modifying the artifact.
- Finding IDs are validated before they are used to build detail URLs, and the browser runner uses the authenticated browser surface rather than an unauthenticated API shortcut.

### Explicit finding actions

- `oracle codex finding --finding <selection-id> --action <action>` provides the action layer for `create-pr`, `chat`, `close`, `adjust`, `copy-content`, `copy-link`, `copy-patch`, and `copy-git-apply`.
- The action runner targets the accessible detail-panel controls with trusted CDP mouse events. This is required because the Radix pointer-event controls can ignore synthetic `element.click()` calls.
- Chat requires `--text`, while mutating actions require `--confirm`; read-only copy actions do not require confirmation.
- Create PR opens the git action menu and checks for `View PR` before clicking Create PR, so rerunning the command returns an existing PR instead of creating a duplicate.
- Actions can be constrained to an expected GitHub repository with `--repo`, and the finding detail is re-read immediately before the action is dispatched.

## Compatibility and safety

The original `oracle codex findings` command remains read-only, and adding the action command does not make list or detail inspection mutating. The runner refuses mutating actions without explicit confirmation and refuses to proceed when trusted browser input is unavailable, so a failed automation primitive cannot be reported as a successful action.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run tests/codex/findings.test.ts` — 16 passed
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm test` — 1,572 passed, 44 skipped

## Exact-head live proof

Current head: `1b7d6c7cfe42dc2668ccfde8c7f6c57b51b1cbc7`

- Authenticated findings launch returned 33 findings.
- A selected finding’s report was read successfully, including its evidence links and validation artifact reference.
- A trusted copy action completed successfully.
- Repeating Create PR returned that existing PR instead of creating a duplicate.
