### PR TITLE
fix(browser): report a disabled effort tier instead of failing verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Browser: stop copying cookies from a live Chrome profile by default because ChatGPT token rotation can invalidate the user's interactive session. Use the persistent `--browser-manual-login` profile (recommended), inline cookies, or explicitly restore the old behavior with `--browser-cookie-sync` / `browser.cookieSync=true`. Fixes #367.
 
+### Fixed
+
+- Browser: detect a disabled ChatGPT effort tier (e.g. an exhausted Pro allotment) before clicking it, and report the account's own reset notice instead of a misleading "selection unverified" failure.
+
 ## 0.17.3 — 2026-08-13
 
 **Highlight:** browser-mode answers and recovery are reliable again — no more

--- a/src/browser/actions/thinkingTime.ts
+++ b/src/browser/actions/thinkingTime.ts
@@ -16,6 +16,12 @@ type ThinkingTimePickerDiagnostic = Record<string, unknown>;
 type ThinkingTimeOutcome = (
   | { status: "already-selected"; label?: string | null }
   | { status: "switched"; label?: string | null }
+  | {
+      status: "option-disabled";
+      label?: string | null;
+      notice?: string | null;
+      diagnostic?: ThinkingTimePickerDiagnostic;
+    }
   | { status: "chip-not-found"; diagnostic?: ThinkingTimePickerDiagnostic }
   | { status: "menu-not-found"; diagnostic?: ThinkingTimePickerDiagnostic }
   | { status: "option-not-found"; diagnostic?: ThinkingTimePickerDiagnostic }
@@ -25,6 +31,42 @@ type ThinkingTimeOutcome = (
       diagnostic?: ThinkingTimePickerDiagnostic;
     }
 ) & { modelKind?: string | null };
+
+export class ThinkingTierUnavailableError extends Error {
+  readonly requestedLevel: string;
+  readonly requestedLabel: string;
+  readonly optionLabel: string | null;
+  readonly notice: string | null;
+  readonly confirmedTarget: string;
+
+  constructor(
+    requestedLevel: string,
+    requestedLabel: string,
+    optionLabel: string | null,
+    notice: string | null,
+    confirmedTarget: string,
+  ) {
+    super(
+      `Thinking time: ${optionLabel ?? requestedLabel} is unavailable on this account (${notice ?? "no reason given"}); refusing to submit without confirmed ${confirmedTarget}.`,
+    );
+    this.name = "ThinkingTierUnavailableError";
+    this.requestedLevel = requestedLevel;
+    this.requestedLabel = requestedLabel;
+    this.optionLabel = optionLabel;
+    this.notice = notice;
+    this.confirmedTarget = confirmedTarget;
+  }
+}
+
+function confirmedThinkingTarget(
+  level: ThinkingTimeLevel,
+  capitalizedLevel: string,
+  targetModelKind: "pro" | "thinking" | "instant" | null,
+  observedModelKind: string | null | undefined,
+): string {
+  const strictModelKind = targetModelKind ?? observedModelKind;
+  return level === "pro" ? "Pro" : strictModelKind === "pro" ? "Pro Extended" : capitalizedLevel;
+}
 
 const BROWSER_THINKING_LOG_PREFIX = "[browser] Thinking time:";
 
