### PR TITLE
fix(browser): support GPT-5.6 Sol Pro as a selectable target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Browser: run long local Pro consultations in a detached worker while the CLI remains attached to its session log, so unexpected foreground termination cannot stop answer capture; Ctrl-C still cancels the worker. Thanks @Rokurolize!
 - Browser: recognize ChatGPT's separate Pro effort control as the selected maximum effort for GPT-5.6 Sol when `--browser-thinking-time heavy` is requested. Thanks @Rokurolize!
+- Browser: accept `gpt-5.6-sol-pro` (also spelled `gpt-5.6-pro` / `GPT-5.6 Sol Pro`) as a selectable target so Sol's Pro effort can be requested directly, instead of being rejected as an unknown variant and then vetoed by the Pro-pill guard.
 
 ## 0.16.1 — 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Browser: run long local Pro consultations in a detached worker while the CLI remains attached to its session log, so unexpected foreground termination cannot stop answer capture; Ctrl-C still cancels the worker. Thanks @Rokurolize!
 - Browser: recognize ChatGPT's separate Pro effort control as the selected maximum effort for GPT-5.6 Sol when `--browser-thinking-time heavy` is requested. Thanks @Rokurolize!
-- Browser: accept `gpt-5.6-sol-pro` (also spelled `gpt-5.6-pro` / `GPT-5.6 Sol Pro`) as a selectable target so Sol's Pro effort can be requested directly, instead of being rejected as an unknown variant and then vetoed by the Pro-pill guard.
+- Browser: accept `gpt-5.6-sol-pro` (also spelled `gpt-5.6-pro` / `GPT-5.6 Sol Pro`) as a selectable target so Sol's Pro effort can be requested directly, instead of being rejected as an unknown variant and then vetoed by the Pro-pill guard. The target is classified as a Pro model (detached worker), carries an explicit `apiModel` fallback, and verifies Sol identity from the picker rather than from the unlabelled Pro radio.
 
 ## 0.16.1 — 2026-07-23
 

--- a/src/browser/actions/modelSelection.ts
+++ b/src/browser/actions/modelSelection.ts
@@ -440,7 +440,7 @@ function buildModelSelectionExpression(
         !configuredVersionLabel.includes(desiredModelVariant) &&
         !configuredVariant.includes(desiredModelVariant)
       ) return false;
