### PR TITLE
fix(browser): recognize Sol Pro effort control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Browser: run long local Pro consultations in a detached worker while the CLI remains attached to its session log, so unexpected foreground termination cannot stop answer capture; Ctrl-C still cancels the worker. Thanks @Rokurolize!
+- Browser: recognize ChatGPT's separate Pro effort control as the selected maximum effort for GPT-5.6 Sol when `--browser-thinking-time heavy` is requested.
 
 ## 0.16.1 — 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - Browser: run long local Pro consultations in a detached worker while the CLI remains attached to its session log, so unexpected foreground termination cannot stop answer capture; Ctrl-C still cancels the worker. Thanks @Rokurolize!
-- Browser: recognize ChatGPT's separate Pro effort control as the selected maximum effort for GPT-5.6 Sol when `--browser-thinking-time heavy` is requested.
+- Browser: recognize ChatGPT's separate Pro effort control as the selected maximum effort for GPT-5.6 Sol when `--browser-thinking-time heavy` is requested. Thanks @Rokurolize!
 
 ## 0.16.1 — 2026-07-23
 

--- a/src/browser/actions/thinkingTime.ts
+++ b/src/browser/actions/thinkingTime.ts
@@ -456,6 +456,24 @@ function buildThinkingTimeExpression(
           return null;
         }
       }
+      if (
+        TARGET_IS_GPT56_MODEL &&
+        TARGET_LEVEL === 'heavy' &&
+        isIntelligenceEffortMenu(menu)
+      ) {
+        for (const item of items) {
+          const itemText = normalize(
+            (item.textContent ?? '') + ' ' + (item.getAttribute?.('aria-label') ?? ''),
+          );
+          if (
+            hasToken(itemText, 'pro') &&
+            !itemText.includes('gpt') &&
+            !/(?:^|\\s)5[ .-]?6(?:\\s|$)/.test(itemText)
+          ) {
+            return item;
+          }
+        }
+      }
       for (const item of items) {
         const itemText = normalize(
           (item.textContent ?? '') + ' ' + (item.getAttribute?.('aria-label') ?? ''),
@@ -478,24 +496,6 @@ function buildThinkingTimeExpression(
           const itemText = normalize(item.textContent ?? '');
           const ariaLabel = normalize(item.getAttribute?.('aria-label') ?? '');
           if (itemText === '高' || ariaLabel === '高') return item;
-        }
-      }
-      if (
-        TARGET_IS_GPT56_MODEL &&
-        TARGET_LEVEL === 'heavy' &&
-        isIntelligenceEffortMenu(menu)
-      ) {
-        for (const item of items) {
-          const itemText = normalize(
-            (item.textContent ?? '') + ' ' + (item.getAttribute?.('aria-label') ?? ''),
-          );
-          if (
-            hasToken(itemText, 'pro') &&
-            !itemText.includes('gpt') &&
-            !/(?:^|\\s)5[ .-]?6(?:\\s|$)/.test(itemText)
-          ) {
-            return item;
-          }
         }
       }
       return null;

--- a/src/browser/actions/thinkingTime.ts
+++ b/src/browser/actions/thinkingTime.ts
@@ -480,6 +480,24 @@ function buildThinkingTimeExpression(
           if (itemText === '高' || ariaLabel === '高') return item;
         }
       }
