### PR TITLE
browser: honor explicit --browser-headless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Browser: recognize the Japanese `詳細設定` → `推論レベル` controls in ChatGPT's unified Intelligence picker, allowing explicit Pro effort selection without weakening the fail-closed guard for unknown languages.
+- Browser: honor explicit `--browser-headless` for locally launched Chrome/Chromium binaries while preserving the headful default and rejecting the launch-only flag in attach-running mode.
 
 ## 0.17.2 — 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - Browser: recognize the Japanese `詳細設定` → `推論レベル` controls in ChatGPT's unified Intelligence picker, allowing explicit Pro effort selection without weakening the fail-closed guard for unknown languages.
-- Browser: honor explicit `--browser-headless` for locally launched Chrome/Chromium binaries while preserving the headful default and rejecting the launch-only flag in attach-running mode.
+- Browser: honor explicit `--browser-headless` for locally launched Chrome/Chromium binaries while preserving the headful default. Explicit `--browser-headless` still conflicts with `--browser-attach-running`; a saved `browser.headless` preference is ignored in attach-running mode.
 
 ## 0.17.2 — 2026-08-10
 

--- a/docs/chromium-forks.md
+++ b/docs/chromium-forks.md
@@ -27,7 +27,7 @@ oracle --engine browser \
   --prompt "Summarize the release notes"
 ```
 
-Headless mode is opt-in; Oracle remains headful by default because some sites reject stock headless Chrome. The selected Chromium binary must provide any compatibility those sites require. Headless is a launch-only option, so it cannot be combined with `--browser-attach-running` and is ignored by standalone `--remote-chrome`.
+Headless mode is opt-in; Oracle remains headful by default because some sites reject stock headless Chrome. The selected Chromium binary must provide any compatibility those sites require. Headless is a launch-only option: an explicit `--browser-headless` flag cannot be combined with `--browser-attach-running`, a saved `browser.headless` preference is ignored in attach-running mode (matching other launch-only defaults), and standalone `--remote-chrome` continues to warn and ignore headless.
 
 ## 2. Tell cookie sync where your session lives
 

--- a/docs/chromium-forks.md
+++ b/docs/chromium-forks.md
@@ -18,6 +18,17 @@ Either pass the CLI flag or set it once in `~/.oracle/config.json`:
 
 `--browser-chrome-path` (also exposed in `oracle --debug-help`) controls which binary `chrome-launcher` starts. You can still keep `chromeProfile: "Default"` if you want to copy cookies from Chrome proper while launching Edge/Chromium.
 
+To launch the selected binary headlessly, add `--browser-headless` or set `browser.headless: true`:
+
+```bash
+oracle --engine browser \
+  --browser-chrome-path "/path/to/chromium" \
+  --browser-headless \
+  --prompt "Summarize the release notes"
+```
+
+Headless mode is opt-in; Oracle remains headful by default because some sites reject stock headless Chrome. The selected Chromium binary must provide any compatibility those sites require. Headless is a launch-only option, so it cannot be combined with `--browser-attach-running` and is ignored by standalone `--remote-chrome`.
+
 ## 2. Tell cookie sync where your session lives
 
 Set the new `--browser-cookie-path` flag (or `browser.chromeCookiePath` in config) to the absolute path of the fork’s `Cookies` SQLite database. When present, Oracle feeds this path straight into the internal cookie reader, skipping Chrome-only heuristics and profile-name guesses.

--- a/src/cli/browserConfig.ts
+++ b/src/cli/browserConfig.ts
@@ -273,7 +273,7 @@ export async function buildBrowserConfig(
     cookieNames,
     inlineCookies: inline?.cookies,
     inlineCookiesSource: inline?.source ?? null,
-    headless: undefined, // disable headless; Cloudflare blocks it
+    headless: options.browserHeadless === true ? true : undefined,
     keepBrowser: options.browserKeepBrowser ? true : undefined,
     manualLogin: options.browserManualLogin === undefined ? undefined : options.browserManualLogin,
     manualLoginProfileDir: options.browserManualLoginProfileDir ?? undefined,
@@ -324,6 +324,7 @@ function validateAttachRunningOptions(
     options.browserChromeProfile ? "--browser-chrome-profile" : null,
     options.browserCookiePath ? "--browser-cookie-path" : null,
     options.browserNoCookieSync ? "--browser-no-cookie-sync" : null,
+    options.browserHeadless ? "--browser-headless" : null,
     options.browserHideWindow ? "--browser-hide-window" : null,
     options.browserKeepBrowser ? "--browser-keep-browser" : null,
     options.browserManualLogin ? "--browser-manual-login" : null,

--- a/src/cli/browserDefaults.ts
+++ b/src/cli/browserDefaults.ts
@@ -131,7 +131,7 @@ export function applyBrowserDefaultsFromConfig(
   if (isUnset("browserCookieWait") && typeof browser.cookieSyncWaitMs === "number") {
     options.browserCookieWait = String(browser.cookieSyncWaitMs);
   }
-  if (isUnset("browserHeadless") && browser.headless !== undefined) {
+  if (!attachRunningRequested && isUnset("browserHeadless") && browser.headless !== undefined) {
     options.browserHeadless = browser.headless;
   }
   if (!attachRunningRequested && isUnset("browserHideWindow") && browser.hideWindow !== undefined) {

--- a/tests/browser/chromeLifecycle.test.ts
+++ b/tests/browser/chromeLifecycle.test.ts
@@ -135,12 +135,12 @@ describe("hidden-window launch flags", () => {
     }
   });
 
-  test("does not add a window position to headless Chrome", async () => {
+  test("adds the headless launch flag without an off-screen window position", async () => {
     const { buildChromeFlagsForTest } = await import("../../src/browser/chromeLifecycle.js");
+    const flags = buildChromeFlagsForTest(true, undefined, true);
 
-    expect(buildChromeFlagsForTest(true, undefined, true)).not.toContain(
-      "--window-position=-32000,-32000",
-    );
+    expect(flags).toContain("--headless=new");
+    expect(flags).not.toContain("--window-position=-32000,-32000");
   });
 
   test("adds no-sandbox flags only when ORACLE_CHROME_NO_SANDBOX=1", async () => {

--- a/tests/browser/index.test.ts
+++ b/tests/browser/index.test.ts
@@ -628,6 +628,15 @@ describe("remote Chrome option warnings", () => {
       }),
     ).toContain("--browser-chrome-path");
   });
+
+  test("marks browser-headless as ignored for classic remote-chrome", () => {
+    expect(
+      __test__.listIgnoredRemoteChromeFlags({
+        attachRunning: false,
+        headless: true,
+      }),
+    ).toContain("--browser-headless");
+  });
 });
 
 describe("remote Chrome cleanup", () => {

--- a/tests/cli/browserConfig.test.ts
+++ b/tests/cli/browserConfig.test.ts
@@ -24,6 +24,15 @@ describe("buildBrowserConfig", () => {
     });
   });
 
+  test("honors explicit headless while keeping explicit false headful", async () => {
+    await expect(
+      buildBrowserConfig({ model: "gpt-5.5-pro", browserHeadless: true }),
+    ).resolves.toMatchObject({ headless: true });
+    await expect(
+      buildBrowserConfig({ model: "gpt-5.5-pro", browserHeadless: false }),
+    ).resolves.toMatchObject({ headless: undefined });
+  });
+
   test("maps gpt-5.4 browser runs to Thinking 5.4", async () => {
     const config = await buildBrowserConfig({ model: "gpt-5.4" });
     expect(config.desiredModel).toBe("Thinking 5.4");
@@ -195,7 +204,7 @@ describe("buildBrowserConfig", () => {
       maxConcurrentTabs: 5,
       cookieSyncWaitMs: 4_000,
       cookieSync: false,
-      headless: undefined,
+      headless: true,
       hideWindow: true,
       keepBrowser: true,
       desiredModel: "Thinking 5.4",
@@ -381,6 +390,16 @@ describe("buildBrowserConfig", () => {
         browserManualLogin: true,
       }),
     ).rejects.toThrow(/attach-running/i);
+  });
+
+  test("rejects headless when attach-running is enabled", async () => {
+    await expect(
+      buildBrowserConfig({
+        model: "gpt-5.2-pro",
+        browserAttachRunning: true,
+        browserHeadless: true,
+      }),
+    ).rejects.toThrow(/browser-attach-running cannot be combined with --browser-headless/);
   });
 
   test("rejects browser-chrome-profile when attach-running is enabled", async () => {

--- a/tests/cli/browserDefaults.test.ts
+++ b/tests/cli/browserDefaults.test.ts
@@ -253,6 +253,7 @@ describe("applyBrowserDefaultsFromConfig", () => {
         attachRunning: false,
         debugPort: 9222,
         timeoutMs: 120_000,
+        headless: true,
         hideWindow: true,
         keepBrowser: true,
         manualLogin: true,
@@ -269,12 +270,30 @@ describe("applyBrowserDefaultsFromConfig", () => {
     expect(options.browserChromeProfile).toBeUndefined();
     expect(options.browserCookiePath).toBeUndefined();
     expect(options.browserPort).toBeUndefined();
+    expect(options.browserHeadless).toBeUndefined();
     expect(options.browserHideWindow).toBeUndefined();
     expect(options.browserKeepBrowser).toBeUndefined();
     expect(options.browserManualLogin).toBeUndefined();
     expect(options.browserManualLoginProfileDir).toBeUndefined();
     expect(options.browserTimeout).toBe("120000");
     expect(options.browserThinkingTime).toBe("extended");
+  });
+
+  test("saved attach-running also skips a saved headless preference", () => {
+    const options: BrowserDefaultsOptions = {};
+    const config: UserConfig = {
+      browser: {
+        attachRunning: true,
+        headless: true,
+        hideWindow: true,
+      },
+    };
+
+    applyBrowserDefaultsFromConfig(options, config, (_key) => "default");
+
+    expect(options.browserAttachRunning).toBe(true);
+    expect(options.browserHeadless).toBeUndefined();
+    expect(options.browserHideWindow).toBeUndefined();
   });
 
   test("does not override manual-login when CLI enabled it", () => {


### PR DESCRIPTION
## Summary

- honor the existing explicit `--browser-headless` option for locally launched Chrome/Chromium binaries
- preserve the current headful default
- reject an explicit `--browser-headless` plus `--browser-attach-running` combination, where Oracle does not launch the browser
- ignore a saved `browser.headless` preference in attach-running mode, matching the other launch-only defaults
- document generic custom-Chromium usage and retain the existing warning for standalone `--remote-chrome`

Oracle already supports selecting a Chromium executable with `--browser-chrome-path`, and the launcher already maps `config.headless` to `--headless=new`. `buildBrowserConfig()` previously discarded the explicit option by always returning `headless: undefined`; this change connects those existing seams without adding browser-specific detection, arbitrary launch flags, or dependencies.

Some sites reject stock headless Chrome. Headless therefore remains opt-in, and users selecting it are responsible for choosing a compatible Chromium binary.

## Compatibility

`applyBrowserDefaultsFromConfig()` now skips saved `browser.headless` when attach-running is selected, the same way it already skips `hideWindow`, `keepBrowser`, profile, cookie path, debug port, and manual-login defaults.

- saved `browser.headless: true` + `--browser-attach-running` → attach succeeds, `headless` stays unset
- saved `browser.attachRunning: true` + saved `browser.headless: true` → attach succeeds, `headless` stays unset
- explicit `--browser-headless --browser-attach-running` → still rejected

## Verification

- `pnpm vitest run tests/cli/browserDefaults.test.ts tests/cli/browserConfig.test.ts tests/browser/chromeLifecycle.test.ts tests/browser/index.test.ts` (167 tests)
- `pnpm run build`
- `pnpm run check`
- `pnpm run docs:check`

Config-path proof after the attach-running repair:

```text
saved-headless + CLI --browser-attach-running { attachRunning: true, headless: undefined, chromeProfile: 'Default' }
saved attachRunning + saved headless { attachRunning: true, headless: undefined }
explicit CLI --browser-headless + --browser-attach-running --browser-attach-running cannot be combined with --browser-headless because attach mode reuses an already-running browser instead of launching and configuring its own Chrome instance.
```

## Real behavior proof

Manual after-fix browser smoke with a user-selected Chromium binary via `--browser-chrome-path` (paths and conversation identifiers redacted):

```bash
oracle --engine browser \
  --browser-chrome-path /path/to/chromium \
  --browser-headless \
  --browser-timeout 180s \
  --model gpt-5.6-sol \
  --prompt "Reply with exactly: ORACLE_HEADLESS_SMOKE_OK"
