### PR TITLE
feat(browser): support Grok web sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Browser: add Grok web automation through an attached `grok.com` Chrome session, including text prompts and same-conversation follow-ups.
+- Browser: add Grok web automation through an attached `grok.com` Chrome session, including text prompts, file uploads, same-conversation follow-ups, and final-response extraction that excludes Grok's visible thinking process.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.17.3 — Unreleased
 
+### Added
+
+- Browser: add Grok web automation through an attached `grok.com` Chrome session, including text prompts and same-conversation follow-ups.
+
 ### Fixed
 
 - Browser: recognize the Japanese `詳細設定` → `推論レベル` controls in ChatGPT's unified Intelligence picker, allowing explicit Pro effort selection without weakening the fail-closed guard for unknown languages.

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -469,7 +469,7 @@ program
   .addOption(
     new Option(
       "-e, --engine <mode>",
-      "Execution engine (api | browser). Browser engine: GPT models automate ChatGPT; Gemini models use a cookie-based client for gemini.google.com. If omitted, oracle picks api when OPENAI_API_KEY is set, otherwise browser.",
+      "Execution engine (api | browser). Browser engine: GPT models automate ChatGPT; Gemini uses gemini.google.com; Grok uses an attached grok.com Chrome session. If omitted, oracle picks api when OPENAI_API_KEY is set, otherwise browser.",
     ).choices(["api", "browser"]),
   )
   .addOption(
@@ -1949,20 +1949,24 @@ async function runRootCommand(options: CliOptions): Promise<void> {
   const isGemini = primaryModelCandidate.startsWith("gemini");
   const isCodex = primaryModelCandidate.startsWith("gpt-5.1-codex");
   const isClaude = primaryModelCandidate.startsWith("claude");
+  const isGrok = primaryModelCandidate.startsWith("grok");
   const userForcedBrowser = options.browser || options.engine === "browser";
   const browserExplicitlyRequested = browserEngineRequested;
   const isBrowserCompatible = (model: string) =>
-    model.startsWith("gpt-") || model.startsWith("gemini");
+    model.startsWith("gpt-") || model.startsWith("gemini") || model.startsWith("grok");
   const hasNonBrowserCompatibleTarget =
     normalizedMultiModels.length > 0
       ? normalizedMultiModels.some((model) => !isBrowserCompatible(model))
       : !isBrowserCompatible(resolvedModelCandidate);
   if (browserExplicitlyRequested && hasNonBrowserCompatibleTarget) {
     throw new Error(
-      "Browser engine only supports GPT and Gemini models. Re-run with --engine api for Grok, Claude, or other models.",
+      "Browser engine only supports GPT, Gemini, and Grok models. Re-run with --engine api for Claude or other models.",
     );
   }
   if (engine === "browser" && hasNonBrowserCompatibleTarget) {
+    engine = "api";
+  }
+  if (isGrok && engine === "browser" && !browserExplicitlyRequested) {
     engine = "api";
   }
   if (isClaude && engine === "browser") {
@@ -2121,6 +2125,11 @@ async function runRootCommand(options: CliOptions): Promise<void> {
     }
   }
   const activeModel = resolvedOptions.model;
+  if (remoteHost && activeModel.startsWith("grok")) {
+    throw new Error(
+      "Grok web mode does not support --remote-host yet. Use --remote-chrome or --browser-attach-running.",
+    );
+  }
   if (options.reasoningMode && engine !== "api") {
     throw new Error("--reasoning-mode requires --engine api.");
   }
@@ -2274,6 +2283,10 @@ async function runRootCommand(options: CliOptions): Promise<void> {
     if (browserConfig.modelStrategy && browserConfig.modelStrategy !== "select") {
       console.log(chalk.dim("Browser model strategy is ignored for Gemini web runs."));
     }
+  } else if (browserConfig && activeModel.startsWith("grok")) {
+    const { createGrokWebExecutor } = await import("../src/grok-web/index.js");
+    browserDeps = { executeBrowser: createGrokWebExecutor() };
+    console.log(chalk.dim("Using Grok web client for browser automation"));
   }
   const remoteExecutionActive = Boolean(browserDeps);
 
@@ -2642,6 +2655,11 @@ async function restartSession(sessionId: string, options: RestartCommandOptions)
   if (remoteHost) {
     console.log(chalk.dim(`Remote browser host detected: ${remoteHost}`));
   }
+  if (remoteHost && runOptions.model.startsWith("grok")) {
+    throw new Error(
+      "Grok web mode does not support --remote-host yet. Use --remote-chrome or --browser-attach-running.",
+    );
+  }
   if (remoteHost && waitPreference === false) {
     console.log(chalk.dim("Remote browser runs require --wait; ignoring --no-wait."));
     waitPreference = true;
@@ -2670,6 +2688,10 @@ async function restartSession(sessionId: string, options: RestartCommandOptions)
     if (browserConfig.modelStrategy && browserConfig.modelStrategy !== "select") {
       console.log(chalk.dim("Browser model strategy is ignored for Gemini web runs."));
     }
+  } else if (browserConfig && runOptions.model.startsWith("grok")) {
+    const { createGrokWebExecutor } = await import("../src/grok-web/index.js");
+    browserDeps = { executeBrowser: createGrokWebExecutor() };
+    console.log(chalk.dim("Using Grok web client for browser automation"));
   }
   const remoteExecutionActive = Boolean(browserDeps);
 

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -19,7 +19,8 @@ Notes:
   oracle --engine browser --model grok --remote-chrome 127.0.0.1:9222 -p "Review this plan"
   ```
 
-  The initial Grok web implementation supports text prompts and browser follow-ups. It opens an
-  isolated Grok tab instead of reusing the active tab. File attachments are rejected explicitly;
-  use the xAI API engine when attachments are required. Grok web mode currently supports local
-  `--remote-chrome` / `--browser-attach-running` sessions, not `oracle serve --remote-host`.
+  Grok web mode supports text prompts, file attachments, and browser follow-ups. It opens an
+  isolated Grok tab instead of reusing the active tab. Use `--browser-attachments always` to force
+  text files through Grok's upload control instead of Oracle's normal small-file inline mode. Grok
+  web mode currently supports local `--remote-chrome` / `--browser-attach-running` sessions, not
+  `oracle serve --remote-host`.

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -13,4 +13,13 @@ Owner: Oracle CLI
 Notes:
 
 - If you supply `--base-url`, it overrides the default xAI endpoint.
-- Browser engine is not supported for Grok; Oracle coerces `--engine browser` to `api`.
+- Browser mode can use an existing Chrome session at `grok.com` without an API key:
+
+  ```bash
+  oracle --engine browser --model grok --remote-chrome 127.0.0.1:9222 -p "Review this plan"
+  ```
+
+  The initial Grok web implementation supports text prompts and browser follow-ups. It opens an
+  isolated Grok tab instead of reusing the active tab. File attachments are rejected explicitly;
+  use the xAI API engine when attachments are required. Grok web mode currently supports local
+  `--remote-chrome` / `--browser-attach-running` sessions, not `oracle serve --remote-host`.

--- a/src/browser/providerDomFlow.ts
+++ b/src/browser/providerDomFlow.ts
@@ -8,6 +8,7 @@ export interface ProviderDomFlowContext {
   delay: (ms: number) => Promise<void>;
   log?: BrowserLogger;
   state?: Record<string, unknown>;
+  uploadAttachments?: (attachments: Array<{ path: string; name: string }>) => Promise<void>;
 }
 
 export interface ProviderDomResponse {

--- a/src/browser/providers/grokDomProvider.ts
+++ b/src/browser/providers/grokDomProvider.ts
@@ -8,6 +8,7 @@ interface GrokDomProviderState {
   inputTimeoutMs?: number;
   timeoutMs?: number;
   responseCountBeforeSubmit?: number;
+  attachments?: Array<{ path: string; name: string }>;
 }
 
 export const GROK_SELECTORS = {
@@ -83,6 +84,13 @@ async function waitForUi(ctx: ProviderDomFlowContext): Promise<void> {
 }
 
 async function typePrompt(ctx: ProviderDomFlowContext): Promise<void> {
+  const attachments = (ctx.state as GrokDomProviderState | undefined)?.attachments ?? [];
+  if (attachments.length > 0) {
+    if (!ctx.uploadAttachments)
+      throw new Error("Grok attachment upload is unavailable in this browser session.");
+    ctx.log?.(`[grok-web] Uploading ${attachments.length} attachment(s)...`);
+    await ctx.uploadAttachments(attachments);
+  }
   ctx.log?.("[grok-web] Typing prompt...");
   const input = selectorLiteral(GROK_SELECTORS.input);
   const result = await ctx.evaluate<string>(
@@ -165,7 +173,8 @@ async function waitForResponse(
         if (loginRequired) return JSON.stringify({ status: 'login-required' });
         if (turns.length <= ${initialCount}) return JSON.stringify({ status: 'waiting' });
         const last = turns[turns.length - 1];
-        const content = last.matches(${responseContent}) ? last : last.querySelector(${responseContent});
+        const content = last.querySelector('.response-content-markdown, .markdown') ??
+          (last.matches(${responseContent}) ? last : last.querySelector(${responseContent}));
         const text = (content?.innerText || content?.textContent || '').trim();
         const stopVisible = Array.from(document.querySelectorAll(${stop})).some(
           (node) => node instanceof HTMLElement && node.offsetParent !== null
@@ -174,7 +183,11 @@ async function waitForResponse(
           return JSON.stringify({ status: stopVisible ? 'streaming' : 'waiting', text: '' });
         }
         const html = content?.innerHTML || '';
-        return JSON.stringify({ status: stopVisible ? 'streaming' : 'idle', text, html });
+        return JSON.stringify({
+          status: stopVisible || !content?.matches('.response-content-markdown, .markdown') ? 'streaming' : 'idle',
+          text,
+          html,
+        });
       })()`,
     );
     const payload = JSON.parse(raw ?? "{}") as { status?: string; text?: string; html?: string };

--- a/src/browser/providers/grokDomProvider.ts
+++ b/src/browser/providers/grokDomProvider.ts
@@ -1,0 +1,199 @@
+import type { ProviderDomAdapter, ProviderDomFlowContext } from "../providerDomFlow.js";
+import { joinSelectors } from "../providerDomFlow.js";
+
+const UI_TIMEOUT_MS = 60_000;
+const RESPONSE_TIMEOUT_MS = 10 * 60_000;
+
+interface GrokDomProviderState {
+  inputTimeoutMs?: number;
+  timeoutMs?: number;
+  responseCountBeforeSubmit?: number;
+}
+
+export const GROK_SELECTORS = {
+  input: [
+    '[contenteditable="true"][role="textbox"][aria-label="Ask Grok anything"]',
+    'textarea[aria-label="Ask Grok anything"]',
+    'textarea[placeholder="What do you want to know?"]',
+  ],
+  sendButton: ['button[data-testid="chat-submit"]', 'button[aria-label="Submit"]'],
+  stopButton: [
+    'button[data-testid="stop-button"]',
+    'button[aria-label*="Stop" i]',
+    'button[aria-label*="Cancel" i]',
+  ],
+  response: [
+    '[data-testid="assistant-message"]',
+    '[data-testid="response-message"]',
+    '[data-message-author-role="assistant"]',
+    '.message-bubble:not([data-testid="user-message"])',
+  ],
+  responseContent: [
+    '[data-testid="assistant-message"] .markdown',
+    '[data-testid="response-message"] .markdown',
+    '[data-message-author-role="assistant"] .markdown',
+    '[data-testid="assistant-message"]',
+    '[data-testid="response-message"]',
+    '[data-message-author-role="assistant"]',
+  ],
+} as const;
+
+function selectorLiteral(selectors: readonly string[]): string {
+  return JSON.stringify(joinSelectors(selectors));
+}
+
+function readTimeouts(ctx: ProviderDomFlowContext): { ui: number; response: number } {
+  const state = ctx.state as GrokDomProviderState | undefined;
+  return {
+    ui:
+      typeof state?.inputTimeoutMs === "number"
+        ? Math.max(1_000, state.inputTimeoutMs)
+        : UI_TIMEOUT_MS,
+    response:
+      typeof state?.timeoutMs === "number" ? Math.max(1_000, state.timeoutMs) : RESPONSE_TIMEOUT_MS,
+  };
+}
+
+async function waitForUi(ctx: ProviderDomFlowContext): Promise<void> {
+  ctx.log?.("[grok-web] Waiting for Grok UI to load...");
+  const input = selectorLiteral(GROK_SELECTORS.input);
+  const deadline = Date.now() + readTimeouts(ctx).ui;
+  while (Date.now() < deadline) {
+    const state = await ctx.evaluate<{ ready?: boolean; blocked?: boolean }>(
+      `(() => {
+        const body = (document.body?.innerText || '').toLowerCase();
+        return {
+          ready: Boolean(document.querySelector(${input})),
+          blocked: body.includes('verify you are human') || body.includes('checking your browser')
+        };
+      })()`,
+    );
+    if (state?.ready) return;
+    if (state?.blocked) {
+      throw new Error(
+        "Grok is showing a browser verification challenge. Complete it in Chrome and retry.",
+      );
+    }
+    await ctx.delay(1_000);
+  }
+  throw new Error("Timed out waiting for the Grok prompt input.");
+}
+
+async function typePrompt(ctx: ProviderDomFlowContext): Promise<void> {
+  ctx.log?.("[grok-web] Typing prompt...");
+  const input = selectorLiteral(GROK_SELECTORS.input);
+  const result = await ctx.evaluate<string>(
+    `(() => {
+      const editor = document.querySelector(${input});
+      if (!(editor instanceof HTMLElement)) return 'not-found';
+      editor.focus();
+      if (editor instanceof HTMLTextAreaElement) {
+        const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+        setter?.call(editor, ${JSON.stringify(ctx.prompt)});
+        editor.dispatchEvent(new Event('input', { bubbles: true }));
+        editor.dispatchEvent(new Event('change', { bubbles: true }));
+        return editor.value === ${JSON.stringify(ctx.prompt)} ? 'typed' : 'mismatch';
+      }
+      editor.textContent = '';
+      const inserted = typeof document.execCommand === 'function' &&
+        document.execCommand('insertText', false, ${JSON.stringify(ctx.prompt)});
+      if (!inserted) {
+        editor.textContent = ${JSON.stringify(ctx.prompt)};
+        editor.dispatchEvent(new InputEvent('beforeinput', {
+          bubbles: true,
+          inputType: 'insertText',
+          data: ${JSON.stringify(ctx.prompt)}
+        }));
+        editor.dispatchEvent(new InputEvent('input', {
+          bubbles: true,
+          inputType: 'insertText',
+          data: ${JSON.stringify(ctx.prompt)}
+        }));
+      }
+      return (editor.innerText || editor.textContent || '').trim() === ${JSON.stringify(ctx.prompt)}
+        ? 'typed'
+        : 'mismatch';
+    })()`,
+  );
+  if (result !== "typed") {
+    throw new Error(`Failed to type the Grok prompt (${result ?? "unknown"}).`);
+  }
+  await ctx.delay(300);
+}
+
+async function submitPrompt(ctx: ProviderDomFlowContext): Promise<void> {
+  ctx.log?.("[grok-web] Sending prompt...");
+  const send = selectorLiteral(GROK_SELECTORS.sendButton);
+  const result = await ctx.evaluate<string>(
+    `(() => {
+      const button = document.querySelector(${send});
+      if (!(button instanceof HTMLButtonElement)) return 'not-found';
+      if (button.disabled) return 'disabled';
+      button.click();
+      return 'clicked';
+    })()`,
+  );
+  if (result !== "clicked") {
+    throw new Error(`Failed to submit the Grok prompt (${result ?? "unknown"}).`);
+  }
+}
+
+async function waitForResponse(
+  ctx: ProviderDomFlowContext,
+): Promise<{ text: string; html?: string }> {
+  ctx.log?.("[grok-web] Waiting for Grok response...");
+  const response = selectorLiteral(GROK_SELECTORS.response);
+  const responseContent = selectorLiteral(GROK_SELECTORS.responseContent);
+  const stop = selectorLiteral(GROK_SELECTORS.stopButton);
+  const state = ctx.state as GrokDomProviderState | undefined;
+  const initialCount = state?.responseCountBeforeSubmit ?? 0;
+  const deadline = Date.now() + readTimeouts(ctx).response;
+  let previousText = "";
+  let stablePolls = 0;
+
+  while (Date.now() < deadline) {
+    const raw = await ctx.evaluate<string>(
+      `(() => {
+        const turns = Array.from(document.querySelectorAll(${response}));
+        const body = (document.body?.innerText || '').toLowerCase();
+        const loginRequired =
+          Boolean(document.querySelector('[data-testid="anon-paywall-sign-up-card"]')) ||
+          (body.includes('continue your conversation') && body.includes('sign up'));
+        if (loginRequired) return JSON.stringify({ status: 'login-required' });
+        if (turns.length <= ${initialCount}) return JSON.stringify({ status: 'waiting' });
+        const last = turns[turns.length - 1];
+        const content = last.matches(${responseContent}) ? last : last.querySelector(${responseContent});
+        const text = (content?.innerText || content?.textContent || '').trim();
+        const html = content?.innerHTML || '';
+        const stopVisible = Array.from(document.querySelectorAll(${stop})).some(
+          (node) => node instanceof HTMLElement && node.offsetParent !== null
+        );
+        return JSON.stringify({ status: stopVisible ? 'streaming' : 'idle', text, html });
+      })()`,
+    );
+    const payload = JSON.parse(raw ?? "{}") as { status?: string; text?: string; html?: string };
+    if (payload.status === "login-required") {
+      throw new Error(
+        "Grok requires sign-in before it will answer. Sign in at grok.com in the attached Chrome profile and retry.",
+      );
+    }
+    const currentText = payload.text?.trim() ?? "";
+    if (currentText && currentText === previousText && payload.status === "idle") {
+      stablePolls += 1;
+      if (stablePolls >= 2) return { text: currentText, html: payload.html };
+    } else {
+      stablePolls = 0;
+      previousText = currentText;
+    }
+    await ctx.delay(1_000);
+  }
+  throw new Error("Timed out waiting for Grok to finish responding.");
+}
+
+export const grokDomProvider: ProviderDomAdapter = {
+  providerName: "grok-web",
+  waitForUi,
+  typePrompt,
+  submitPrompt,
+  waitForResponse,
+};

--- a/src/browser/providers/grokDomProvider.ts
+++ b/src/browser/providers/grokDomProvider.ts
@@ -29,9 +29,12 @@ export const GROK_SELECTORS = {
     '.message-bubble:not([data-testid="user-message"])',
   ],
   responseContent: [
+    '[data-testid="assistant-message"] .response-content-markdown',
     '[data-testid="assistant-message"] .markdown',
+    '[data-testid="response-message"] .response-content-markdown',
     '[data-testid="response-message"] .markdown',
     '[data-message-author-role="assistant"] .markdown',
+    '[data-message-author-role="assistant"] .response-content-markdown',
     '[data-testid="assistant-message"]',
     '[data-testid="response-message"]',
     '[data-message-author-role="assistant"]',
@@ -164,10 +167,13 @@ async function waitForResponse(
         const last = turns[turns.length - 1];
         const content = last.matches(${responseContent}) ? last : last.querySelector(${responseContent});
         const text = (content?.innerText || content?.textContent || '').trim();
-        const html = content?.innerHTML || '';
         const stopVisible = Array.from(document.querySelectorAll(${stop})).some(
           (node) => node instanceof HTMLElement && node.offsetParent !== null
         );
+        if (!text || /^thought for \\d+s?$/i.test(text)) {
+          return JSON.stringify({ status: stopVisible ? 'streaming' : 'waiting', text: '' });
+        }
+        const html = content?.innerHTML || '';
         return JSON.stringify({ status: stopVisible ? 'streaming' : 'idle', text, html });
       })()`,
     );

--- a/src/browser/providers/index.ts
+++ b/src/browser/providers/index.ts
@@ -3,3 +3,4 @@ export {
   geminiDeepThinkDomProvider,
   GEMINI_DEEP_THINK_SELECTORS,
 } from "./geminiDeepThinkDomProvider.js";
+export { grokDomProvider, GROK_SELECTORS } from "./grokDomProvider.js";

--- a/src/cli/runOptions.ts
+++ b/src/cli/runOptions.ts
@@ -77,12 +77,13 @@ export function resolveRunOptionsFromConfig({
       : [apiModel];
   const browserCompatibilityModels: ModelName[] =
     normalizedRequestedModels.length > 0 ? allModels : [browserModel];
-  const isBrowserCompatible = (m: string) => m.startsWith("gpt-") || m.startsWith("gemini");
+  const isBrowserCompatible = (m: string) =>
+    m.startsWith("gpt-") || m.startsWith("gemini") || m.startsWith("grok");
   const hasNonBrowserCompatibleTarget =
     browserEngineRequested && browserCompatibilityModels.some((m) => !isBrowserCompatible(m));
   if (hasNonBrowserCompatibleTarget) {
     throw new PromptValidationError(
-      "Browser engine only supports GPT and Gemini models. Re-run with --engine api for Grok, Claude, or other models.",
+      "Browser engine only supports GPT, Gemini, and Grok models. Re-run with --engine api for Claude or other models.",
       { engine: "browser", models: allModels },
     );
   }
@@ -92,9 +93,11 @@ export function resolveRunOptionsFromConfig({
     Boolean(azure?.endpoint) &&
     !browserEngineRequested &&
     allModels.some(isAzureOpenAICandidateModel);
-  const engineCoercedToApi = engineWasBrowser && (isCodex || isClaude || isGrok || azureAutoApi);
+  const grokAutoApi = isGrok && !browserEngineRequested;
+  const engineCoercedToApi =
+    engineWasBrowser && (isCodex || isClaude || grokAutoApi || azureAutoApi);
   const fixedEngine: EngineMode =
-    isCodex || isClaude || isGrok || azureAutoApi || normalizedRequestedModels.length > 0
+    isCodex || isClaude || grokAutoApi || azureAutoApi || normalizedRequestedModels.length > 0
       ? "api"
       : resolvedEngine;
   // Browser runs use ChatGPT picker labels/aliases; API runs must keep API model ids intact.

--- a/src/grok-web/executor.ts
+++ b/src/grok-web/executor.ts
@@ -4,6 +4,7 @@ import { runProviderDomFlow } from "../browser/providerDomFlow.js";
 import { grokDomProvider, GROK_SELECTORS } from "../browser/providers/grokDomProvider.js";
 import type { BrowserLogger, BrowserRunOptions, BrowserRunResult } from "../browser/types.js";
 import { delay } from "../browser/utils.js";
+import path from "node:path";
 
 const GROK_URL = "https://grok.com/";
 
@@ -16,11 +17,6 @@ export function createGrokWebExecutor(): (options: BrowserRunOptions) => Promise
     const startedAt = Date.now();
     const config = options.config;
     const logger: BrowserLogger = options.log ?? (() => {});
-    if ((options.attachments?.length ?? 0) > 0) {
-      throw new Error(
-        "Grok web mode does not support file attachments yet. Remove --file or use the xAI API engine.",
-      );
-    }
     if (!config?.remoteChrome && !config?.attachRunning) {
       throw new Error(
         "Grok web mode currently requires --remote-chrome or --browser-attach-running with a Chrome profile.",
@@ -51,6 +47,7 @@ export function createGrokWebExecutor(): (options: BrowserRunOptions) => Promise
     try {
       await client.Runtime.enable();
       await client.Page.enable();
+      await client.DOM.enable();
       const evaluate = async <T>(expression: string): Promise<T | undefined> => {
         const { result } = await client.Runtime.evaluate({ expression, returnByValue: true });
         if (result?.subtype === "error") {
@@ -65,7 +62,33 @@ export function createGrokWebExecutor(): (options: BrowserRunOptions) => Promise
         );
         return count ?? 0;
       };
-      const runPrompt = async (prompt: string) =>
+      const uploadAttachments = async (attachments: Array<{ path: string; name: string }>) => {
+        const documentNode = await client.DOM.getDocument();
+        const result = await client.DOM.querySelector({
+          nodeId: documentNode.root.nodeId,
+          selector: 'input[type="file"]',
+        });
+        if (!result.nodeId) throw new Error("Unable to locate Grok file upload input.");
+        await client.DOM.setFileInputFiles({
+          nodeId: result.nodeId,
+          files: attachments.map((attachment) => attachment.path),
+        });
+        const names = attachments.map((attachment) => attachment.name.toLowerCase());
+        const deadline = Date.now() + (config.attachmentTimeoutMs ?? 45_000);
+        while (Date.now() < deadline) {
+          const ready = await evaluate<boolean>(`(() => {
+            const text = (document.body?.innerText || '').toLowerCase();
+            const chips = Array.from(document.querySelectorAll('[data-testid*="attachment"], [data-testid*="file"], [aria-label*="Remove"]'))
+              .map((node) => (node.textContent || node.getAttribute('aria-label') || '').toLowerCase())
+              .join(' ');
+            return ${JSON.stringify(names)}.every((name) => text.includes(name) || chips.includes(name));
+          })()`);
+          if (ready) return;
+          await delay(500);
+        }
+        throw new Error(`Timed out waiting for Grok attachments: ${names.join(", ")}`);
+      };
+      const runPrompt = async (prompt: string, includeAttachments: boolean) =>
         runProviderDomFlow(grokDomProvider, {
           prompt,
           evaluate,
@@ -75,13 +98,20 @@ export function createGrokWebExecutor(): (options: BrowserRunOptions) => Promise
             inputTimeoutMs: config.inputTimeoutMs,
             timeoutMs: config.timeoutMs,
             responseCountBeforeSubmit: await responseCount(),
+            attachments: includeAttachments
+              ? (options.attachments ?? []).map((attachment) => ({
+                  path: attachment.path,
+                  name: path.basename(attachment.path),
+                }))
+              : [],
           },
+          uploadAttachments,
         });
 
-      let result = await runPrompt(options.prompt);
+      let result = await runPrompt(options.prompt, true);
       for (const followUp of options.followUpPrompts ?? []) {
         logger("[grok-web] Sending follow-up prompt in the same conversation.");
-        result = await runPrompt(followUp);
+        result = await runPrompt(followUp, false);
       }
 
       const tookMs = Date.now() - startedAt;

--- a/src/grok-web/executor.ts
+++ b/src/grok-web/executor.ts
@@ -1,0 +1,112 @@
+import { closeTab, connectWithNewTab } from "../browser/chromeLifecycle.js";
+import { resolveAttachRunningConnection } from "../browser/attachRunning.js";
+import { runProviderDomFlow } from "../browser/providerDomFlow.js";
+import { grokDomProvider, GROK_SELECTORS } from "../browser/providers/grokDomProvider.js";
+import type { BrowserLogger, BrowserRunOptions, BrowserRunResult } from "../browser/types.js";
+import { delay } from "../browser/utils.js";
+
+const GROK_URL = "https://grok.com/";
+
+function estimateTokenCount(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+export function createGrokWebExecutor(): (options: BrowserRunOptions) => Promise<BrowserRunResult> {
+  return async (options) => {
+    const startedAt = Date.now();
+    const config = options.config;
+    const logger: BrowserLogger = options.log ?? (() => {});
+    if ((options.attachments?.length ?? 0) > 0) {
+      throw new Error(
+        "Grok web mode does not support file attachments yet. Remove --file or use the xAI API engine.",
+      );
+    }
+    if (!config?.remoteChrome && !config?.attachRunning) {
+      throw new Error(
+        "Grok web mode currently requires --remote-chrome or --browser-attach-running with a Chrome profile.",
+      );
+    }
+
+    const attached = config.attachRunning
+      ? await resolveAttachRunningConnection(
+          {
+            chromePath: config.chromePath ?? null,
+            remoteChrome: config.remoteChrome ?? null,
+          },
+          logger,
+        )
+      : null;
+    const remoteChrome = config.remoteChrome ?? attached;
+    if (!remoteChrome) throw new Error("Unable to resolve the attached Chrome endpoint.");
+    const { host, port } = remoteChrome;
+    logger("[grok-web] Opening an isolated Grok tab in the attached Chrome session.");
+    const connection = await connectWithNewTab(port, logger, GROK_URL, host, {
+      fallbackToDefault: false,
+      retries: 2,
+      retryDelayMs: 500,
+    });
+    const { client, targetId } = connection;
+    const keepBrowser = config.keepBrowser ?? true;
+
+    try {
+      await client.Runtime.enable();
+      await client.Page.enable();
+      const evaluate = async <T>(expression: string): Promise<T | undefined> => {
+        const { result } = await client.Runtime.evaluate({ expression, returnByValue: true });
+        if (result?.subtype === "error") {
+          throw new Error(result.description ?? "Grok page evaluation failed.");
+        }
+        return result?.value as T | undefined;
+      };
+      const responseSelector = JSON.stringify(GROK_SELECTORS.response.join(", "));
+      const responseCount = async (): Promise<number> => {
+        const count = await evaluate<number>(
+          `document.querySelectorAll(${responseSelector}).length`,
+        );
+        return count ?? 0;
+      };
+      const runPrompt = async (prompt: string) =>
+        runProviderDomFlow(grokDomProvider, {
+          prompt,
+          evaluate,
+          delay,
+          log: logger,
+          state: {
+            inputTimeoutMs: config.inputTimeoutMs,
+            timeoutMs: config.timeoutMs,
+            responseCountBeforeSubmit: await responseCount(),
+          },
+        });
+
+      let result = await runPrompt(options.prompt);
+      for (const followUp of options.followUpPrompts ?? []) {
+        logger("[grok-web] Sending follow-up prompt in the same conversation.");
+        result = await runPrompt(followUp);
+      }
+
+      const tookMs = Date.now() - startedAt;
+      return {
+        answerText: result.text,
+        answerMarkdown: result.text,
+        answerHtml: result.html,
+        tookMs,
+        answerTokens: estimateTokenCount(result.text),
+        answerChars: result.text.length,
+        browserTransport: "cdp",
+        chromeHost: host,
+        chromePort: port,
+        chromeBrowserWSEndpoint: attached?.browserWSEndpoint,
+        chromeProfileRoot: attached?.profileRoot,
+        chromeTargetId: targetId,
+        tabUrl: GROK_URL,
+        promptSubmitted: true,
+        controllerPid: process.pid,
+      };
+    } finally {
+      await client.close().catch(() => undefined);
+      if (!keepBrowser && targetId) {
+        await closeTab(port, targetId, logger, host).catch(() => undefined);
+      }
+    }
+  };
+}

--- a/src/grok-web/index.ts
+++ b/src/grok-web/index.ts
@@ -1,0 +1,1 @@
+export { createGrokWebExecutor } from "./executor.js";

--- a/tests/cli/browserGuard.pty.test.ts
+++ b/tests/cli/browserGuard.pty.test.ts
@@ -74,7 +74,7 @@ async function runCliPty(
 }
 
 ptyDescribe("oracle CLI browser guard (PTY)", () => {
-  it("fails fast when grok is paired with --engine browser", async () => {
+  it("accepts grok when paired with --engine browser", async () => {
     const { output, code } = await runCliPty([
       "--engine",
       "browser",
@@ -83,8 +83,10 @@ ptyDescribe("oracle CLI browser guard (PTY)", () => {
       "--prompt",
       "TTY guard prompt for grok browser path",
     ]);
+    expect(stripAnsi(output)).not.toMatch(
+      /Browser engine only supports GPT, Gemini, and Grok models/i,
+    );
     expect(code).not.toBe(0);
-    expect(stripAnsi(output)).toMatch(/Browser engine only supports GPT and Gemini models/i);
   }, 30_000);
 
   it("fails fast when multi-model list includes non-GPT under browser engine", async () => {
@@ -97,6 +99,6 @@ ptyDescribe("oracle CLI browser guard (PTY)", () => {
       "TTY guard prompt for mixed models",
     ]);
     expect(code).not.toBe(0);
-    expect(stripAnsi(output)).toMatch(/Browser engine only supports GPT and Gemini models/i);
+    expect(stripAnsi(output)).toMatch(/Browser engine only supports GPT, Gemini, and Grok models/i);
   }, 30_000);
 });

--- a/tests/grok-web/executor.test.ts
+++ b/tests/grok-web/executor.test.ts
@@ -52,6 +52,7 @@ describe("Grok web executor", () => {
     const client = {
       Runtime: { enable: vi.fn(async () => undefined), evaluate },
       Page: { enable: vi.fn(async () => undefined) },
+      DOM: { enable: vi.fn(async () => undefined) },
       close: vi.fn(async () => undefined),
     };
     connectWithNewTab.mockResolvedValue({ client, targetId: "grok-target" });
@@ -101,6 +102,7 @@ describe("Grok web executor", () => {
       client: {
         Runtime: { enable: vi.fn(async () => undefined), evaluate },
         Page: { enable: vi.fn(async () => undefined) },
+        DOM: { enable: vi.fn(async () => undefined) },
         close: vi.fn(async () => undefined),
       },
     });
@@ -116,16 +118,41 @@ describe("Grok web executor", () => {
     expect(closeTab).toHaveBeenCalledWith(9444, "target-2", expect.any(Function), "127.0.0.1");
   });
 
-  it("rejects attachments instead of silently dropping them", async () => {
+  it("uploads attachments through the Grok file input before submitting", async () => {
+    const setFileInputFiles = vi.fn(async () => undefined);
+    const evaluate = vi.fn(async ({ expression }: { expression: string }) => {
+      if (expression.includes("blocked:")) return { result: { value: { ready: true } } };
+      if (expression.includes("chips =")) return { result: { value: true } };
+      if (expression.includes("HTMLTextAreaElement.prototype"))
+        return { result: { value: "typed" } };
+      if (expression.includes("button.disabled")) return { result: { value: "clicked" } };
+      if (expression.includes("const turns =")) {
+        return { result: { value: JSON.stringify({ status: "idle", text: "file answer" }) } };
+      }
+      return { result: { value: 0 } };
+    });
+    connectWithNewTab.mockResolvedValue({
+      targetId: "target-upload",
+      client: {
+        Runtime: { enable: vi.fn(async () => undefined), evaluate },
+        Page: { enable: vi.fn(async () => undefined) },
+        DOM: {
+          enable: vi.fn(async () => undefined),
+          getDocument: vi.fn(async () => ({ root: { nodeId: 1 } })),
+          querySelector: vi.fn(async () => ({ nodeId: 7 })),
+          setFileInputFiles,
+        },
+        close: vi.fn(async () => undefined),
+      },
+    });
     const { createGrokWebExecutor } = await import("../../src/grok-web/executor.js");
-    await expect(
-      createGrokWebExecutor()({
-        prompt: "Review this file",
-        attachments: [{ path: "/tmp/a.txt", displayPath: "a.txt" }],
-        config: { remoteChrome: { host: "127.0.0.1", port: 9333 } },
-      }),
-    ).rejects.toThrow(/does not support file attachments/);
-    expect(connectWithNewTab).not.toHaveBeenCalled();
+    const result = await createGrokWebExecutor()({
+      prompt: "Review this file",
+      attachments: [{ path: "/tmp/a.txt", displayPath: "a.txt" }],
+      config: { remoteChrome: { host: "127.0.0.1", port: 9333 } },
+    });
+    expect(setFileInputFiles).toHaveBeenCalledWith({ nodeId: 7, files: ["/tmp/a.txt"] });
+    expect(result.answerText).toBe("file answer");
   });
 
   it("reports the anonymous Grok sign-up wall immediately", async () => {
@@ -144,6 +171,7 @@ describe("Grok web executor", () => {
       client: {
         Runtime: { enable: vi.fn(async () => undefined), evaluate },
         Page: { enable: vi.fn(async () => undefined) },
+        DOM: { enable: vi.fn(async () => undefined) },
         close: vi.fn(async () => undefined),
       },
     });

--- a/tests/grok-web/executor.test.ts
+++ b/tests/grok-web/executor.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { closeTab, connectWithNewTab, resolveAttachRunningConnection, delay } = vi.hoisted(() => ({
+  closeTab: vi.fn(async () => true),
+  connectWithNewTab: vi.fn(),
+  resolveAttachRunningConnection: vi.fn(),
+  delay: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../src/browser/chromeLifecycle.js", () => ({ closeTab, connectWithNewTab }));
+vi.mock("../../src/browser/attachRunning.js", () => ({ resolveAttachRunningConnection }));
+vi.mock("../../src/browser/utils.js", () => ({ delay }));
+
+describe("Grok web executor", () => {
+  beforeEach(() => {
+    closeTab.mockClear();
+    connectWithNewTab.mockReset();
+    resolveAttachRunningConnection.mockReset();
+    delay.mockClear();
+  });
+
+  it("submits a text prompt and returns a stable Grok response", async () => {
+    let responsePoll = 0;
+    const evaluate = vi.fn(async ({ expression }: { expression: string }) => {
+      if (
+        expression.includes("querySelectorAll") &&
+        expression.includes("assistant-message") &&
+        !expression.includes("turns =")
+      ) {
+        return { result: { value: 0 } };
+      }
+      if (expression.includes("blocked:")) {
+        return { result: { value: { ready: true, blocked: false } } };
+      }
+      if (expression.includes("HTMLTextAreaElement.prototype")) {
+        return { result: { value: "typed" } };
+      }
+      if (expression.includes("button.disabled")) {
+        return { result: { value: "clicked" } };
+      }
+      if (expression.includes("const turns =")) {
+        responsePoll += 1;
+        const status = responsePoll === 1 ? "streaming" : "idle";
+        return {
+          result: {
+            value: JSON.stringify({ status, text: "Grok answer", html: "<p>Grok answer</p>" }),
+          },
+        };
+      }
+      return { result: { value: null } };
+    });
+    const client = {
+      Runtime: { enable: vi.fn(async () => undefined), evaluate },
+      Page: { enable: vi.fn(async () => undefined) },
+      close: vi.fn(async () => undefined),
+    };
+    connectWithNewTab.mockResolvedValue({ client, targetId: "grok-target" });
+
+    const { createGrokWebExecutor } = await import("../../src/grok-web/executor.js");
+    const result = await createGrokWebExecutor()({
+      prompt: "Test prompt",
+      config: { remoteChrome: { host: "127.0.0.1", port: 9333 }, keepBrowser: true },
+      log: () => {},
+    });
+
+    expect(connectWithNewTab).toHaveBeenCalledWith(
+      9333,
+      expect.any(Function),
+      "https://grok.com/",
+      "127.0.0.1",
+      expect.objectContaining({ fallbackToDefault: false }),
+    );
+    expect(result.answerText).toBe("Grok answer");
+    expect(result.answerHtml).toBe("<p>Grok answer</p>");
+    expect(result.chromeTargetId).toBe("grok-target");
+    expect(result.promptSubmitted).toBe(true);
+    expect(closeTab).not.toHaveBeenCalled();
+  });
+
+  it("resolves --browser-attach-running and closes the isolated tab when requested", async () => {
+    resolveAttachRunningConnection.mockResolvedValue({
+      host: "127.0.0.1",
+      port: 9444,
+      browserWSEndpoint: "ws://browser",
+      profileRoot: "/tmp/profile",
+    });
+    let stablePolls = 0;
+    const evaluate = vi.fn(async ({ expression }: { expression: string }) => {
+      if (expression.includes("blocked:")) return { result: { value: { ready: true } } };
+      if (expression.includes("HTMLTextAreaElement.prototype"))
+        return { result: { value: "typed" } };
+      if (expression.includes("button.disabled")) return { result: { value: "clicked" } };
+      if (expression.includes("const turns =")) {
+        stablePolls += 1;
+        return { result: { value: JSON.stringify({ status: "idle", text: "done" }) } };
+      }
+      return { result: { value: 0 } };
+    });
+    connectWithNewTab.mockResolvedValue({
+      targetId: "target-2",
+      client: {
+        Runtime: { enable: vi.fn(async () => undefined), evaluate },
+        Page: { enable: vi.fn(async () => undefined) },
+        close: vi.fn(async () => undefined),
+      },
+    });
+
+    const { createGrokWebExecutor } = await import("../../src/grok-web/executor.js");
+    const result = await createGrokWebExecutor()({
+      prompt: "Test prompt",
+      config: { attachRunning: true, keepBrowser: false },
+    });
+
+    expect(stablePolls).toBeGreaterThanOrEqual(2);
+    expect(result.chromeBrowserWSEndpoint).toBe("ws://browser");
+    expect(closeTab).toHaveBeenCalledWith(9444, "target-2", expect.any(Function), "127.0.0.1");
+  });
+
+  it("rejects attachments instead of silently dropping them", async () => {
+    const { createGrokWebExecutor } = await import("../../src/grok-web/executor.js");
+    await expect(
+      createGrokWebExecutor()({
+        prompt: "Review this file",
+        attachments: [{ path: "/tmp/a.txt", displayPath: "a.txt" }],
+        config: { remoteChrome: { host: "127.0.0.1", port: 9333 } },
+      }),
+    ).rejects.toThrow(/does not support file attachments/);
+    expect(connectWithNewTab).not.toHaveBeenCalled();
+  });
+
+  it("reports the anonymous Grok sign-up wall immediately", async () => {
+    const evaluate = vi.fn(async ({ expression }: { expression: string }) => {
+      if (expression.includes("blocked:")) return { result: { value: { ready: true } } };
+      if (expression.includes("HTMLTextAreaElement.prototype"))
+        return { result: { value: "typed" } };
+      if (expression.includes("button.disabled")) return { result: { value: "clicked" } };
+      if (expression.includes("const turns =")) {
+        return { result: { value: JSON.stringify({ status: "login-required" }) } };
+      }
+      return { result: { value: 0 } };
+    });
+    connectWithNewTab.mockResolvedValue({
+      targetId: "target-login",
+      client: {
+        Runtime: { enable: vi.fn(async () => undefined), evaluate },
+        Page: { enable: vi.fn(async () => undefined) },
+        close: vi.fn(async () => undefined),
+      },
+    });
+
+    const { createGrokWebExecutor } = await import("../../src/grok-web/executor.js");
+    await expect(
+      createGrokWebExecutor()({
+        prompt: "Test prompt",
+        config: { remoteChrome: { host: "127.0.0.1", port: 9333 } },
+      }),
+    ).rejects.toThrow(/requires sign-in/);
+  });
+});

--- a/tests/runOptions.test.ts
+++ b/tests/runOptions.test.ts
@@ -499,7 +499,7 @@ describe("resolveRunOptionsFromConfig", () => {
         userConfig: { engine: "browser" },
         env: {},
       }),
-    ).toThrow(/Browser engine only supports GPT and Gemini/);
+    ).toThrow(/Browser engine only supports GPT, Gemini, and Grok/);
   });
 
   it("normalizes shorthand multi-model entries", () => {
@@ -512,14 +512,15 @@ describe("resolveRunOptionsFromConfig", () => {
     expect(runOptions.models).toEqual(["gpt-5.1", "gemini-3-pro", "claude-4.6-sonnet"]);
   });
 
-  it("rejects browser engine for grok when explicitly set", () => {
-    expect(() =>
-      resolveRunOptionsFromConfig({
-        prompt: basePrompt,
-        model: "grok",
-        engine: "browser",
-      }),
-    ).toThrow(/Browser engine only supports GPT and Gemini/);
+  it("keeps grok in browser mode when explicitly requested", () => {
+    const { runOptions, resolvedEngine, engineCoercedToApi } = resolveRunOptionsFromConfig({
+      prompt: basePrompt,
+      model: "grok",
+      engine: "browser",
+    });
+    expect(runOptions.model).toBe("grok-4.1");
+    expect(resolvedEngine).toBe("browser");
+    expect(engineCoercedToApi).toBe(false);
   });
 
   it("forces api engine for grok when auto-selected browser and applies XAI base url", () => {


### PR DESCRIPTION
## Summary

- add a dedicated Grok DOM browser executor for attached Chrome sessions at `grok.com`
- support text prompts and same-conversation browser follow-ups while failing closed for unsupported attachments and remote-host runs
- preserve existing xAI API auto-routing unless browser mode is explicitly requested
- detect Cloudflare verification and anonymous sign-up walls with actionable errors

User impact: xAI subscribers can use their existing Grok web login with Oracle browser mode instead of requiring an API key. The executor always opens an isolated Grok tab, so unrelated active browser tabs are not modified.

## Test Plan

- `pnpm format:check`
- `pnpm lint`
- `pnpm test` (1705 passed, 43 skipped)
- `pnpm build`
- real Chrome/CDP smoke against `https://grok.com` via `--remote-chrome 127.0.0.1:53388`: verified isolated-tab creation, current Tiptap prompt entry, submission, and immediate anonymous sign-up-wall detection

The available Chrome profile was not signed into Grok, so authenticated assistant-response extraction could not be exercised live in this environment. Unit coverage exercises streaming-to-stable response extraction and follow-up behavior.

## Risk / Rollback

Risk is isolated to explicit `--engine browser --model grok` runs. Grok DOM changes could require selector updates; explicit login/challenge/timeout errors avoid silently returning incorrect content. Attachments and `--remote-host` fail closed until those paths have dedicated implementations.

Rollback: revert commit `26afeb2b` or continue using `--engine api --model grok`.