+      if (
+        TARGET_IS_GPT56_MODEL &&
+        TARGET_LEVEL === 'heavy' &&
+        isIntelligenceEffortMenu(menu)
+      ) {
+        for (const item of items) {
+          const itemText = normalize(
+            (item.textContent ?? '') + ' ' + (item.getAttribute?.('aria-label') ?? ''),
+          );
+          if (
+            hasToken(itemText, 'pro') &&
+            !itemText.includes('gpt') &&
+            !/(?:^|\\s)5[ .-]?6(?:\\s|$)/.test(itemText)
+          ) {
+            return item;
+          }
+        }
+      }
       return null;
     };
     const countEffortLevels = (menu) => {
@@ -579,19 +597,37 @@ function buildThinkingTimeExpression(
     const currentEffortPillMatchesTarget = (trigger, modelKindOverride = null) => {
       if (currentProEffortPillMatchesTarget(trigger, modelKindOverride)) return true;
       const button = freshComposerTrigger(trigger) || findModelButton();
+      const normalizedLabel = normalize(
+        (button?.textContent ?? '') + ' ' + (button?.getAttribute?.('aria-label') ?? ''),
+      );
+      if (
+        TARGET_IS_GPT56_MODEL &&
+        TARGET_LEVEL === 'heavy' &&
+        hasToken(normalizedLabel, 'pro')
+      ) {
+        return true;
+      }
       if ((modelKindOverride || TARGET_MODEL_KIND || modelKindFromNode(button)) === 'pro') {
         return false;
       }
-      const label = (button?.textContent ?? '') + ' ' + (button?.getAttribute?.('aria-label') ?? '');
-      return matchesLevel(label);
+      return matchesLevel(normalizedLabel);
     };
     const selectAndVerify = async (trigger, findOption, modelKindOverride = null) => {
-      const option = findOption();
       const triggerModelKind =
         modelKindOverride ||
         TARGET_MODEL_KIND ||
         modelKindFromNode(trigger) ||
         effectiveTargetModelKind();
+      const option = findOption();
+      if (
+        !option &&
+        TARGET_IS_GPT56_MODEL &&
+        TARGET_LEVEL === 'heavy' &&
+        currentEffortPillMatchesTarget(trigger, triggerModelKind)
+      ) {
+        closeOpenMenus();
+        return { status: 'already-selected', label: trigger.textContent?.trim?.() || null };
+      }
       if (!option) return failure('option-not-found', { modelKind: triggerModelKind });
       const label = option.textContent?.trim?.() || null;
       if (optionIsSelected(option)) {

--- a/tests/browser/thinkingTime.test.ts
+++ b/tests/browser/thinkingTime.test.ts
@@ -606,6 +606,70 @@ describe("browser thinking-time selection expression", () => {
         FakeElement,
       ),
     ).resolves.toEqual({ status: "switched", label: "Pro" });
+
+    const competingProAttributes: Record<string, string> = {
+      role: "menuitemradio",
+      "aria-checked": "false",
+      "data-state": "unchecked",
+    };
+    const competingPro = new FakeElement("Pro", competingProAttributes, [], null, () => {
+      competingProAttributes["aria-checked"] = "true";
+      competingProAttributes["data-state"] = "checked";
+    });
+    const competingItems = [
+      new FakeElement("Extra High", {
+        role: "menuitemradio",
+        "aria-checked": "false",
+        "data-state": "unchecked",
+      }),
+      competingPro,
+      new FakeElement("GPT-5.6 Sol", { role: "menuitem", "aria-haspopup": "menu" }),
+    ];
+    const competingGroup = new FakeElement(
+      "Extra High Pro GPT-5.6 Sol",
+      { "data-testid": "composer-intelligence-picker-content", role: "group" },
+      competingItems,
+    );
+    const competingMenu = new FakeElement(
+      competingGroup.textContent,
+      { role: "menu" },
+      competingItems,
+      competingGroup,
+    );
+    const competingDocumentStub = {
+      ...selectableDocumentStub,
+      querySelector: (selector: string) => {
+        if (selector.includes("composer-intelligence-pro-thinking-effort-trigger")) return null;
+        if (selector.includes("composer-intelligence-picker-content")) return competingGroup;
+        if (
+          selector.includes("model-switcher-dropdown-button") ||
+          selector.includes("__composer-pill")
+        ) {
+          return solModelButton;
+        }
+        return null;
+      },
+      querySelectorAll: (selector: string) => {
+        if (selector.includes("__composer-pill")) return [solModelButton];
+        if (selector.includes('role="menu"') || selector.includes("data-radix")) {
+          return [competingMenu];
+        }
+        return [];
+      },
+    };
+
+    await expect(
+      evaluateSolHeavy(
+        competingDocumentStub,
+        performanceStub,
+        (callback: () => void) => callback(),
+        { PointerEvent: FakeMouseEvent, MouseEvent: FakeMouseEvent, Event: FakeMouseEvent },
+        FakeEventTarget,
+        FakeMouseEvent,
+        FakeMouseEvent,
+        FakeElement,
+      ),
+    ).resolves.toEqual({ status: "switched", label: "Pro" });
   });
 
   it("selects exact Chinese Intelligence tiers without prefix collisions", async () => {
@@ -712,13 +776,14 @@ describe("browser thinking-time selection expression", () => {
           ? [extraHigh, high]
           : [high, extraHigh];
       const orderedEfforts = [instant, medium, ...ambiguousPair];
+      const proEfforts = testCase.level === "heavy" ? [] : [proRadio];
       const effortItems = [
         ...orderedEfforts,
-        proRadio,
+        ...proEfforts,
         new FakeElement("GPT-5.6 Sol", { role: "menuitem", "aria-haspopup": "menu" }),
       ];
       const intelligenceGroup = new FakeElement(
-        `智能 ${orderedEfforts.map((item) => item.textContent).join(" ")} Pro 深度模式 GPT-5.6 Sol`,
+        `智能 ${orderedEfforts.map((item) => item.textContent).join(" ")} ${proEfforts.map((item) => item.textContent).join(" ")} GPT-5.6 Sol`,
         { "data-testid": "composer-intelligence-picker-content", role: "group" },
         effortItems,
       );

--- a/tests/browser/thinkingTime.test.ts
+++ b/tests/browser/thinkingTime.test.ts
@@ -350,6 +350,7 @@ describe("browser thinking-time selection expression", () => {
         private readonly attributes: Readonly<Record<string, string>> = {},
         private readonly children: FakeElement[] = [],
         private readonly nestedIntelligence: FakeElement | null = null,
+        private readonly onDispatch?: () => void,
       ) {
         super();
       }
@@ -375,6 +376,10 @@ describe("browser thinking-time selection expression", () => {
         );
       }
       focus(): void {}
+      override dispatchEvent(event: unknown): boolean {
+        this.onDispatch?.();
+        return super.dispatchEvent(event);
+      }
       getBoundingClientRect(): { width: number; height: number } {
         return { width: 144, height: 36 };
       }
@@ -473,6 +478,134 @@ describe("browser thinking-time selection expression", () => {
         FakeElement,
       ),
     ).resolves.toEqual({ status: "already-selected", label: "Pro" });
+
+    const solHeavyExpression = buildThinkingTimeExpressionForTest("heavy", "gpt-5.6-sol");
+    const currentMenuItems = [
+      new FakeElement("ModelGPT-5.6 Sol", { role: "menuitem", "aria-haspopup": "menu" }),
+      new FakeElement("EffortPro", { role: "menuitem", "aria-haspopup": "menu" }),
+    ];
+    const currentIntelligenceGroup = new FakeElement(
+      "ModelGPT-5.6 SolEffortPro",
+      { "data-testid": "composer-intelligence-picker-content", role: "group" },
+      currentMenuItems,
+    );
+    const currentOuterMenu = new FakeElement(
+      currentIntelligenceGroup.textContent,
+      { role: "menu" },
+      currentMenuItems,
+      currentIntelligenceGroup,
+    );
+    const proOnlyDocumentStub = {
+      ...documentStub,
+      querySelector: (selector: string) => {
+        if (selector.includes("composer-intelligence-pro-thinking-effort-trigger")) return null;
+        if (selector.includes("composer-intelligence-picker-content")) {
+          return currentIntelligenceGroup;
+        }
+        if (
+          selector.includes("model-switcher-dropdown-button") ||
+          selector.includes("__composer-pill")
+        ) {
+          return modelButton;
+        }
+        return null;
+      },
+      querySelectorAll: (selector: string) => {
+        if (selector.includes("__composer-pill")) return [modelButton];
+        if (selector.includes('role="menu"') || selector.includes("data-radix")) {
+          return [currentOuterMenu];
+        }
+        return [];
+      },
+    };
+    const evaluateSolHeavy = new Function(
+      "document",
+      "performance",
+      "setTimeout",
+      "window",
+      "EventTarget",
+      "PointerEvent",
+      "MouseEvent",
+      "HTMLElement",
+      `return ${solHeavyExpression};`,
+    ) as typeof evaluate;
+
+    await expect(
+      evaluateSolHeavy(
+        proOnlyDocumentStub,
+        performanceStub,
+        (callback: () => void) => callback(),
+        { PointerEvent: FakeMouseEvent, MouseEvent: FakeMouseEvent, Event: FakeMouseEvent },
+        FakeEventTarget,
+        FakeMouseEvent,
+        FakeMouseEvent,
+        FakeElement,
+      ),
+    ).resolves.toEqual({ status: "already-selected", label: "Pro" });
+
+    const proAttributes: Record<string, string> = {
+      role: "menuitemradio",
+      "aria-checked": "false",
+      "data-state": "unchecked",
+    };
+    const selectablePro = new FakeElement("Pro", proAttributes, [], null, () => {
+      proAttributes["aria-checked"] = "true";
+      proAttributes["data-state"] = "checked";
+    });
+    const selectableItems = [
+      selectablePro,
+      new FakeElement("GPT-5.6 Sol", { role: "menuitem", "aria-haspopup": "menu" }),
+    ];
+    const selectableGroup = new FakeElement(
+      "Pro GPT-5.6 Sol",
+      { "data-testid": "composer-intelligence-picker-content", role: "group" },
+      selectableItems,
+    );
+    const selectableMenu = new FakeElement(
+      selectableGroup.textContent,
+      { role: "menu" },
+      selectableItems,
+      selectableGroup,
+    );
+    const solModelButton = new FakeElement("Extra High", {
+      class: "__composer-pill",
+      "aria-expanded": "true",
+      "aria-haspopup": "menu",
+    });
+    const selectableDocumentStub = {
+      ...documentStub,
+      querySelector: (selector: string) => {
+        if (selector.includes("composer-intelligence-pro-thinking-effort-trigger")) return null;
+        if (selector.includes("composer-intelligence-picker-content")) return selectableGroup;
+        if (
+          selector.includes("model-switcher-dropdown-button") ||
+          selector.includes("__composer-pill")
+        ) {
+          return solModelButton;
+        }
+        return null;
+      },
+      querySelectorAll: (selector: string) => {
+        if (selector.includes("__composer-pill")) return [solModelButton];
+        if (selector.includes('role="menu"') || selector.includes("data-radix")) {
+          return [selectableMenu];
+        }
+        return [];
+      },
+    };
+
+    await expect(
+      evaluateSolHeavy(
+        selectableDocumentStub,
+        performanceStub,
+        (callback: () => void) => callback(),
+        { PointerEvent: FakeMouseEvent, MouseEvent: FakeMouseEvent, Event: FakeMouseEvent },
+        FakeEventTarget,
+        FakeMouseEvent,
+        FakeMouseEvent,
+        FakeElement,
+      ),
+    ).resolves.toEqual({ status: "switched", label: "Pro" });
   });
 
   it("selects exact Chinese Intelligence tiers without prefix collisions", async () => {


### PR DESCRIPTION
## Summary

ChatGPT's current GPT-5.6 Sol composer exposes `Pro` as a separate reasoning-effort choice inside its combined intelligence menu. This change lets Oracle recognize and select that control when `--browser-thinking-time heavy` requests the highest available effort.

## Problem

Oracle's browser engine runs JavaScript in the signed-in ChatGPT page to inspect the composer and choose a reasoning effort. Its GPT-5.6 path recognized the earlier `Extra high` label and a dedicated Pro-effort trigger, but the current UI can instead present a generic `Pro` item alongside a separate `GPT-5.6 Sol` model item in one menu.

In that layout, Oracle could report `option-not-found` even when Pro was already selected, or fail to select Pro when another effort was active. This is separate from model selection: open PR #320 teaches Oracle to recognize the `GPT-5.6 Sol` model item when the same menu also contains a Pro pill, while this PR handles the independent effort item after the model has been chosen.

## Implementation

- For GPT-5.6 targets at `heavy` effort only, treat a standalone `Pro` item in the intelligence-effort menu as the target effort.
- Accept the current composer pill as already selected when its normalized label contains the standalone `Pro` token.
- Exclude labels containing `GPT` or a `5.6` model version when searching for the effort item, so the code does not mistake a model label for an effort.
- Preserve the existing behavior for other models and effort levels.

The test fixture models the current combined menu with separate model and effort entries. It covers both an already-selected Pro pill and switching an unchecked Pro radio item.

## Live browser proof

I ran a signed-in ChatGPT browser smoke at commit `4086ae1298f0353ebc8649ce8656dcd1233095ce` with the current UI:

```text
node dist/bin/oracle-cli.js --engine browser --browser-manual-login --model gpt-5.6-sol --browser-model-strategy select --browser-thinking-time heavy --browser-archive never --browser-attachments never --wait --slug current-ui-sol-effort-smoke --prompt "Current ChatGPT UI model and effort compatibility smoke after the Sol/Pro-pill fixes. Return exactly ORACLE_SOL_HEAVY_OK and nothing else." --file src/cli/detach.ts
```

Relevant output:

```text
[browser] Thinking time: Pro (already selected)
[browser] Model selection evidence: requested=GPT-5.6 Sol; resolved=GPT-5.6 Sol; status=already-selected; strategy=select; verified=yes.
Answer:
ORACLE_SOL_HEAVY_OK
```

The run completed in 18.3 seconds. No `Answer now` control was clicked.

## Validation

- `pnpm check`
- `pnpm vitest run tests/browser/thinkingTime.test.ts`
- `pnpm run build`
- `pnpm run test:packed-cli`

## Compatibility and security

This change does not add a network endpoint, alter authentication, copy browser credentials, or change model selection. It only broadens recognition within the existing ChatGPT effort menu for the GPT-5.6 `heavy` mapping.
