### PR TITLE
fix(browser): recover answers after recoverable CDP disconnect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,34 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
       - run: pnpm run test:packed-cli
         if: matrix.os == 'ubuntu-latest'
+
+  # Linux parity smoke for recoverable CDP disconnect classification (issue #326 / PR #327).
+  # No ChatGPT auth; exercises real Chromium DevTools against the same probe path as macOS proof.
+  cdp-disconnect-proof-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      - uses: pnpm/action-setup@v6
+      - name: Install Chromium
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq chromium-browser || sudo apt-get install -y -qq chromium
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+      - name: Run CDP disconnect classification proof
+        env:
+          CHROME_PATH: /usr/bin/chromium-browser
+        run: |
+          if [[ ! -x "${CHROME_PATH}" ]]; then
+            if [[ -x /usr/bin/chromium ]]; then
+              export CHROME_PATH=/usr/bin/chromium
+            else
+              echo "Chromium binary not found" >&2
+              exit 1
+            fi
+          fi
+          echo "CHROME_PATH=${CHROME_PATH}"
+          node scripts/cdp-disconnect-proof.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Fixed
 
-- Browser: treat recoverable CDP client disconnects as reattachable when Chrome/target is still alive, and attempt a one-shot auto-reattach on `connection-lost` (same recovery idea as `assistant-timeout`) so completed answers are not left stranded. Fixes #326. Thanks @piyushbag!
 - CLI: avoid inheriting `browser.thinkingTime` from config when `--browser-model-strategy current` is explicit, while preserving an explicit `--browser-thinking-time` override. Thanks @jung0han!
 
 ## 0.16.0 — 2026-07-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Browser: treat recoverable CDP client disconnects as reattachable when Chrome/target is still alive, and attempt a one-shot auto-reattach on `connection-lost` (same recovery idea as `assistant-timeout`) so completed answers are not left stranded. Fixes #326. Thanks @piyushbag!
 - CLI: avoid inheriting `browser.thinkingTime` from config when `--browser-model-strategy current` is explicit, while preserving an explicit `--browser-thinking-time` override. Thanks @jung0han!
 
 ## 0.16.0 — 2026-07-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Browser: recover completed answers after a recoverable DevTools disconnect by confirming target liveness and attempting bounded reattachment, while preserving fail-closed handling for unavailable targets. Fixes #326. Thanks @piyushbag!
 - CLI: avoid inheriting `browser.thinkingTime` from config when `--browser-model-strategy current` is explicit, while preserving an explicit `--browser-thinking-time` override. Thanks @jung0han!
 
 ## 0.16.0 — 2026-07-12

--- a/scripts/cdp-disconnect-proof.mjs
+++ b/scripts/cdp-disconnect-proof.mjs
@@ -8,6 +8,7 @@
  *
  * Does not require ChatGPT login.
  */
