### PR TITLE
fix(security): restrict session artifact file permissions to owner-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Security: restrict existing and newly created session transcripts, model metadata, and browser artifacts to the current user, without following symlinks during upgrade hardening. Thanks @bunlongheng!
 - Browser: select reasoning effort in ChatGPT's unified Intelligence picker, where the tiers moved behind an `Advanced` → `Effort` submenu next to a power slider. `--browser-thinking-time` matched nothing in that layout and silently kept whatever effort the tab already had, which also left the Pro tier unreachable. Submenu openers are no longer treated as selectable tiers, so a `Model` row reading `GPT-5.6 Pro` cannot satisfy a Pro request, and a composer pill showing the Pro effort is no longer mistaken for a Pro model.
 
 ## 0.17.1 — 2026-08-02

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -359,9 +359,13 @@ const DEFAULT_SLUG = "session";
 const MAX_SLUG_WORDS = 5;
 const MIN_CUSTOM_SLUG_WORDS = 3;
 const MAX_SLUG_WORD_LENGTH = 10;
+// Session artifacts (prompt, attached file contents, model responses) are sensitive.
+// Keep them owner-only, matching the meta.json / bridge-config posture (0o600/0o700).
+const SESSION_DIR_MODE = 0o700;
+const SESSION_FILE_MODE = 0o600;
 
 async function ensureDir(dirPath: string): Promise<void> {
-  await fs.mkdir(dirPath, { recursive: true });
+  await fs.mkdir(dirPath, { recursive: true, mode: SESSION_DIR_MODE });
 }
 
 export async function ensureSessionStorage(): Promise<void> {
@@ -467,7 +471,7 @@ async function reserveUniqueSessionDir(baseSlug: string): Promise<string> {
   for (;;) {
     const dir = sessionDir(candidate);
     try {
-      await fs.mkdir(dir, { recursive: false });
+      await fs.mkdir(dir, { recursive: false, mode: SESSION_DIR_MODE });
       return candidate;
     } catch (error) {
       if (!isFileExistsError(error)) {
@@ -534,7 +538,10 @@ export async function updateModelRunMetadata(
     ...updates,
     model,
   });
-  await fs.writeFile(modelJsonPath(sessionId, model), JSON.stringify(next, null, 2), "utf8");
+  await fs.writeFile(modelJsonPath(sessionId, model), JSON.stringify(next, null, 2), {
+    encoding: "utf8",
+    mode: SESSION_FILE_MODE,
+  });
   return next;
 }
 
@@ -639,12 +646,15 @@ export async function initializeSession(
           status: "pending",
           log: { path: path.relative(sessionDir(sessionId), logFilePath) },
         };
-        await fs.writeFile(jsonPath, JSON.stringify(modelRecord, null, 2), "utf8");
-        await fs.writeFile(logFilePath, "", "utf8");
+        await fs.writeFile(jsonPath, JSON.stringify(modelRecord, null, 2), {
+          encoding: "utf8",
+          mode: SESSION_FILE_MODE,
+        });
+        await fs.writeFile(logFilePath, "", { encoding: "utf8", mode: SESSION_FILE_MODE });
       },
     ),
   );
-  await fs.writeFile(logPath(sessionId), "", "utf8");
+  await fs.writeFile(logPath(sessionId), "", { encoding: "utf8", mode: SESSION_FILE_MODE });
   return metadata;
 }
 