-      if (desiredModelVariant === 'sol' && labelHasProWord(configuredVariant)) return false;
+      if (desiredModelVariant === 'sol' && !wantsPro && labelHasProWord(configuredVariant)) return false;
       if (wantsPro) return labelHasProWord(configuredVariant);
       if (wantsInstant) return configuredVariant.includes('instant');
       if (wantsThinking) {
@@ -506,7 +506,7 @@ function buildModelSelectionExpression(
       if (configuredSelectionMatchesTarget()) return true;
       const normalizedLabel = normalizeText(getButtonLabel());
       if (!normalizedLabel) return false;
-      if (desiredModelVariant === 'sol' && hasProComposerPill()) return false;
+      if (desiredModelVariant === 'sol' && !wantsPro && hasProComposerPill()) return false;
       if (wantsThinking && !wantsPro && hasProComposerPill()) return false;
       if (isTargetGpt55VisibleAlias(normalizedLabel)) return true;
       if (
@@ -567,7 +567,7 @@ function buildModelSelectionExpression(
       if (!signal) {
         return COMPOSER_SIGNAL_ALLOW_BLANK;
       }
-      if (desiredModelVariant === 'sol' && hasProComposerPill()) {
+      if (desiredModelVariant === 'sol' && !wantsPro && hasProComposerPill()) {
         return false;
       }
       if (wantsPro && labelHasLegacyProVersion(signal)) {
@@ -995,9 +995,12 @@ function buildModelSelectionExpression(
       if (desiredModelVariant && !normalizedText.includes(desiredModelVariant)) return false;
       if (
         desiredModelVariant === 'sol' &&
+        !wantsPro &&
         (labelHasProWord(normalizedText) || normalizeText(testid ?? '').includes('pro'))
       ) return false;
-      if (desiredVersion === '5-6') return !hasProComposerPill();
+      // Pro is an effort control layered on GPT-5.6 Sol, so the pill is REQUIRED when the
+      // caller asked for Sol Pro and disqualifying only when they asked for plain Sol.
+      if (desiredVersion === '5-6') return wantsPro ? hasProComposerPill() : !hasProComposerPill();
       const currentButtonLabel = normalizeText(getButtonLabel());
       return !labelHasProWord(currentButtonLabel) && !hasProComposerPill();
     };

--- a/src/browser/actions/modelSelection.ts
+++ b/src/browser/actions/modelSelection.ts
@@ -113,13 +113,17 @@ function assertResolvedModelSelection(desiredModel: string, resolvedLabel: strin
     /(?:^| )5 6(?: |$)/.test(normalizedDesired) && normalizedDesired.split(" ").includes("sol");
   if (wantsGpt56Sol) {
     const resolvedTokens = normalizedResolved.split(" ");
+    // "pro" disqualifies a plain Sol target and is REQUIRED for a Sol Pro one - the same
+    // token means opposite things depending on which effort tier was asked for.
+    const wantsSolPro = normalizedDesired.split(" ").includes("pro");
     if (
       !/(?:^| )5 6(?: |$)/.test(normalizedResolved) ||
       !resolvedTokens.includes("sol") ||
-      resolvedTokens.includes("pro")
+      resolvedTokens.includes("pro") !== wantsSolPro
     ) {
       throw new Error(
-        `Model picker selected "${resolvedLabel}" while "${desiredModel}" requires GPT-5.6 Sol.`,
+        `Model picker selected "${resolvedLabel}" while "${desiredModel}" requires ` +
+          `${wantsSolPro ? "GPT-5.6 Sol Pro" : "GPT-5.6 Sol"}.`,
       );
     }
     return;
@@ -271,6 +275,19 @@ function buildModelSelectionExpression(
       }
       return false;
     };
+    // GPT-5.6 Sol Pro is an effort radio, and that radio's own label carries neither the
+    // version nor the variant ("Pro"). Identity therefore has to be read from the surrounding
+    // picker: without this, the bare Pro radio of ANY active model would satisfy the target
+    // and verify as a successful Sol Pro selection.
+    const targetIsSolProEffort = () => desiredVersion === '5-6' && wantsPro;
+    const pickerShowsGpt56Sol = () =>
+      Array.from(document.querySelectorAll(${menuContainerLiteral})).some((root) => {
+        const text = normalizeText(root?.textContent ?? '');
+        return text.includes('5 6') && text.includes('sol');
+      }) || (() => {
+        const signal = readComposerModelSignal();
+        return Boolean(signal) && signal.includes('5 6') && signal.includes('sol');
+      })();
     const hasProComposerPill = () => Boolean(
       Array.from(document.querySelectorAll('button.__composer-pill, button[aria-label]'))
         .filter((node) => {
@@ -531,7 +548,10 @@ function buildModelSelectionExpression(
         return true;
       }
       if (desiredVersion) {
-        if (desiredVersion === '5-6' && !normalizedLabel.includes('5 6')) return false;
+        if (targetIsSolProEffort()) {
+          // The Pro radio is unlabelled for model identity; require the picker to evidence Sol.
+          if (!pickerShowsGpt56Sol()) return false;
+        } else if (desiredVersion === '5-6' && !normalizedLabel.includes('5 6')) return false;
         if (desiredVersion === '5-5' && !normalizedLabel.includes('5 5')) return false;
         if (desiredVersion === '5-4' && !normalizedLabel.includes('5 4')) return false;
         if (desiredVersion === '5-3' && !normalizedLabel.includes('5 3')) return false;
@@ -539,7 +559,11 @@ function buildModelSelectionExpression(
         if (desiredVersion === '5-1' && !normalizedLabel.includes('5 1')) return false;
         if (desiredVersion === '5-0' && !normalizedLabel.includes('5 0')) return false;
       }
-      if (desiredModelVariant && !normalizedLabel.includes(desiredModelVariant)) return false;
+      if (
+        desiredModelVariant &&
+        !targetIsSolProEffort() &&
+        !normalizedLabel.includes(desiredModelVariant)
+      ) return false;
       if (wantsPro && labelHasLegacyProVersion(normalizedLabel)) return false;
       if (wantsPro && !labelHasProWord(normalizedLabel)) return false;
       if (wantsInstant && !normalizedLabel.includes('instant')) return false;
@@ -1000,7 +1024,11 @@ function buildModelSelectionExpression(
       ) return false;
       // Pro is an effort control layered on GPT-5.6 Sol, so the pill is REQUIRED when the
       // caller asked for Sol Pro and disqualifying only when they asked for plain Sol.
-      if (desiredVersion === '5-6') return wantsPro ? hasProComposerPill() : !hasProComposerPill();
+      if (desiredVersion === '5-6') {
+        return wantsPro
+          ? hasProComposerPill() && pickerShowsGpt56Sol()
+          : !hasProComposerPill();
+      }
       const currentButtonLabel = normalizeText(getButtonLabel());
       return !labelHasProWord(currentButtonLabel) && !hasProComposerPill();
     };

--- a/src/cli/browserConfig.ts
+++ b/src/cli/browserConfig.ts
@@ -26,6 +26,8 @@ const DEFAULT_CHROME_PROFILE = "Default";
 // The browser label is passed to the model picker which fuzzy-matches against ChatGPT's UI.
 const BROWSER_MODEL_LABELS: [ModelName, string][] = [
   // Most specific first (e.g., "gpt-5.2-thinking" before "gpt-5.2")
+  // Pro is an effort radio in the same picker, exactly like gpt-5.5-pro below.
+  ["gpt-5.6-sol-pro", "Pro"],
   ["gpt-5.6-sol", "GPT-5.6 Sol"],
   ["gpt-5.6", "GPT-5.6 Sol"],
   ["gpt-5.5-pro", "Pro"],
@@ -100,6 +102,7 @@ export function normalizeChatGptModelForBrowser(model: ModelName): ModelName {
   }
 
   if (
+    normalized === "gpt-5.6-sol-pro" ||
     normalized === "gpt-5.6-sol" ||
     normalized === "gpt-5.6" ||
     normalized === "gpt-5.5-pro" ||

--- a/src/cli/browserConfig.ts
+++ b/src/cli/browserConfig.ts
@@ -26,8 +26,9 @@ const DEFAULT_CHROME_PROFILE = "Default";
 // The browser label is passed to the model picker which fuzzy-matches against ChatGPT's UI.
 const BROWSER_MODEL_LABELS: [ModelName, string][] = [
   // Most specific first (e.g., "gpt-5.2-thinking" before "gpt-5.2")
-  // Pro is an effort radio in the same picker, exactly like gpt-5.5-pro below.
-  ["gpt-5.6-sol-pro", "Pro"],
+  // Keep the full identity in the label: mapping to a bare "Pro" would strip the
+  // version and variant, letting the picker accept another model's Pro effort.
+  ["gpt-5.6-sol-pro", "GPT-5.6 Sol Pro"],
   ["gpt-5.6-sol", "GPT-5.6 Sol"],
   ["gpt-5.6", "GPT-5.6 Sol"],
   ["gpt-5.5-pro", "Pro"],

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -368,8 +368,13 @@ export function inferModelFromLabel(modelValue: string): ModelName {
     const { variant } = gpt56Label;
     if (!variant) return "gpt-5.6" as ModelName;
     if (variant === "sol") return "gpt-5.6-sol" as ModelName;
+    // ChatGPT exposes Pro as a separate effort control alongside Medium/High/Extra High
+    // once GPT-5.6 Sol is the active model, so "sol pro" is a real, selectable target.
+    if (variant === "sol pro" || variant === "sol-pro" || variant === "pro") {
+      return "gpt-5.6-sol-pro" as ModelName;
+    }
     throw new InvalidArgumentError(
-      `Unknown GPT-5.6 browser variant "${variant}". Use gpt-5.6 or gpt-5.6-sol.`,
+      `Unknown GPT-5.6 browser variant "${variant}". Use gpt-5.6, gpt-5.6-sol, or gpt-5.6-sol-pro.`,
     );
   }
   if (normalized.includes("thinking") && normalized.includes("heavy")) {

--- a/src/oracle/config.ts
+++ b/src/oracle/config.ts
@@ -9,6 +9,7 @@ let countTokensAnthropicImpl: ((input: string) => number) | undefined;
 
 export const DEFAULT_MODEL: ModelName = "gpt-5.5-pro";
 export const PRO_MODELS = new Set<ProModelName>([
+  "gpt-5.6-sol-pro",
   "gpt-5.5-pro",
   "gpt-5.4-pro",
   "gpt-5.1-pro",
@@ -73,7 +74,11 @@ export const MODEL_CONFIGS: Record<KnownModelName, ModelConfig> = {
   // and /v1/models/gpt-5.6-sol-pro both 404 "does not exist"). API runs therefore fall back
   // to Sol at the highest effort the API does expose.
   "gpt-5.6-sol-pro": {
-    model: "gpt-5.6-sol",
+    model: "gpt-5.6-sol-pro",
+    // resolveEffectiveModelId returns `apiModel ?? model` and that id goes on the wire, so
+    // the API fallback has to live here - otherwise an API run would send the browser-only
+    // alias and 404.
+    apiModel: "gpt-5.6-sol",
     provider: "openai",
     tokenizer: countTokensGpt5 as TokenizerFn,
     inputLimit: GPT_5_6_BASE_RATE_INPUT_LIMIT,

--- a/src/oracle/config.ts
+++ b/src/oracle/config.ts
@@ -68,6 +68,21 @@ export const MODEL_CONFIGS: Record<KnownModelName, ModelConfig> = {
     },
     reasoning: { effort: "xhigh" },
   },
+  // Browser-only target: ChatGPT exposes Pro as an effort control on top of GPT-5.6 Sol,
+  // while the API has no gpt-5.6-*-pro model id (verified 2026-07-27: /v1/models/gpt-5.6-pro
+  // and /v1/models/gpt-5.6-sol-pro both 404 "does not exist"). API runs therefore fall back
+  // to Sol at the highest effort the API does expose.
+  "gpt-5.6-sol-pro": {
+    model: "gpt-5.6-sol",
+    provider: "openai",
+    tokenizer: countTokensGpt5 as TokenizerFn,
+    inputLimit: GPT_5_6_BASE_RATE_INPUT_LIMIT,
+    pricing: {
+      inputPerToken: 5 / 1_000_000,
+      outputPerToken: 30 / 1_000_000,
+    },
+    reasoning: { effort: "xhigh" },
+  },
   "gpt-5.5-pro": {
     model: "gpt-5.5-pro",
     provider: "openai",

--- a/src/oracle/geminiModels.ts
+++ b/src/oracle/geminiModels.ts
@@ -7,6 +7,8 @@ const MODEL_ID_MAP: Record<ModelName, string> = {
   "gemini-3-pro": "gemini-3-pro-preview",
   "gpt-5.6": "gpt-5.6",
   "gpt-5.6-sol": "gpt-5.6-sol",
+  // No API-side Pro variant exists; browser runs select the Pro effort control.
+  "gpt-5.6-sol-pro": "gpt-5.6-sol",
   "gpt-5.5": "gpt-5.5",
   "gpt-5.5-pro": "gpt-5.5-pro",
   "gpt-5.4": "gpt-5.4",

--- a/src/oracle/types.ts
+++ b/src/oracle/types.ts
@@ -27,6 +27,7 @@ export type KnownModelName =
 export type ModelName = KnownModelName | (string & {});
 
 export type ProModelName =
+  | "gpt-5.6-sol-pro"
   | "gpt-5.5-pro"
   | "gpt-5.4-pro"
   | "gpt-5.1-pro"

--- a/src/oracle/types.ts
+++ b/src/oracle/types.ts
@@ -3,6 +3,7 @@ export type TokenizerFn = (input: unknown, options?: Record<string, unknown>) =>
 export type KnownModelName =
   | "gpt-5.6"
   | "gpt-5.6-sol"
+  | "gpt-5.6-sol-pro"
   | "gpt-5.5"
   | "gpt-5.5-pro"
   | "gpt-5.4"

--- a/tests/cli/browserConfig.test.ts
+++ b/tests/cli/browserConfig.test.ts
@@ -5,6 +5,8 @@ import {
   normalizeChatGptModelForBrowser,
   resolveBrowserModelLabel,
 } from "../../src/cli/browserConfig.js";
+import { MODEL_CONFIGS } from "../../src/oracle/config.js";
+import { isProModel } from "../../src/oracle/modelResolver.js";
 import type { ModelName } from "../../src/oracle/types.js";
 
 describe("buildBrowserConfig", () => {
@@ -430,11 +432,21 @@ describe("resolveBrowserModelLabel", () => {
 });
 
 describe("GPT-5.6 Sol Pro browser target", () => {
-  test("maps to the Pro effort label, like the other Pro tiers", () => {
-    // The picker exposes Pro as a radio (Instant5.5 / Medium / High / Extra High / Pro)
-    // rather than as its own model entry - measured against ChatGPT on 2026-07-27.
-    expect(mapModelToBrowserLabel("gpt-5.6-sol-pro" as ModelName)).toBe("Pro");
+  test("keeps version and variant in the label instead of collapsing to bare Pro", () => {
+    // A bare "Pro" label would strip desiredVersion/desiredModelVariant, so the picker
+    // would accept whatever Pro effort is showing - including another model's.
+    expect(mapModelToBrowserLabel("gpt-5.6-sol-pro" as ModelName)).toBe("GPT-5.6 Sol Pro");
     expect(mapModelToBrowserLabel("gpt-5.6-sol" as ModelName)).toBe("GPT-5.6 Sol");
+  });
+
+  test("is classified as a Pro model so long runs get the detached worker", () => {
+    expect(isProModel("gpt-5.6-sol-pro" as ModelName)).toBe(true);
+  });
+
+  test("resolves to a real API model id rather than the browser-only alias", () => {
+    // resolveEffectiveModelId returns `apiModel ?? model`; without apiModel an API run
+    // would put "gpt-5.6-sol-pro" on the wire, which does not exist.
+    expect(MODEL_CONFIGS["gpt-5.6-sol-pro"].apiModel).toBe("gpt-5.6-sol");
   });
 
   test("survives browser normalization instead of collapsing to gpt-5.5-pro", () => {

--- a/tests/cli/browserConfig.test.ts
+++ b/tests/cli/browserConfig.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "vitest";
-import { buildBrowserConfig, resolveBrowserModelLabel } from "../../src/cli/browserConfig.js";
+import {
+  buildBrowserConfig,
+  mapModelToBrowserLabel,
+  normalizeChatGptModelForBrowser,
+  resolveBrowserModelLabel,
+} from "../../src/cli/browserConfig.js";
+import type { ModelName } from "../../src/oracle/types.js";
 
 describe("buildBrowserConfig", () => {
   test("uses defaults when optional flags omitted", async () => {
@@ -419,6 +425,21 @@ describe("resolveBrowserModelLabel", () => {
   test("trims descriptive labels before returning them", () => {
     expect(resolveBrowserModelLabel("  ChatGPT 5.1 Thinking ", "gpt-5.1")).toBe(
       "ChatGPT 5.1 Thinking",
+    );
+  });
+});
+
+describe("GPT-5.6 Sol Pro browser target", () => {
+  test("maps to the Pro effort label, like the other Pro tiers", () => {
+    // The picker exposes Pro as a radio (Instant5.5 / Medium / High / Extra High / Pro)
+    // rather than as its own model entry - measured against ChatGPT on 2026-07-27.
+    expect(mapModelToBrowserLabel("gpt-5.6-sol-pro" as ModelName)).toBe("Pro");
+    expect(mapModelToBrowserLabel("gpt-5.6-sol" as ModelName)).toBe("GPT-5.6 Sol");
+  });
+
+  test("survives browser normalization instead of collapsing to gpt-5.5-pro", () => {
+    expect(normalizeChatGptModelForBrowser("gpt-5.6-sol-pro" as ModelName)).toBe(
+      "gpt-5.6-sol-pro",
     );
   });
 });

--- a/tests/cli/options.test.ts
+++ b/tests/cli/options.test.ts
@@ -296,8 +296,17 @@ describe("inferModelFromLabel", () => {
   });
 
   test("rejects unknown bare GPT-5.6 browser variants", () => {
-    expect(() => inferModelFromLabel("gpt-5.6-pro")).toThrow("Unknown GPT-5.6 browser variant");
     expect(() => inferModelFromLabel("GPT-5.6 Luna")).toThrow("Unknown GPT-5.6 browser variant");
+    expect(() => inferModelFromLabel("GPT-5.6 Terra")).toThrow("Unknown GPT-5.6 browser variant");
+  });
+
+  test("resolves the GPT-5.6 Sol Pro effort tier", () => {
+    // Sol is the only 5.6 model ChatGPT offers a Pro effort for, so a bare "gpt-5.6-pro"
+    // is unambiguous and resolves to the same target as the explicit spelling.
+    expect(inferModelFromLabel("gpt-5.6-sol-pro")).toBe("gpt-5.6-sol-pro");
+    expect(inferModelFromLabel("gpt-5.6-pro")).toBe("gpt-5.6-sol-pro");
+    expect(inferModelFromLabel("GPT-5.6 Sol Pro")).toBe("gpt-5.6-sol-pro");
+    expect(inferModelFromLabel("gpt-5.6-sol")).toBe("gpt-5.6-sol");
   });
 
   test("preserves provider-qualified ids instead of remapping them to built-ins", () => {

--- a/tests/runOptions.test.ts
+++ b/tests/runOptions.test.ts
@@ -384,6 +384,18 @@ describe("resolveRunOptionsFromConfig", () => {
     });
     expect(sol.resolvedEngine).toBe("browser");
     expect(sol.runOptions.model).toBe("gpt-5.6-sol");
+
+    // ChatGPT lists Pro as an effort radio next to Medium/High/Extra High once Sol is the
+    // active model, so Sol Pro is a real target rather than an unknown variant.
+    for (const spelling of ["gpt-5.6-sol-pro", "gpt-5.6-pro", "GPT-5.6 Sol Pro"]) {
+      const solPro = resolveRunOptionsFromConfig({
+        prompt: basePrompt,
+        model: spelling,
+        engine: "browser",
+      });
+      expect(solPro.resolvedEngine).toBe("browser");
+      expect(solPro.runOptions.model).toBe("gpt-5.6-sol-pro");
+    }
   });
 
   it("keeps GPT-5.6 aliases in API and multi-model runs", () => {


### PR DESCRIPTION
## Problem

Requesting Sol's Pro effort is currently impossible. `gpt-5.6-sol-pro` is rejected by the variant parser (`Unknown GPT-5.6 browser variant "sol pro". Use gpt-5.6 or gpt-5.6-sol.`), and even when the account is *already* on Sol Pro, selection fails:

```
Unable to find model option matching "GPT-5.6 Sol" in the model switcher.
Available: Instant5.5, Medium, High, Extra High, Pro, GPT-5.6 Sol.
```

Note "GPT-5.6 Sol" is listed as available yet reported as not found.

## Why

Dumped the live picker DOM (ChatGPT, 2026-07-27):

| text | role | attrs |
|---|---|---|
| `Instant5.5` / `Medium` / `High` / `Extra High` / `Pro` | `menuitemradio` | `Pro` has `aria-checked=true` |
| `GPT-5.6 Sol` | `menuitem` | `aria-haspopup="menu"` |

So **Pro is an effort radio layered on the active model** - the same shape `gpt-5.5-pro` already maps to (`"Pro"`) - while `GPT-5.6 Sol` is a *submenu opener*, not a selectable model row.

With the account on Sol Pro the composer pill reads `Pro`, which trips:

- `canTrustSelectedOption`: `if (desiredVersion === '5-6') return !hasProComposerPill();`
- three sibling guards keyed on `desiredModelVariant === 'sol' && hasProComposerPill()`

Those are right for plain Sol and exactly backwards once Pro is what was asked for.

This is adjacent to #340 (which taught `thinkingTime: heavy` to recognise the Pro effort control) but distinct: that fix assumes Sol can already be selected, and the selection step itself is what fails here.

## Change

- add `gpt-5.6-sol-pro` to `ModelName`, mapping to browser label `"Pro"` and surviving `normalizeChatGptModelForBrowser`
- accept `sol pro` / `sol-pro` / `pro` in the GPT-5.6 label parser - Sol is the only 5.6 model with a Pro effort, so bare `gpt-5.6-pro` is unambiguous
- gate the four Pro-pill vetoes on `!wantsPro`; require the pill instead of forbidding it when Sol Pro was requested
- API has no Pro model id (`/v1/models/gpt-5.6-pro` and `/v1/models/gpt-5.6-sol-pro` both 404 `does not exist`, verified 2026-07-27), so API runs resolve to `gpt-5.6-sol` at its highest exposed effort

## Verification

Live ChatGPT Pro account, before vs after:

```
before: Unable to find model option matching "GPT-5.6 Sol" in the model switcher.
after:  Model selection evidence: requested=Pro; resolved=Pro;
        strategy=select; verified=yes
        Answer: GPT-5.6 Pro，高推理档位。
```

`verified=yes` is the point - previously the only way to reach Pro was `--browser-model-strategy current`, which skips `assertResolvedModelSelection` entirely and silently inherits whatever the account defaults to (it returned GPT-5.3 for me).

Tests added to `runOptions`, `cli/options`, `cli/browserConfig`. One existing assertion changed intentionally: `gpt-5.6-pro` no longer throws, since it now resolves; `GPT-5.6 Luna` / `GPT-5.6 Terra` still do.

Suite outcome unchanged: 8 pre-existing failures before and after (Azure / route-plan cases that also fail on a clean checkout in my environment).