@@ -79,6 +121,28 @@ export async function ensureThinkingTime(
     case "switched":
       logger(formatBrowserThinkingLog(result.label ?? capitalizedLevel));
       return;
+    case "option-disabled": {
+      await logDomFailure(Runtime, logger, "thinking-option-disabled");
+      logPickerDiagnostic(result, logger);
+      if (strictProEffort) {
+        throw new ThinkingTierUnavailableError(
+          level,
+          capitalizedLevel,
+          result.label ?? null,
+          result.notice ?? null,
+          confirmedThinkingTarget(level, capitalizedLevel, targetModelKind, observedModelKind),
+        );
+      }
+      // A non-strict caller goes on to submit, so this log must not borrow the
+      // strict error's "refusing to submit" wording: the request really is sent,
+      // at whatever effort ChatGPT already had selected.
+      logger(
+        formatBrowserThinkingLog(
+          `${result.label ?? capitalizedLevel} is unavailable on this account (${result.notice ?? "no reason given"}); keeping the effort already selected in ChatGPT.`,
+        ),
+      );
+      return;
+    }
     case "chip-not-found":
     case "menu-not-found":
     case "option-not-found":
@@ -148,6 +212,13 @@ export async function ensureThinkingTimeIfAvailable(
       case "switched":
         logger(formatBrowserThinkingLog(result.label ?? capitalizedLevel));
         return true;
+      case "option-disabled":
+        logger(
+          formatBrowserThinkingLog(
+            `${result.label ?? capitalizedLevel} is unavailable on this account (${result.notice ?? "no reason given"}); keeping the effort already selected in ChatGPT.`,
+          ),
+        );
+        return false;
       case "chip-not-found":
       case "menu-not-found":
       case "option-not-found":
@@ -359,6 +430,21 @@ function buildThinkingTimeExpression(
         .replace(/\\s+/g, ' ')
         .trim()
         .slice(0, maxLength);
+    const isOptionDisabled = (node) => {
+      if (!node || typeof node.getAttribute !== 'function') return false;
+      // data-disabled is Radix's valueless-presence convention, but an explicit
+      // "false" must not read as disabled: that would refuse a perfectly usable
+      // tier and report it as unavailable.
+      const dataDisabled = node.getAttribute('data-disabled');
+      const dataDisabledOn = dataDisabled !== null && String(dataDisabled).toLowerCase() !== 'false';
+      return (
+        node.getAttribute('aria-disabled') === 'true' ||
+        dataDisabledOn ||
+        (node.getAttribute('data-state') || '').toLowerCase() === 'disabled' ||
+        Boolean(node.disabled) ||
+        node.getAttribute('disabled') !== null
+      );
+    };
     const describeNode = (el) => {
       if (!el || typeof el.getAttribute !== 'function') return null;
       let rect = null;
@@ -381,7 +467,10 @@ function buildThinkingTimeExpression(
         ariaChecked: el.getAttribute('aria-checked'),
         ariaSelected: el.getAttribute('aria-selected'),
         ariaHaspopup: el.getAttribute('aria-haspopup'),
+        ariaDisabled: el.getAttribute('aria-disabled'),
+        dataDisabled: el.getAttribute('data-disabled'),
         dataState: el.getAttribute('data-state'),
+        disabled: isOptionDisabled(el),
         text: redactDiagnosticText(el.textContent, 80),
         rect,
       };
@@ -657,6 +746,77 @@ function buildThinkingTimeExpression(
       }
       return matchesLevel(normalizedLabel);
     };
+    const nonEmptyNotice = (value) => {
+      const text = redactDiagnosticText(value, 160);
+      return text || null;
+    };
+    // The notice must be ROW-OWNED, and preferably this hover's own.
+    //
+    // NOTE: no backticks in this comment — it lives inside the injected template
+    // literal, where a backtick would terminate the string.
+    //
+    // A document-wide role=tooltip scan is what this must never become: novelty is
+    // not causality, and an unrelated control with an armed open-delay can mount its
+    // tooltip inside this hover's window. Every pass below is anchored on the row.
+    //
+    // Preference order, strongest provenance first:
+    //   1. an id this hover ADDED whose target is role=tooltip — Radix keeps an
+    //      application-supplied description and APPENDS its tooltip id when opening,
+    //      so the delta is what separates the real notice from a permanent blurb;
+    //   2. any other id this hover added;
+    //   3. an already-associated role=tooltip target, for a tooltip that was open
+    //      before the probe arrived;
+    //   4. the row's static title, only once the poll has expired.
+    //
+    // Passes 3 and 4 are row-owned but NOT causal: a page that permanently points a
+    // disabled row at generic role=tooltip help, or gives it a generic title, will
+    // have that text reported. That is accepted deliberately — the value is an opaque
+    // notice for a human or a caller to interpret, not a parsed reset time — and the
+    // verified live target has neither at rest.
+    const describedIds = (option) =>
+      (option?.getAttribute?.('aria-describedby') || '').split(/\\s+/).filter(Boolean);
+    const isTooltipNode = (node) => node?.getAttribute?.('role') === 'tooltip';
+    const readDisabledNotice = (option, priorIds, allowTitle) => {
+      const ids = describedIds(option);
+      const prior = priorIds instanceof Set ? priorIds : new Set();
+      const fresh = ids.filter((id) => !prior.has(id));
+      for (const pass of [
+        fresh.filter((id) => isTooltipNode(document.getElementById?.(id))),
+        fresh,
+        ids.filter((id) => isTooltipNode(document.getElementById?.(id))),
+      ]) {
+        for (const id of pass) {
+          const notice = nonEmptyNotice(document.getElementById?.(id)?.textContent);
+          if (notice) return notice;
+        }
+      }
+      if (!allowTitle) return null;
+      return nonEmptyNotice(option?.getAttribute?.('title'));
+    };
+    const waitForDisabledNotice = async (option, priorIds) => {
+      const deadline = performance.now() + 400;
+      while (performance.now() < deadline) {
+        const notice = readDisabledNotice(option, priorIds, false);
+        if (notice) return notice;
+        await sleep(50);
+      }
+      // Only now may a static title speak: the association had its full window.
+      return readDisabledNotice(option, priorIds, true);
+    };
+    // Opening a tooltip stacks another Radix dismissable layer over the menu, and
+    // the topmost layer eats the Escape. One blind Escape therefore leaves the
+    // effort menu open, which matters for the non-strict caller that goes on to
+    // submit. Dismiss, let the layer unmount, and only Escape again while a menu is
+    // still there — never two unconditional Escapes, which could close an unrelated
+    // outer surface.
+    const closeMenusAfterTooltip = async () => {
+      closeOpenMenus();
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        await sleep(50);
+        if (!Array.from(document.querySelectorAll(MENU_CONTAINER_SELECTOR)).some(isVisible)) return;
+        closeOpenMenus();
+      }
+    };
     const selectAndVerify = async (trigger, findOption, modelKindOverride = null) => {
       const triggerModelKind =
         modelKindOverride ||
@@ -682,6 +842,22 @@ function buildThinkingTimeExpression(
       }
       if (!option) return failure('option-not-found', { modelKind: triggerModelKind });
       const label = option.textContent?.trim?.() || null;
+      if (isOptionDisabled(option)) {
+        // Captured BEFORE the hover: the ids already here describe the row for other
+        // reasons and cannot be this hover's reason.
+        const priorIds = new Set(describedIds(option));
+        dispatchHoverSequence(option);
+        const notice = await waitForDisabledNotice(option, priorIds);
+        const result = failure('option-disabled', {
+          // The label is page text that reaches logs and diagnostics, so it is
+          // redacted like every other reported string.
+          label: redactDiagnosticText(option.textContent, 80) || null,
+          notice,
+          modelKind: triggerModelKind,
+        });
+        await closeMenusAfterTooltip();
+        return result;
+      }
       if (optionIsSelected(option)) {
         closeOpenMenus();
         return { status: 'already-selected', label };

--- a/tests/browser/thinkingTime.test.ts
+++ b/tests/browser/thinkingTime.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { ThinkingTimeLevel } from "../../src/oracle/types.js";
 import {
+  ThinkingTierUnavailableError,
   buildThinkingTimeExpressionForTest,
   ensureThinkingTime,
+  ensureThinkingTimeIfAvailable,
   inferThinkingTargetModelKindForTest,
 } from "../../src/browser/actions/thinkingTime.js";
 
@@ -2821,6 +2823,19 @@ describe("unified Intelligence picker with Advanced -> Effort submenu", () => {
     ) {}
   }
 
+  // The probe closes menus with a real KeyboardEvent, so the harness must provide
+  // one: without it the constructor throws inside the probe's try/catch and no
+  // Escape is ever observable, which is what let the tooltip-layer bug hide.
+  class FakeKeyboardEvent {
+    public readonly key: string;
+    constructor(
+      public readonly type: string,
+      init: { key?: string } = {},
+    ) {
+      this.key = init.key ?? "";
+    }
+  }
+
   function buildDom(currentTier: string) {
     const tierNames = ["Instant", "Medium", "High", "Extra High", "Pro"];
     let selectedTier = currentTier;
@@ -2936,6 +2951,7 @@ describe("unified Intelligence picker with Advanced -> Effort submenu", () => {
       "PointerEvent",
       "MouseEvent",
       "HTMLElement",
+      "KeyboardEvent",
       `return ${buildThinkingTimeExpressionForTest(level as ThinkingTimeLevel, model)};`,
     ) as (...args: unknown[]) => Promise<{ status: string; label: string | null }>;
     return evaluate(
@@ -2947,6 +2963,7 @@ describe("unified Intelligence picker with Advanced -> Effort submenu", () => {
       FakeMouseEvent,
       FakeMouseEvent,
       Node,
+      FakeKeyboardEvent,
     );
   }
 
@@ -3146,5 +3163,374 @@ describe("unified Intelligence picker with Advanced -> Effort submenu", () => {
     await run(dom.documentStub, "pro");
     expect(decoy?.clicks).toBe(0);
     expect(dom.getSelectedTier()).toBe("High");
+  });
+  type DisabledProbeResult = {
+    status: string;
+    label?: string | null;
+    notice?: string | null;
+    diagnostic?: {
+      menus?: Array<{ items?: Array<Record<string, unknown>> }>;
+    };
+  };
+
+  function disabledDom() {
+    const dom = buildDom("High");
+    const option = dom.tierRows[4]!;
+    option.setAttribute("aria-disabled", "true");
+    option.setAttribute("data-state", "unchecked");
+    return { dom, option };
+  }
+
+  type PickerDomStub = {
+    documentStub: {
+      querySelectorAll: (selector: string) => Node[];
+      getElementById: (id: string) => Node | null;
+      dispatchEvent: (event: unknown) => boolean;
+    };
+  };
+
+  it("keeps closing until the menu is gone when a tooltip layer eats the first Escape", async () => {
+    // Radix tooltip content is its own dismissable layer, and the topmost layer
+    // consumes Escape. One blind Escape would leave the effort menu open, which the
+    // non-strict caller then submits underneath.
+    const { dom } = disabledDom();
+    const stub = dom.documentStub as PickerDomStub["documentStub"];
+    let escapes = 0;
+    let menusOpen = true;
+    stub.dispatchEvent = (event: unknown) => {
+      if (String((event as { key?: string }).key) === "Escape") {
+        escapes += 1;
+        // The first Escape only dismisses the tooltip layer.
+        if (escapes >= 2) menusOpen = false;
+      }
+      return true;
+    };
+    const querySelectorAll = stub.querySelectorAll;
+    stub.querySelectorAll = (selector: string) => {
+      const menuQuery = selector.includes('role="menu"') || selector.includes("data-radix");
+      if (menuQuery && !menusOpen) return [];
+      return querySelectorAll(selector);
+    };
+    await expect(run(dom.documentStub, "pro", "gpt-5.5-pro")).resolves.toMatchObject({
+      status: "option-disabled",
+    });
+    expect(escapes).toBeGreaterThanOrEqual(2);
+    expect(menusOpen).toBe(false);
+  });
+
+  it("uses an already-associated role=tooltip target when this hover adds nothing", async () => {
+    // Pass 3: row-owned but not causal. A tooltip that was already open for this row
+    // is the best evidence available when the hover adds no association, and the
+    // static-description helper deliberately builds a target WITHOUT role=tooltip, so
+    // without this case the third pass is never exercised.
+    const { dom, option } = disabledDom();
+    const described = new Node("Limit reached. Try again after Aug 16, 2026.");
+    described.setAttribute("role", "tooltip");
+    option.setAttribute("aria-describedby", "open-tip");
+    const getElementById = dom.documentStub.getElementById;
+    dom.documentStub.getElementById = (id: string) =>
+      id === "open-tip" ? described : getElementById(id);
+    await expect(run(dom.documentStub, "pro", "gpt-5.5-pro")).resolves.toMatchObject({
+      status: "option-disabled",
+      notice: "Limit reached. Try again after Aug 16, 2026.",
+    });
+  });
+
+  // Radix APPENDS its tooltip id to whatever aria-describedby the app already set,
+  // and only while the tooltip is open. This helper reproduces that transition: a
+  // pre-existing description stays, and the tooltip id (plus its node) appears only
+  // after this row is hovered.
+  function appendTooltipOnHover(
+    dom: PickerDomStub,
+    option: Node,
+    id: string,
+    text: string,
+    opts: { role?: string | null; polls?: number } = {},
+  ) {
+    const { role = "tooltip", polls = 2 } = opts;
+    const described = new Node(text);
+    if (role) described.setAttribute("role", role);
+    let hovered = false;
+    let seen = 0;
+    const baseDescribedBy = option.getAttribute("aria-describedby") || "";
+    const originalDispatch = option.dispatchEvent.bind(option);
+    option.dispatchEvent = (event: unknown) => {
+      const type = String((event as { type?: string }).type ?? "");
+      if (type.startsWith("pointer") || type.startsWith("mouse")) {
+        hovered = true;
+        option.setAttribute("aria-describedby", `${baseDescribedBy} ${id}`.trim());
+      }
+      return originalDispatch(event);
+    };
+    const getElementById = dom.documentStub.getElementById;
+    dom.documentStub.getElementById = (candidate: string) => {
+      if (candidate !== id) return getElementById(candidate);
+      if (!hovered) return null;
+      seen += 1;
+      return seen >= polls ? described : null;
+    };
+    return described;
+  }
+
+  // A static description the row already carried: row ownership, but not this
+  // hover's reason.
+  function describeStatically(dom: PickerDomStub, option: Node, id: string, text: string) {
+    const described = new Node(text);
+    const existing = option.getAttribute("aria-describedby") || "";
+    option.setAttribute("aria-describedby", `${existing} ${id}`.trim());
+    const getElementById = dom.documentStub.getElementById;
+    dom.documentStub.getElementById = (candidate: string) =>
+      candidate === id ? described : getElementById(candidate);
+    return described;
+  }
+
+  // An unrelated tooltip that mounts DURING this hover, which is what defeats a
+  // novelty-based rule.
+  function addUnrelatedTooltipOnHover(dom: PickerDomStub, option: Node, text: string) {
+    const tooltip = new Node(text);
+    tooltip.setAttribute("role", "tooltip");
+    let hovered = false;
+    const originalDispatch = option.dispatchEvent.bind(option);
+    option.dispatchEvent = (event: unknown) => {
+      const type = String((event as { type?: string }).type ?? "");
+      if (type.startsWith("pointer") || type.startsWith("mouse")) hovered = true;
+      return originalDispatch(event);
+    };
+    const querySelectorAll = dom.documentStub.querySelectorAll;
+    dom.documentStub.querySelectorAll = (selector: string) => {
+      if (!selector.includes('[role="tooltip"]')) return querySelectorAll(selector);
+      return hovered ? [tooltip] : [];
+    };
+    return tooltip;
+  }
+
+  it("returns option-disabled without clicking an aria-disabled row", async () => {
+    const { dom, option } = disabledDom();
+    await expect(run(dom.documentStub, "pro", "gpt-5.5-pro")).resolves.toMatchObject({
+      status: "option-disabled",
+      label: "Pro",
+      notice: null,
+    });
+    expect(option.clicks).toBe(0);
+  });
+
+  it("splits multiple aria-describedby ids on any whitespace", async () => {
+    // Guards the injected /\\s+/: if it ever cooks down to /s+/ the appended id is
+    // never separated from the pre-existing ones and the notice vanishes.
+    const { dom, option } = disabledDom();
+    describeStatically(dom, option, "decoy-a", "Pro is the highest reasoning tier");
+    describeStatically(dom, option, "decoy-b", "Keyboard shortcut");
+    option.setAttribute("aria-describedby", "decoy-a \t decoy-b");
+    appendTooltipOnHover(
+      dom,
+      option,
+      "tier-notice",
+      "Limit reached. Try again after Aug 16, 2026.",
+    );
+    await expect(run(dom.documentStub, "pro", "gpt-5.5-pro")).resolves.toMatchObject({
+      status: "option-disabled",
+      notice: "Limit reached. Try again after Aug 16, 2026.",
+    });
+  });
+
+  it("prefers the tooltip this hover appended over a static description", async () => {
+    // Radix keeps an app-supplied description and appends its own id, so mere
+    // presence of aria-describedby proves the ROW but not the REASON. Returning the
+    // static blurb would hand the caller a confident wrong answer.
+    const { dom, option } = disabledDom();
+    describeStatically(dom, option, "tier-help", "Pro is the highest reasoning tier");
+    appendTooltipOnHover(
+      dom,
+      option,
+      "tier-notice",
+      "Limit reached. Try again after Aug 16, 2026.",
+    );
+    await expect(run(dom.documentStub, "pro", "gpt-5.5-pro")).resolves.toMatchObject({
+      status: "option-disabled",
+      notice: "Limit reached. Try again after Aug 16, 2026.",
+    });
+  });
+
+  it("ignores an unrelated tooltip that opens during this hover", async () => {
+    const { dom, option } = disabledDom();
+    // Novelty is not ownership: another control's armed open-delay can fire inside
+    // this hover's window, and its date has nothing to do with this tier.
+    addUnrelatedTooltipOnHover(dom, option, "Limit reached. Try again after Dec 31, 2099.");
+    await expect(run(dom.documentStub, "pro", "gpt-5.5-pro")).resolves.toMatchObject({
+      status: "option-disabled",
+      notice: null,
+    });
+  });
+
+  it("lets the appended association win over a static title", async () => {
+    // title is consulted only after the association poll expires, so a permanent
+    // tooltip attribute cannot preempt the real reason while it is still mounting.
+    const { dom, option } = disabledDom();
+    option.setAttribute("title", "Highest reasoning tier");
+    // polls high enough that the association is still mounting across several poll
+    // iterations: with a lower value the tooltip resolves inside the first
+    // iteration and the test could not detect a title that preempts it.
+    appendTooltipOnHover(
+      dom,
+      option,
+      "tier-notice",
+      "Limit reached. Try again after Aug 16, 2026.",
+      {
+        polls: 6,
+      },
+    );
+    await expect(run(dom.documentStub, "pro", "gpt-5.5-pro")).resolves.toMatchObject({
+      status: "option-disabled",
+      notice: "Limit reached. Try again after Aug 16, 2026.",
+    });
+  });
+
+  it("falls back to the row's title attribute when nothing associates", async () => {
+    const { dom, option } = disabledDom();
+    option.setAttribute("title", "Limit reached. Try again after Aug 16, 2026.");
+    await expect(run(dom.documentStub, "pro", "gpt-5.5-pro")).resolves.toMatchObject({
+      status: "option-disabled",
+      notice: "Limit reached. Try again after Aug 16, 2026.",
+    });
+  });
+
+  it("redacts the disabled row's label", async () => {
+    const { dom, option } = disabledDom();
+    option.textContent = "Pro  contact\nsupport@example.com now";
+    const result = (await run(dom.documentStub, "pro", "gpt-5.5-pro")) as DisabledProbeResult;
+    expect(result.label).toBe("Pro contact [redacted-email] now");
+  });
+
+  it('treats data-disabled="false" as enabled and still clicks the row', async () => {
+    const dom = buildDom("High");
+    const option = dom.tierRows[4]!;
+    option.setAttribute("data-disabled", "false");
+    const result = (await run(dom.documentStub, "pro", "gpt-5.5-pro")) as DisabledProbeResult;
+    expect(result.status).not.toBe("option-disabled");
+    expect(option.clicks).toBe(1);
+  });
+
+  it("refuses a row that is disabled even while it is the selected effort", async () => {
+    // Deliberate ordering: disabled wins over already-selected. Being checked does
+    // not prove the tier is still usable, and refusing costs nothing, while
+    // submitting may spend a request and come back silently degraded. A future
+    // cleanup that hoists the selected check above the disabled check must fail
+    // here.
+    const dom = buildDom("Pro");
+    const option = dom.tierRows[4]!;
+    option.setAttribute("aria-disabled", "true");
+    const result = (await run(dom.documentStub, "pro", "gpt-5.5-pro")) as DisabledProbeResult;
+    expect(result.status).toBe("option-disabled");
+    expect(option.clicks).toBe(0);
+  });
+  it("returns a null notice when no tooltip renders", async () => {
+    const { dom } = disabledDom();
+    await expect(run(dom.documentStub, "pro", "gpt-5.5-pro")).resolves.toMatchObject({
+      status: "option-disabled",
+      notice: null,
+    });
+  });
+
+  it("includes disabled state attributes in picker diagnostics", async () => {
+    const { dom } = disabledDom();
+    const result = (await run(dom.documentStub, "pro", "gpt-5.5-pro")) as DisabledProbeResult;
+    // The effort rows live in the submenu, so scan every captured menu: the
+    // assertion is about the disabled attributes reaching the diagnostic, not
+    // about which menu index the harness happens to expose them under.
+    const items = (result.diagnostic?.menus ?? []).flatMap((menu) => menu.items ?? []);
+    const item = items.find((entry) => entry.ariaDisabled === "true");
+    expect(item).toMatchObject({ ariaDisabled: "true", dataDisabled: null, disabled: true });
+  });
+
+  it("throws ThinkingTierUnavailableError when disabled Pro is requested", async () => {
+    const runtime = {
+      evaluate: async () => ({
+        result: {
+          value: {
+            status: "option-disabled",
+            label: "Pro",
+            notice: "Limit reached. Try again after Aug 16, 2026.",
+          },
+        },
+      }),
+    };
+    const strictSelection = ensureThinkingTime(
+      runtime as never,
+      "pro",
+      (() => {}) as never,
+      "gpt-5.5-pro",
+    );
+    await expect(strictSelection).rejects.toBeInstanceOf(ThinkingTierUnavailableError);
+    await expect(strictSelection).rejects.toMatchObject({
+      name: "ThinkingTierUnavailableError",
+      message:
+        "Thinking time: Pro is unavailable on this account (Limit reached. Try again after Aug 16, 2026.); refusing to submit without confirmed Pro.",
+      requestedLevel: "pro",
+      requestedLabel: "Pro",
+      optionLabel: "Pro",
+      notice: "Limit reached. Try again after Aug 16, 2026.",
+      confirmedTarget: "Pro",
+    });
+
+    const logs: string[] = [];
+    await expect(
+      ensureThinkingTime(
+        runtime as never,
+        "extended",
+        ((line: string) => logs.push(line)) as never,
+        null,
+      ),
+    ).resolves.toBeUndefined();
+    expect(logs.join(" ")).toContain("Limit reached. Try again after Aug 16, 2026.");
+  });
+
+  it("names the requested tier, not a hard-coded one, in the strict error", async () => {
+    // Extended on a Pro model is the other strict path, and its confirmation
+    // target must follow the request instead of being spelled out for Pro alone.
+    const runtime = {
+      evaluate: async () => ({
+        result: {
+          value: {
+            status: "option-disabled",
+            label: "Pro Extended",
+            notice: "Unavailable on this plan.",
+          },
+        },
+      }),
+    };
+    await expect(
+      ensureThinkingTime(runtime as never, "extended", (() => {}) as never, "gpt-5.5-pro"),
+    ).rejects.toMatchObject({
+      name: "ThinkingTierUnavailableError",
+      requestedLevel: "extended",
+      confirmedTarget: "Pro Extended",
+      message: expect.stringContaining("refusing to submit without confirmed Pro Extended"),
+    });
+  });
+
+  it("keeps the current effort when IfAvailable sees a disabled row", async () => {
+    const runtime = {
+      evaluate: async () => ({
+        result: {
+          value: {
+            status: "option-disabled",
+            label: "Pro",
+            notice: "Limit reached. Try again after Aug 16, 2026.",
+          },
+        },
+      }),
+    };
+    const logs: string[] = [];
+    await expect(
+      ensureThinkingTimeIfAvailable(
+        runtime as never,
+        "pro",
+        ((line: string) => logs.push(line)) as never,
+        "gpt-5.5-pro",
+      ),
+    ).resolves.toBe(false);
+    const logged = logs.join(" ");
+    expect(logged).toContain("keeping the effort already selected in ChatGPT");
+    expect(logged).not.toContain("continuing with default");
   });
 });


### PR DESCRIPTION

## fix(browser): report a disabled effort tier instead of failing verification

### Problem

On a capped ChatGPT plan the effort submenu still lists a tier the account can no longer use. The row is rendered with `aria-disabled="true"` and, on hover, a tooltip carrying the reset date, e.g. `Limit reached. Try again after Aug 16, 2026.`, while cheaper tiers stay selectable.

`ensureThinkingTime` has no notion of a disabled row, so today it: matches that row like any other candidate, dispatches a click at it which Radix ignores, polls the composer pill for ~2.4s and gives up with `selection-unverified`, and throws `Thinking time: selection unverified ...`.

Two very different situations therefore produce the same error: "your plan has exhausted this tier" and "chatgpt.com changed its picker markup". Worse, the reason is thrown away — the tooltip already states when the tier comes back, and an automated caller has no way to learn it.

### Change

- New `option-disabled` picker outcome. The row is detected before any click, via `aria-disabled="true"`, `data-state="disabled"`, a truthy `disabled` property or attribute, or a present `data-disabled` whose value is not `"false"` — Radix's valueless-presence convention without misreading an explicitly enabled row.
- No click is dispatched at a disabled row. The existing `dispatchHoverSequence` opens the tooltip and the reason is read from the row's own association.
- **Attribution is row-owned, delta first.** Radix preserves an application-supplied `aria-describedby` and appends its tooltip id only while open, so a row carrying a permanent blurb would otherwise report that blurb as the reset reason. Ids present after the hover but not before win, preferring a `role="tooltip"` target; an already-associated `role="tooltip"` target is accepted for a tooltip that was already open; `title` is consulted only after the bounded ~400ms poll expires, so a static attribute cannot preempt an association that is still mounting. There is no document-wide `[role="tooltip"]` scan: an unrelated control with an armed open-delay can mount its tooltip inside the same window, and "this is a popper" is not "this popper belongs to this row". With nothing associated the notice is `null` — an unknown reason a caller can act on, rather than a confident wrong one. The last two passes are row-owned but not causal, and the code says so: a page that permanently points a disabled row at generic `role="tooltip"` help, or gives it a generic `title`, will have that text reported. The value is an opaque notice, not a parsed reset time.
- **Cleanup survives the tooltip layer.** Tooltip content is itself a dismissable layer and the topmost layer consumes Escape, so closing the menu dismisses, waits for the layer to unmount, and escapes again only while a menu is still visible — never one Escape the tooltip can eat, nor two blind ones that could close an unrelated surface.
- Both the notice and the row label pass through the existing `redactDiagnosticText`, since a caller may log them.
- `describeNode` records `ariaDisabled`, `dataDisabled` and the resolved `disabled` verdict, so `--verbose` picker diagnostics prove the state even when no notice renders.
- New exported `ThinkingTierUnavailableError` carrying `requestedLevel`, `requestedLabel`, `optionLabel`, `notice` and `confirmedTarget`, so a caller can branch on the cause without parsing prose, and a non-Pro request is never described as `Pro Extended`.
- Fail-closed behaviour is unchanged. Where the strict gate already refused to submit, it still refuses — the message now names the real reason. `ensureThinkingTimeIfAvailable` keeps its best-effort contract and only logs, with wording that says the current effort is kept instead of borrowing the strict refusal text while continuing.
- The disabled check deliberately precedes the already-selected check. Being checked does not prove a capped tier is still usable; the state is only reachable when a cap lands mid-session, refusing costs nothing, and proceeding may spend a request that comes back silently degraded.

The notice is returned verbatim. Oracle deliberately does not parse the date: the picker is localized (this repo already recognizes English and Chinese effort labels), so interpreting the reset instant belongs to the caller.

### Tests

Added to `tests/browser/thinkingTime.test.ts`, reusing that file's existing unified-Intelligence-picker harness: `option-disabled` with no click on the disabled row; the appended tooltip winning over a static description; an unrelated tooltip that opens *during* this hover being ignored; `title` losing to an association that is still mounting, and winning when nothing associates; multiple whitespace-separated `aria-describedby` ids (which also guards the injected regex escape that a single-id test cannot); a tooltip layer eating the first Escape; `notice: null` when nothing renders; the disabled attributes reaching the picker diagnostic; label redaction; `data-disabled="false"` still clicked; a row that is disabled while selected still refused with zero clicks; the strict path throwing `ThinkingTierUnavailableError` with the exact message and fields; and the confirmation target following the requested tier.

The harness now injects `KeyboardEvent`. Without it the probe's Escape constructor threw inside its own `try/catch`, so no test could observe menu cleanup at all — which is how the dismissable-layer bug stayed hidden.

Each new regression was mutation-checked: reverting the association delta, the retrying cleanup, or the `title` ordering fails exactly one test and no others.

### Verification

- `pnpm run typecheck` clean.
- `pnpm vitest run tests/browser` — 48 files, 853 passed, 1 skipped.
- `pnpm oxlint` and `pnpm oxfmt --check` clean on the changed files.
- The picker probe is an injected template literal that no ordinary gate parses, so the branch was additionally checked by `new Function`-compiling the built expression for every effort level. That check caught three real defects during development: a lost `if (optionIsSelected(option))` guard, a `/\s+/` that must be written `/\\s+/`, and a comment containing backticks that terminated the template string.
- Exercised live against the capped account through the fork overlay: the picker is driven for real and the run aborts before submission, which returned the exact tooltip text (`Limit reached. Try again after Aug 16, 2026.`) through the association-delta path. The underlying DOM facts were also confirmed by read-only accessibility inspection: disabled `Pro` row at position 5, `AXEnabled=false`, `data-disabled=""`, siblings enabled, and no accessible description at rest.

### Real-browser proof

ClawSweeper (Codex-backed automated review) rated the PR 2/6 "needs proof" at `3f15c948`: the "exercised live" claim above had no inspectable artifact attached, only prose. Fresh capture posted as [a PR comment](https://github.com/steipete/oracle/pull/376#issuecomment-5293949862) against the same capped account: the unmodified `web_result.json` (`submitted: false`, `failure_class: tier_limited`, the real `effort_notice`), the last picker diagnostic before the throw — all five effort rows, `Extra High` checked, `Pro` disabled on `aria-disabled`, `data-disabled`, and the DOM `disabled` property — and the full unredacted stdout, scanned for emails/URLs/session-length hex (none present, so nothing needed redacting beyond the account itself staying unnamed). Cost: zero ChatGPT requests, since the branch's own fail-closed contract detects the disabled row before any click reaches it.