@@ -759,9 +769,9 @@ async function attachModelRuns(meta: SessionMetadata, sessionId: string): Promis
 export function createSessionLogWriter(sessionId: string, model?: string): SessionLogWriter {
   const targetPath = model ? modelLogPath(sessionId, model) : logPath(sessionId);
   if (model) {
-    mkdirSync(modelsDir(sessionId), { recursive: true });
+    mkdirSync(modelsDir(sessionId), { recursive: true, mode: SESSION_DIR_MODE });
   }
-  const stream = createWriteStream(targetPath, { flags: "a" });
+  const stream = createWriteStream(targetPath, { flags: "a", mode: SESSION_FILE_MODE });
   const logLine = (line = ""): void => {
     stream.write(`${line}\n`);
   };

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -363,13 +363,86 @@ const MAX_SLUG_WORD_LENGTH = 10;
 // Keep them owner-only, matching the meta.json / bridge-config posture (0o600/0o700).
 const SESSION_DIR_MODE = 0o700;
 const SESSION_FILE_MODE = 0o600;
+const sessionStorageHardening = new Map<string, Promise<void>>();
 
 async function ensureDir(dirPath: string): Promise<void> {
   await fs.mkdir(dirPath, { recursive: true, mode: SESSION_DIR_MODE });
 }
 
+function isMissingPathError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+}
+
+async function chmodIfPresent(targetPath: string, mode: number): Promise<boolean> {
+  try {
+    await fs.chmod(targetPath, mode);
+    return true;
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function hardenSessionStorageEntry(targetPath: string): Promise<void> {
+  let stats;
+  try {
+    stats = await fs.lstat(targetPath);
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return;
+    }
+    throw error;
+  }
+
+  if (stats.isSymbolicLink()) {
+    return;
+  }
+  if (stats.isDirectory()) {
+    if (!(await chmodIfPresent(targetPath, SESSION_DIR_MODE))) {
+      return;
+    }
+    let entries: string[];
+    try {
+      entries = await fs.readdir(targetPath);
+    } catch (error) {
+      if (isMissingPathError(error)) {
+        return;
+      }
+      throw error;
+    }
+    for (const entry of entries) {
+      await hardenSessionStorageEntry(path.join(targetPath, entry));
+    }
+    return;
+  }
+  if (stats.isFile()) {
+    await chmodIfPresent(targetPath, SESSION_FILE_MODE);
+  }
+}
+
 export async function ensureSessionStorage(): Promise<void> {
-  await ensureDir(getSessionsDir());
+  const sessionsDir = getSessionsDir();
+  await ensureDir(sessionsDir);
+  if (process.platform === "win32") {
+    return;
+  }
+
+  const stats = await fs.lstat(sessionsDir);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    return;
+  }
+  const identity = `${sessionsDir}:${stats.dev}:${stats.ino}`;
+  let hardening = sessionStorageHardening.get(identity);
+  if (!hardening) {
+    hardening = hardenSessionStorageEntry(sessionsDir).catch((error) => {
+      sessionStorageHardening.delete(identity);
+      throw error;
+    });
+    sessionStorageHardening.set(identity, hardening);
+  }
+  await hardening;
 }
 
 function slugify(text: string | undefined, maxWords = MAX_SLUG_WORDS): string {

--- a/tests/sessionManager.test.ts
+++ b/tests/sessionManager.test.ts
@@ -1,5 +1,16 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
-import { mkdtemp, rm, readFile, readdir, stat } from "node:fs/promises";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  rm,
+  readFile,
+  readdir,
+  stat,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 import { setOracleHomeDirOverrideForTest } from "../src/oracleHome.js";
@@ -33,6 +44,69 @@ describe("session storage setup", () => {
     await sessionModule.ensureSessionStorage();
     const stats = await stat(sessionModule.getSessionsDir());
     expect(stats.isDirectory()).toBe(true);
+  });
+
+  test("ensureSessionStorage hardens existing artifacts without following symlinks", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const migrationHome = await mkdtemp(path.join(os.tmpdir(), "oracle-session-migration-"));
+    try {
+      const sessionsDir = path.join(migrationHome, "sessions");
+      const sessionDir = path.join(sessionsDir, "existing-session");
+      const modelsDir = path.join(sessionDir, "models");
+      const nestedArtifactsDir = path.join(sessionDir, "artifacts", "nested");
+      const outsideDir = path.join(migrationHome, "outside-dir");
+      const outsideFile = path.join(migrationHome, "outside.txt");
+
+      await mkdir(modelsDir, { recursive: true });
+      await mkdir(nestedArtifactsDir, { recursive: true });
+      await mkdir(outsideDir);
+      await writeFile(path.join(sessionDir, "output.log"), "sensitive transcript", "utf8");
+      await writeFile(path.join(modelsDir, "gpt.json"), "{}", "utf8");
+      await writeFile(path.join(nestedArtifactsDir, "report.md"), "sensitive report", "utf8");
+      await writeFile(outsideFile, "outside", "utf8");
+      await symlink(outsideDir, path.join(sessionDir, "linked-dir"));
+      await symlink(outsideFile, path.join(sessionDir, "linked-file"));
+
+      for (const dir of [
+        sessionsDir,
+        sessionDir,
+        modelsDir,
+        path.dirname(nestedArtifactsDir),
+        nestedArtifactsDir,
+        outsideDir,
+      ]) {
+        await chmod(dir, 0o755);
+      }
+      for (const file of [
+        path.join(sessionDir, "output.log"),
+        path.join(modelsDir, "gpt.json"),
+        path.join(nestedArtifactsDir, "report.md"),
+        outsideFile,
+      ]) {
+        await chmod(file, 0o644);
+      }
+
+      setOracleHomeDirOverrideForTest(migrationHome);
+      await sessionModule.ensureSessionStorage();
+
+      const mode = async (targetPath: string) => (await stat(targetPath)).mode & 0o777;
+      expect(await mode(sessionsDir)).toBe(0o700);
+      expect(await mode(sessionDir)).toBe(0o700);
+      expect(await mode(modelsDir)).toBe(0o700);
+      expect(await mode(nestedArtifactsDir)).toBe(0o700);
+      expect(await mode(path.join(sessionDir, "output.log"))).toBe(0o600);
+      expect(await mode(path.join(modelsDir, "gpt.json"))).toBe(0o600);
+      expect(await mode(path.join(nestedArtifactsDir, "report.md"))).toBe(0o600);
+      expect((await lstat(path.join(sessionDir, "linked-dir"))).isSymbolicLink()).toBe(true);
+      expect((await lstat(path.join(sessionDir, "linked-file"))).isSymbolicLink()).toBe(true);
+      expect(await mode(outsideDir)).toBe(0o755);
+      expect(await mode(outsideFile)).toBe(0o644);
+    } finally {
+      setOracleHomeDirOverrideForTest(oracleHomeDir);
+      await rm(migrationHome, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/sessionManager.test.ts
+++ b/tests/sessionManager.test.ts
@@ -113,6 +113,31 @@ describe("session lifecycle", () => {
     }
   });
 
+  test("session directory and log artifacts are owner-only (no world/group read)", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const meta = await sessionModule.initializeSession(
+      { prompt: "sensitive prompt", model: "gpt-5.2-pro" },
+      "/tmp/cwd",
+    );
+    const baseDir = path.join(sessionModule.getSessionsDir(), meta.id);
+    // The output log receives the full prompt + attached file contents + model response,
+    // so it must not be readable by other local users.
+    const writer = sessionModule.createSessionLogWriter(meta.id);
+    writer.writeChunk("SENSITIVE MODEL RESPONSE\n");
+    writer.stream.end();
+    await new Promise((resolve) => writer.stream.on("close", resolve));
+
+    const mode = async (p: string) => (await stat(p)).mode & 0o777;
+    expect(await mode(sessionModule.getSessionsDir())).toBe(0o700);
+    expect(await mode(baseDir)).toBe(0o700);
+    expect(await mode(path.join(baseDir, "models"))).toBe(0o700);
+    expect(await mode(path.join(baseDir, "output.log"))).toBe(0o600);
+    expect(await mode(path.join(baseDir, "models", "gpt-5.2-pro.json"))).toBe(0o600);
+    expect(await mode(path.join(baseDir, "models", "gpt-5.2-pro.log"))).toBe(0o600);
+  });
+
   test("readSessionMetadata returns null for missing sessions and updateSessionMetadata persists changes", async () => {
     expect(await sessionModule.readSessionMetadata("missing")).toBeNull();
     const meta = await sessionModule.initializeSession(


### PR DESCRIPTION
## Problem

Oracle sends a run's full context (the prompt, every attached file's contents, and the model's streamed response) and persists all of it under `~/.oracle/sessions/<id>/`. Those artifacts were created with the process umask default, leaving them readable by every local account:

| Path | Before | Contains |
|------|--------|----------|
| `sessions/`, `sessions/<id>/`, `<id>/models/` | `0755` | (traversable) |
| `<id>/output.log`, `models/*.log` | `0644` | full prompt + attached file contents + model response |
| `<id>/models/*.json` | `0644` | usage, response ids |
| `<id>/meta.json` | `0600` | already locked down |

On a shared or multi-user host, any other local user can read another user's oracle history - which routinely includes proprietary source code and can include secrets the user attached to the consult. This is a local information disclosure (CWE-732 *Incorrect Permission Assignment for Critical Resource* / CWE-200).

The inconsistency is the tell: `meta.json` is already written with `mode: 0o600` (`writeSessionMetadataFile`), and the bridge config/token files use `0o600`/`0o700` (`src/cli/bridge/host.ts`, `src/bridge/userConfigFile.ts`) - but the sibling files that hold the **most** sensitive content were left at the umask default.

### Reproduction (before)
```
$ oracle -p "review this" --file ./src   # sends code to GPT
$ ls -ld ~/.oracle/sessions/<id> ~/.oracle/sessions/<id>/output.log
drwxr-xr-x  ... ~/.oracle/sessions/<id>          # 0755 - traversable by anyone
-rw-r--r--  ... ~/.oracle/sessions/<id>/output.log  # 0644 - world-readable transcript
```

## Fix

Align the session artifacts with the posture already used for `meta.json` and the bridge files:

- session/model **directories** created `0o700`
- `output.log`, per-model `.log` and `.json` files written `0o600`
- the appended log stream in `createSessionLogWriter` opened with `mode: 0o600`

Two named constants (`SESSION_DIR_MODE`, `SESSION_FILE_MODE`) keep it consistent and self-documenting. No behavior change on single-user machines; on Windows the mode bits are effectively ignored (test skips there).

Note: file mode is applied at creation, so this hardens newly created sessions. Existing session directories keep their prior permissions unless recreated.

## Test

Added `session directory and log artifacts are owner-only` in `tests/sessionManager.test.ts`, asserting `sessions/`, the session dir, and `models/` are `0700` and `output.log` / `models/*.json` / `models/*.log` are `0600`.

- Before the fix the test fails: `expected 493 to be 448` (0o755 vs 0o700).
- After the fix the full session suite passes (`sessionManager`, `sessionStore`, `sessionStore.prune`, plus `mcp/sessions`, `cli/sessionCommand`, `mcp/consult`).
- `tsc --noEmit`, `oxlint`, and `oxfmt --check` all clean on the changed files.
