### PR TITLE
fix(browser): wait for durable ChatGPT conversation URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Browser: ignore transient `/c/WEB:<request-id>` routes until ChatGPT exposes the durable conversation URL, preventing completed GPT-5.6 and Pro answers from hanging until timeout under a mismatched response scope. Fixes #333. Thanks @kesslerio!
+- Browser: ignore transient `/c/WEB:<request-id>` routes until ChatGPT exposes the durable conversation URL, preventing completed GPT-5.6 and Pro answers from hanging until timeout under a mismatched response scope. Fixes #333. Thanks @dbachko and @kesslerio!
 - Browser: recover completed answers after a recoverable DevTools disconnect by confirming target liveness and attempting bounded reattachment, while preserving fail-closed handling for unavailable targets. Fixes #326. Thanks @piyushbag!
 - CLI: avoid inheriting `browser.thinkingTime` from config when `--browser-model-strategy current` is explicit, while preserving an explicit `--browser-thinking-time` override. Thanks @jung0han!
 - Browser/Serve: keep the authenticated manual-login Chrome process alive while closing each successfully captured service-owned run tab, preventing renderer and memory accumulation across repeated remote consultations without changing explicit `--browser-keep-browser`, attached-tab, or incomplete-run recovery behavior. Thanks @rtl-ai!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Browser: ignore transient `/c/WEB:<request-id>` routes until ChatGPT exposes the durable conversation URL, preventing completed GPT-5.6 and Pro answers from hanging until timeout under a mismatched response scope. Fixes #333. Thanks @kesslerio!
 - Browser: recover completed answers after a recoverable DevTools disconnect by confirming target liveness and attempting bounded reattachment, while preserving fail-closed handling for unavailable targets. Fixes #326. Thanks @piyushbag!
 - CLI: avoid inheriting `browser.thinkingTime` from config when `--browser-model-strategy current` is explicit, while preserving an explicit `--browser-thinking-time` override. Thanks @jung0han!
 - Browser/Serve: keep the authenticated manual-login Chrome process alive while closing each successfully captured service-owned run tab, preventing renderer and memory accumulation across repeated remote consultations without changing explicit `--browser-keep-browser`, attached-tab, or incomplete-run recovery behavior. Thanks @rtl-ai!

