### PR TITLE
feat(api): add Atlas Cloud provider routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - API: add explicit GPT-5.6 reasoning mode and effort controls, including Pro mode, session persistence, long-run handling, and fail-closed route validation. Thanks @enki!
+- API: add explicit Atlas Cloud routing with `ATLASCLOUD_API_KEY`, a default compatible endpoint, and arbitrary model ID passthrough.
 
 ### Changed
 

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -611,9 +611,9 @@ program
   .addOption(
     new Option(
       "--provider <provider>",
-      "Choose API provider routing: auto, openai, or azure. Use openai to ignore Azure env/config.",
+      "Choose API provider routing: auto, openai, azure, or atlas. Use openai to ignore Azure env/config.",
     )
-      .choices(["auto", "openai", "azure"])
+      .choices(["auto", "openai", "azure", "atlas"])
       .default("auto"),
   )
   .option("--no-azure", "Disable Azure OpenAI routing for this run (same as --provider openai).")
@@ -1141,8 +1141,11 @@ program
   .option("--models <models>", "Comma-separated API model list to inspect.")
   .option("-m, --model <model>", "Single API model to inspect.")
   .addOption(
-    new Option("--provider <provider>", "Choose API provider routing: auto, openai, or azure.")
-      .choices(["auto", "openai", "azure"])
+    new Option(
+      "--provider <provider>",
+      "Choose API provider routing: auto, openai, azure, or atlas.",
+    )
+      .choices(["auto", "openai", "azure", "atlas"])
       .default("auto"),
   )
   .option("--no-azure", "Disable Azure OpenAI routing for this inspection.")