```

```text
Session: reply-with-exactly-oracle-headless-4
Mode: browser foreground
Launching browser mode (target=GPT-5.6 Sol; requested=gpt-5.6-sol) with ~18 tokens.
[browser] Browser control: launch headless Chrome; does not use a visible local browser window.
[browser] Browser guidance: Headless mode avoids visible UI but may be blocked by ChatGPT or Cloudflare.
[browser] Archived ChatGPT conversation after saving local artifacts.
[browser] Model selection evidence: requestedKey=gpt-5.6-sol; target=GPT-5.6 Sol; resolvedLabel=GPT-5.6 Sol; status=already-selected; strategy=select; verified=yes; source=chatgpt-model-picker; capturedAt=2026-08-13T02:25:28.278Z
Answer:
ORACLE_HEADLESS_SMOKE_OK

27.6s · GPT-5.6 Sol[browser] · ↑18 ↓6 ↻0 Δ24
```

Redacted session metadata:

```json
{
  "status": "completed",
  "mode": "browser",
  "browser": {
    "config": {
      "chromePath": "/path/to/chromium",
      "attachRunning": false,
      "headless": true,
      "desiredModel": "GPT-5.6 Sol",
      "modelStrategy": "select"
    },
    "runtime": {
      "promptSubmitted": true
    },
    "modelSelection": {
      "requestedModel": "GPT-5.6 Sol",
      "resolvedLabel": "GPT-5.6 Sol",
      "status": "already-selected",
      "verified": true,
      "source": "chatgpt-model-picker"
    },
    "warnings": []
  },
  "startedAt": "2026-08-13T02:25:22.127Z",
  "completedAt": "2026-08-13T02:25:52.619Z",
  "elapsedMs": 27629,
  "usage": { "inputTokens": 18, "outputTokens": 6, "reasoningTokens": 0, "totalTokens": 24 }
}
```

Redacted transcript:

```md
## Prompt

Reply with exactly: ORACLE_HEADLESS_SMOKE_OK

## Answer

ORACLE_HEADLESS_SMOKE_OK
```

The launched Chrome PID was gone after process exit.