--- a/src/browser/conversationUrl.ts
+++ b/src/browser/conversationUrl.ts
@@ -1,0 +1,17 @@
+const CONVERSATION_ID_PATH = /\/c\/([a-zA-Z0-9-]+)(?=[/?#]|$)/;
+
+/**
+ * Extract a durable ChatGPT conversation id from a URL.
+ *
+ * ChatGPT can briefly expose client-created routes such as `/c/WEB:<request-id>`
+ * before replacing them with the persisted conversation URL. Those transient
+ * routes must not be used to scope assistant-response capture or reattachment.
+ */
+export function extractStableConversationIdFromUrl(url: string): string | undefined {
+  if (!url) return undefined;
+  return url.match(CONVERSATION_ID_PATH)?.[1];
+}
+
+export function isStableConversationUrl(url: string): boolean {
+  return extractStableConversationIdFromUrl(url) !== undefined;
+}

--- a/src/browser/conversationUrlMonitor.ts
+++ b/src/browser/conversationUrlMonitor.ts
@@ -1,5 +1,6 @@
 import type { BrowserLogger } from "./types.js";
 import { delay } from "./utils.js";
+import { isStableConversationUrl } from "./conversationUrl.js";
 
 export interface ConversationUrlMonitor {
   update: (label: string, timeoutMs?: number) => Promise<boolean>;
@@ -31,7 +32,7 @@ export function createConversationUrlMonitor(options: {
         if (stopped) {
           return false;
         }
-        if (url && isConversationUrl(url)) {
+        if (url && isStableConversationUrl(url)) {
           options.logger(`[browser] conversation url (${label}) = ${url}`);
           const persist = options.persistUrl(url);
           activePersists.add(persist);
@@ -75,8 +76,4 @@ export function createConversationUrlMonitor(options: {
       await Promise.allSettled(activePersists);
     },
   };
-}
-
-function isConversationUrl(url: string): boolean {
-  return /\/c\/[a-z0-9-]+/i.test(url);
 }

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -113,6 +113,10 @@ import {
   createConversationUrlMonitor,
   type ConversationUrlMonitor,
 } from "./conversationUrlMonitor.js";
+import {
+  extractStableConversationIdFromUrl as extractConversationIdFromUrl,
+  isStableConversationUrl as isConversationUrl,
+} from "./conversationUrl.js";
 
 export type { BrowserAutomationConfig, BrowserRunOptions, BrowserRunResult } from "./types.js";
 export { CHATGPT_URL, DEFAULT_MODEL_STRATEGY, DEFAULT_MODEL_TARGET } from "./constants.js";
@@ -4147,10 +4151,6 @@ async function readConversationTurnCount(
   return null;
 }
 
-function isConversationUrl(url: string): boolean {
-  return /\/c\/[a-z0-9-]+/i.test(url);
-}
-
 function describeDevtoolsFirewallHint(host: string, port: number): string | null {
   if (!isWsl()) return null;
   return [
@@ -4168,11 +4168,6 @@ function isWsl(): boolean {
   if (process.platform !== "linux") return false;
   if (process.env.WSL_DISTRO_NAME) return true;
   return os.release().toLowerCase().includes("microsoft");
-}
-
-function extractConversationIdFromUrl(url: string): string | undefined {
-  const match = url.match(/\/c\/([a-zA-Z0-9-]+)/);
-  return match?.[1];
 }
 
 async function resolveUserDataBaseDir(): Promise<string> {

--- a/src/browser/liveTabs.ts
+++ b/src/browser/liveTabs.ts
@@ -11,6 +11,7 @@ import {
 } from "./constants.js";
 import { captureAssistantMarkdown, readAssistantSnapshot } from "./actions/assistantResponse.js";
 import { buildConversationTurnListExpression } from "./conversationTurns.js";
+import { extractStableConversationIdFromUrl } from "./conversationUrl.js";
 import { delay } from "./utils.js";
 
 export const DEFAULT_REMOTE_CHROME_HOST = "127.0.0.1";
@@ -631,8 +632,7 @@ export async function harvestChatGptTab(
 }
 
 export function extractConversationIdFromUrl(url: string): string | undefined {
-  const match = normalizeUrl(url).match(/\/c\/([^/?#]+)/);
-  return match?.[1] ?? undefined;
+  return extractStableConversationIdFromUrl(normalizeUrl(url));
 }
 
 export function formatBrowserTabState(

--- a/src/browser/reattachHelpers.ts
+++ b/src/browser/reattachHelpers.ts
@@ -1,6 +1,7 @@
 import type { BrowserLogger, ChromeClient } from "./types.js";
 import { CONVERSATION_TURN_SELECTOR } from "./constants.js";
 import { buildConversationTurnCountExpression } from "./conversationTurns.js";
+import { extractStableConversationIdFromUrl } from "./conversationUrl.js";
 import { delay } from "./utils.js";
 import { readAssistantSnapshot } from "./pageActions.js";
 
@@ -52,9 +53,7 @@ export function pickTarget(
 }
 
 export function extractConversationIdFromUrl(url: string): string | undefined {
-  if (!url) return undefined;
-  const match = url.match(/\/c\/([a-zA-Z0-9-]+)/);
-  return match?.[1];
+  return extractStableConversationIdFromUrl(url);
 }
 
 export function buildConversationUrl(
@@ -62,7 +61,7 @@ export function buildConversationUrl(
   baseUrl: string,
 ): string | null {
   if (runtime.tabUrl) {
-    if (runtime.tabUrl.includes("/c/")) {
+    if (extractConversationIdFromUrl(runtime.tabUrl)) {
       return runtime.tabUrl;
     }
     return null;

--- a/src/browser/reattachability.ts
+++ b/src/browser/reattachability.ts
@@ -1,4 +1,5 @@
 import type { BrowserRuntimeMetadata } from "../sessionStore.js";
+import { isStableConversationUrl } from "./conversationUrl.js";
 
 /**
  * True when the URL points at a specific ChatGPT conversation (`/c/<id>`) on
@@ -19,7 +20,7 @@ export function isRecoverableChatGptConversationUrl(candidate: string | null | u
     if (url.hostname !== "chatgpt.com" && url.hostname !== "chat.openai.com") {
       return false;
     }
-    return /(?:^|\/)c\/[^/]+/.test(url.pathname);
+    return isStableConversationUrl(url.href);
   } catch {
     return false;
   }

--- a/src/browser/reattachability.ts
+++ b/src/browser/reattachability.ts
@@ -20,7 +20,7 @@ export function isRecoverableChatGptConversationUrl(candidate: string | null | u
     if (url.hostname !== "chatgpt.com" && url.hostname !== "chat.openai.com") {
       return false;
     }
-    return isStableConversationUrl(url.href);
+    return isStableConversationUrl(url.pathname);
   } catch {
     return false;
   }

--- a/tests/browser/conversationUrlMonitor.test.ts
+++ b/tests/browser/conversationUrlMonitor.test.ts
@@ -29,6 +29,32 @@ describe("createConversationUrlMonitor", () => {
     );
   });
 
+  test("ignores transient WEB request routes until the durable conversation URL appears", async () => {
+    const readUrl = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce("https://chatgpt.com/c/WEB:32229414-5afa-4478-890c-9ca80aa82430")
+      .mockResolvedValue("https://chatgpt.com/c/6a61036f-4cc4-83e8-8415-efb820f52db9");
+    const persistUrl = vi.fn(async () => {});
+    let now = 0;
+    const monitor = createConversationUrlMonitor({
+      readUrl,
+      persistUrl,
+      logger: vi.fn() as BrowserLogger,
+      wait: async () => {
+        now += 250;
+      },
+      now: () => now,
+    });
+
+    await expect(monitor.update("assistant-wait", 1_000)).resolves.toBe(true);
+
+    expect(readUrl).toHaveBeenCalledTimes(2);
+    expect(persistUrl).toHaveBeenCalledOnce();
+    expect(persistUrl).toHaveBeenCalledWith(
+      "https://chatgpt.com/c/6a61036f-4cc4-83e8-8415-efb820f52db9",
+    );
+  });
+
   test("keeps polling through read errors until the URL appears", async () => {
     let reads = 0;
     const persistUrl = vi.fn(async () => {});

--- a/tests/browser/reattach.test.ts
+++ b/tests/browser/reattach.test.ts
@@ -346,6 +346,11 @@ describe("reattach helpers", () => {
 
   test("extracts conversation id from a chat URL", () => {
     expect(extractConversationIdFromUrl("https://chatgpt.com/c/abc-123")).toBe("abc-123");
+    expect(
+      extractConversationIdFromUrl(
+        "https://chatgpt.com/c/WEB:32229414-5afa-4478-890c-9ca80aa82430",
+      ),
+    ).toBeUndefined();
     expect(extractConversationIdFromUrl("")).toBeUndefined();
   });
 

--- a/tests/browser/reattachability.test.ts
+++ b/tests/browser/reattachability.test.ts
@@ -27,6 +27,11 @@ describe("hasRecoverableChatGptConversation", () => {
         tabUrl: "https://chatgpt.com/g/g-p-demo/project",
       }),
     ).toBe(false);
+    expect(
+      hasRecoverableChatGptConversation({
+        tabUrl: "https://chatgpt.com/c/WEB:32229414-5afa-4478-890c-9ca80aa82430",
+      }),
+    ).toBe(false);
   });
 
   test("rejects malformed or non-ChatGPT URLs", () => {

--- a/tests/browser/reattachability.test.ts
+++ b/tests/browser/reattachability.test.ts
@@ -37,5 +37,11 @@ describe("hasRecoverableChatGptConversation", () => {
   test("rejects malformed or non-ChatGPT URLs", () => {
     expect(hasRecoverableChatGptConversation({ tabUrl: "not a url" })).toBe(false);
     expect(hasRecoverableChatGptConversation({ tabUrl: "https://example.com/c/abc" })).toBe(false);
+    expect(hasRecoverableChatGptConversation({ tabUrl: "https://chatgpt.com/?next=/c/abc" })).toBe(
+      false,
+    );
+    expect(hasRecoverableChatGptConversation({ tabUrl: "https://chatgpt.com/#/c/abc" })).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
## Summary

- ignore ChatGPT's transient `/c/WEB:<request-id>` route until the durable conversation URL appears
- centralize stable conversation URL extraction across response capture, live-tab harvesting, and reattachment
- cover the transient-to-durable navigation sequence with regression tests

## Root cause

ChatGPT can briefly navigate to `/c/WEB:<request-id>` after submission before replacing it with `/c/<conversation-uuid>`. Oracle's loose conversation URL matcher accepted the transient route and persisted `WEB` as the expected conversation ID. The completed assistant turn belonged to the durable UUID, so response capture rejected it as out of scope and continued polling until timeout even though the answer was visible and terminal.

The shared extractor now requires the conversation path segment to end before `/`, `?`, or `#`, which rejects the colon-delimited transient route. Monitoring continues until the durable URL is available, and reattach/live-tab helpers use the same rule.

This runtime fix is separate from #318, which corrects display and provenance for the bare `Pro` picker label.

## Validation

- `pnpm check`
- focused browser suite: 303 passed, 1 skipped
- full suite: 1,591 passed, 43 skipped
- live GPT-5.6 Sol browser run: explicitly selected and verified, completed in 13.5 seconds
- live Pro browser run: explicitly selected and verified, completed in 16.4 seconds
- live Pro Deep Research run: completed in 2 minutes 47 seconds and reattached with validated report/transcript artifacts
- pre-fix stuck GPT-5.6 Sol session: reattached and marked completed with the patched URL scope

No live test clicked ChatGPT's **Answer now** control.

Fixes #333.