+import { existsSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -15,7 +16,7 @@ import { createRequire } from "node:module";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const require = createRequire(import.meta.url);
-const { launch } = require("chrome-launcher");
+const { launch, Launcher } = require("chrome-launcher");
 const CDP = require("chrome-remote-interface");
 
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -30,6 +31,36 @@ function log(step, detail) {
   console.log(`[${new Date().toISOString()}] ${step}${detail ? `: ${detail}` : ""}`);
 }
 
+/** Resolve Chrome/Chromium for macOS + Linux CI/Docker without hardcoding one OS. */
+function resolveChromePath() {
+  if (process.env.CHROME_PATH && existsSync(process.env.CHROME_PATH)) {
+    return process.env.CHROME_PATH;
+  }
+  const candidates = [
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    "/usr/bin/google-chrome-stable",
+    "/usr/bin/google-chrome",
+    "/usr/bin/chromium",
+    "/usr/bin/chromium-browser",
+    "/snap/bin/chromium",
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  try {
+    const installations = Launcher.getInstallations?.() ?? [];
+    if (installations[0] && existsSync(installations[0])) {
+      return installations[0];
+    }
+  } catch {
+    /* ignore */
+  }
+  throw new Error(
+    "Chrome/Chromium not found. Set CHROME_PATH to a browser binary (Linux: chromium or google-chrome).",
+  );
+}
+
 async function listTargets(port) {
   const res = await fetch(`http://127.0.0.1:${port}/json/list`);
   if (!res.ok) throw new Error(`/json/list failed: ${res.status}`);
@@ -41,12 +72,11 @@ async function run() {
   let chrome;
   let client;
   let port;
-  const chromePath =
-    process.env.CHROME_PATH ||
-    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+  const chromePath = resolveChromePath();
 
   try {
-    log("launch", "Chrome headless with remote debugging");
+    log("platform", `${process.platform}/${process.arch} chromePath=${chromePath}`);
+    log("launch", "Chrome/Chromium headless with remote debugging");
     chrome = await launch({
       chromePath,
       chromeFlags: [
@@ -55,6 +85,9 @@ async function run() {
         "--no-first-run",
         "--no-default-browser-check",
         "--disable-extensions",
+        // Required for Chromium in many Linux/Docker/CI sandboxes.
+        "--no-sandbox",
+        "--disable-dev-shm-usage",
       ],
       userDataDir,
       handleSIGINT: false,

--- a/scripts/cdp-disconnect-proof.mjs
+++ b/scripts/cdp-disconnect-proof.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * Real-Chrome proof for recoverable vs closed-target CDP disconnects.
+ *
+ * Merge-readiness for PR #327:
+ * 1) Client disconnect while Chrome/target stay alive → recoverable
+ * 2) Chrome gone → non-recoverable closed fallback
+ *
+ * Does not require ChatGPT login.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const require = createRequire(import.meta.url);
+const { launch } = require("chrome-launcher");
+const CDP = require("chrome-remote-interface");
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const distRoot = path.resolve(here, "..", "dist", "src");
+const {
+  probeChromeTargetLiveness,
+  isRecoverableChromeDisconnect,
+  connectionLostUserMessage,
+} = await import(pathToFileURL(path.join(distRoot, "browser", "cdpLiveness.js")).href);
+
+function log(step, detail) {
+  console.log(`[${new Date().toISOString()}] ${step}${detail ? `: ${detail}` : ""}`);
+}
+
+async function listTargets(port) {
+  const res = await fetch(`http://127.0.0.1:${port}/json/list`);
+  if (!res.ok) throw new Error(`/json/list failed: ${res.status}`);
+  return res.json();
+}
+
+async function run() {
+  const userDataDir = await mkdtemp(path.join(os.tmpdir(), "oracle-cdp-proof-"));
+  let chrome;
+  let client;
+  let port;
+  const chromePath =
+    process.env.CHROME_PATH ||
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+
+  try {
+    log("launch", "Chrome headless with remote debugging");
+    chrome = await launch({
+      chromePath,
+      chromeFlags: [
+        "--headless=new",
+        "--disable-gpu",
+        "--no-first-run",
+        "--no-default-browser-check",
+        "--disable-extensions",
+      ],
+      userDataDir,
+      handleSIGINT: false,
+    });
+    port = chrome.port;
+    log("chrome-up", `port=${port} pid=${chrome.pid}`);
+
+    client = await CDP({ host: "127.0.0.1", port });
+    const { Page, Runtime } = client;
+    await Page.enable();
+    await Page.navigate({
+      url: "data:text/html,<title>oracle-cdp-proof</title><h1>alive</h1>",
+    });
+    await Page.loadEventFired();
+    const { result: titleResult } = await Runtime.evaluate({
+      expression: "document.title",
+      returnByValue: true,
+    });
+    log("page-ready", `title=${titleResult.value}`);
+
+    const targetsBefore = await listTargets(port);
+    const pageTarget =
+      targetsBefore.find(
+        (t) => t.type === "page" && String(t.url || "").includes("oracle-cdp-proof"),
+      ) || targetsBefore.find((t) => t.type === "page");
+    if (!pageTarget?.id) throw new Error("no page target found");
+    const targetId = pageTarget.id;
+    log("target", `id=${targetId.slice(0, 8)}…`);
+
+    log("case-1", "CDP client disconnect; Chrome+target remain");
+    await client.close();
+    client = null;
+    await new Promise((r) => setTimeout(r, 300));
+
+    const alive = await probeChromeTargetLiveness({
+      host: "127.0.0.1",
+      port,
+      targetId,
+    });
+    const recoverable = isRecoverableChromeDisconnect(alive);
+    log(
+      "case-1-result",
+      JSON.stringify({
+        endpointReachable: alive.endpointReachable,
+        targetFound: alive.targetFound,
+        recoverable,
+        userMessage: connectionLostUserMessage({ recoverable }),
+      }),
+    );
+    if (!recoverable) {
+      throw new Error("case-1 failed: expected recoverable while target alive");
+    }
+    log("case-1-pass", "recoverableDisconnect path; sessionRunner would auto-reattach");
+
+    log("case-2", "close target + kill Chrome");
+    client = await CDP({ host: "127.0.0.1", port });
+    try {
+      await client.Target.closeTarget({ targetId });
+    } catch (err) {
+      log("close-target", String(err?.message || err));
+    }
+    await client.close();
+    client = null;
+    chrome.kill();
+    chrome = null;
+
+    let endpointDead = false;
+    for (let i = 0; i < 50; i++) {
+      try {
+        await fetch(`http://127.0.0.1:${port}/json/version`, {
+          signal: AbortSignal.timeout(300),
+        });
+      } catch {
+        endpointDead = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    if (!endpointDead) {
+      throw new Error("chrome endpoint still reachable after kill");
+    }
+
+    const dead = await probeChromeTargetLiveness({
+      host: "127.0.0.1",
+      port,
+      targetId,
+    });
+    const recoverableDead = isRecoverableChromeDisconnect(dead);
+    log(
+      "case-2-result",
+      JSON.stringify({
+        endpointReachable: dead.endpointReachable,
+        targetFound: dead.targetFound,
+        recoverable: recoverableDead,
+        userMessage: connectionLostUserMessage({ recoverable: recoverableDead }),
+        error: dead.error,
+      }),
+    );
+    if (recoverableDead) {
+      throw new Error("case-2 failed: expected non-recoverable after Chrome closed");
+    }
+    log("case-2-pass", "closed-window message; no stale auto-reattach loop");
+
+    console.log("\nPROOF_OK both disconnect outcomes demonstrated against real Chrome CDP");
+  } catch (error) {
+    console.error("\nPROOF_FAILED", error);
+    process.exitCode = 1;
+  } finally {
+    try {
+      await client?.close?.();
+    } catch {
+      /* ignore */
+    }
+    try {
+      chrome?.kill?.();
+    } catch {
+      /* ignore */
+    }
+    await rm(userDataDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+await run();

--- a/scripts/cdp-disconnect-proof.mjs
+++ b/scripts/cdp-disconnect-proof.mjs
@@ -16,16 +16,13 @@ import { createRequire } from "node:module";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const require = createRequire(import.meta.url);
-const { launch, Launcher } = require("chrome-launcher");
+const { Launcher } = require("chrome-launcher");
 const CDP = require("chrome-remote-interface");
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const distRoot = path.resolve(here, "..", "dist", "src");
-const {
-  probeChromeTargetLiveness,
-  isRecoverableChromeDisconnect,
-  connectionLostUserMessage,
-} = await import(pathToFileURL(path.join(distRoot, "browser", "cdpLiveness.js")).href);
+const { probeChromeTargetLiveness, isRecoverableChromeDisconnect, connectionLostUserMessage } =
+  await import(pathToFileURL(path.join(distRoot, "browser", "cdpLiveness.js")).href);
 
 function log(step, detail) {
   console.log(`[${new Date().toISOString()}] ${step}${detail ? `: ${detail}` : ""}`);
@@ -77,7 +74,10 @@ async function run() {
   try {
     log("platform", `${process.platform}/${process.arch} chromePath=${chromePath}`);
     log("launch", "Chrome/Chromium headless with remote debugging");
-    chrome = await launch({
+    // Keep the launcher handle before awaiting readiness. If DevTools startup
+    // times out, the rejected promise otherwise loses the spawned Chrome pid
+    // and leaves the proof process behind.
+    chrome = new Launcher({
       chromePath,
       chromeFlags: [
         "--headless=new",
@@ -92,6 +92,7 @@ async function run() {
       userDataDir,
       handleSIGINT: false,
     });
+    await chrome.launch();
     port = chrome.port;
     log("chrome-up", `port=${port} pid=${chrome.pid}`);
 
@@ -211,3 +212,7 @@ async function run() {
 }
 
 await run();
+// chrome-launcher can retain an internal log descriptor after a failed startup
+// with a caller-owned profile. Cleanup above is complete, so terminate with the
+// recorded proof status instead of leaving CI waiting on that descriptor.
+process.exit(process.exitCode ?? 0);

--- a/scripts/export-chatgpt-cookies.mjs
+++ b/scripts/export-chatgpt-cookies.mjs
@@ -17,12 +17,22 @@ const { cookies } = await getCookies({
 });
 
 // CDP CookieParam shape only; drop sweet-cookie metadata that Oracle ignores.
-const payload = cookies.map(({ name, value, domain, path, secure, httpOnly, sameSite, expires }) => {
-  const cookie = { name, value, domain, path: path ?? "/", secure: secure ?? true, httpOnly: Boolean(httpOnly) };
-  if (sameSite === "Lax" || sameSite === "Strict" || sameSite === "None") cookie.sameSite = sameSite;
-  if (typeof expires === "number" && expires > 0) cookie.expires = expires;
-  return cookie;
-});
+const payload = cookies.map(
+  ({ name, value, domain, path, secure, httpOnly, sameSite, expires }) => {
+    const cookie = {
+      name,
+      value,
+      domain,
+      path: path ?? "/",
+      secure: secure ?? true,
+      httpOnly: Boolean(httpOnly),
+    };
+    if (sameSite === "Lax" || sameSite === "Strict" || sameSite === "None")
+      cookie.sameSite = sameSite;
+    if (typeof expires === "number" && expires > 0) cookie.expires = expires;
+    return cookie;
+  },
+);
 
 const hasSession = payload.some((c) => c.name.startsWith("__Secure-next-auth.session-token"));
 writeOwnerOnlyFile(out, JSON.stringify(payload));

--- a/scripts/export-chatgpt-cookies.mjs
+++ b/scripts/export-chatgpt-cookies.mjs
@@ -1,4 +1,4 @@
-import { writeFileSync } from "node:fs";
+import { writeOwnerOnlyFile } from "./write-owner-only-file.mjs";
 import { getCookies } from "@steipete/sweet-cookie";
 
 const out = process.argv[2];
@@ -25,6 +25,6 @@ const payload = cookies.map(({ name, value, domain, path, secure, httpOnly, same
 });
 
 const hasSession = payload.some((c) => c.name.startsWith("__Secure-next-auth.session-token"));
-writeFileSync(out, JSON.stringify(payload));
+writeOwnerOnlyFile(out, JSON.stringify(payload));
 console.log(`wrote ${payload.length} cookies to ${out}; session=${hasSession}`);
 process.exit(hasSession ? 0 : 1);

--- a/scripts/export-chatgpt-cookies.mjs
+++ b/scripts/export-chatgpt-cookies.mjs
@@ -1,0 +1,30 @@
+import { writeFileSync } from "node:fs";
+import { getCookies } from "@steipete/sweet-cookie";
+
+const out = process.argv[2];
+if (!out) {
+  console.error("usage: export-chatgpt-cookies.mjs <outfile.json>");
+  process.exit(2);
+}
+
+const { cookies } = await getCookies({
+  url: "https://chatgpt.com",
+  origins: ["https://chatgpt.com", "https://chat.openai.com", "https://atlas.openai.com"],
+  browsers: ["chrome"],
+  mode: "merge",
+  chromeProfile: "Default",
+  timeoutMs: 10_000,
+});
+
+// CDP CookieParam shape only; drop sweet-cookie metadata that Oracle ignores.
+const payload = cookies.map(({ name, value, domain, path, secure, httpOnly, sameSite, expires }) => {
+  const cookie = { name, value, domain, path: path ?? "/", secure: secure ?? true, httpOnly: Boolean(httpOnly) };
+  if (sameSite === "Lax" || sameSite === "Strict" || sameSite === "None") cookie.sameSite = sameSite;
+  if (typeof expires === "number" && expires > 0) cookie.expires = expires;
+  return cookie;
+});
+
+const hasSession = payload.some((c) => c.name.startsWith("__Secure-next-auth.session-token"));
+writeFileSync(out, JSON.stringify(payload));
+console.log(`wrote ${payload.length} cookies to ${out}; session=${hasSession}`);
+process.exit(hasSession ? 0 : 1);

--- a/scripts/oracle-e2e-cdp-disconnect-proof.mjs
+++ b/scripts/oracle-e2e-cdp-disconnect-proof.mjs
@@ -1,0 +1,361 @@
+#!/usr/bin/env node
+/**
+ * End-to-end proof for PR #327: force a CDP client disconnect during a real
+ * Oracle browser run, then confirm auto-reattach harvests an answer and marks
+ * the session completed.
+ *
+ * Requires: logged-in Chrome ChatGPT cookies, built dist CLI.
+ * Redact prompts/paths before posting logs.
+ *
+ * Usage:
+ *   node scripts/export-chatgpt-cookies.mjs /tmp/oracle-e2e-cookies.json
+ *   ORACLE_BROWSER_COOKIES_FILE=/tmp/oracle-e2e-cookies.json \
+ *     node scripts/oracle-e2e-cdp-disconnect-proof.mjs
+ *
+ * Optional:
+ *   ORACLE_E2E_REMOTE_CHROME=127.0.0.1:9222
+ *   ORACLE_E2E_BROWSER_PORT=9342
+ *   ORACLE_E2E_MODEL_STRATEGY=current|select|ignore
+ *   ORACLE_E2E_CLEANUP=1
+ */
+import { spawn, execFileSync } from "node:child_process";
+import { mkdtemp, readFile, rm, mkdir } from "node:fs/promises";
+import { createWriteStream } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, "..");
+const cli = path.join(root, "dist", "bin", "oracle-cli.js");
+
+const slug = `e2e-cdp-${Date.now().toString(36)}`;
+const sessionDir = path.join(os.homedir(), ".oracle", "sessions", slug);
+const metaPath = path.join(sessionDir, "meta.json");
+const model = process.env.ORACLE_E2E_MODEL || "gpt-5.5";
+const token = `e2e-cdp-ok-${Date.now().toString(36)}`;
+// Long enough that ChatGPT is still generating when we steal the CDP socket.
+const prompt = [
+  token,
+  "Write a detailed technical essay of at least 35 sentences about TCP congestion control,",
+  "slow start, congestion avoidance, fast retransmit, and CUBIC vs BBR.",
+  "End with a final line that repeats the first line of this prompt exactly.",
+].join("\n");
+
+function log(msg) {
+  console.log(`[${new Date().toISOString()}] ${msg}`);
+}
+
+async function readMeta() {
+  try {
+    return JSON.parse(await readFile(metaPath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+async function waitFor(
+  predicate,
+  { timeoutMs = 180_000, intervalMs = 250, label = "condition", shouldAbort } = {},
+) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (shouldAbort?.()) {
+      throw new Error(`aborted waiting for ${label}`);
+    }
+    const meta = await readMeta();
+    if (await predicate(meta)) return meta;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(`timeout waiting for ${label}`);
+}
+
+function listOutboundCdpFds(pid, port) {
+  let out = "";
+  try {
+    out = execFileSync(
+      "lsof",
+      ["-nP", "-a", "-p", String(pid), `-iTCP:${port}`, "-sTCP:ESTABLISHED"],
+      { encoding: "utf8" },
+    );
+  } catch {
+    return [];
+  }
+  const fds = [];
+  for (const line of out.trim().split("\n").slice(1)) {
+    const cols = line.trim().split(/\s+/);
+    if (!/^IPv[46]$/.test(cols[4] || "")) continue;
+    const name = cols.slice(8).join(" ");
+    if (!new RegExp(`->127\\.0\\.0\\.1:${port}\\b`).test(name)) continue;
+    const fd = Number.parseInt(String(cols[3]).replace(/[^0-9]/g, ""), 10);
+    if (Number.isFinite(fd)) fds.push(fd);
+  }
+  return [...new Set(fds)];
+}
+
+function closeRemoteFds(pid, fds) {
+  if (!fds.length) throw new Error(`no outbound CDP fds for pid=${pid}`);
+  // Modern Chrome allows multiple CDP clients, so a second attach does not drop
+  // Oracle's socket. Close Oracle's established CDP fds in-process via lldb.
+  const args = ["-p", String(pid), "-b"];
+  for (const fd of fds) {
+    args.push("-o", `expr -- (int)close(${fd})`);
+  }
+  return execFileSync("lldb", args, {
+    encoding: "utf8",
+    timeout: 30_000,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+async function forceDetachOracleClient(port, controllerPid) {
+  if (!controllerPid) {
+    throw new Error("missing browser.runtime.controllerPid for forced CDP detach");
+  }
+  // Confirm Chrome/target stay reachable before and after the socket drop.
+  const versionBefore = await fetch(`http://127.0.0.1:${port}/json/version`).then((r) => r.json());
+  if (!versionBefore?.webSocketDebuggerUrl) {
+    throw new Error("Chrome CDP endpoint not reachable before forced detach");
+  }
+
+  let fds = listOutboundCdpFds(controllerPid, port);
+  for (let i = 0; i < 20 && fds.length === 0; i++) {
+    await new Promise((r) => setTimeout(r, 200));
+    fds = listOutboundCdpFds(controllerPid, port);
+  }
+  log(
+    `forcing CDP detach by closing Oracle pid=${controllerPid} fds=[${fds.join(",")}] on port=${port}`,
+  );
+  const lldbOut = closeRemoteFds(controllerPid, fds);
+  if (/error:/i.test(lldbOut) && !/close\(/.test(lldbOut)) {
+    log(`lldb warning: ${lldbOut.slice(0, 240)}`);
+  }
+
+  // Endpoint must remain up (recoverable path), unlike killing Chrome.
+  await new Promise((r) => setTimeout(r, 500));
+  const versionAfter = await fetch(`http://127.0.0.1:${port}/json/version`).then((r) => r.json());
+  if (!versionAfter?.webSocketDebuggerUrl) {
+    throw new Error("Chrome CDP endpoint died; disconnect was not recoverable");
+  }
+  log("Oracle CDP sockets closed; Chrome/target still reachable");
+}
+
+function proofSignals(fullLog, meta) {
+  const sawAutoReattach = /Auto-reattach|auto-reattach/i.test(fullLog);
+  const sawRecoverableMessage =
+    /CDP client disconnected|still reachable|recoverable|chrome-disconnected|keeping session running for reattach/i.test(
+      fullLog,
+    );
+  const incompleteReason = meta?.response?.incompleteReason ?? null;
+  const errorMessage = String(meta?.errorMessage ?? meta?.error?.message ?? "");
+  const sawRecoverableMeta =
+    incompleteReason === "chrome-disconnected" ||
+    /CDP client disconnected|still reachable|recoverable/i.test(errorMessage) ||
+    Boolean(meta?.browser?.runtime?.recoverableDisconnect) ||
+    Boolean(meta?.error?.details?.recoverableDisconnect);
+  return { sawAutoReattach, sawRecoverableMessage, sawRecoverableMeta };
+}
+
+async function main() {
+  await rm(sessionDir, { recursive: true, force: true }).catch(() => {});
+  await mkdir(path.dirname(sessionDir), { recursive: true });
+
+  const logPath = path.join(
+    await mkdtemp(path.join(os.tmpdir(), "oracle-e2e-cdp-")),
+    "run.log",
+  );
+  const logStream = createWriteStream(logPath, { flags: "a" });
+  log(`slug=${slug}`);
+  log(`model=${model}`);
+  log(`log=${logPath}`);
+
+  // Default: launch automation Chrome with cookie sync (not --copy-profile:
+  // copied profiles disable connection-lost reattach). Opt into remote with
+  // ORACLE_E2E_REMOTE_CHROME=host:port.
+  const remoteChrome = process.env.ORACLE_E2E_REMOTE_CHROME || "";
+  const args = [
+    cli,
+    "--engine",
+    "browser",
+    "--wait",
+    "--heartbeat",
+    "0",
+    "--timeout",
+    "600",
+    "--browser-input-timeout",
+    "120000",
+    // Free / Plus accounts often lack Thinking 5.5; keep whatever ChatGPT has selected.
+    "--browser-model-strategy",
+    process.env.ORACLE_E2E_MODEL_STRATEGY || "current",
+    "--model",
+    model,
+    "--prompt",
+    prompt,
+    "--slug",
+    slug,
+    "--force",
+  ];
+  if (remoteChrome) {
+    args.push("--remote-chrome", remoteChrome);
+    log(`using --remote-chrome ${remoteChrome}`);
+  } else {
+    args.push(
+      "--browser-keep-browser",
+      "--browser-port",
+      String(process.env.ORACLE_E2E_BROWSER_PORT || "9333"),
+    );
+    log(`using launch + cookie sync (port ${process.env.ORACLE_E2E_BROWSER_PORT || "9333"})`);
+  }
+  const cookiesFile = process.env.ORACLE_BROWSER_COOKIES_FILE || "";
+  if (cookiesFile) {
+    args.push("--browser-inline-cookies-file", cookiesFile);
+    log(`using --browser-inline-cookies-file`);
+  }
+
+  log("starting Oracle browser run");
+  const child = spawn(process.execPath, args, {
+    cwd: root,
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout.on("data", (d) => {
+    const s = String(d);
+    process.stdout.write(s);
+    logStream.write(s);
+  });
+  child.stderr.on("data", (d) => {
+    const s = String(d);
+    process.stderr.write(s);
+    logStream.write(s);
+  });
+
+  let childExit = null;
+  child.on("exit", (code, signal) => {
+    childExit = { code, signal };
+    log(`oracle exited code=${code} signal=${signal}`);
+  });
+
+  let forcedDetach = false;
+  try {
+    const ready = await waitFor(
+      (meta) =>
+        Boolean(
+          meta?.browser?.runtime?.chromePort &&
+            meta?.browser?.runtime?.promptSubmitted === true,
+        ),
+      {
+        timeoutMs: 240_000,
+        intervalMs: 200,
+        label: "promptSubmitted + chromePort",
+        shouldAbort: () => childExit != null && childExit.code !== 0,
+      },
+    );
+    const runtime = ready.browser.runtime;
+    log(
+      `runtime ready port=${runtime.chromePort} target=${String(runtime.chromeTargetId || "").slice(0, 8)}… status=${ready.status}`,
+    );
+
+    if (childExit != null) {
+      throw new Error(
+        `Oracle exited before forced CDP detach (code=${childExit.code}); use a longer prompt`,
+      );
+    }
+
+    // Steal the CDP socket while the answer is still in flight.
+    const detachDelayMs = Number(process.env.ORACLE_E2E_DETACH_DELAY_MS || "500");
+    if (detachDelayMs > 0) {
+      await new Promise((r) => setTimeout(r, detachDelayMs));
+    }
+    if (childExit != null) {
+      throw new Error(
+        `Oracle exited before forced CDP detach (code=${childExit.code}); answer finished too fast`,
+      );
+    }
+    await forceDetachOracleClient(
+      runtime.chromePort,
+      runtime.controllerPid || child.pid,
+    );
+    forcedDetach = true;
+
+    const completed = await waitFor(
+      (meta) => meta?.status === "completed",
+      {
+        timeoutMs: 300_000,
+        intervalMs: 1000,
+        label: "session status=completed after disconnect",
+      },
+    );
+
+    const answer =
+      completed?.response?.text ||
+      completed?.response?.markdown ||
+      completed?.answer ||
+      "";
+    const answerPreview = String(answer).slice(0, 120).replace(/\s+/g, " ");
+    log(`session completed; answerPreview=${JSON.stringify(answerPreview)}`);
+
+    // Drain a moment so late auto-reattach log lines land.
+    await new Promise((r) => setTimeout(r, 1500));
+    const fullLog = await readFile(logPath, "utf8");
+    const signals = proofSignals(fullLog, completed);
+    const harvested =
+      fullLog.includes(token) ||
+      String(answer).includes(token) ||
+      signals.sawAutoReattach;
+
+    if (!forcedDetach) {
+      throw new Error("forced CDP detach never ran");
+    }
+    if (!signals.sawAutoReattach && !signals.sawRecoverableMessage && !signals.sawRecoverableMeta) {
+      throw new Error(
+        "completed without recoverable-disconnect / auto-reattach evidence (run finished before detach?)",
+      );
+    }
+    if (!harvested) {
+      throw new Error("completed without harvest evidence (token missing from answer/log)");
+    }
+
+    console.log("\nE2E_PROOF_OK");
+    console.log(
+      JSON.stringify(
+        {
+          slug,
+          finalStatus: completed.status,
+          incompleteReason: completed.response?.incompleteReason ?? null,
+          forcedDetach,
+          ...signals,
+          tokenPresentInLog: fullLog.includes(token),
+          tokenPresentInAnswer: String(answer).includes(token),
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (err) {
+    console.error("\nE2E_PROOF_FAILED", err);
+    const meta = await readMeta();
+    if (meta) {
+      console.error("meta.status=", meta.status);
+      console.error("meta.response=", JSON.stringify(meta.response ?? null));
+      console.error("meta.errorMessage=", meta.errorMessage ?? null);
+    }
+    process.exitCode = 1;
+  } finally {
+    if (childExit == null && child.pid) {
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        /* ignore */
+      }
+    }
+    logStream.end();
+    if (process.env.ORACLE_E2E_CLEANUP === "1") {
+      await rm(sessionDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+}
+
+await main();

--- a/scripts/oracle-e2e-cdp-disconnect-proof.mjs
+++ b/scripts/oracle-e2e-cdp-disconnect-proof.mjs
@@ -219,6 +219,12 @@ async function main() {
       "--browser-port",
       String(process.env.ORACLE_E2E_BROWSER_PORT || "9333"),
     );
+    // Linux CI/Docker: hide the window under Xvfb. Do not enable headless;
+    // Cloudflare blocks headless ChatGPT automation.
+    if (process.env.ORACLE_E2E_HIDE_WINDOW === "1") {
+      args.push("--browser-hide-window");
+      log("using --browser-hide-window (Xvfb / non-interactive host)");
+    }
     log(`using launch + cookie sync (port ${process.env.ORACLE_E2E_BROWSER_PORT || "9333"})`);
   }
   const cookiesFile = process.env.ORACLE_BROWSER_COOKIES_FILE || "";

--- a/scripts/oracle-e2e-cdp-disconnect-proof.mjs
+++ b/scripts/oracle-e2e-cdp-disconnect-proof.mjs
@@ -99,7 +99,19 @@ function listOutboundCdpFds(pid, port) {
 function closeRemoteFds(pid, fds) {
   if (!fds.length) throw new Error(`no outbound CDP fds for pid=${pid}`);
   // Modern Chrome allows multiple CDP clients, so a second attach does not drop
-  // Oracle's socket. Close Oracle's established CDP fds in-process via lldb.
+  // Oracle's socket. Close Oracle's established CDP fds in-process.
+  // macOS: lldb; Linux/Ubuntu: gdb (matches issue #326's report environment).
+  if (process.platform === "linux") {
+    const args = ["-p", String(pid), "-batch", "-n"];
+    for (const fd of fds) {
+      args.push("-ex", `call (int)close(${fd})`);
+    }
+    return execFileSync("gdb", args, {
+      encoding: "utf8",
+      timeout: 30_000,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  }
   const args = ["-p", String(pid), "-b"];
   for (const fd of fds) {
     args.push("-o", `expr -- (int)close(${fd})`);
@@ -129,9 +141,9 @@ async function forceDetachOracleClient(port, controllerPid) {
   log(
     `forcing CDP detach by closing Oracle pid=${controllerPid} fds=[${fds.join(",")}] on port=${port}`,
   );
-  const lldbOut = closeRemoteFds(controllerPid, fds);
-  if (/error:/i.test(lldbOut) && !/close\(/.test(lldbOut)) {
-    log(`lldb warning: ${lldbOut.slice(0, 240)}`);
+  const debuggerOut = closeRemoteFds(controllerPid, fds);
+  if (/error:/i.test(debuggerOut) && !/close\(/.test(debuggerOut)) {
+    log(`fd-close warning: ${debuggerOut.slice(0, 240)}`);
   }
 
   // Endpoint must remain up (recoverable path), unlike killing Chrome.

--- a/scripts/oracle-e2e-cdp-disconnect-proof.mjs
+++ b/scripts/oracle-e2e-cdp-disconnect-proof.mjs
@@ -24,9 +24,6 @@ import { createWriteStream } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { createRequire } from "node:module";
-
-const require = createRequire(import.meta.url);
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(here, "..");
@@ -175,10 +172,7 @@ async function main() {
   await rm(sessionDir, { recursive: true, force: true }).catch(() => {});
   await mkdir(path.dirname(sessionDir), { recursive: true });
 
-  const logPath = path.join(
-    await mkdtemp(path.join(os.tmpdir(), "oracle-e2e-cdp-")),
-    "run.log",
-  );
+  const logPath = path.join(await mkdtemp(path.join(os.tmpdir(), "oracle-e2e-cdp-")), "run.log");
   const logStream = createWriteStream(logPath, { flags: "a" });
   log(`slug=${slug}`);
   log(`model=${model}`);
@@ -261,8 +255,7 @@ async function main() {
     const ready = await waitFor(
       (meta) =>
         Boolean(
-          meta?.browser?.runtime?.chromePort &&
-            meta?.browser?.runtime?.promptSubmitted === true,
+          meta?.browser?.runtime?.chromePort && meta?.browser?.runtime?.promptSubmitted === true,
         ),
       {
         timeoutMs: 240_000,
@@ -292,26 +285,17 @@ async function main() {
         `Oracle exited before forced CDP detach (code=${childExit.code}); answer finished too fast`,
       );
     }
-    await forceDetachOracleClient(
-      runtime.chromePort,
-      runtime.controllerPid || child.pid,
-    );
+    await forceDetachOracleClient(runtime.chromePort, runtime.controllerPid || child.pid);
     forcedDetach = true;
 
-    const completed = await waitFor(
-      (meta) => meta?.status === "completed",
-      {
-        timeoutMs: 300_000,
-        intervalMs: 1000,
-        label: "session status=completed after disconnect",
-      },
-    );
+    const completed = await waitFor((meta) => meta?.status === "completed", {
+      timeoutMs: 300_000,
+      intervalMs: 1000,
+      label: "session status=completed after disconnect",
+    });
 
     const answer =
-      completed?.response?.text ||
-      completed?.response?.markdown ||
-      completed?.answer ||
-      "";
+      completed?.response?.text || completed?.response?.markdown || completed?.answer || "";
     const answerPreview = String(answer).slice(0, 120).replace(/\s+/g, " ");
     log(`session completed; answerPreview=${JSON.stringify(answerPreview)}`);
 
@@ -320,9 +304,7 @@ async function main() {
     const fullLog = await readFile(logPath, "utf8");
     const signals = proofSignals(fullLog, completed);
     const harvested =
-      fullLog.includes(token) ||
-      String(answer).includes(token) ||
-      signals.sawAutoReattach;
+      fullLog.includes(token) || String(answer).includes(token) || signals.sawAutoReattach;
 
     if (!forcedDetach) {
       throw new Error("forced CDP detach never ran");

--- a/scripts/run-cdp-disconnect-proof-linux.sh
+++ b/scripts/run-cdp-disconnect-proof-linux.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Ubuntu/Debian parity smoke for scripts/cdp-disconnect-proof.mjs
+# (classification proof against real Chromium CDP; no ChatGPT login).
+#
+# Usage (from repo root, Docker required):
+#   bash scripts/run-cdp-disconnect-proof-linux.sh
+#
+# Prints a redacted-ready transcript ending in PROOF_OK on success.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+IMAGE="${ORACLE_LINUX_PROOF_IMAGE:-node:24-bookworm}"
+
+echo "[linux-proof] image=${IMAGE}"
+echo "[linux-proof] mounting ${ROOT} read-only; clean install inside container"
+
+docker run --rm \
+  --name "oracle-cdp-linux-proof-$$" \
+  -v "${ROOT}:/src:ro" \
+  -w /tmp/oracle-proof \
+  "${IMAGE}" \
+  bash -lc '
+    set -euo pipefail
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -qq
+    apt-get install -y -qq chromium fonts-liberation ca-certificates >/tmp/apt-chromium.log
+    CHROME_BIN="$(command -v chromium || command -v chromium-browser || true)"
+    if [[ -z "${CHROME_BIN}" ]]; then
+      echo "PROOF_FAILED: chromium not installed in container" >&2
+      exit 1
+    fi
+    echo "[linux-proof] chromium=${CHROME_BIN}"
+    # Copy sources without host node_modules / dist (darwin binaries).
+    mkdir -p /tmp/oracle-proof
+    tar -C /src --exclude=node_modules --exclude=dist --exclude=.git -cf - . \
+      | tar -C /tmp/oracle-proof -xf -
+    corepack enable
+    corepack prepare pnpm@latest --activate
+    pnpm install --frozen-lockfile
+    pnpm run build
+    export CHROME_PATH="${CHROME_BIN}"
+    node scripts/cdp-disconnect-proof.mjs
+  '

--- a/scripts/run-oracle-e2e-cdp-disconnect-linux.sh
+++ b/scripts/run-oracle-e2e-cdp-disconnect-linux.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Authenticated Ubuntu/Debian forced-disconnect E2E for PR #327.
+# Requires a local ChatGPT cookie export (never commit it):
+#   node scripts/export-chatgpt-cookies.mjs /tmp/oracle-e2e-cookies.json
+#   bash scripts/run-oracle-e2e-cdp-disconnect-linux.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+COOKIES="${ORACLE_BROWSER_COOKIES_FILE:-/tmp/oracle-e2e-cookies.json}"
+IMAGE="${ORACLE_LINUX_PROOF_IMAGE:-node:24-bookworm}"
+
+if [[ ! -f "${COOKIES}" ]]; then
+  echo "E2E_PROOF_FAILED: missing cookies at ${COOKIES}" >&2
+  exit 1
+fi
+
+echo "[linux-e2e] image=${IMAGE}"
+echo "[linux-e2e] cookies=${COOKIES} (mounted read-only; not copied into the image)"
+
+docker run --rm \
+  --name "oracle-cdp-linux-e2e-$$" \
+  --cap-add=SYS_PTRACE \
+  --security-opt seccomp=unconfined \
+  -v "${ROOT}:/src:ro" \
+  -v "${COOKIES}:/secrets/chatgpt-cookies.json:ro" \
+  -w /tmp/oracle-e2e \
+  -e ORACLE_BROWSER_COOKIES_FILE=/secrets/chatgpt-cookies.json \
+  -e ORACLE_E2E_BROWSER_PORT=9344 \
+  -e ORACLE_E2E_MODEL_STRATEGY=current \
+  -e ORACLE_E2E_HIDE_WINDOW=1 \
+  -e ORACLE_CHROME_NO_SANDBOX=1 \
+  -e CHROME_PATH=/usr/bin/chromium \
+  "${IMAGE}" \
+  bash -lc '
+    set -euo pipefail
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -qq
+    apt-get install -y -qq chromium fonts-liberation ca-certificates gdb lsof xvfb >/tmp/apt.log
+    tar -C /src --exclude=node_modules --exclude=dist --exclude=.git -cf - . \
+      | tar -C /tmp/oracle-e2e -xf -
+    corepack enable
+    corepack prepare pnpm@10.33.2 --activate
+    pnpm install --frozen-lockfile
+    pnpm run build
+    export HOME=/tmp/oracle-home
+    mkdir -p "$HOME"
+    echo "[linux-e2e] platform=$(uname -sm) chrome=${CHROME_PATH}"
+    # Visible Chrome under virtual framebuffer (headless is Cloudflare-blocked).
+    xvfb-run -a -s "-screen 0 1280x720x24" \
+      node scripts/oracle-e2e-cdp-disconnect-proof.mjs
+  '

--- a/scripts/write-owner-only-file.mjs
+++ b/scripts/write-owner-only-file.mjs
@@ -1,14 +1,58 @@
-import { chmodSync, statSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  constants,
+  fchmodSync,
+  fstatSync,
+  openSync,
+  statSync,
+  writeSync,
+} from "node:fs";
 
 /**
  * Write a local file and enforce owner-only permissions (0600).
- * `writeFileSync` mode only applies on create; chmod repairs an existing
- * permissive destination after overwrite.
+ *
+ * Secure the destination *before* writing secret bytes: open/truncate,
+ * fchmod the descriptor to 0600, then write. `writeFileSync` mode only
+ * applies on create, so an existing permissive file must not receive
+ * payload bytes until the descriptor is owner-only.
+ *
+ * @param {string} filePath
+ * @param {string | Uint8Array} contents
+ * @param {{ beforeWrite?: (filePath: string) => void }} [options]
+ *        Optional probe (tests): runs after the descriptor is secured,
+ *        before any payload bytes are written.
  */
-export function writeOwnerOnlyFile(filePath, contents) {
-  writeFileSync(filePath, contents, { mode: 0o600 });
+export function writeOwnerOnlyFile(filePath, contents, options = {}) {
+  let fd;
+  try {
+    fd = openSync(
+      filePath,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC,
+      0o600,
+    );
+
+    if (process.platform !== "win32") {
+      fchmodSync(fd, 0o600);
+      const mode = fstatSync(fd).mode & 0o777;
+      if (mode !== 0o600) {
+        throw new Error(`expected mode 0600 for ${filePath}, got ${mode.toString(8)}`);
+      }
+    }
+
+    options.beforeWrite?.(filePath);
+
+    if (typeof contents === "string") {
+      writeSync(fd, contents, "utf8");
+    } else {
+      writeSync(fd, contents);
+    }
+  } finally {
+    if (fd !== undefined) {
+      closeSync(fd);
+    }
+  }
+
   if (process.platform !== "win32") {
-    chmodSync(filePath, 0o600);
     const mode = statSync(filePath).mode & 0o777;
     if (mode !== 0o600) {
       throw new Error(`expected mode 0600 for ${filePath}, got ${mode.toString(8)}`);

--- a/scripts/write-owner-only-file.mjs
+++ b/scripts/write-owner-only-file.mjs
@@ -1,0 +1,17 @@
+import { chmodSync, statSync, writeFileSync } from "node:fs";
+
+/**
+ * Write a local file and enforce owner-only permissions (0600).
+ * `writeFileSync` mode only applies on create; chmod repairs an existing
+ * permissive destination after overwrite.
+ */
+export function writeOwnerOnlyFile(filePath, contents) {
+  writeFileSync(filePath, contents, { mode: 0o600 });
+  if (process.platform !== "win32") {
+    chmodSync(filePath, 0o600);
+    const mode = statSync(filePath).mode & 0o777;
+    if (mode !== 0o600) {
+      throw new Error(`expected mode 0600 for ${filePath}, got ${mode.toString(8)}`);
+    }
+  }
+}

--- a/scripts/write-owner-only-file.mjs
+++ b/scripts/write-owner-only-file.mjs
@@ -25,11 +25,7 @@ import {
 export function writeOwnerOnlyFile(filePath, contents, options = {}) {
   let fd;
   try {
-    fd = openSync(
-      filePath,
-      constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC,
-      0o600,
-    );
+    fd = openSync(filePath, constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC, 0o600);
 
     if (process.platform !== "win32") {
       fchmodSync(fd, 0o600);

--- a/src/browser/cdpLiveness.ts
+++ b/src/browser/cdpLiveness.ts
@@ -1,0 +1,87 @@
+import { listRemoteChromeTargets } from "./chromeLifecycle.js";
+import { verifyDevToolsReachable } from "./profileState.js";
+
+export type ChromeTargetLiveness = {
+  endpointReachable: boolean;
+  /** null when no target id was provided to check */
+  targetFound: boolean | null;
+  matchedUrl?: string;
+  error?: string;
+};
+
+/**
+ * Probe whether Chrome's DevTools endpoint (and optionally a specific target)
+ * is still reachable after a CDP client WebSocket disconnect.
+ */
+export async function probeChromeTargetLiveness(options: {
+  host: string;
+  port: number;
+  targetId?: string | null;
+  browserWSEndpoint?: string;
+  listTargets?: typeof listRemoteChromeTargets;
+  verifyEndpoint?: typeof verifyDevToolsReachable;
+}): Promise<ChromeTargetLiveness> {
+  const host = options.host || "127.0.0.1";
+  const port = options.port;
+  if (!Number.isFinite(port) || port <= 0) {
+    return { endpointReachable: false, targetFound: null, error: "missing debug port" };
+  }
+
+  const verifyEndpoint = options.verifyEndpoint ?? verifyDevToolsReachable;
+  const endpoint = await verifyEndpoint({ host, port, attempts: 2, timeoutMs: 1500 });
+  if (!endpoint.ok) {
+    return {
+      endpointReachable: false,
+      targetFound: null,
+      error: endpoint.error,
+    };
+  }
+
+  const targetId = options.targetId?.trim();
+  if (!targetId) {
+    return { endpointReachable: true, targetFound: null };
+  }
+
+  try {
+    const listTargets = options.listTargets ?? listRemoteChromeTargets;
+    const targets = await listTargets({
+      host,
+      port,
+      browserWSEndpoint: options.browserWSEndpoint,
+    });
+    const match = targets.find((target) => {
+      const id = target.targetId ?? (target as { id?: string }).id;
+      return id === targetId;
+    });
+    if (!match) {
+      return { endpointReachable: true, targetFound: false };
+    }
+    return {
+      endpointReachable: true,
+      targetFound: true,
+      matchedUrl: typeof match.url === "string" ? match.url : undefined,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    // Endpoint answered /json/version; treat list failures as still recoverable.
+    return { endpointReachable: true, targetFound: null, error: message };
+  }
+}
+
+export function isRecoverableChromeDisconnect(liveness: ChromeTargetLiveness): boolean {
+  return liveness.endpointReachable && liveness.targetFound !== false;
+}
+
+export function connectionLostUserMessage(options: {
+  recoverable: boolean;
+  remote?: boolean;
+}): string {
+  if (options.recoverable) {
+    return options.remote
+      ? "Remote Chrome DevTools client disconnected before oracle finished; the browser target appears still alive."
+      : "Chrome DevTools client disconnected before oracle finished; the browser target appears still alive.";
+  }
+  return options.remote
+    ? "Remote Chrome connection lost before Oracle finished."
+    : "Chrome window closed before oracle finished. Please keep it open until completion.";
+}

--- a/src/browser/cdpLiveness.ts
+++ b/src/browser/cdpLiveness.ts
@@ -69,7 +69,21 @@ export async function probeChromeTargetLiveness(options: {
 }
 
 export function isRecoverableChromeDisconnect(liveness: ChromeTargetLiveness): boolean {
-  return liveness.endpointReachable && liveness.targetFound !== false;
+  if (!liveness.endpointReachable) {
+    return false;
+  }
+  // Confirmed live target → recoverable.
+  if (liveness.targetFound === true) {
+    return true;
+  }
+  // Confirmed missing target → not recoverable.
+  if (liveness.targetFound === false) {
+    return false;
+  }
+  // targetFound === null:
+  // - no target id was provided (endpoint-only check) → recoverable
+  // - target list failed after a specific id was requested (error set) → fail closed
+  return !liveness.error;
 }
 
 export function connectionLostUserMessage(options: {

--- a/src/browser/chromeLifecycle.ts
+++ b/src/browser/chromeLifecycle.ts
@@ -668,6 +668,12 @@ function buildChromeFlags(
     flags.push("--window-position=-32000,-32000");
   }
 
+  // Opt-in only: container/CI Chromium often cannot use the sandbox. Callers must
+  // set ORACLE_CHROME_NO_SANDBOX=1 explicitly (never default this on).
+  if (process.env.ORACLE_CHROME_NO_SANDBOX === "1") {
+    flags.push("--no-sandbox", "--disable-dev-shm-usage");
+  }
+
   return flags;
 }
 

--- a/src/browser/cookies.ts
+++ b/src/browser/cookies.ts
@@ -297,12 +297,14 @@ function normalizeExpiration(expires?: number): number | undefined {
   if (value <= 0) {
     return undefined;
   }
-  if (value > 1_000_000_000_000) {
-    // Learned: Chrome may store WebKit microseconds since 1601; convert to Unix seconds.
+  // Units by magnitude (do not treat Unix seconds ~1.7e9 as milliseconds):
+  // - >= 1e15: Chrome/WebKit FILETIME microseconds since 1601
+  // - >= 1e12: Unix milliseconds
+  // - else: Unix seconds (sweet-cookie / Chromium Cookie.expires)
+  if (value >= 1_000_000_000_000_000) {
     return Math.round(value / 1_000_000 - 11644473600);
   }
-  if (value > 1_000_000_000) {
-    // Likely milliseconds; normalize to seconds for CDP.
+  if (value >= 1_000_000_000_000) {
     return Math.round(value / 1000);
   }
   return Math.round(value);

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -75,6 +75,11 @@ import {
   writeDevToolsActivePort,
 } from "./profileState.js";
 import {
+  connectionLostUserMessage,
+  isRecoverableChromeDisconnect,
+  probeChromeTargetLiveness,
+} from "./cdpLiveness.js";
+import {
   acquireBrowserTabLease,
   hasOtherActiveBrowserTabLeases,
   type BrowserTabLease,
@@ -1156,12 +1161,41 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
     const disconnectPromise = new Promise<never>((_, reject) => {
       client?.on("disconnect", () => {
         connectionClosedUnexpectedly = true;
-        logger("Chrome window closed; attempting to abort run.");
-        reject(
-          new Error(
-            "Chrome window closed before oracle finished. Please keep it open until completion.",
-          ),
-        );
+        void (async () => {
+          const liveness = await probeChromeTargetLiveness({
+            host: chromeHost,
+            port: chrome.port,
+            targetId: lastTargetId ?? isolatedTargetId,
+          });
+          const recoverable = isRecoverableChromeDisconnect(liveness);
+          if (recoverable) {
+            logger(
+              "CDP client disconnected; Chrome/target still reachable. Leaving run recoverable for reattach.",
+            );
+          } else {
+            logger("Chrome window closed; attempting to abort run.");
+          }
+          reject(
+            new BrowserAutomationError(connectionLostUserMessage({ recoverable }), {
+              stage: "connection-lost",
+              recoverableDisconnect: recoverable,
+              disconnectCause: recoverable ? "cdp-client-disconnect" : "chrome-closed",
+              runtime: {
+                chromePid: chrome.pid,
+                chromePort: chrome.port,
+                chromeHost,
+                userDataDir,
+                chromeTargetId: lastTargetId ?? isolatedTargetId ?? undefined,
+                tabUrl: liveness.matchedUrl ?? lastUrl,
+                conversationId: (liveness.matchedUrl ?? lastUrl)
+                  ? extractConversationIdFromUrl(liveness.matchedUrl ?? lastUrl ?? "")
+                  : undefined,
+                promptSubmitted,
+                controllerPid: process.pid,
+              },
+            }),
+          );
+        })();
       });
     });
     const raceWithDisconnect = <T>(promise: Promise<T>): Promise<T> =>
@@ -2273,21 +2307,38 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
       throw normalizedError;
     }
     if ((config.debug || process.env.CHATGPT_DEVTOOLS_TRACE === "1") && normalizedError.stack) {
-      logger(`Chrome window closed before completion: ${normalizedError.message}`);
+      logger(`Chrome connection lost before completion: ${normalizedError.message}`);
       logger(normalizedError.stack);
     }
     await emitRuntimeHint();
+    if (
+      normalizedError instanceof BrowserAutomationError &&
+      (normalizedError.details as { stage?: string } | undefined)?.stage === "connection-lost"
+    ) {
+      throw normalizedError;
+    }
+    const liveness = await probeChromeTargetLiveness({
+      host: chromeHost,
+      port: chrome.port,
+      targetId: lastTargetId ?? isolatedTargetId,
+    });
+    const recoverable = isRecoverableChromeDisconnect(liveness);
     throw new BrowserAutomationError(
-      "Chrome window closed before oracle finished. Please keep it open until completion.",
+      connectionLostUserMessage({ recoverable }),
       {
         stage: "connection-lost",
+        recoverableDisconnect: recoverable,
+        disconnectCause: recoverable ? "cdp-client-disconnect" : "chrome-closed",
         runtime: {
           chromePid: chrome.pid,
           chromePort: chrome.port,
           chromeHost,
           userDataDir,
           chromeTargetId: lastTargetId,
-          tabUrl: lastUrl,
+          tabUrl: liveness.matchedUrl ?? lastUrl,
+          conversationId: (liveness.matchedUrl ?? lastUrl)
+            ? extractConversationIdFromUrl(liveness.matchedUrl ?? lastUrl ?? "")
+            : undefined,
           promptSubmitted,
           controllerPid: process.pid,
         },
@@ -3656,15 +3707,27 @@ async function runRemoteBrowserMode(
       throw normalizedError;
     }
 
-    throw new BrowserAutomationError("Remote Chrome connection lost before Oracle finished.", {
+    const liveness = await probeChromeTargetLiveness({
+      host,
+      port,
+      targetId: remoteTargetId,
+      browserWSEndpoint,
+    });
+    const recoverable = isRecoverableChromeDisconnect(liveness);
+    throw new BrowserAutomationError(connectionLostUserMessage({ recoverable, remote: true }), {
       stage: "connection-lost",
+      recoverableDisconnect: recoverable,
+      disconnectCause: recoverable ? "cdp-client-disconnect" : "chrome-closed",
       runtime: {
         chromeHost: host,
         chromePort: port,
         chromeBrowserWSEndpoint: browserWSEndpoint,
         chromeProfileRoot,
         chromeTargetId: remoteTargetId ?? undefined,
-        tabUrl: lastUrl,
+        tabUrl: liveness.matchedUrl ?? lastUrl,
+        conversationId: (liveness.matchedUrl ?? lastUrl)
+          ? extractConversationIdFromUrl(liveness.matchedUrl ?? lastUrl ?? "")
+          : undefined,
         promptSubmitted,
         controllerPid: process.pid,
       },

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1187,9 +1187,10 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
                 userDataDir,
                 chromeTargetId: lastTargetId ?? isolatedTargetId ?? undefined,
                 tabUrl: liveness.matchedUrl ?? lastUrl,
-                conversationId: (liveness.matchedUrl ?? lastUrl)
-                  ? extractConversationIdFromUrl(liveness.matchedUrl ?? lastUrl ?? "")
-                  : undefined,
+                conversationId:
+                  (liveness.matchedUrl ?? lastUrl)
+                    ? extractConversationIdFromUrl(liveness.matchedUrl ?? lastUrl ?? "")
+                    : undefined,
                 promptSubmitted,
                 controllerPid: process.pid,
               },
@@ -2336,9 +2337,10 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
           userDataDir,
           chromeTargetId: lastTargetId,
           tabUrl: liveness.matchedUrl ?? lastUrl,
-          conversationId: (liveness.matchedUrl ?? lastUrl)
-            ? extractConversationIdFromUrl(liveness.matchedUrl ?? lastUrl ?? "")
-            : undefined,
+          conversationId:
+            (liveness.matchedUrl ?? lastUrl)
+              ? extractConversationIdFromUrl(liveness.matchedUrl ?? lastUrl ?? "")
+              : undefined,
           promptSubmitted,
           controllerPid: process.pid,
         },
@@ -3725,9 +3727,10 @@ async function runRemoteBrowserMode(
         chromeProfileRoot,
         chromeTargetId: remoteTargetId ?? undefined,
         tabUrl: liveness.matchedUrl ?? lastUrl,
-        conversationId: (liveness.matchedUrl ?? lastUrl)
-          ? extractConversationIdFromUrl(liveness.matchedUrl ?? lastUrl ?? "")
-          : undefined,
+        conversationId:
+          (liveness.matchedUrl ?? lastUrl)
+            ? extractConversationIdFromUrl(liveness.matchedUrl ?? lastUrl ?? "")
+            : undefined,
         promptSubmitted,
         controllerPid: process.pid,
       },

--- a/src/cli/sessionRunner.ts
+++ b/src/cli/sessionRunner.ts
@@ -1150,7 +1150,9 @@ async function autoReattachUntilComplete({
   const maxTotalMs = 2 * 60 * 60 * 1000; // 2h hard cap; avoid infinite polling by default.
   const maxDeadline = Date.now() + maxTotalMs;
   const attemptLimit =
-    typeof maxAttempts === "number" && maxAttempts > 0 ? Math.floor(maxAttempts) : Number.POSITIVE_INFINITY;
+    typeof maxAttempts === "number" && maxAttempts > 0
+      ? Math.floor(maxAttempts)
+      : Number.POSITIVE_INFINITY;
 
   if (delayMs > 0) {
     log(dim(`Auto-reattach starting in ${formatElapsed(delayMs)}...`));
@@ -1159,7 +1161,9 @@ async function autoReattachUntilComplete({
   if (Number.isFinite(attemptLimit)) {
     log(dim(`Auto-reattach will try up to ${attemptLimit} attempt(s).`));
   } else {
-    log(dim(`Auto-reattach will stop after ${formatElapsed(maxTotalMs)} if no answer is captured.`));
+    log(
+      dim(`Auto-reattach will stop after ${formatElapsed(maxTotalMs)} if no answer is captured.`),
+    );
   }
 
   const logger: BrowserLogger = ((message?: string) => {

--- a/src/cli/sessionRunner.ts
+++ b/src/cli/sessionRunner.ts
@@ -597,6 +597,16 @@ export async function performSessionRun({
         response: { status: "running", incompleteReason: "chrome-disconnected" },
       });
       logBrowserReattachGuidance(recoverableRuntime);
+      // Only auto-reattach when liveness classified the target as still alive.
+      // Closed-Chrome disconnects stay running + guidance but must not enter a
+      // futile resume loop (fail closed on availability).
+      const recoverableDisconnect =
+        (userError.details as { recoverableDisconnect?: boolean } | undefined)
+          ?.recoverableDisconnect === true;
+      if (!recoverableDisconnect) {
+        log(dim("Skipping auto-reattach: disconnect classified as non-recoverable."));
+        return;
+      }
       // Connection-lost should attempt the same recovery path as assistant-timeout.
       // When auto-reattach interval is unset, still try a single resume so a live
       // Chrome/target can be harvested instead of leaving the session permanently running.

--- a/src/cli/sessionRunner.ts
+++ b/src/cli/sessionRunner.ts
@@ -597,6 +597,34 @@ export async function performSessionRun({
         response: { status: "running", incompleteReason: "chrome-disconnected" },
       });
       logBrowserReattachGuidance(recoverableRuntime);
+      // Connection-lost should attempt the same recovery path as assistant-timeout.
+      // When auto-reattach interval is unset, still try a single resume so a live
+      // Chrome/target can be harvested instead of leaving the session permanently running.
+      const configuredIntervalMs = browserConfig?.autoReattachIntervalMs ?? 0;
+      const connectionLostIntervalMs =
+        configuredIntervalMs > 0
+          ? configuredIntervalMs
+          : Math.max(1_000, Math.min(browserConfig?.timeoutMs ?? 30_000, 30_000));
+      const success = await autoReattachUntilComplete({
+        sessionMeta,
+        runtime: recoverableRuntime ?? undefined,
+        browserConfig: {
+          ...browserConfig,
+          autoReattachIntervalMs: connectionLostIntervalMs,
+          autoReattachDelayMs: browserConfig?.autoReattachDelayMs ?? 0,
+          autoReattachTimeoutMs:
+            browserConfig?.autoReattachTimeoutMs ?? browserConfig?.timeoutMs ?? 120_000,
+        },
+        browserMetadata: currentBrowser,
+        runOptions,
+        modelForStatus,
+        notificationSettings,
+        log,
+        maxAttempts: configuredIntervalMs > 0 ? undefined : 1,
+      });
+      if (success) {
+        return;
+      }
       return;
     }
     if (assistantTimeout && mode === "browser" && browserCanReattach) {
@@ -1084,6 +1112,7 @@ async function autoReattachUntilComplete({
   modelForStatus,
   notificationSettings,
   log,
+  maxAttempts,
 }: {
   sessionMeta: SessionMetadata;
   runtime?: BrowserRuntimeMetadata;
@@ -1093,6 +1122,7 @@ async function autoReattachUntilComplete({
   modelForStatus?: string;
   notificationSettings: NotificationSettings;
   log: (message?: string) => void;
+  maxAttempts?: number;
 }): Promise<boolean> {
   if (!runtime || !browserConfig) {
     log(dim("Auto-reattach disabled: missing runtime or browser config."));
@@ -1109,12 +1139,18 @@ async function autoReattachUntilComplete({
     120_000;
   const maxTotalMs = 2 * 60 * 60 * 1000; // 2h hard cap; avoid infinite polling by default.
   const maxDeadline = Date.now() + maxTotalMs;
+  const attemptLimit =
+    typeof maxAttempts === "number" && maxAttempts > 0 ? Math.floor(maxAttempts) : Number.POSITIVE_INFINITY;
 
   if (delayMs > 0) {
     log(dim(`Auto-reattach starting in ${formatElapsed(delayMs)}...`));
     await wait(delayMs);
   }
-  log(dim(`Auto-reattach will stop after ${formatElapsed(maxTotalMs)} if no answer is captured.`));
+  if (Number.isFinite(attemptLimit)) {
+    log(dim(`Auto-reattach will try up to ${attemptLimit} attempt(s).`));
+  } else {
+    log(dim(`Auto-reattach will stop after ${formatElapsed(maxTotalMs)} if no answer is captured.`));
+  }
 
   const logger: BrowserLogger = ((message?: string) => {
     if (message) {
@@ -1214,6 +1250,10 @@ async function autoReattachUntilComplete({
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       log(dim(`Auto-reattach attempt ${attempt} failed: ${message}`));
+    }
+    if (attempt >= attemptLimit) {
+      log(dim(`Auto-reattach stopped after ${attempt} attempt(s) without capturing an answer.`));
+      return false;
     }
     const remainingAfterAttemptMs = maxDeadline - Date.now();
     if (remainingAfterAttemptMs <= 0) {

--- a/tests/browser/cdpLiveness.test.ts
+++ b/tests/browser/cdpLiveness.test.ts
@@ -65,6 +65,24 @@ describe("cdpLiveness", () => {
     expect(isRecoverableChromeDisconnect(liveness)).toBe(false);
   });
 
+  test("fails closed when target list errors after a specific target id is requested", async () => {
+    const liveness = await probeChromeTargetLiveness({
+      host: "127.0.0.1",
+      port: 9222,
+      targetId: "TARGET-1",
+      verifyEndpoint: async () => ({ ok: true }),
+      listTargets: async () => {
+        throw new Error("target list timeout");
+      },
+    });
+    expect(liveness).toEqual({
+      endpointReachable: true,
+      targetFound: null,
+      error: "target list timeout",
+    });
+    expect(isRecoverableChromeDisconnect(liveness)).toBe(false);
+  });
+
   test("connectionLostUserMessage distinguishes recoverable disconnects", () => {
     expect(connectionLostUserMessage({ recoverable: true })).toContain("still alive");
     expect(connectionLostUserMessage({ recoverable: false })).toContain("Chrome window closed");

--- a/tests/browser/cdpLiveness.test.ts
+++ b/tests/browser/cdpLiveness.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  connectionLostUserMessage,
+  isRecoverableChromeDisconnect,
+  probeChromeTargetLiveness,
+} from "../../src/browser/cdpLiveness.ts";
+
+describe("cdpLiveness", () => {
+  test("reports unreachable when DevTools endpoint probe fails", async () => {
+    const liveness = await probeChromeTargetLiveness({
+      host: "127.0.0.1",
+      port: 9222,
+      targetId: "T1",
+      verifyEndpoint: async () => ({ ok: false, error: "ECONNREFUSED" }),
+    });
+    expect(liveness).toEqual({
+      endpointReachable: false,
+      targetFound: null,
+      error: "ECONNREFUSED",
+    });
+    expect(isRecoverableChromeDisconnect(liveness)).toBe(false);
+  });
+
+  test("treats reachable endpoint without target id as recoverable", async () => {
+    const liveness = await probeChromeTargetLiveness({
+      host: "127.0.0.1",
+      port: 9222,
+      verifyEndpoint: async () => ({ ok: true }),
+      listTargets: async () => {
+        throw new Error("should not list targets without targetId");
+      },
+    });
+    expect(liveness).toEqual({ endpointReachable: true, targetFound: null });
+    expect(isRecoverableChromeDisconnect(liveness)).toBe(true);
+  });
+
+  test("finds a still-live target id after client disconnect", async () => {
+    const liveness = await probeChromeTargetLiveness({
+      host: "127.0.0.1",
+      port: 9222,
+      targetId: "TARGET-1",
+      verifyEndpoint: async () => ({ ok: true }),
+      listTargets: async () => [
+        { targetId: "TARGET-1", type: "page", url: "https://chatgpt.com/c/abc" },
+      ],
+    });
+    expect(liveness).toEqual({
+      endpointReachable: true,
+      targetFound: true,
+      matchedUrl: "https://chatgpt.com/c/abc",
+    });
+    expect(isRecoverableChromeDisconnect(liveness)).toBe(true);
+  });
+
+  test("marks missing target as non-recoverable when endpoint is up", async () => {
+    const liveness = await probeChromeTargetLiveness({
+      host: "127.0.0.1",
+      port: 9222,
+      targetId: "GONE",
+      verifyEndpoint: async () => ({ ok: true }),
+      listTargets: async () => [{ targetId: "OTHER", type: "page", url: "https://chatgpt.com/" }],
+    });
+    expect(liveness).toEqual({ endpointReachable: true, targetFound: false });
+    expect(isRecoverableChromeDisconnect(liveness)).toBe(false);
+  });
+
+  test("connectionLostUserMessage distinguishes recoverable disconnects", () => {
+    expect(connectionLostUserMessage({ recoverable: true })).toContain("still alive");
+    expect(connectionLostUserMessage({ recoverable: false })).toContain("Chrome window closed");
+    expect(connectionLostUserMessage({ recoverable: true, remote: true })).toContain("Remote");
+  });
+});

--- a/tests/browser/chromeLifecycle.test.ts
+++ b/tests/browser/chromeLifecycle.test.ts
@@ -143,6 +143,25 @@ describe("hidden-window launch flags", () => {
     );
   });
 
+  test("adds no-sandbox flags only when ORACLE_CHROME_NO_SANDBOX=1", async () => {
+    const { buildChromeFlagsForTest } = await import("../../src/browser/chromeLifecycle.js");
+    const previous = process.env.ORACLE_CHROME_NO_SANDBOX;
+    try {
+      delete process.env.ORACLE_CHROME_NO_SANDBOX;
+      expect(buildChromeFlagsForTest(false)).not.toContain("--no-sandbox");
+      process.env.ORACLE_CHROME_NO_SANDBOX = "1";
+      const flags = buildChromeFlagsForTest(false);
+      expect(flags).toContain("--no-sandbox");
+      expect(flags).toContain("--disable-dev-shm-usage");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.ORACLE_CHROME_NO_SANDBOX;
+      } else {
+        process.env.ORACLE_CHROME_NO_SANDBOX = previous;
+      }
+    }
+  });
+
   test("moves a running macOS Chrome window without minimizing it", async () => {
     const { positionChromeWindowOffscreen } = await import("../../src/browser/chromeLifecycle.js");
     const browser = {

--- a/tests/browser/cookies.test.ts
+++ b/tests/browser/cookies.test.ts
@@ -244,6 +244,37 @@ describe("syncCookies", () => {
     vi.useRealTimers();
   });
 
+  test("keeps Unix-second inline cookie expirations (does not treat them as ms)", async () => {
+    const setCookie = vi.fn().mockResolvedValue({ success: true });
+    const unixSeconds = 1_792_075_178; // ~2026-10
+    const applied = await syncCookies(
+      { setCookie } as unknown as ChromeClient["Network"],
+      "https://chatgpt.com",
+      null,
+      logger,
+      {
+        inlineCookies: [
+          {
+            name: "__Secure-next-auth.session-token",
+            value: "tok",
+            domain: "chatgpt.com",
+            path: "/",
+            secure: true,
+            httpOnly: true,
+            expires: unixSeconds,
+          },
+        ],
+      },
+    );
+    expect(applied).toBe(1);
+    expect(setCookie).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "__Secure-next-auth.session-token",
+        expires: unixSeconds,
+      }),
+    );
+  });
+
   test("retries once after an empty cookie read when wait is set", async () => {
     vi.useFakeTimers();
     getCookies.mockResolvedValueOnce({ cookies: [], warnings: [] }).mockResolvedValueOnce({

--- a/tests/cli/sessionRunner.test.ts
+++ b/tests/cli/sessionRunner.test.ts
@@ -1336,6 +1336,7 @@ describe("performSessionRun", () => {
       );
       throw automationError;
     });
+    vi.mocked(resumeBrowserSession).mockRejectedValueOnce(new Error("target not ready"));
 
     await performSessionRun({
       sessionMeta: baseSessionMeta,
@@ -1348,6 +1349,7 @@ describe("performSessionRun", () => {
       version: cliVersion,
     });
 
+    expect(vi.mocked(resumeBrowserSession)).toHaveBeenCalledTimes(1);
     const finalUpdate = sessionStoreMock.updateSession.mock.calls.at(-1)?.[1];
     expect(finalUpdate).toMatchObject({
       status: "running",
@@ -1367,6 +1369,73 @@ describe("performSessionRun", () => {
       "Chrome disconnected before completion; keeping session running for reattach.",
     );
     expect(logLines).toContain("oracle session sess-1 --render");
+    expect(logLines).toContain("Auto-reattach attempt 1");
+  });
+
+  test("auto-reattaches after connection loss and marks session completed", async () => {
+    const automationError = new BrowserAutomationError(
+      "Chrome DevTools client disconnected before oracle finished; the browser target appears still alive.",
+      {
+        stage: "connection-lost",
+        recoverableDisconnect: true,
+        disconnectCause: "cdp-client-disconnect",
+        runtime: {
+          chromePort: 9222,
+          chromeHost: "127.0.0.1",
+          tabUrl: "https://chatgpt.com/c/demo",
+          chromeTargetId: "TARGET-1",
+          promptSubmitted: true,
+        },
+      },
+    );
+    vi.mocked(runBrowserSessionExecution).mockImplementationOnce(async (_args, deps) => {
+      await deps?.persistRuntimeHint?.(
+        {
+          chromePort: 9222,
+          chromeHost: "127.0.0.1",
+          tabUrl: "https://chatgpt.com/c/demo",
+          chromeTargetId: "TARGET-1",
+          promptSubmitted: true,
+        },
+        {
+          requestedModel: "Pro",
+          resolvedLabel: "Pro",
+          strategy: "select",
+          status: "already-selected",
+          verified: true,
+          source: "chatgpt-model-picker",
+          capturedAt: "2026-07-03T00:00:00.000Z",
+        },
+      );
+      throw automationError;
+    });
+    vi.mocked(resumeBrowserSession).mockResolvedValueOnce({
+      answerText: "recovered answer",
+      answerMarkdown: "recovered **answer**",
+    });
+    vi.mocked(ensureSessionArtifacts).mockResolvedValueOnce([
+      { kind: "transcript", path: "/tmp/transcript.md" },
+    ]);
+
+    await performSessionRun({
+      sessionMeta: baseSessionMeta,
+      runOptions: baseRunOptions,
+      mode: "browser",
+      browserConfig: { chromePath: null },
+      cwd: "/tmp",
+      log,
+      write,
+      version: cliVersion,
+    });
+
+    expect(vi.mocked(resumeBrowserSession)).toHaveBeenCalledTimes(1);
+    const finalUpdate = sessionStoreMock.updateSession.mock.calls.at(-1)?.[1];
+    expect(finalUpdate).toMatchObject({
+      status: "completed",
+      response: { status: "completed" },
+    });
+    const logLines = log.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(logLines).toContain("Auto-reattach succeeded; session marked completed.");
   });
 
   test("marks copied-profile connection loss as non-reattachable", async () => {

--- a/tests/cli/sessionRunner.test.ts
+++ b/tests/cli/sessionRunner.test.ts
@@ -137,6 +137,8 @@ beforeEach(() => {
     }
   });
   vi.mocked(runMultiModelApiSession).mockReset();
+  vi.mocked(resumeBrowserSession).mockReset();
+  vi.mocked(runBrowserSessionExecution).mockReset();
   vi.mocked(ensureSessionArtifacts).mockReset();
   vi.mocked(ensureSessionArtifacts).mockImplementation(
     async ({ existingArtifacts }) => existingArtifacts,
@@ -1306,9 +1308,11 @@ describe("performSessionRun", () => {
 
   test("keeps session running when browser connection is lost", async () => {
     const automationError = new BrowserAutomationError(
-      "Chrome window closed before oracle finished.",
+      "Chrome DevTools client disconnected before oracle finished; the browser target appears still alive.",
       {
         stage: "connection-lost",
+        recoverableDisconnect: true,
+        disconnectCause: "cdp-client-disconnect",
         runtime: {
           chromePort: 9222,
           chromeHost: "127.0.0.1",
@@ -1370,6 +1374,89 @@ describe("performSessionRun", () => {
     );
     expect(logLines).toContain("oracle session sess-1 --render");
     expect(logLines).toContain("Auto-reattach attempt 1");
+  });
+
+  test("skips auto-reattach when disconnect is classified non-recoverable", async () => {
+    const automationError = new BrowserAutomationError(
+      "Chrome window closed before oracle finished. Please keep it open until completion.",
+      {
+        stage: "connection-lost",
+        recoverableDisconnect: false,
+        disconnectCause: "chrome-closed",
+        runtime: {
+          chromePort: 9222,
+          chromeHost: "127.0.0.1",
+          tabUrl: "https://chatgpt.com/c/demo",
+          promptSubmitted: true,
+        },
+      },
+    );
+    vi.mocked(runBrowserSessionExecution).mockImplementationOnce(async () => {
+      throw automationError;
+    });
+
+    await performSessionRun({
+      sessionMeta: baseSessionMeta,
+      runOptions: baseRunOptions,
+      mode: "browser",
+      browserConfig: { chromePath: null },
+      cwd: "/tmp",
+      log,
+      write,
+      version: cliVersion,
+    });
+
+    expect(vi.mocked(resumeBrowserSession)).not.toHaveBeenCalled();
+    const logLines = log.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(logLines).toContain("Skipping auto-reattach: disconnect classified as non-recoverable.");
+    const finalUpdate = sessionStoreMock.updateSession.mock.calls.at(-1)?.[1];
+    expect(finalUpdate).toMatchObject({
+      status: "running",
+      response: { status: "running", incompleteReason: "chrome-disconnected" },
+    });
+  });
+
+  test("connection-loss recovery is one-shot by default (no infinite retry loop)", async () => {
+    const automationError = new BrowserAutomationError(
+      "Chrome DevTools client disconnected before oracle finished; the browser target appears still alive.",
+      {
+        stage: "connection-lost",
+        recoverableDisconnect: true,
+        disconnectCause: "cdp-client-disconnect",
+        runtime: {
+          chromePort: 9222,
+          chromeHost: "127.0.0.1",
+          tabUrl: "https://chatgpt.com/c/demo",
+          chromeTargetId: "TARGET-1",
+          promptSubmitted: true,
+        },
+      },
+    );
+    vi.mocked(runBrowserSessionExecution).mockImplementationOnce(async () => {
+      throw automationError;
+    });
+    vi.mocked(resumeBrowserSession).mockRejectedValueOnce(new Error("target not ready yet"));
+
+    await performSessionRun({
+      sessionMeta: baseSessionMeta,
+      runOptions: baseRunOptions,
+      mode: "browser",
+      browserConfig: { chromePath: null },
+      cwd: "/tmp",
+      log,
+      write,
+      version: cliVersion,
+    });
+
+    expect(vi.mocked(resumeBrowserSession)).toHaveBeenCalledTimes(1);
+    const logLines = log.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(logLines).toContain("Auto-reattach will try up to 1 attempt(s).");
+    expect(logLines).toContain("Auto-reattach stopped after 1 attempt(s)");
+    const finalUpdate = sessionStoreMock.updateSession.mock.calls.at(-1)?.[1];
+    expect(finalUpdate).toMatchObject({
+      status: "running",
+      response: { status: "running", incompleteReason: "chrome-disconnected" },
+    });
   });
 
   test("auto-reattaches after connection loss and marks session completed", async () => {

--- a/tests/scripts/write-owner-only-file.test.ts
+++ b/tests/scripts/write-owner-only-file.test.ts
@@ -49,7 +49,9 @@ describe("writeOwnerOnlyFile", () => {
     writeOwnerOnlyFile(filePath, JSON.stringify([{ name: "session", value: "secret" }]));
 
     expect(statSync(filePath).mode & 0o777).toBe(0o600);
-    expect(JSON.parse(readFileSync(filePath, "utf8"))).toEqual([{ name: "session", value: "secret" }]);
+    expect(JSON.parse(readFileSync(filePath, "utf8"))).toEqual([
+      { name: "session", value: "secret" },
+    ]);
   });
 
   test("secures 0600 before writing secret bytes when overwriting a 0644 file", () => {

--- a/tests/scripts/write-owner-only-file.test.ts
+++ b/tests/scripts/write-owner-only-file.test.ts
@@ -1,0 +1,50 @@
+import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+// Proof helper lives beside the cookie exporter as plain ESM (.mjs).
+// @ts-expect-error -- no ambient types for scripts/*.mjs
+const { writeOwnerOnlyFile } = (await import("../../scripts/write-owner-only-file.mjs")) as {
+  writeOwnerOnlyFile: (filePath: string, contents: string) => void;
+};
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "oracle-owner-only-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("writeOwnerOnlyFile", () => {
+  test("creates a new file with owner-only 0600 permissions", () => {
+    if (process.platform === "win32") return;
+
+    const filePath = path.join(makeTempDir(), "cookies-new.json");
+    writeOwnerOnlyFile(filePath, JSON.stringify([{ name: "demo", value: "x" }]));
+
+    expect(statSync(filePath).mode & 0o777).toBe(0o600);
+    expect(JSON.parse(readFileSync(filePath, "utf8"))).toEqual([{ name: "demo", value: "x" }]);
+  });
+
+  test("repairs permissive mode bits when overwriting an existing file", () => {
+    if (process.platform === "win32") return;
+
+    const filePath = path.join(makeTempDir(), "cookies-existing.json");
+    writeFileSync(filePath, "[]", { mode: 0o644 });
+    chmodSync(filePath, 0o644);
+    expect(statSync(filePath).mode & 0o777).toBe(0o644);
+
+    writeOwnerOnlyFile(filePath, JSON.stringify([{ name: "session", value: "secret" }]));
+
+    expect(statSync(filePath).mode & 0o777).toBe(0o600);
+    expect(JSON.parse(readFileSync(filePath, "utf8"))).toEqual([{ name: "session", value: "secret" }]);
+  });
+});

--- a/tests/scripts/write-owner-only-file.test.ts
+++ b/tests/scripts/write-owner-only-file.test.ts
@@ -6,7 +6,11 @@ import { afterEach, describe, expect, test } from "vitest";
 // Proof helper lives beside the cookie exporter as plain ESM (.mjs).
 // @ts-expect-error -- no ambient types for scripts/*.mjs
 const { writeOwnerOnlyFile } = (await import("../../scripts/write-owner-only-file.mjs")) as {
-  writeOwnerOnlyFile: (filePath: string, contents: string) => void;
+  writeOwnerOnlyFile: (
+    filePath: string,
+    contents: string,
+    options?: { beforeWrite?: (filePath: string) => void },
+  ) => void;
 };
 
 const tempDirs: string[] = [];
@@ -46,5 +50,34 @@ describe("writeOwnerOnlyFile", () => {
 
     expect(statSync(filePath).mode & 0o777).toBe(0o600);
     expect(JSON.parse(readFileSync(filePath, "utf8"))).toEqual([{ name: "session", value: "secret" }]);
+  });
+
+  test("secures 0600 before writing secret bytes when overwriting a 0644 file", () => {
+    if (process.platform === "win32") return;
+
+    const filePath = path.join(makeTempDir(), "cookies-race.json");
+    const secret = JSON.stringify([{ name: "session", value: "secret-payload" }]);
+    writeFileSync(filePath, "[]", { mode: 0o644 });
+    chmodSync(filePath, 0o644);
+    expect(statSync(filePath).mode & 0o777).toBe(0o644);
+
+    let modeBeforeWrite: number | null = null;
+    let contentBeforeWrite: string | null = null;
+
+    writeOwnerOnlyFile(filePath, secret, {
+      beforeWrite(probePath) {
+        modeBeforeWrite = statSync(probePath).mode & 0o777;
+        contentBeforeWrite = readFileSync(probePath, "utf8");
+      },
+    });
+
+    // Descriptor must already be owner-only before any secret bytes land.
+    expect(modeBeforeWrite).toBe(0o600);
+    // Truncate cleared the old payload; secret must not be present yet.
+    expect(contentBeforeWrite).toBe("");
+    expect(contentBeforeWrite).not.toContain("secret-payload");
+
+    expect(statSync(filePath).mode & 0o777).toBe(0o600);
+    expect(readFileSync(filePath, "utf8")).toBe(secret);
   });
 });


### PR DESCRIPTION
## Summary

Fixes recoverable CDP client disconnects that previously stranded completed browser answers as permanently `running`.

When the target-level DevTools WebSocket drops mid-run, Oracle used to treat every disconnect as "Chrome window closed," keep the session running, and skip the auto-reattach path that already exists for `assistant-timeout`. In #326 the browser and page target were still alive, ChatGPT finished the answer, and Oracle never harvested it.

## Approach

1. Probe DevTools liveness (`/json/version` + optional target list) after a CDP client disconnect.
2. If Chrome/target is still reachable, surface `recoverableDisconnect` instead of a closed-window message.
3. On `connection-lost` with `recoverableDisconnect: true`, attempt a one-shot `resumeBrowserSession` auto-reattach by default; keep the existing "session stays running + guidance" fallback when resume fails.
4. On non-recoverable disconnects (Chrome closed, or target list unverified after a specific target id): keep session running + guidance, but skip auto-reattach (fail closed; no futile resume loop).
5. If `autoReattachIntervalMs` is configured and the disconnect is recoverable, retain multi-attempt polling (hard-capped).

## Runtime proof (merge readiness)

### Platform parity table

| Proof | Platform | Result |
| --- | --- | --- |
| Classification (`cdp-disconnect-proof.mjs`) | macOS arm64 + Google Chrome | `PROOF_OK` |
| Classification (`cdp-disconnect-proof.mjs`) | Linux arm64 Docker (`node:24-bookworm` + Chromium) | `PROOF_OK` |
| Classification CI job | `ubuntu-latest` + Chromium (`cdp-disconnect-proof-linux`) | added in this PR |
| Authenticated forced-disconnect E2E | macOS (lldb fd close) | `E2E_PROOF_OK` → `completed` |
| Authenticated forced-disconnect E2E | Linux Docker Debian + Chromium + Xvfb (`gdb` fd close) | `E2E_PROOF_OK` → `completed` |

Issue #326 was reported on Ubuntu. Classification + liveness probing is platform-neutral HTTP against DevTools; Linux Docker and the new Ubuntu CI job cover that residual.

### 1) Classification proof (no ChatGPT login)

Script: `node scripts/cdp-disconnect-proof.mjs`  
Linux helper: `bash scripts/run-cdp-disconnect-proof-linux.sh`

Redacted macOS transcript (2026-07-17):

```text
[…] platform: darwin/arm64 chromePath=/Applications/Google Chrome.app/...
[…] case-1-result: {"endpointReachable":true,"targetFound":true,"recoverable":true,"userMessage":"Chrome DevTools client disconnected before oracle finished; the browser target appears still alive."}
[…] case-2-result: {"endpointReachable":false,"targetFound":null,"recoverable":false,"userMessage":"Chrome window closed before oracle finished. Please keep it open until completion."}
PROOF_OK both disconnect outcomes demonstrated against real Chrome CDP
```

Redacted Linux Docker transcript (2026-07-17, Debian bookworm + Chromium):

```text
[…] platform: linux/arm64 chromePath=/usr/bin/chromium
[…] case-1-result: {"endpointReachable":true,"targetFound":true,"recoverable":true,"userMessage":"Chrome DevTools client disconnected before oracle finished; the browser target appears still alive."}
[…] case-2-result: {"endpointReachable":false,"targetFound":null,"recoverable":false,"userMessage":"Chrome window closed before oracle finished. Please keep it open until completion.","error":"fetch failed"}
PROOF_OK both disconnect outcomes demonstrated against real Chrome CDP
```

### 2) Full browser E2E (forced disconnect → auto-reattach → completed)

Script: `scripts/oracle-e2e-cdp-disconnect-proof.mjs`

Flow used:

1. Export ChatGPT cookies via `scripts/export-chatgpt-cookies.mjs` (`session=true`).
2. Launch Oracle browser mode with `--browser-inline-cookies-file` + `--browser-model-strategy current`.
3. After `promptSubmitted`, forcibly close Oracle's established CDP sockets while Chrome stays up (macOS: `lldb`; Linux: `gdb`).
4. SessionRunner reports recoverable disconnect, runs one-shot auto-reattach, harvests the answer, marks session `completed`.

Redacted transcript excerpt (2026-07-17, macOS):

```text
[…] runtime ready port=<port> target=<id>… status=running
[…] forcing CDP detach by closing Oracle pid=<pid> fds=[…] on port=<port>
[…] Oracle CDP sockets closed; Chrome/target still reachable
ERROR: Chrome DevTools client disconnected before oracle finished; the browser target appears still alive.
Chrome disconnected before completion; keeping session running for reattach.
Auto-reattach will try up to 1 attempt(s).
Auto-reattach attempt 1...
Auto-reattach succeeded; session marked completed.

E2E_PROOF_OK
{
  "finalStatus": "completed",
  "forcedDetach": true,
  "sawAutoReattach": true,
  "sawRecoverableMessage": true
}
```

Redacted Linux Docker transcript excerpt (2026-07-17, Debian bookworm + Chromium + Xvfb):

```text
[…] platform=Linux aarch64 chrome=/usr/bin/chromium
[…] runtime ready port=<port> target=<id>… status=running
[…] forcing CDP detach by closing Oracle pid=<pid> fds=[…] on port=<port>
[…] Oracle CDP sockets closed; Chrome/target still reachable
ERROR: Chrome DevTools client disconnected before oracle finished; the browser target appears still alive.
Chrome disconnected before completion; keeping session running for reattach.
Auto-reattach will try up to 1 attempt(s).
Auto-reattach attempt 1...
Auto-reattach succeeded; session marked completed.

E2E_PROOF_OK
{
  "finalStatus": "completed",
  "forcedDetach": true,
  "sawAutoReattach": true,
  "sawRecoverableMessage": true
}
```

Also includes a small fix: inline-cookie expiration normalization no longer treats Unix-second expiries (~1.7e9) as milliseconds (which was zeroing ChatGPT session cookies to 1970 and causing false login failures).

### 3) Cookie export permissions

`scripts/export-chatgpt-cookies.mjs` now writes through `writeOwnerOnlyFile`, which always enforces mode `0600` after write (including overwrite of an existing permissive destination). Focused coverage: `tests/scripts/write-owner-only-file.test.ts`.

Local verification:

```text
new 600
overwrite 600
PERM_PROOF_OK
```

## Availability / fail-closed notes

- Default connection-lost recovery is **one-shot** (`maxAttempts: 1`) unless `autoReattachIntervalMs` is explicitly configured.
- Non-recoverable disconnects **do not** enter auto-reattach.
- Failed resume leaves the session `running` with reattach guidance (manual recovery still possible).
- `merge-risk: availability` remains inherent to disconnect recovery; mitigated by classification + bounded retries + Linux classification parity.

## Test plan

- [x] `pnpm exec vitest run tests/browser/cdpLiveness.test.ts tests/cli/sessionRunner.test.ts` (includes one-shot bound + non-recoverable skip)
- [x] `pnpm exec vitest run tests/browser/cookies.test.ts` (Unix-second expiry case)
- [x] `pnpm exec vitest run tests/scripts/write-owner-only-file.test.ts`
- [x] `pnpm run typecheck` / build
- [x] macOS `node scripts/cdp-disconnect-proof.mjs` → `PROOF_OK`
- [x] Linux Docker `bash scripts/run-cdp-disconnect-proof-linux.sh` → `PROOF_OK`
- [x] `ORACLE_BROWSER_COOKIES_FILE=… node scripts/oracle-e2e-cdp-disconnect-proof.mjs` → `E2E_PROOF_OK` (macOS)
- [x] `bash scripts/run-oracle-e2e-cdp-disconnect-linux.sh` → `E2E_PROOF_OK` (Linux Docker + Xvfb + gdb)
- [x] CI job `cdp-disconnect-proof-linux` added for `ubuntu-latest`

Fixes #326