@@ -1395,8 +1398,8 @@ function buildRunOptions(
 
 function resolveApiProviderMode(options: Pick<CliOptions, "provider" | "azure">): ApiProviderMode {
   const provider = options.provider ?? "auto";
-  if (provider === "azure" && options.azure === false) {
-    throw new Error("--provider azure cannot be combined with --no-azure.");
+  if ((provider === "azure" || provider === "atlas") && options.azure === false) {
+    throw new Error(`--provider ${provider} cannot be combined with --no-azure.`);
   }
   if (options.azure === false) {
     return "openai";
@@ -1860,9 +1863,9 @@ async function runRootCommand(options: CliOptions): Promise<void> {
   const retentionHours = typeof options.retainHours === "number" ? options.retainHours : undefined;
   await sessionStore.ensureStorage();
   await pruneOldSessions(retentionHours, (message) => console.log(chalk.dim(message)));
-  if (providerMode === "openai") {
+  if (providerMode === "openai" || providerMode === "atlas") {
     if (hasExplicitAzureOption(optionUsesDefault)) {
-      throw new Error("--provider openai/--no-azure cannot be combined with Azure options.");
+      throw new Error(`--provider ${providerMode} cannot be combined with Azure options.`);
     }
     options.azureEndpoint = undefined;
     options.azureDeployment = undefined;
@@ -1896,6 +1899,7 @@ async function runRootCommand(options: CliOptions): Promise<void> {
 
   const azureAutoApiRequested =
     providerMode !== "openai" &&
+    providerMode !== "atlas" &&
     Boolean(options.azureEndpoint?.trim()) &&
     engineModels.some((model) => isAzureOpenAICandidateModel(model));
   const explicitApiProviderRequested =

--- a/docs/openai-endpoints.md
+++ b/docs/openai-endpoints.md
@@ -45,6 +45,20 @@ oracle --route --model gpt-5.4
 
 The output is redacted and local: provider, base host, key source, Azure status, and missing-route errors. These commands exit before sending a prompt or creating a session.
 
+## Atlas Cloud
+
+Atlas Cloud exposes an OpenAI-compatible Chat Completions endpoint. Select it explicitly so
+Oracle uses the Atlas Cloud key and endpoint instead of treating provider-qualified model IDs as
+OpenRouter routes:
+
+```bash
+export ATLASCLOUD_API_KEY="..."
+oracle --provider atlas --model deepseek-ai/deepseek-v4-pro -p "Review this"
+```
+
+The default base URL is `https://api.atlascloud.ai/v1`. Set `ATLASCLOUD_BASE_URL` or pass
+`--base-url` to use a compatible proxy.
+
 When Azure env/config is present, GPT-family API models route through Azure unless you force first-party OpenAI:
 
 ```bash

--- a/src/cli/providerDoctor.ts
+++ b/src/cli/providerDoctor.ts
@@ -88,8 +88,8 @@ function resolveModels(options: ProviderDoctorCliOptions, userConfig: UserConfig
 
 function resolveProviderMode(options: ProviderDoctorCliOptions): ApiProviderMode {
   const provider = options.provider ?? "auto";
-  if (provider === "azure" && options.azure === false) {
-    throw new Error("--provider azure cannot be combined with --no-azure.");
+  if ((provider === "azure" || provider === "atlas") && options.azure === false) {
+    throw new Error(`--provider ${provider} cannot be combined with --no-azure.`);
   }
   if (options.azure === false) {
     return "openai";

--- a/src/oracle/providerFailures.ts
+++ b/src/oracle/providerFailures.ts
@@ -207,6 +207,8 @@ function keyEnvForProvider(provider: string): string | undefined {
       return "XAI_API_KEY";
     case "azure":
       return "AZURE_OPENAI_API_KEY";
+    case "atlas":
+      return "ATLASCLOUD_API_KEY";
     case "openrouter":
       return "OPENROUTER_API_KEY";
     case "openai":

--- a/src/oracle/providerRoutePlan.ts
+++ b/src/oracle/providerRoutePlan.ts
@@ -10,6 +10,7 @@ import type { ApiProviderMode, AzureOptions, ModelConfig, ModelName } from "./ty
 
 const DEFAULT_PROVIDER_HOSTS: Record<string, string> = {
   anthropic: "api.anthropic.com",
+  atlas: "api.atlascloud.ai",
   google: "generativelanguage.googleapis.com",
   openai: "api.openai.com",
   xai: "api.x.ai",
@@ -83,7 +84,11 @@ function buildResolvedProviderRoute(input: ProviderRoutePlanInput): ResolvedProv
     });
     const provider =
       state?.provider ??
-      (providerMode === "openai" ? "openai" : inferProviderFromModel(input.model));
+      (providerMode === "openai"
+        ? "openai"
+        : providerMode === "atlas"
+          ? "atlas"
+          : inferProviderFromModel(input.model));
     const isAzureOpenAI = state?.isAzureOpenAI ?? providerMode === "azure";
     const key = getKeyForRoute({
       model: input.model,
@@ -128,7 +133,10 @@ function buildResolvedProviderRoute(input: ProviderRoutePlanInput): ResolvedProv
   const isAzureOpenAI = state.isAzureOpenAI;
   let baseUrl = input.baseUrl?.trim();
   const providerQualifiedOpenRouterCandidate =
-    !isAzureOpenAI && providerMode !== "openai" && input.model.includes("/");
+    !isAzureOpenAI &&
+    providerMode !== "openai" &&
+    providerMode !== "atlas" &&
+    input.model.includes("/");
   if (
     baseUrl &&
     providerQualifiedOpenRouterCandidate &&
@@ -139,7 +147,9 @@ function buildResolvedProviderRoute(input: ProviderRoutePlanInput): ResolvedProv
   }
   if (!baseUrl) {
     let envBaseUrl: string | undefined;
-    if (input.model.startsWith("grok")) {
+    if (providerMode === "atlas") {
+      envBaseUrl = env.ATLASCLOUD_BASE_URL?.trim() || "https://api.atlascloud.ai/v1";
+    } else if (input.model.startsWith("grok")) {
       envBaseUrl = env.XAI_BASE_URL?.trim() || "https://api.x.ai/v1";
     } else if (provider === "anthropic") {
       envBaseUrl = env.ANTHROPIC_BASE_URL?.trim();
@@ -176,6 +186,7 @@ function buildResolvedProviderRoute(input: ProviderRoutePlanInput): ResolvedProv
     !baseUrl &&
     (providerQualifiedOpenRouterRoute ||
       (providerMode !== "openai" &&
+        providerMode !== "atlas" &&
         providerKeyMissing &&
         (provider === "other" || openRouterKey.present)));
 
@@ -285,6 +296,9 @@ function getKeyForRoute({
   if (isAzureOpenAI) {
     return readKey(["AZURE_OPENAI_API_KEY", "OPENAI_API_KEY"], env);
   }
+  if (providerMode === "atlas") {
+    return readKey(["ATLASCLOUD_API_KEY"], env);
+  }
   if (providerMode === "openai") {
     return readKey(["OPENAI_API_KEY"], env);
   }
@@ -342,6 +356,7 @@ function routeProviderLabel({
   isAzureOpenAI: boolean;
 }): string {
   if (isAzureOpenAI) return "Azure OpenAI";
+  if (provider === "atlas") return "Atlas Cloud";
   if (isOpenRouterBaseUrl(baseUrl) || openRouterFallback) return "OpenRouter";
   if (baseUrl && isCustomBaseUrl(baseUrl)) return "OpenAI-compatible";
   return providerLabel(provider);
@@ -349,6 +364,7 @@ function routeProviderLabel({
 
 function providerLabel(provider: NonNullable<ModelConfig["provider"]>): string {
   if (provider === "anthropic") return "Anthropic";
+  if (provider === "atlas") return "Atlas Cloud";
   if (provider === "google") return "Google Gemini";
   if (provider === "xai") return "xAI";
   return "OpenAI";
@@ -370,6 +386,7 @@ function inferProviderFromModel(model: ModelName): NonNullable<ModelConfig["prov
   const prefix = model.includes("/") ? model.split("/", 1)[0] : undefined;
   if (prefix === "openai") return "openai";
   if (prefix === "anthropic") return "anthropic";
+  if (prefix === "atlas") return "atlas";
   if (prefix === "google") return "google";
   if (prefix === "xai") return "xai";
   if (model.startsWith("claude")) return "anthropic";
@@ -385,6 +402,7 @@ function azureNote(
 ): string | undefined {
   if (!azureConfigured) return undefined;
   if (providerMode === "openai") return "ignored, --provider openai/--no-azure is active";
+  if (providerMode === "atlas") return "ignored, --provider atlas is active";
   if (isAzureOpenAI) return "active because Azure endpoint is configured";
   return "configured, not used for this model";
 }

--- a/src/oracle/providerRouting.ts
+++ b/src/oracle/providerRouting.ts
@@ -29,10 +29,12 @@ export function resolveProviderRoutingState({
   azure,
 }: ProviderRoutingInput): ProviderRoutingState {
   const knownModelConfig = isKnownModel(model) ? MODEL_CONFIGS[model] : undefined;
-  const provider = knownModelConfig?.provider ?? inferNativeProviderFromModelId(model) ?? "other";
+  const nativeProvider =
+    knownModelConfig?.provider ?? inferNativeProviderFromModelId(model) ?? "other";
+  const provider = providerMode === "atlas" ? "atlas" : nativeProvider;
   const azureEndpoint = azure?.endpoint?.trim();
   const azureDeploymentOption = azure?.deployment?.trim();
-  const isNonOpenAIModel = provider !== "openai" && provider !== "other";
+  const isNonOpenAIModel = nativeProvider !== "openai" && nativeProvider !== "other";
   const isProviderQualifiedModelId = model.includes("/");
 
   if (providerMode === "azure" && !azureEndpoint) {
@@ -65,11 +67,12 @@ export function resolveProviderRoutingState({
     );
   }
 
-  const isOpenAIFamilyModel = provider === "openai" || model.startsWith("gpt");
-  const isCustomAzureModelId = provider === "other" && !model.includes("/");
+  const isOpenAIFamilyModel = nativeProvider === "openai" || model.startsWith("gpt");
+  const isCustomAzureModelId = nativeProvider === "other" && !model.includes("/");
   const isAzureOpenAI = Boolean(
     azureEndpoint &&
     providerMode !== "openai" &&
+    providerMode !== "atlas" &&
     !isNonOpenAIModel &&
     (providerMode === "azure" ||
       (!isProviderQualifiedModelId &&

--- a/src/oracle/run.ts
+++ b/src/oracle/run.ts
@@ -90,7 +90,9 @@ function runtimeKeySource({
     optionsApiKey &&
     (route.isAzureOpenAI ||
       providerMode === "openai" ||
+      providerMode === "atlas" ||
       route.provider === "openai" ||
+      route.provider === "atlas" ||
       route.providerLabel === "OpenAI-compatible")
   ) {
     return "apiKey option";
@@ -100,6 +102,9 @@ function runtimeKeySource({
   }
   if (providerMode === "openai") {
     return "OPENAI_API_KEY";
+  }
+  if (providerMode === "atlas") {
+    return "ATLASCLOUD_API_KEY";
   }
   if (isOpenRouterBaseUrl(route.baseUrl) || route.openRouterFallback || route.model.includes("/")) {
     return "OPENROUTER_API_KEY";

--- a/src/oracle/types.ts
+++ b/src/oracle/types.ts
@@ -47,7 +47,7 @@ export interface AzureOptions {
   deployment?: string;
 }
 
-export type ApiProviderMode = "auto" | "openai" | "azure";
+export type ApiProviderMode = "auto" | "openai" | "azure" | "atlas";
 export type PartialMode = "fail" | "ok";
 
 export type ClientFactory = (
@@ -66,7 +66,7 @@ export interface ModelConfig {
   /** Provider-specific model id used for API calls (defaults to `model`). */
   apiModel?: string;
   /** Upstream provider to help with OpenRouter mapping and auth precedence. */
-  provider?: "openai" | "anthropic" | "google" | "xai" | "other";
+  provider?: "openai" | "anthropic" | "google" | "xai" | "atlas" | "other";
   /** Explicit OpenRouter model id when it differs from apiModel/model. */
   openRouterId?: string;
   tokenizer: TokenizerFn;

--- a/tests/cli/runOracle/runOracle.request-payload.test.ts
+++ b/tests/cli/runOracle/runOracle.request-payload.test.ts
@@ -265,6 +265,50 @@ describe("runOracle request payload", () => {
     expect(captured).toEqual([{ apiKey: "sk-test", baseUrl: "https://litellm.test/v1" }]);
   });
 
+  test("uses the Atlas Cloud key, endpoint, and model id", async () => {
+    const originalAtlasKey = process.env.ATLASCLOUD_API_KEY;
+    const originalAtlasBaseUrl = process.env.ATLASCLOUD_BASE_URL;
+    process.env.ATLASCLOUD_API_KEY = "atlas-test-key";
+    delete process.env.ATLASCLOUD_BASE_URL;
+    const stream = new MockStream([], buildResponse());
+    const client = new MockClient(stream);
+    const captured: Array<{ apiKey: string; baseUrl?: string }> = [];
+    const logs: string[] = [];
+
+    try {
+      await runOracle(
+        {
+          prompt: "Atlas endpoint check",
+          model: "deepseek-ai/deepseek-v4-pro",
+          provider: "atlas",
+          background: false,
+          search: false,
+        },
+        {
+          clientFactory: (apiKey, options) => {
+            captured.push({ apiKey, baseUrl: options?.baseUrl });
+            return client;
+          },
+          log: (message: string) => logs.push(message),
+          write: () => true,
+        },
+      );
+    } finally {
+      if (originalAtlasKey === undefined) delete process.env.ATLASCLOUD_API_KEY;
+      else process.env.ATLASCLOUD_API_KEY = originalAtlasKey;
+      if (originalAtlasBaseUrl === undefined) delete process.env.ATLASCLOUD_BASE_URL;
+      else process.env.ATLASCLOUD_BASE_URL = originalAtlasBaseUrl;
+    }
+
+    expect(captured).toEqual([
+      { apiKey: "atlas-test-key", baseUrl: "https://api.atlascloud.ai/v1" },
+    ]);
+    expect(client.lastRequest?.model).toBe("deepseek-ai/deepseek-v4-pro");
+    expect(logs.join("\n")).toContain(
+      "Provider: Atlas Cloud | base: api.atlascloud.ai/v1 | key: ATLASCLOUD_API_KEY",
+    );
+  });
+
   test("does not fallback to OpenRouter for first-party models with explicit proxy baseUrl", async () => {
     const originalOpenai = process.env.OPENAI_API_KEY;
     const originalOpenRouter = process.env.OPENROUTER_API_KEY;

--- a/tests/oracle/providerRoutePlan.test.ts
+++ b/tests/oracle/providerRoutePlan.test.ts
@@ -37,6 +37,39 @@ describe("provider route plan", () => {
     expect(plan.azureNote).toContain("ignored");
   });
 
+  test("routes arbitrary model ids through Atlas Cloud when explicitly selected", () => {
+    const plan = buildProviderRoutePlan({
+      model: "deepseek-ai/deepseek-v4-pro",
+      providerMode: "atlas",
+      env: {
+        ATLASCLOUD_API_KEY: "atlas-test-key",
+        OPENROUTER_API_KEY: "or-test-key",
+      },
+    });
+
+    expect(plan.ok).toBe(true);
+    expect(plan.provider).toBe("atlas");
+    expect(plan.providerLabel).toBe("Atlas Cloud");
+    expect(plan.base).toBe("api.atlascloud.ai/v1");
+    expect(plan.keySource).toBe("ATLASCLOUD_API_KEY");
+  });
+
+  test("allows overriding the Atlas Cloud compatible endpoint", () => {
+    const plan = buildProviderRoutePlan({
+      model: "qwen/qwen3.5-397b-a17b",
+      providerMode: "atlas",
+      baseUrl: "https://atlas-proxy.test/v1",
+      env: {
+        ATLASCLOUD_API_KEY: "atlas-test-key",
+      },
+    });
+
+    expect(plan.ok).toBe(true);
+    expect(plan.providerLabel).toBe("Atlas Cloud");
+    expect(plan.base).toBe("atlas-proxy.test/v1");
+    expect(plan.keySource).toBe("ATLASCLOUD_API_KEY");
+  });
+
   test("auto Azure route reports missing deployment before request dispatch", () => {
     const plan = buildProviderRoutePlan({
       model: "gpt-5.4",


### PR DESCRIPTION
## Summary

- add an explicit `--provider atlas` route backed by `ATLASCLOUD_API_KEY`
- default Atlas Cloud runs to `https://api.atlascloud.ai/v1` while preserving arbitrary model IDs
- expose Atlas routing in provider diagnostics and auth recovery, with endpoint override support

## Validation

- `pnpm test` (1673 passed, 43 skipped)
- `pnpm run typecheck`
- `pnpm run format:check`
- focused `oxlint`
- `pnpm run docs:check`
- `pnpm run build`
- live CLI call through `deepseek-ai/deepseek-v4-pro` returned the expected response via the default Atlas endpoint