### PR TITLE
browser: bound Pro answer-now placeholder detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Browser: recognize the Japanese `詳細設定` → `推論レベル` controls in ChatGPT's unified Intelligence picker, allowing explicit Pro effort selection without weakening the fail-closed guard for unknown languages.
+- Browser: treat the skip-ahead control labels as placeholder signals only when the entire turn text is short chrome text, so substantial assistant answers that mention those labels are no longer discarded.
 
 ## 0.17.2 — 2026-08-10
 

--- a/src/browser/actions/assistantResponse.ts
+++ b/src/browser/actions/assistantResponse.ts
@@ -138,21 +138,70 @@ function matchesThinkingStatusLabel(trimmed: string): boolean {
   return trimmed.startsWith("pro thinking") && trimmed.length <= 40;
 }
 
-export function isAnswerNowPlaceholderText(value: string): boolean {
-  const text = value.toLowerCase().replace(/\s+/g, " ").trim();
-  if (!text) return false;
-  // Learned: "Pro thinking" shows a placeholder turn that contains "Answer now".
-  // That is not the final answer and must be ignored in browser automation.
-  if (text === "chatgpt said:" || text === "chatgpt said") return true;
-  if (
-    text.includes("file upload request") &&
-    (text.includes("pro thinking") || text.includes("chatgpt said"))
-  ) {
-    return true;
+// Single source of truth for the "Answer now" placeholder test.
+//
+// This function is ALSO injected verbatim into page expressions via
+// buildAnswerNowPlaceholderPredicateJs (it is stringified with
+// Function.prototype.toString), so it MUST stay closure-free: no imports, no module
+// constants, no helpers. Anything it references must be declared inside its own body
+// or it will throw a ReferenceError inside the renderer.
+//
+// Learned the hard way: ChatGPT's Pro UI keeps the "Answer now" skip-ahead control
+// mounted for the whole reasoning phase, so a bare `text.includes('answer now')` test
+// matched real answers that merely ended with that chrome and discarded them wholesale
+// at every extraction layer. A placeholder is short UI furniture, so this matches the
+// WHOLE trimmed string against known chrome labels behind a length cap, the way the
+// sibling predicates in this file already do.
+//
+// The cap is 60, taken from isActiveLabel in ./thinkingStatus.ts rather than the 40 used
+// by matchesThinkingStatusLabel above: 40 bounds a single status label, while the longest
+// genuine placeholder here is the composite
+// "chatgpt said: file upload request pro thinking answer now" (57 chars), which a 40 cap
+// would wrongly let through.
+export function isAnswerNowPlaceholderText(value: unknown): boolean {
+  let raw = "";
+  if (typeof value === "string") {
+    raw = value;
+  } else if (value && typeof value === "object" && "text" in value) {
+    const candidate = (value as { text?: unknown }).text;
+    if (typeof candidate === "string") raw = candidate;
   }
-  return (
-    text.includes("answer now") && (text.includes("pro thinking") || text.includes("chatgpt said"))
-  );
+  const text = raw.toLowerCase().replace(/\s+/g, " ").trim();
+  if (!text) return false;
+  if (text === "chatgpt said:" || text === "chatgpt said") return true;
+  if (text.length > 60) return false;
+  // Whole-string match: consume the text left to right, longest chrome label first.
+  // Any residue means real content is present, so this is an answer, not a placeholder.
+  const chromeLabels = [
+    "chatgpt said:",
+    "chatgpt said",
+    "file upload request",
+    "pro thinking",
+    "answer now",
+  ];
+  let rest = text;
+  let sawOwner = false; // "pro thinking" / "chatgpt said"
+  let sawGate = false; // "answer now" / "file upload request"
+  while (rest.length > 0) {
+    let matched = "";
+    for (const label of chromeLabels) {
+      if (label.length > matched.length && rest.startsWith(label)) matched = label;
+    }
+    if (!matched) return false;
+    if (matched === "answer now" || matched === "file upload request") sawGate = true;
+    else sawOwner = true;
+    rest = rest.slice(matched.length).replace(/^[\s:.,;|\u00b7\u2022-]+/, "");
+  }
+  return sawGate && sawOwner;
+}
+
+// Exported: the two page expressions below and the tests all consume this one builder,
+// so the predicate cannot drift between the node side and the renderer.
+export function buildAnswerNowPlaceholderPredicateJs(fnName: string): string {
+  // Inject the node-side definition itself so a correction can never land in only one
+  // copy. `const x = function name(){}` is a valid expression, so the exported
+  // declaration stringifies straight into the page expression.
+  return `const ${fnName} = ${isAnswerNowPlaceholderText.toString()};`;
 }
 
 function buildActiveThinkingStatusPredicateJs(fnName: string): string {
@@ -421,6 +470,13 @@ export function buildAssistantSnapshotExpressionForTest(
   expectedConversationId?: string,
 ): string {
   return buildAssistantSnapshotExpression(minTurnIndex, expectedConversationId);
+}
+export function buildResponseObserverExpressionForTest(
+  timeoutMs: number,
+  minTurnIndex?: number,
+  expectedConversationId?: string,
+): string {
+  return buildResponseObserverExpression(timeoutMs, minTurnIndex, expectedConversationId);
 }
 
 export function buildConversationDebugExpressionForTest(): string {
@@ -879,14 +935,7 @@ function buildAssistantSnapshotExpression(
     // Learned: the default turn DOM misses project view; keep a fallback extractor.
     ${buildAssistantExtractor("extractAssistantTurn")}
     const extracted = extractAssistantTurn();
-    const isPlaceholder = (snapshot) => {
-      const normalized = String(snapshot?.text ?? '').toLowerCase().trim();
-      if (normalized === 'chatgpt said:' || normalized === 'chatgpt said') return true;
-      if (normalized.includes('file upload request') && (normalized.includes('pro thinking') || normalized.includes('chatgpt said'))) {
-        return true;
-      }
-      return normalized.includes('answer now') && (normalized.includes('pro thinking') || normalized.includes('chatgpt said'));
-    };
+    ${buildAnswerNowPlaceholderPredicateJs("isPlaceholder")}
     ${buildActiveThinkingStatusPredicateJs("isActiveThinkingStatus")}
     if (
       extracted &&
@@ -939,14 +988,7 @@ function buildResponseObserverExpression(
       const currentId = currentConversationId();
       return !currentId || currentId === EXPECTED_CONVERSATION_ID;
     };
-    const isAnswerNowPlaceholder = (snapshot) => {
-      const normalized = String(snapshot?.text ?? '').toLowerCase().trim();
-      if (normalized === 'chatgpt said:' || normalized === 'chatgpt said') return true;
-      if (normalized.includes('file upload request') && (normalized.includes('pro thinking') || normalized.includes('chatgpt said'))) {
-        return true;
-      }
-      return normalized.includes('answer now') && (normalized.includes('pro thinking') || normalized.includes('chatgpt said'));
-    };
+    ${buildAnswerNowPlaceholderPredicateJs("isAnswerNowPlaceholder")}
     ${buildActiveThinkingStatusPredicateJs("isActiveThinkingStatus")}
     ${buildThinkingActivePredicateJs("isThinkingActiveNow")}
 

--- a/tests/browser/assistantResponseStatus.test.ts
+++ b/tests/browser/assistantResponseStatus.test.ts
@@ -2,13 +2,16 @@ import { createContext, Script } from "node:vm";
 import { describe, expect, test } from "vitest";
 import {
   buildActiveThinkingStatusPredicateJsForTest,
+  buildAnswerNowPlaceholderPredicateJs,
   buildAssistantSnapshotExpressionForTest,
   buildCompletionVisibilityExpressionForTest,
   buildMarkdownFallbackExtractorForTest,
+  buildResponseObserverExpressionForTest,
   buildStopButtonVisibilityExpressionForTest,
   classifyTurnTerminal,
   createTerminalGateState,
   hasScopedCompletionProof,
+  isAnswerNowPlaceholderText,
   matchesThinkingStatusLabelForTest,
   type TerminalGateConfig,
   type TerminalSample,
@@ -689,5 +692,89 @@ describe("thinking-active completion veto", () => {
 
   test("does NOT fire on an idle DOM (finished, no controls)", () => {
     expect(evalThinkingActive({})).toBe(false);
+  });
+});
+
+// Regression: ChatGPT's Pro UI keeps the "Answer now" skip-ahead control mounted for the
+// whole reasoning phase, so a substring test for "answer now" + "pro thinking" discarded
+// every in-progress Pro turn that had real content, at every extraction layer.
+describe("answer-now placeholder detection", () => {
+  const LONG_ANSWER_WITH_TRAILING_CHROME = [
+    "Searched the repository for the failing predicate",
+    "Read src/browser/actions/assistantResponse.ts",
+    "Ran the assistant-response test file",
+    "",
+    "I reviewed the capture pipeline and found three problems worth fixing before the next",
+    "long-running Pro submission. The placeholder gate is the most serious of them, because",
+    "it silently throws away captured text instead of failing loudly.",
+    "",
+    "1. The placeholder predicate matches by substring anywhere in the turn.",
+    "2. The same predicate is copied verbatim into two generated page expressions.",
+    "3. The interrupted-stream notice is invisible to the warning classifier.",
+    "",
+    "Pro thinking",
+    "Answer now",
+  ].join("\n");
+
+  const GENUINE_PLACEHOLDERS = [
+    "ChatGPT said:",
+    "ChatGPT said",
+    "Pro thinking Answer now",
+    "ChatGPT said: Answer now",
+    "ChatGPT said: Pro thinking Answer now",
+    "ChatGPT said: File upload request Pro thinking Answer now",
+  ];
+
+  test("the long answer is long enough to defeat a naive substring test", () => {
+    expect(LONG_ANSWER_WITH_TRAILING_CHROME.length).toBeGreaterThan(600);
+    expect(LONG_ANSWER_WITH_TRAILING_CHROME.toLowerCase()).toContain("pro thinking");
+    expect(LONG_ANSWER_WITH_TRAILING_CHROME.toLowerCase()).toContain("answer now");
+  });
+
+  test("node-side predicate keeps a long answer that merely ends with skip-ahead chrome", () => {
+    expect(isAnswerNowPlaceholderText(LONG_ANSWER_WITH_TRAILING_CHROME)).toBe(false);
+  });
+
+  test.each(GENUINE_PLACEHOLDERS)("node-side predicate still discards %s", (text) => {
+    expect(isAnswerNowPlaceholderText(text)).toBe(true);
+  });
+
+  test("the longest genuine placeholder sits under the 60-character cap", () => {
+    const longest = "chatgpt said: file upload request pro thinking answer now";
+    expect(longest.length).toBeGreaterThan(40);
+    expect(longest.length).toBeLessThanOrEqual(60);
+  });
+
+  test("short text that is chrome plus real content is not a placeholder", () => {
+    expect(isAnswerNowPlaceholderText("Pro thinking Answer now: use a mutex")).toBe(false);
+  });
+
+  describe("in-page copies", () => {
+    const predicateSource = buildAnswerNowPlaceholderPredicateJs("isPlaceholder");
+
+    const runInPage = (text: string): boolean =>
+      new Script(
+        `${predicateSource}\nisPlaceholder({ text: ${JSON.stringify(text)} });`,
+      ).runInContext(createContext({ String })) as boolean;
+
+    test("the snapshot extractor embeds the shared predicate, not a private copy", () => {
+      const expression = buildAssistantSnapshotExpressionForTest();
+      expect(expression).toContain(predicateSource);
+      expect(expression).not.toContain("normalized.includes('answer now')");
+    });
+
+    test("the response observer embeds the shared predicate, not a private copy", () => {
+      const expression = buildResponseObserverExpressionForTest(1000);
+      expect(expression).toContain(buildAnswerNowPlaceholderPredicateJs("isAnswerNowPlaceholder"));
+      expect(expression).not.toContain("normalized.includes('answer now')");
+    });
+
+    test("the injected page source keeps a long answer with trailing chrome", () => {
+      expect(runInPage(LONG_ANSWER_WITH_TRAILING_CHROME)).toBe(false);
+    });
+
+    test.each(GENUINE_PLACEHOLDERS)("the injected page source discards %s", (text) => {
+      expect(runInPage(text)).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Problem

Oracle needs to ignore ChatGPT's short `Pro thinking` / `Answer now` placeholder while generation is still running. Capturing that UI-only value would return an incomplete response.

The current guard is broader than that intent. `isAnswerNowPlaceholderText()` runs against the extracted text of the whole assistant turn and returns `true` whenever that value contains both `answer now` and either `pro thinking` or `chatgpt said` anywhere:

```ts
return (
  text.includes("answer now") &&
  (text.includes("pro thinking") || text.includes("chatgpt said"))
);
```

Consequently, substantive assistant content is discarded whenever those strings are present in the same extracted value. Every extraction layer applies this predicate, so Oracle keeps waiting instead of passing the content to its normal completion gate.

This is a false-positive repair, not removal of the incomplete-response guard.

## Change

- Continue treating known short, UI-only `Pro thinking` / `Answer now` combinations as placeholders.
- Treat a value as a placeholder only when its whole normalized text matches that bounded UI grammar.
- Preserve substantive assistant text that merely contains those strings.
- Use the same closure-free predicate in Node-side parsing and both injected page expressions, so the extraction paths cannot drift.

The 60-character bound covers the longest known UI-only composite (57 characters). Unknown substantive text falls through to Oracle's existing completion checks; this PR does not bypass the stop/thinking/action-bar terminal gate.

## Behavior proof

A real after-fix ChatGPT Pro browser run intentionally requested a two-paragraph answer containing both trigger strings. This exercises the deterministic false-positive path in the upstream predicate: current upstream would classify the returned value as a placeholder solely because both substrings are present.

Command (browser path redacted):

```bash
oracle --engine browser \
  --browser-chrome-path /path/to/chromium \
  --browser-headless \
  --browser-timeout 300s \
  --model gpt-5.6-sol \
  --browser-thinking-time pro \
  --prompt 'Write two short paragraphs about why TCP retries. Include the words Pro thinking and Answer now somewhere in the prose. End with exactly: HARVEST_PLACEHOLDER_SMOKE_OK'
```

Observed output:

```text
[browser] Thinking time: Pro (already selected)
[browser] ChatGPT thinking - 30s elapsed; status=response streaming; source=inline
[browser] Archived ChatGPT conversation after saving local artifacts.
[browser] Model selection evidence: requestedKey=gpt-5.6-sol; target=GPT-5.6 Sol; resolvedLabel=GPT-5.6 Sol; status=already-selected; strategy=select; verified=yes; source=chatgpt-model-picker

Answer:
TCP retries because packets or acknowledgements can be lost, corrupted, or delayed in transit. When the sender does not receive confirmation within the expected time, it retransmits the missing data; Pro thinking about sequence numbers and checksums explains how TCP avoids accepting duplicates.

TCP also uses duplicate acknowledgements and adaptive timers to detect loss without retrying too aggressively. Answer now: these mechanisms provide reliable, ordered delivery over an unreliable network. HARVEST_PLACEHOLDER_SMOKE_OK

57.2s · GPT-5.6 Sol[browser] · ↑42 ↓132 ↻0 Δ174
```

Saved session evidence:

```json
{
  "status": "completed",
  "mode": "browser",
  "browser": {
    "runtime": { "promptSubmitted": true },
    "modelSelection": {
      "requestedModel": "GPT-5.6 Sol",
      "resolvedLabel": "GPT-5.6 Sol",
      "status": "already-selected",
      "verified": true,
      "source": "chatgpt-model-picker"
    },
    "warnings": []
  },
  "elapsedMs": 57154,
  "usage": {
    "inputTokens": 42,
    "outputTokens": 132,
    "reasoningTokens": 0,
    "totalTokens": 174
  }
}
```

This proves the repaired path returns substantive Pro output containing both trigger strings while retaining normal response-streaming and terminal-completion handling. It does **not** claim to be a preserved raw-DOM capture of mounted skip-ahead controls; the source defect does not depend on why those strings enter the extracted turn.

## Automated verification

- `pnpm vitest run tests/browser/assistantResponseStatus.test.ts` (93 tests)
- `pnpm run check`
- `pnpm run docs:check`
- GitHub CI: Ubuntu, macOS, Windows, CDP disconnect proof, and GitGuardian all pass

Regression coverage includes:

- long substantive answers containing both trigger strings;
- genuine short UI-only placeholder combinations;
- Node-side classification;
- execution of the injected predicate in snapshot and response-observer page contexts.

## Risk

If ChatGPT adds a new short UI-only label combination outside the known grammar, it could pass into the existing completion checks rather than being filtered immediately. The shared predicate and focused fixture table make additions explicit; the PR does not alter Oracle's independent positive terminal-completion gate.
