### PR TITLE
browser: sync cookies during authenticated session recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Browser: recognize the Japanese `詳細設定` → `推論レベル` controls in ChatGPT's unified Intelligence picker, allowing explicit Pro effort selection without weakening the fail-closed guard for unknown languages.
+- Browser: align reattach recovery cookie sync with the launch path for manual-login profiles with explicit cookie sync, so recovery can reopen an authenticated conversation with supplied cookies instead of skipping sync.
 
 ## 0.17.2 — 2026-08-10
 

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -109,6 +109,7 @@ import {
   resolveManualLoginWaitMs,
 } from "./manualLoginProfile.js";
 import { describeBrowserControlPlan, formatBrowserControlPlan } from "./controlPlan.js";
+import { shouldSyncBrowserCookies } from "./policies.js";
 import {
   createConversationUrlMonitor,
   type ConversationUrlMonitor,
@@ -1253,7 +1254,10 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
     }
 
     const manualLoginCookieSync = manualLogin && Boolean(config.manualLoginCookieSync);
-    const cookieSyncEnabled = config.cookieSync && (!profileIsPreSigned || manualLoginCookieSync);
+    const cookieSyncEnabled = shouldSyncBrowserCookies(config, {
+      manualLogin,
+      profileIsPreSigned,
+    });
     if (cookieSyncEnabled) {
       if (manualLoginCookieSync) {
         logger(

--- a/src/browser/policies.ts
+++ b/src/browser/policies.ts
@@ -1,5 +1,5 @@
 import { formatFileSections } from "../oracle/markdown.js";
-import type { BrowserAttachment } from "./types.js";
+import type { BrowserAttachment, ResolvedBrowserConfig } from "./types.js";
 import type { BrowserSessionConfig } from "../sessionManager.js";
 
 export interface AttachmentSection {
@@ -55,6 +55,17 @@ export type CookiePlan =
   | { type: "inline"; description: string }
   | { type: "disabled"; description: string }
   | { type: "copy"; description: string };
+
+export function shouldSyncBrowserCookies(
+  config: Pick<ResolvedBrowserConfig, "cookieSync" | "manualLoginCookieSync">,
+  {
+    manualLogin,
+    profileIsPreSigned = manualLogin,
+  }: { manualLogin: boolean; profileIsPreSigned?: boolean },
+): boolean {
+  const explicitManualLoginSync = manualLogin && config.manualLoginCookieSync === true;
+  return config.cookieSync && (!profileIsPreSigned || explicitManualLoginSync);
+}
 
 export function buildCookiePlan(config?: BrowserSessionConfig): CookiePlan {
   if (config?.inlineCookies && config.inlineCookies.length > 0) {

--- a/src/browser/projectSourcesRunner.ts
+++ b/src/browser/projectSourcesRunner.ts
@@ -51,6 +51,7 @@ import {
 import { normalizeProjectSourcesUrl } from "../projectSources/url.js";
 import { buildProjectSourcesUploadPlan, diffAddedProjectSources } from "../projectSources/plan.js";
 import type { ProjectSourcesRequest, ProjectSourcesResult } from "../projectSources/types.js";
+import { shouldSyncBrowserCookies } from "./policies.js";
 
 type BrowserChrome = LaunchedChrome & { host?: string };
 
@@ -335,8 +336,7 @@ async function applyProjectSourcesCookies({
   manualLogin: boolean;
   logger: BrowserLogger;
 }): Promise<number> {
-  const manualLoginCookieSync = manualLogin && Boolean(config.manualLoginCookieSync);
-  const cookieSyncEnabled = config.cookieSync && (!manualLogin || manualLoginCookieSync);
+  const cookieSyncEnabled = shouldSyncBrowserCookies(config, { manualLogin });
   if (!cookieSyncEnabled) {
     logger(
       manualLogin

--- a/src/browser/reattach.ts
+++ b/src/browser/reattach.ts
@@ -12,7 +12,7 @@ import {
   ensurePromptReady,
   waitForResumedConversationHydration,
 } from "./pageActions.js";
-import type { BrowserLogger, ChromeClient } from "./types.js";
+import type { BrowserLogger, ChromeClient, ResolvedBrowserConfig } from "./types.js";
 import {
   launchChrome,
   connectToChrome,
@@ -49,6 +49,9 @@ export interface ReattachDeps {
   captureAssistantMarkdown?: typeof captureAssistantMarkdown;
   waitForDeepResearchCompletion?: typeof waitForDeepResearchCompletion;
   waitForConversationHydration?: typeof waitForResumedConversationHydration;
+  launchChrome?: typeof launchChrome;
+  connectToChrome?: typeof connectToChrome;
+  syncCookies?: typeof syncCookies;
   recoverSession?: (
     runtime: BrowserRuntimeMetadata,
     config: BrowserSessionConfig | undefined,
@@ -276,6 +279,17 @@ function inferPortFromBrowserWSEndpoint(browserWSEndpoint?: string): number | un
   }
   return undefined;
 }
+/**
+ * Manual-login profiles normally reuse their persistent profile cookies, so recovery
+ * skips cookie sync by default. When explicit cookie sync is requested for a
+ * manual-login profile, supplied cookies must still be applied so the relaunched
+ * browser can reopen an authenticated conversation. Matches the launch-path gate
+ * `cookieSync && (!manualLogin || manualLoginCookieSync)`.
+ */
+function shouldSyncReattachCookies(manualLogin: boolean, resolved: ResolvedBrowserConfig): boolean {
+  const manualLoginCookieSync = manualLogin && Boolean(resolved.manualLoginCookieSync);
+  return resolved.cookieSync && (!manualLogin || manualLoginCookieSync);
+}
 
 async function resumeBrowserSessionViaNewChrome(
   runtime: BrowserRuntimeMetadata,
@@ -291,9 +305,37 @@ async function resumeBrowserSessionViaNewChrome(
   if (manualLogin) {
     await mkdir(userDataDir, { recursive: true });
   }
-  const chrome = await launchChrome(resolved, userDataDir, logger);
-  const chromeHost = (chrome as unknown as { host?: string }).host ?? "127.0.0.1";
-  const client = await connectToChrome(chrome.port, logger, chromeHost);
+  const launch = deps.launchChrome ?? launchChrome;
+  const connectToLaunchedChrome = deps.connectToChrome ?? connectToChrome;
+  const chrome = await launch(resolved, userDataDir, logger);
+  const chromeHost =
+    chrome && typeof chrome === "object" && "host" in chrome && typeof chrome.host === "string"
+      ? chrome.host
+      : "127.0.0.1";
+  const client = await connectToLaunchedChrome(chrome.port, logger, chromeHost);
+  const cleanup = async () => {
+    if (client && typeof client.close === "function") {
+      try {
+        await client.close();
+      } catch {
+        // ignore
+      }
+    }
+    if (!resolved.keepBrowser) {
+      try {
+        await chrome.kill();
+      } catch {
+        // ignore
+      }
+      if (manualLogin) {
+        await cleanupStaleProfileState(userDataDir, logger, { lockRemovalMode: "never" }).catch(
+          () => undefined,
+        );
+      } else {
+        await rm(userDataDir, { recursive: true, force: true }).catch(() => undefined);
+      }
+    }
+  };
   const { Network, Page, Runtime, DOM, Target } = client;
 
   if (Runtime?.enable) {
@@ -306,14 +348,20 @@ async function resumeBrowserSessionViaNewChrome(
     await positionChromeWindowOffscreen(client, logger);
   }
   let appliedCookies = 0;
-  if (!manualLogin && resolved.cookieSync) {
-    appliedCookies = await syncCookies(Network, resolved.url, resolved.chromeProfile, logger, {
-      allowErrors: resolved.allowCookieErrors,
-      filterNames: resolved.cookieNames ?? undefined,
-      inlineCookies: resolved.inlineCookies ?? undefined,
-      cookiePath: resolved.chromeCookiePath ?? undefined,
-      waitMs: resolved.cookieSyncWaitMs ?? 0,
-    });
+  if (shouldSyncReattachCookies(manualLogin, resolved)) {
+    const sync = deps.syncCookies ?? syncCookies;
+    try {
+      appliedCookies = await sync(Network, resolved.url, resolved.chromeProfile, logger, {
+        allowErrors: resolved.allowCookieErrors,
+        filterNames: resolved.cookieNames ?? undefined,
+        inlineCookies: resolved.inlineCookies ?? undefined,
+        cookiePath: resolved.chromeCookiePath ?? undefined,
+        waitMs: resolved.cookieSyncWaitMs ?? 0,
+      });
+    } catch (error) {
+      await cleanup();
+      throw error;
+    }
   }
 
   await clearStaleChatGptConversationCookies(Network, Target, logger, {
@@ -369,29 +417,6 @@ async function resumeBrowserSessionViaNewChrome(
   const waitForResponse = deps.waitForAssistantResponse ?? waitForAssistantResponse;
   const captureMarkdown = deps.captureAssistantMarkdown ?? captureAssistantMarkdown;
   const timeoutMs = resolved.timeoutMs ?? 120_000;
-  const cleanup = async () => {
-    if (client && typeof client.close === "function") {
-      try {
-        await client.close();
-      } catch {
-        // ignore
-      }
-    }
-    if (!resolved.keepBrowser) {
-      try {
-        await chrome.kill();
-      } catch {
-        // ignore
-      }
-      if (manualLogin) {
-        await cleanupStaleProfileState(userDataDir, logger, { lockRemovalMode: "never" }).catch(
-          () => undefined,
-        );
-      } else {
-        await rm(userDataDir, { recursive: true, force: true }).catch(() => undefined);
-      }
-    }
-  };
   const minTurnIndex =
     (await readPromptPreviewTurnIndex(Runtime, deps.promptPreview)) ??
     (deps.promptPreview ? null : await readConversationTurnIndex(Runtime, logger));
@@ -428,7 +453,6 @@ async function resumeBrowserSessionViaNewChrome(
   const aligned = alignPromptEchoMarkdown(recovered.text, markdown, promptEcho, logger);
 
   await cleanup();
-
   return { answerText: aligned.answerText, answerMarkdown: aligned.answerMarkdown };
 }
 
@@ -470,4 +494,5 @@ export const __test__ = {
   buildConversationUrl,
   openConversationFromSidebar,
   readPromptPreviewTurnIndex,
+  shouldSyncReattachCookies,
 };

--- a/src/browser/reattach.ts
+++ b/src/browser/reattach.ts
@@ -12,7 +12,7 @@ import {
   ensurePromptReady,
   waitForResumedConversationHydration,
 } from "./pageActions.js";
-import type { BrowserLogger, ChromeClient, ResolvedBrowserConfig } from "./types.js";
+import type { BrowserLogger, ChromeClient } from "./types.js";
 import {
   launchChrome,
   connectToChrome,
@@ -41,6 +41,7 @@ import {
   type TargetInfoLite,
 } from "./reattachHelpers.js";
 import { waitForDeepResearchCompletion } from "./actions/deepResearch.js";
+import { shouldSyncBrowserCookies } from "./policies.js";
 
 export interface ReattachDeps {
   listTargets?: () => Promise<TargetInfoLite[]>;
@@ -279,18 +280,6 @@ function inferPortFromBrowserWSEndpoint(browserWSEndpoint?: string): number | un
   }
   return undefined;
 }
-/**
- * Manual-login profiles normally reuse their persistent profile cookies, so recovery
- * skips cookie sync by default. When explicit cookie sync is requested for a
- * manual-login profile, supplied cookies must still be applied so the relaunched
- * browser can reopen an authenticated conversation. Matches the launch-path gate
- * `cookieSync && (!manualLogin || manualLoginCookieSync)`.
- */
-function shouldSyncReattachCookies(manualLogin: boolean, resolved: ResolvedBrowserConfig): boolean {
-  const manualLoginCookieSync = manualLogin && Boolean(resolved.manualLoginCookieSync);
-  return resolved.cookieSync && (!manualLogin || manualLoginCookieSync);
-}
-
 async function resumeBrowserSessionViaNewChrome(
   runtime: BrowserRuntimeMetadata,
   config: BrowserSessionConfig | undefined,
@@ -348,7 +337,7 @@ async function resumeBrowserSessionViaNewChrome(
     await positionChromeWindowOffscreen(client, logger);
   }
   let appliedCookies = 0;
-  if (shouldSyncReattachCookies(manualLogin, resolved)) {
+  if (shouldSyncBrowserCookies(resolved, { manualLogin })) {
     const sync = deps.syncCookies ?? syncCookies;
     try {
       appliedCookies = await sync(Network, resolved.url, resolved.chromeProfile, logger, {
@@ -494,5 +483,4 @@ export const __test__ = {
   buildConversationUrl,
   openConversationFromSidebar,
   readPromptPreviewTurnIndex,
-  shouldSyncReattachCookies,
 };

--- a/src/cli/browserConfig.ts
+++ b/src/cli/browserConfig.ts
@@ -270,7 +270,11 @@ export async function buildBrowserConfig(
     cookieSyncWaitMs: options.browserCookieWait
       ? parseBrowserDuration(options.browserCookieWait, "--browser-cookie-wait", 0)
       : undefined,
-    cookieSync: options.browserNoCookieSync ? false : undefined,
+    cookieSync: options.browserNoCookieSync
+      ? false
+      : options.browserManualLoginCookieSync === true
+        ? true
+        : undefined,
     cookieNames,
     inlineCookies: inline?.cookies,
     inlineCookiesSource: inline?.source ?? null,

--- a/src/cli/browserConfig.ts
+++ b/src/cli/browserConfig.ts
@@ -78,6 +78,7 @@ export interface BrowserFlagOptions {
   browserKeepBrowser?: boolean;
   browserManualLogin?: boolean;
   browserManualLoginProfileDir?: string | null;
+  browserManualLoginCookieSync?: boolean;
   copyProfile?: string;
   remoteHost?: string;
   /** Thinking time intensity: 'light', 'standard', 'extended', 'extra-high', 'pro', 'heavy' */
@@ -277,6 +278,7 @@ export async function buildBrowserConfig(
     keepBrowser: options.browserKeepBrowser ? true : undefined,
     manualLogin: options.browserManualLogin === undefined ? undefined : options.browserManualLogin,
     manualLoginProfileDir: options.browserManualLoginProfileDir ?? undefined,
+    manualLoginCookieSync: options.browserManualLoginCookieSync,
     copyProfileSource: options.copyProfile ?? undefined,
     hideWindow: options.browserHideWindow ? true : undefined,
     desiredModel,

--- a/src/cli/browserDefaults.ts
+++ b/src/cli/browserDefaults.ts
@@ -175,7 +175,11 @@ export function applyBrowserDefaultsFromConfig(
   ) {
     options.browserManualLoginProfileDir = browser.manualLoginProfileDir;
   }
-  if (isUnset("browserManualLoginCookieSync") && browser.manualLoginCookieSync !== undefined) {
+  if (
+    !attachRunningRequested &&
+    isUnset("browserManualLoginCookieSync") &&
+    browser.manualLoginCookieSync !== undefined
+  ) {
     options.browserManualLoginCookieSync = browser.manualLoginCookieSync;
   }
 }

--- a/src/cli/browserDefaults.ts
+++ b/src/cli/browserDefaults.ts
@@ -38,6 +38,7 @@ export interface BrowserDefaultsOptions {
   browserArchive?: BrowserArchiveMode;
   browserManualLogin?: boolean;
   browserManualLoginProfileDir?: string | null;
+  browserManualLoginCookieSync?: boolean;
 }
 
 type SourceGetter = (key: keyof BrowserDefaultsOptions) => string | undefined;
@@ -173,5 +174,8 @@ export function applyBrowserDefaultsFromConfig(
     browser.manualLoginProfileDir !== undefined
   ) {
     options.browserManualLoginProfileDir = browser.manualLoginProfileDir;
+  }
+  if (isUnset("browserManualLoginCookieSync") && browser.manualLoginCookieSync !== undefined) {
+    options.browserManualLoginCookieSync = browser.manualLoginCookieSync;
   }
 }

--- a/src/cli/projectSources.ts
+++ b/src/cli/projectSources.ts
@@ -108,14 +108,23 @@ export async function buildProjectSourcesBrowserConfig({
         envProfileDir ??
         null)
       : null;
+  const manualLoginCookieSync =
+    flagConfig.manualLoginCookieSync ?? configuredBrowser.manualLoginCookieSync;
+  const cookieSync =
+    flagConfig.cookieSync === false
+      ? false
+      : manualLogin
+        ? manualLoginCookieSync === true
+        : configuredBrowser.cookieSync;
   return {
     ...configuredBrowser,
     ...flagConfig,
     url: projectUrl,
     chatgptUrl: projectUrl,
-    cookieSync: manualLogin ? false : (flagConfig.cookieSync ?? configuredBrowser.cookieSync),
+    cookieSync,
     manualLogin,
     manualLoginProfileDir,
+    manualLoginCookieSync,
     desiredModel: null,
     modelStrategy: "ignore",
     researchMode: "off",

--- a/src/config.ts
+++ b/src/config.ts
@@ -67,6 +67,8 @@ export interface BrowserConfigDefaults {
   manualLogin?: boolean;
   /** Manual-login profile directory override (also available via ORACLE_BROWSER_PROFILE_DIR). */
   manualLoginProfileDir?: string | null;
+  /** Seed a manual-login profile from configured Chrome/inline cookies. */
+  manualLoginCookieSync?: boolean;
 }
 
 export interface AzureConfig {

--- a/src/mcp/tools/consult.ts
+++ b/src/mcp/tools/consult.ts
@@ -353,7 +353,7 @@ export function buildConsultBrowserConfig({
     ...configuredBrowser,
     url: configuredUrl,
     chatgptUrl: configuredUrl,
-    cookieSync: !manualLogin,
+    cookieSync: !manualLogin || configuredBrowser.manualLoginCookieSync === true,
     headless: configuredBrowser.headless ?? false,
     hideWindow: configuredBrowser.hideWindow ?? false,
     keepBrowser: browserKeepBrowser ?? configuredBrowser.keepBrowser ?? false,

--- a/tests/browser/policies.test.ts
+++ b/tests/browser/policies.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest";
-import { buildAttachmentPlan, buildCookiePlan } from "../../src/browser/policies.js";
+import {
+  buildAttachmentPlan,
+  buildCookiePlan,
+  shouldSyncBrowserCookies,
+} from "../../src/browser/policies.js";
+import { resolveBrowserConfig } from "../../src/browser/config.js";
 
 const sections = [
   { displayPath: "a.txt", absolutePath: "/repo/a.txt", content: "hello" },
@@ -70,5 +75,37 @@ describe("buildCookiePlan", () => {
     const plan = buildCookiePlan({ cookieNames: ["__Secure-next-auth.session-token", "_account"] });
     expect(plan.type).toBe("copy");
     expect(plan.description).toContain("__Secure-next-auth.session-token, _account");
+  });
+});
+
+describe("shouldSyncBrowserCookies", () => {
+  test("syncs ordinary temporary profiles when cookie sync is enabled", () => {
+    const config = resolveBrowserConfig({ cookieSync: true });
+    expect(shouldSyncBrowserCookies(config, { manualLogin: false })).toBe(true);
+  });
+
+  test("skips persistent manual-login profiles by default", () => {
+    const config = resolveBrowserConfig({
+      cookieSync: true,
+      manualLogin: true,
+      manualLoginCookieSync: false,
+    });
+    expect(shouldSyncBrowserCookies(config, { manualLogin: true })).toBe(false);
+  });
+
+  test("syncs persistent manual-login profiles only with the explicit opt-in", () => {
+    const config = resolveBrowserConfig({
+      cookieSync: true,
+      manualLogin: true,
+      manualLoginCookieSync: true,
+    });
+    expect(shouldSyncBrowserCookies(config, { manualLogin: true })).toBe(true);
+  });
+
+  test("does not sync a pre-signed copied profile", () => {
+    const config = resolveBrowserConfig({ cookieSync: true });
+    expect(shouldSyncBrowserCookies(config, { manualLogin: false, profileIsPreSigned: true })).toBe(
+      false,
+    );
   });
 });

--- a/tests/browser/reattach.test.ts
+++ b/tests/browser/reattach.test.ts
@@ -1,5 +1,9 @@
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
 import { describe, expect, test, vi } from "vitest";
 import { resumeBrowserSession, __test__ } from "../../src/browser/reattach.js";
+import { resolveBrowserConfig } from "../../src/browser/config.js";
 import type { BrowserLogger, ChromeClient } from "../../src/browser/types.js";
 
 type FakeTarget = { id?: string; targetId?: string; type?: string; url?: string };
@@ -462,5 +466,83 @@ describe("reattach helpers", () => {
     const call = evaluate.mock.calls[0]?.[0] as EvaluateParams | undefined;
     expect(call?.expression).toContain("const conversationId = null");
     expect(call?.expression).toContain("const preferProjects = false");
+  });
+});
+
+describe("shouldSyncReattachCookies", () => {
+  const { shouldSyncReattachCookies } = __test__;
+
+  test("syncs cookies for non-manual-login profiles when cookie sync is enabled", () => {
+    const resolved = resolveBrowserConfig({ manualLogin: false, cookieSync: true });
+    expect(shouldSyncReattachCookies(false, resolved)).toBe(true);
+  });
+
+  test("skips cookie sync for manual-login profiles without explicit cookie sync", () => {
+    const resolved = resolveBrowserConfig({
+      manualLogin: true,
+      cookieSync: true,
+      manualLoginCookieSync: false,
+    });
+    expect(shouldSyncReattachCookies(true, resolved)).toBe(false);
+  });
+
+  test("syncs cookies for manual-login profiles with explicit cookie sync", () => {
+    const resolved = resolveBrowserConfig({
+      manualLogin: true,
+      cookieSync: true,
+      manualLoginCookieSync: true,
+    });
+    expect(shouldSyncReattachCookies(true, resolved)).toBe(true);
+  });
+
+  test("invokes cookie sync while reopening an explicitly synchronized manual-login profile", async () => {
+    const profileDir = await mkdtemp(path.join(os.tmpdir(), "oracle-reattach-cookie-sync-"));
+    try {
+      const expected = new Error("stop after cookie sync");
+      const kill = vi.fn(async () => {});
+      const close = vi.fn(async () => {});
+      const launchChrome = vi.fn(async () => ({ port: 9222, kill }));
+      const connectToChrome = vi.fn(async () => ({
+        // biome-ignore lint/style/useNamingConvention: mirrors DevTools protocol domain names
+        Network: {},
+        // biome-ignore lint/style/useNamingConvention: mirrors DevTools protocol domain names
+        Page: {},
+        // biome-ignore lint/style/useNamingConvention: mirrors DevTools protocol domain names
+        Runtime: { enable: vi.fn() },
+        // biome-ignore lint/style/useNamingConvention: mirrors DevTools protocol domain names
+        DOM: { enable: vi.fn() },
+        // biome-ignore lint/style/useNamingConvention: mirrors DevTools protocol domain names
+        Target: {},
+        close,
+      }));
+      const syncCookies = vi.fn(async () => {
+        throw expected;
+      });
+      const logger = vi.fn() as BrowserLogger;
+
+      await expect(
+        resumeBrowserSession(
+          { tabUrl: "https://chatgpt.com/c/abc" },
+          {
+            manualLogin: true,
+            manualLoginProfileDir: profileDir,
+            cookieSync: true,
+            manualLoginCookieSync: true,
+          },
+          logger,
+          {
+            launchChrome: launchChrome as never,
+            connectToChrome: connectToChrome as never,
+            syncCookies: syncCookies as never,
+          },
+        ),
+      ).rejects.toBe(expected);
+
+      expect(syncCookies).toHaveBeenCalledOnce();
+      expect(close).toHaveBeenCalledOnce();
+      expect(kill).toHaveBeenCalledOnce();
+    } finally {
+      await rm(profileDir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/browser/reattach.test.ts
+++ b/tests/browser/reattach.test.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import { mkdtemp, rm } from "node:fs/promises";
 import { describe, expect, test, vi } from "vitest";
 import { resumeBrowserSession, __test__ } from "../../src/browser/reattach.js";
-import { resolveBrowserConfig } from "../../src/browser/config.js";
 import type { BrowserLogger, ChromeClient } from "../../src/browser/types.js";
 
 type FakeTarget = { id?: string; targetId?: string; type?: string; url?: string };
@@ -469,32 +468,7 @@ describe("reattach helpers", () => {
   });
 });
 
-describe("shouldSyncReattachCookies", () => {
-  const { shouldSyncReattachCookies } = __test__;
-
-  test("syncs cookies for non-manual-login profiles when cookie sync is enabled", () => {
-    const resolved = resolveBrowserConfig({ manualLogin: false, cookieSync: true });
-    expect(shouldSyncReattachCookies(false, resolved)).toBe(true);
-  });
-
-  test("skips cookie sync for manual-login profiles without explicit cookie sync", () => {
-    const resolved = resolveBrowserConfig({
-      manualLogin: true,
-      cookieSync: true,
-      manualLoginCookieSync: false,
-    });
-    expect(shouldSyncReattachCookies(true, resolved)).toBe(false);
-  });
-
-  test("syncs cookies for manual-login profiles with explicit cookie sync", () => {
-    const resolved = resolveBrowserConfig({
-      manualLogin: true,
-      cookieSync: true,
-      manualLoginCookieSync: true,
-    });
-    expect(shouldSyncReattachCookies(true, resolved)).toBe(true);
-  });
-
+describe("manual-login cookie sync recovery", () => {
   test("invokes cookie sync while reopening an explicitly synchronized manual-login profile", async () => {
     const profileDir = await mkdtemp(path.join(os.tmpdir(), "oracle-reattach-cookie-sync-"));
     try {

--- a/tests/cli/browserConfig.test.ts
+++ b/tests/cli/browserConfig.test.ts
@@ -32,6 +32,7 @@ describe("buildBrowserConfig", () => {
     });
 
     expect(config.manualLoginCookieSync).toBe(true);
+    expect(config.cookieSync).toBe(true);
   });
 
   test("maps gpt-5.4 browser runs to Thinking 5.4", async () => {

--- a/tests/cli/browserConfig.test.ts
+++ b/tests/cli/browserConfig.test.ts
@@ -24,6 +24,16 @@ describe("buildBrowserConfig", () => {
     });
   });
 
+  test("forwards configured manual-login cookie sync to browser sessions", async () => {
+    const config = await buildBrowserConfig({
+      model: "gpt-5.5-pro",
+      browserManualLogin: true,
+      browserManualLoginCookieSync: true,
+    });
+
+    expect(config.manualLoginCookieSync).toBe(true);
+  });
+
   test("maps gpt-5.4 browser runs to Thinking 5.4", async () => {
     const config = await buildBrowserConfig({ model: "gpt-5.4" });
     expect(config.desiredModel).toBe("Thinking 5.4");

--- a/tests/cli/browserDefaults.test.ts
+++ b/tests/cli/browserDefaults.test.ts
@@ -222,6 +222,7 @@ describe("applyBrowserDefaultsFromConfig", () => {
       browser: {
         manualLogin: true,
         manualLoginProfileDir: "/tmp/oracle-profile",
+        manualLoginCookieSync: true,
       },
     };
 
@@ -229,6 +230,7 @@ describe("applyBrowserDefaultsFromConfig", () => {
 
     expect(options.browserManualLogin).toBe(true);
     expect(options.browserManualLoginProfileDir).toBe("/tmp/oracle-profile");
+    expect(options.browserManualLoginCookieSync).toBe(true);
   });
 
   test("applies attach-running defaults from config when CLI flags are untouched", () => {

--- a/tests/cli/browserDefaults.test.ts
+++ b/tests/cli/browserDefaults.test.ts
@@ -255,6 +255,7 @@ describe("applyBrowserDefaultsFromConfig", () => {
         attachRunning: false,
         debugPort: 9222,
         timeoutMs: 120_000,
+        manualLoginCookieSync: true,
         hideWindow: true,
         keepBrowser: true,
         manualLogin: true,
@@ -271,6 +272,7 @@ describe("applyBrowserDefaultsFromConfig", () => {
     expect(options.browserChromeProfile).toBeUndefined();
     expect(options.browserCookiePath).toBeUndefined();
     expect(options.browserPort).toBeUndefined();
+    expect(options.browserManualLoginCookieSync).toBeUndefined();
     expect(options.browserHideWindow).toBeUndefined();
     expect(options.browserKeepBrowser).toBeUndefined();
     expect(options.browserManualLogin).toBeUndefined();

--- a/tests/cli/projectSources.test.ts
+++ b/tests/cli/projectSources.test.ts
@@ -78,4 +78,21 @@ describe("project sources CLI helpers", () => {
       modelStrategy: "ignore",
     });
   });
+
+  test("honors explicit cookie sync for a persistent manual-login profile", async () => {
+    const config = await buildProjectSourcesBrowserConfig({
+      options: {},
+      projectUrl: "https://chatgpt.com/g/g-p-123/project?tab=sources",
+      configuredBrowser: {
+        manualLogin: true,
+        manualLoginCookieSync: true,
+      },
+    });
+
+    expect(config).toMatchObject({
+      manualLogin: true,
+      manualLoginCookieSync: true,
+      cookieSync: true,
+    });
+  });
 });

--- a/tests/mcp/consult.test.ts
+++ b/tests/mcp/consult.test.ts
@@ -211,6 +211,26 @@ describe("summarizeModelRunsForConsult", () => {
     expect(config.cookieSync).toBe(process.platform !== "win32");
   });
 
+  test("honors explicit cookie sync for MCP manual-login consults", () => {
+    const config = buildConsultBrowserConfig({
+      userConfig: {
+        browser: {
+          manualLogin: true,
+          manualLoginCookieSync: true,
+        },
+      },
+      env: {},
+      runModel: "gpt-5.5-pro",
+      inputModel: "gpt-5.5-pro",
+    });
+
+    expect(config).toMatchObject({
+      manualLogin: true,
+      manualLoginCookieSync: true,
+      cookieSync: true,
+    });
+  });
+
   test("lets explicit consult inputs override config defaults", () => {
     const config = buildConsultBrowserConfig({
       userConfig: {


### PR DESCRIPTION
## Problem

Oracle uses cookie synchronization to seed authentication before the first ChatGPT navigation. Initial launch treats manual-login profiles as pre-signed and synchronizes them only when both `cookieSync` and `manualLoginCookieSync` are enabled.

Session recovery used `cookieSync && !manualLogin`. A persistent manual-login profile configured with that explicit opt-in could therefore receive cookies during initial launch but not when Oracle relaunched Chrome to reopen the saved conversation.

The documented `browser.manualLoginCookieSync` user setting was also dropped while converting user configuration into a one-shot browser session, so that CLI path could not activate this explicit opt-in.

## Change

- Apply the same manual-login cookie-sync opt-in during new-Chrome session recovery as during initial launch.
- Continue skipping cookie sync for ordinary manual-login profiles, which reuse their persistent profile cookies.
- Apply configured Chrome/inline cookies when `manualLoginCookieSync` explicitly opts a manual-login profile into synchronization.
- Forward `browser.manualLoginCookieSync` through CLI defaults and browser-session construction.
- Attempt to close the recovery CDP client and, unless `keepBrowser` is enabled, terminate the launched Chrome before propagating a cookie-sync failure.

## Verification

The cookie-sync-focused tests set `cookieSync` explicitly, so their expectations are independent of platform defaults. The recovery-path regression calls public `resumeBrowserSession()` without a live Chrome endpoint, lets it select the default new-Chrome recovery path, and injects launch/connect/cookie-sync dependencies. It proves that explicit manual-login synchronization invokes `syncCookies`; the failure case also proves that the CDP client is closed and the launched Chrome is killed under the default `keepBrowser: false` policy before the error is returned.

- `pnpm vitest run tests/cli/browserDefaults.test.ts tests/cli/browserConfig.test.ts tests/browser/reattach.test.ts` (97 tests)
- `pnpm run check`
- `pnpm run build`
- `pnpm run docs:check`

## Redacted real-browser recovery proof

Revision `14810ecafb27` first created an unarchived conversation through the configured manual-login cookie-sync path. A separate one-shot harness then called public `resumeBrowserSession()` with no live Chrome endpoint and a newly created target profile containing only an empty `Default/` directory. It supplied the saved conversation URL and an authenticated local Chrome profile as redacted environment values.

The harness delegated to Oracle's production `launchChrome()` and `syncCookies()` implementations, wrapping them only to record the launched PID and applied-cookie count. Chrome connection, cookie application through CDP, authentication checks, saved-conversation navigation, DOM response capture, and cleanup all used the production recovery path.

```text
proof_commit=14810ecafb27
source_worktree_clean=true
new_chrome_launched=true
target_profile_started_empty=true
manual_login_cookie_sync=enabled
cookies_applied=3
authenticated_conversation_reopened=true
answer=PR371_RECOVERY_PROOF_OK
launched_chrome_stopped=true
proof_status=passed
```

The empty target profile rules out authentication inherited from the recovery profile. Cookie values, account data, local paths, browser identifiers, and the private conversation URL are omitted.
