### PR TITLE
fix(browser): report unavailable effort tiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Browser: detect a disabled ChatGPT effort tier (e.g. an exhausted Pro allotment) before clicking it, and report the account's own reset notice instead of a misleading "selection unverified" failure.
+- Browser: detect a disabled ChatGPT effort tier (e.g. an exhausted Pro allotment) before clicking it, and report the account's own reset notice instead of a misleading "selection unverified" failure. Thanks @enieuwy!
 
 ## 0.17.3 — 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Browser: stop copying cookies from a live Chrome profile by default because ChatGPT token rotation can invalidate the user's interactive session. Use the persistent `--browser-manual-login` profile (recommended), inline cookies, or explicitly restore the old behavior with `--browser-cookie-sync` / `browser.cookieSync=true`. Fixes #367.
 
+### Fixed
+
+- Browser: detect a disabled ChatGPT effort tier (e.g. an exhausted Pro allotment) before clicking it, and report the account's own reset notice instead of a misleading "selection unverified" failure.
+
 ## 0.17.3 — 2026-08-13
 
 **Highlight:** browser-mode answers and recovery are reliable again — no more

--- a/src/browser/actions/thinkingTime.ts
+++ b/src/browser/actions/thinkingTime.ts
@@ -7,6 +7,7 @@ import {
 } from "../constants.js";
 import { logDomFailure } from "../domDebug.js";
 import { buildClickDispatcher } from "./domEvents.js";
+import { BrowserAutomationError } from "../../oracle/errors.js";
 
 // Snapshot of the model-picker / thinking-effort subtree, captured at the moment
 // detection fails so a chip-not-found can be diagnosed without re-running with
@@ -32,7 +33,7 @@ type ThinkingTimeOutcome = (
     }
 ) & { modelKind?: string | null };
 
-export class ThinkingTierUnavailableError extends Error {
+export class ThinkingTierUnavailableError extends BrowserAutomationError {
   readonly requestedLevel: string;
   readonly requestedLabel: string;
   readonly optionLabel: string | null;
@@ -46,9 +47,15 @@ export class ThinkingTierUnavailableError extends Error {
     notice: string | null,
     confirmedTarget: string,
   ) {
-    super(
-      `Thinking time: ${optionLabel ?? requestedLabel} is unavailable on this account (${notice ?? "no reason given"}); refusing to submit without confirmed ${confirmedTarget}.`,
-    );
+    const message = `Thinking time: ${optionLabel ?? requestedLabel} is unavailable on this account (${notice ?? "no reason given"}); refusing to submit without confirmed ${confirmedTarget}.`;
+    super(message, {
+      stage: "thinking-tier-unavailable",
+      requestedLevel,
+      requestedLabel,
+      optionLabel,
+      notice,
+      confirmedTarget,
+    });
     this.name = "ThinkingTierUnavailableError";
     this.requestedLevel = requestedLevel;
     this.requestedLabel = requestedLabel;

--- a/src/browser/actions/thinkingTime.ts
+++ b/src/browser/actions/thinkingTime.ts
@@ -16,6 +16,12 @@ type ThinkingTimePickerDiagnostic = Record<string, unknown>;
 type ThinkingTimeOutcome = (
   | { status: "already-selected"; label?: string | null }
   | { status: "switched"; label?: string | null }
+  | {
+      status: "option-disabled";
+      label?: string | null;
+      notice?: string | null;
+      diagnostic?: ThinkingTimePickerDiagnostic;
+    }
   | { status: "chip-not-found"; diagnostic?: ThinkingTimePickerDiagnostic }
   | { status: "menu-not-found"; diagnostic?: ThinkingTimePickerDiagnostic }
   | { status: "option-not-found"; diagnostic?: ThinkingTimePickerDiagnostic }
@@ -25,6 +31,42 @@ type ThinkingTimeOutcome = (
       diagnostic?: ThinkingTimePickerDiagnostic;
     }
 ) & { modelKind?: string | null };
+
+export class ThinkingTierUnavailableError extends Error {
+  readonly requestedLevel: string;
+  readonly requestedLabel: string;
+  readonly optionLabel: string | null;
+  readonly notice: string | null;
+  readonly confirmedTarget: string;
+
+  constructor(
+    requestedLevel: string,
+    requestedLabel: string,
+    optionLabel: string | null,
+    notice: string | null,
+    confirmedTarget: string,
+  ) {
+    super(
+      `Thinking time: ${optionLabel ?? requestedLabel} is unavailable on this account (${notice ?? "no reason given"}); refusing to submit without confirmed ${confirmedTarget}.`,
+    );
+    this.name = "ThinkingTierUnavailableError";
+    this.requestedLevel = requestedLevel;
+    this.requestedLabel = requestedLabel;
+    this.optionLabel = optionLabel;
+    this.notice = notice;
+    this.confirmedTarget = confirmedTarget;
+  }
+}
+
+function confirmedThinkingTarget(
+  level: ThinkingTimeLevel,
+  capitalizedLevel: string,
+  targetModelKind: "pro" | "thinking" | "instant" | null,
+  observedModelKind: string | null | undefined,
+): string {
+  const strictModelKind = targetModelKind ?? observedModelKind;
+  return level === "pro" ? "Pro" : strictModelKind === "pro" ? "Pro Extended" : capitalizedLevel;
+}
 
 const BROWSER_THINKING_LOG_PREFIX = "[browser] Thinking time:";
 
@@ -79,6 +121,28 @@ export async function ensureThinkingTime(
     case "switched":
       logger(formatBrowserThinkingLog(result.label ?? capitalizedLevel));
       return;
+    case "option-disabled": {
+      await logDomFailure(Runtime, logger, "thinking-option-disabled");
+      logPickerDiagnostic(result, logger);
+      if (strictProEffort) {
+        throw new ThinkingTierUnavailableError(
+          level,
+          capitalizedLevel,
+          result.label ?? null,
+          result.notice ?? null,
+          confirmedThinkingTarget(level, capitalizedLevel, targetModelKind, observedModelKind),
+        );
+      }
+      // A non-strict caller goes on to submit, so this log must not borrow the
+      // strict error's "refusing to submit" wording: the request really is sent,
+      // at whatever effort ChatGPT already had selected.
+      logger(
+        formatBrowserThinkingLog(
+          `${result.label ?? capitalizedLevel} is unavailable on this account (${result.notice ?? "no reason given"}); keeping the effort already selected in ChatGPT.`,
+        ),
+      );
+      return;
+    }
     case "chip-not-found":
     case "menu-not-found":
     case "option-not-found":
@@ -148,6 +212,13 @@ export async function ensureThinkingTimeIfAvailable(
       case "switched":
         logger(formatBrowserThinkingLog(result.label ?? capitalizedLevel));
         return true;
+      case "option-disabled":
+        logger(
+          formatBrowserThinkingLog(
+            `${result.label ?? capitalizedLevel} is unavailable on this account (${result.notice ?? "no reason given"}); keeping the effort already selected in ChatGPT.`,
+          ),
+        );
+        return false;
       case "chip-not-found":
       case "menu-not-found":
       case "option-not-found":
@@ -359,6 +430,21 @@ function buildThinkingTimeExpression(
         .replace(/\\s+/g, ' ')
         .trim()
         .slice(0, maxLength);
+    const isOptionDisabled = (node) => {
+      if (!node || typeof node.getAttribute !== 'function') return false;
+      // data-disabled is Radix's valueless-presence convention, but an explicit
+      // "false" must not read as disabled: that would refuse a perfectly usable
+      // tier and report it as unavailable.
+      const dataDisabled = node.getAttribute('data-disabled');
+      const dataDisabledOn = dataDisabled !== null && String(dataDisabled).toLowerCase() !== 'false';
+      return (
+        node.getAttribute('aria-disabled') === 'true' ||
+        dataDisabledOn ||
+        (node.getAttribute('data-state') || '').toLowerCase() === 'disabled' ||
+        Boolean(node.disabled) ||
+        node.getAttribute('disabled') !== null
+      );
+    };
     const describeNode = (el) => {
       if (!el || typeof el.getAttribute !== 'function') return null;
       let rect = null;
@@ -381,7 +467,10 @@ function buildThinkingTimeExpression(
         ariaChecked: el.getAttribute('aria-checked'),
         ariaSelected: el.getAttribute('aria-selected'),
         ariaHaspopup: el.getAttribute('aria-haspopup'),
+        ariaDisabled: el.getAttribute('aria-disabled'),
+        dataDisabled: el.getAttribute('data-disabled'),
         dataState: el.getAttribute('data-state'),
+        disabled: isOptionDisabled(el),
         text: redactDiagnosticText(el.textContent, 80),
         rect,
       };
@@ -657,6 +746,77 @@ function buildThinkingTimeExpression(
       }
       return matchesLevel(normalizedLabel);
     };
+    const nonEmptyNotice = (value) => {
+      const text = redactDiagnosticText(value, 160);
+      return text || null;
+    };
+    // The notice must be ROW-OWNED, and preferably this hover's own.
+    //
+    // NOTE: no backticks in this comment — it lives inside the injected template
+    // literal, where a backtick would terminate the string.
+    //
+    // A document-wide role=tooltip scan is what this must never become: novelty is
+    // not causality, and an unrelated control with an armed open-delay can mount its
+    // tooltip inside this hover's window. Every pass below is anchored on the row.
+    //
+    // Preference order, strongest provenance first:
+    //   1. an id this hover ADDED whose target is role=tooltip — Radix keeps an
+    //      application-supplied description and APPENDS its tooltip id when opening,
+    //      so the delta is what separates the real notice from a permanent blurb;
+    //   2. any other id this hover added;
+    //   3. an already-associated role=tooltip target, for a tooltip that was open
+    //      before the probe arrived;
+    //   4. the row's static title, only once the poll has expired.
+    //
+    // Passes 3 and 4 are row-owned but NOT causal: a page that permanently points a
+    // disabled row at generic role=tooltip help, or gives it a generic title, will
+    // have that text reported. That is accepted deliberately — the value is an opaque
+    // notice for a human or a caller to interpret, not a parsed reset time — and the
+    // verified live target has neither at rest.
+    const describedIds = (option) =>
+      (option?.getAttribute?.('aria-describedby') || '').split(/\\s+/).filter(Boolean);
+    const isTooltipNode = (node) => node?.getAttribute?.('role') === 'tooltip';
+    const readDisabledNotice = (option, priorIds, allowTitle) => {
+      const ids = describedIds(option);
+      const prior = priorIds instanceof Set ? priorIds : new Set();
+      const fresh = ids.filter((id) => !prior.has(id));
+      for (const pass of [
+        fresh.filter((id) => isTooltipNode(document.getElementById?.(id))),
+        fresh,
+        ids.filter((id) => isTooltipNode(document.getElementById?.(id))),
+      ]) {
+        for (const id of pass) {
+          const notice = nonEmptyNotice(document.getElementById?.(id)?.textContent);
+          if (notice) return notice;
+        }
+      }
+      if (!allowTitle) return null;
+      return nonEmptyNotice(option?.getAttribute?.('title'));
+    };
+    const waitForDisabledNotice = async (option, priorIds) => {
+      const deadline = performance.now() + 400;
+      while (performance.now() < deadline) {
+        const notice = readDisabledNotice(option, priorIds, false);
+        if (notice) return notice;
+        await sleep(50);
+      }
+      // Only now may a static title speak: the association had its full window.
+      return readDisabledNotice(option, priorIds, true);
+    };
+    // Opening a tooltip stacks another Radix dismissable layer over the menu, and
+    // the topmost layer eats the Escape. One blind Escape therefore leaves the
+    // effort menu open, which matters for the non-strict caller that goes on to
+    // submit. Dismiss, let the layer unmount, and only Escape again while a menu is
+    // still there — never two unconditional Escapes, which could close an unrelated
+    // outer surface.
+    const closeMenusAfterTooltip = async () => {
+      closeOpenMenus();
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        await sleep(50);
+        if (!Array.from(document.querySelectorAll(MENU_CONTAINER_SELECTOR)).some(isVisible)) return;
+        closeOpenMenus();
+      }
+    };
     const selectAndVerify = async (trigger, findOption, modelKindOverride = null) => {
       const triggerModelKind =
         modelKindOverride ||
@@ -682,6 +842,22 @@ function buildThinkingTimeExpression(
       }
       if (!option) return failure('option-not-found', { modelKind: triggerModelKind });
       const label = option.textContent?.trim?.() || null;
+      if (isOptionDisabled(option)) {
+        // Captured BEFORE the hover: the ids already here describe the row for other
+        // reasons and cannot be this hover's reason.
+        const priorIds = new Set(describedIds(option));
+        dispatchHoverSequence(option);
+        const notice = await waitForDisabledNotice(option, priorIds);
+        const result = failure('option-disabled', {
+          // The label is page text that reaches logs and diagnostics, so it is
+          // redacted like every other reported string.
+          label: redactDiagnosticText(option.textContent, 80) || null,
+          notice,
+          modelKind: triggerModelKind,
+        });
+        await closeMenusAfterTooltip();
+        return result;
+      }
       if (optionIsSelected(option)) {
         closeOpenMenus();
         return { status: 'already-selected', label };

--- a/tests/browser/thinkingTime.test.ts
+++ b/tests/browser/thinkingTime.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { ThinkingTimeLevel } from "../../src/oracle/types.js";
 import {
+  ThinkingTierUnavailableError,
   buildThinkingTimeExpressionForTest,
   ensureThinkingTime,
+  ensureThinkingTimeIfAvailable,
   inferThinkingTargetModelKindForTest,
 } from "../../src/browser/actions/thinkingTime.js";
 
@@ -2821,6 +2823,19 @@ describe("unified Intelligence picker with Advanced -> Effort submenu", () => {
     ) {}
   }
 
+  // The probe closes menus with a real KeyboardEvent, so the harness must provide
+  // one: without it the constructor throws inside the probe's try/catch and no
+  // Escape is ever observable, which is what let the tooltip-layer bug hide.
+  class FakeKeyboardEvent {
+    public readonly key: string;
+    constructor(
+      public readonly type: string,
+      init: { key?: string } = {},
+    ) {
+      this.key = init.key ?? "";
+    }
+  }
+
   function buildDom(currentTier: string) {
     const tierNames = ["Instant", "Medium", "High", "Extra High", "Pro"];
     let selectedTier = currentTier;
@@ -2936,6 +2951,7 @@ describe("unified Intelligence picker with Advanced -> Effort submenu", () => {
       "PointerEvent",
       "MouseEvent",
       "HTMLElement",
+      "KeyboardEvent",
       `return ${buildThinkingTimeExpressionForTest(level as ThinkingTimeLevel, model)};`,
     ) as (...args: unknown[]) => Promise<{ status: string; label: string | null }>;
     return evaluate(
@@ -2947,6 +2963,7 @@ describe("unified Intelligence picker with Advanced -> Effort submenu", () => {
       FakeMouseEvent,
       FakeMouseEvent,
       Node,
+      FakeKeyboardEvent,
     );
   }
 
@@ -3146,5 +3163,374 @@ describe("unified Intelligence picker with Advanced -> Effort submenu", () => {
     await run(dom.documentStub, "pro");
     expect(decoy?.clicks).toBe(0);
     expect(dom.getSelectedTier()).toBe("High");
+  });
+  type DisabledProbeResult = {
+    status: string;
+    label?: string | null;
+    notice?: string | null;
+    diagnostic?: {
+      menus?: Array<{ items?: Array<Record<string, unknown>> }>;
+    };
+  };
+
+  function disabledDom() {
+    const dom = buildDom("High");
+    const option = dom.tierRows[4]!;
+    option.setAttribute("aria-disabled", "true");
+    option.setAttribute("data-state", "unchecked");
+    return { dom, option };
+  }
+
+  type PickerDomStub = {
+    documentStub: {
+      querySelectorAll: (selector: string) => Node[];
+      getElementById: (id: string) => Node | null;
+      dispatchEvent: (event: unknown) => boolean;
+    };
+  };
+
+  it("keeps closing until the menu is gone when a tooltip layer eats the first Escape", async () => {
+    // Radix tooltip content is its own dismissable layer, and the topmost layer
+    // consumes Escape. One blind Escape would leave the effort menu open, which the
+    // non-strict caller then submits underneath.
+    const { dom } = disabledDom();
+    const stub = dom.documentStub as PickerDomStub["documentStub"];
+    let escapes = 0;
+    let menusOpen = true;
+    stub.dispatchEvent = (event: unknown) => {
+      if (String((event as { key?: string }).key) === "Escape") {
+        escapes += 1;
+        // The first Escape only dismisses the tooltip layer.
+        if (escapes >= 2) menusOpen = false;
+      }
+      return true;
+    };
+    const querySelectorAll = stub.querySelectorAll;
+    stub.querySelectorAll = (selector: string) => {
+      const menuQuery = selector.includes('role="menu"') || selector.includes("data-radix");
+      if (menuQuery && !menusOpen) return [];
+      return querySelectorAll(selector);
+    };
+    await expect(run(dom.documentStub, "pro", "gpt-5.5-pro")).resolves.toMatchObject({
+      status: "option-disabled",
+    });
+    expect(escapes).toBeGreaterThanOrEqual(2);
+    expect(menusOpen).toBe(false);
+  });
+
+  it("uses an already-associated role=tooltip target when this hover adds nothing", async () => {
+    // Pass 3: row-owned but not causal. A tooltip that was already open for this row
+    // is the best evidence available when the hover adds no association, and the
+    // static-description helper deliberately builds a target WITHOUT role=tooltip, so
+    // without this case the third pass is never exercised.
+    const { dom, option } = disabledDom();
+    const described = new Node("Limit reached. Try again after Aug 16, 2026.");
+    described.setAttribute("role", "tooltip");
+    option.setAttribute("aria-describedby", "open-tip");
+    const getElementById = dom.documentStub.getElementById;
+    dom.documentStub.getElementById = (id: string) =>
+      id === "open-tip" ? described : getElementById(id);
+    await expect(run(dom.documentStub, "pro", "gpt-5.5-pro")).resolves.toMatchObject({
+      status: "option-disabled",
+      notice: "Limit reached. Try again after Aug 16, 2026.",
+    });
+  });
+
+  // Radix APPENDS its tooltip id to whatever aria-describedby the app already set,
+  // and only while the tooltip is open. This helper reproduces that transition: a
+  // pre-existing description stays, and the tooltip id (plus its node) appears only
+  // after this row is hovered.
+  function appendTooltipOnHover(
+    dom: PickerDomStub,
+    option: Node,
+    id: string,
+    text: string,
+    opts: { role?: string | null; polls?: number } = {},
+  ) {
+    const { role = "tooltip", polls = 2 } = opts;
+    const described = new Node(text);
+    if (role) described.setAttribute("role", role);
+    let hovered = false;
+    let seen = 0;
+    const baseDescribedBy = option.getAttribute("aria-describedby") || "";
+    const originalDispatch = option.dispatchEvent.bind(option);
+    option.dispatchEvent = (event: unknown) => {
+      const type = String((event as { type?: string }).type ?? "");
+      if (type.startsWith("pointer") || type.startsWith("mouse")) {
+        hovered = true;
+        option.setAttribute("aria-describedby", `${baseDescribedBy} ${id}`.trim());
+      }
+      return originalDispatch(event);
+    };
+    const getElementById = dom.documentStub.getElementById;
+    dom.documentStub.getElementById = (candidate: string) => {
+      if (candidate !== id) return getElementById(candidate);
+      if (!hovered) return null;
+      seen += 1;
+      return seen >= polls ? described : null;
+    };
+    return described;
+  }
+
+  // A static description the row already carried: row ownership, but not this
+  // hover's reason.
+  function describeStatically(dom: PickerDomStub, option: Node, id: string, text: string) {
+    const described = new Node(text);
+    const existing = option.getAttribute("aria-describedby") || "";
+    option.setAttribute("aria-describedby", `${existing} ${id}`.trim());
+    const getElementById = dom.documentStub.getElementById;
+    dom.documentStub.getElementById = (candidate: string) =>
+      candidate === id ? described : getElementById(candidate);
+    return described;
+  }
+
+  // An unrelated tooltip that mounts DURING this hover, which is what defeats a
+  // novelty-based rule.
+  function addUnrelatedTooltipOnHover(dom: PickerDomStub, option: Node, text: string) {
+    const tooltip = new Node(text);
+    tooltip.setAttribute("role", "tooltip");
+    let hovered = false;
+    const originalDispatch = option.dispatchEvent.bind(option);
+    option.dispatchEvent = (event: unknown) => {
+      const type = String((event as { type?: string }).type ?? "");
+      if (type.startsWith("pointer") || type.startsWith("mouse")) hovered = true;
+      return originalDispatch(event);
+    };
+    const querySelectorAll = dom.documentStub.querySelectorAll;
+    dom.documentStub.querySelectorAll = (selector: string) => {
+      if (!selector.includes('[role="tooltip"]')) return querySelectorAll(selector);
+      return hovered ? [tooltip] : [];
+    };
+    return tooltip;
+  }
+
+  it("returns option-disabled without clicking an aria-disabled row", async () => {
+    const { dom, option } = disabledDom();
+    await expect(run(dom.documentStub, "pro", "gpt-5.5-pro")).resolves.toMatchObject({
+      status: "option-disabled",
+      label: "Pro",
+      notice: null,
+    });
+    expect(option.clicks).toBe(0);
+  });
+
+  it("splits multiple aria-describedby ids on any whitespace", async () => {
+    // Guards the injected /\\s+/: if it ever cooks down to /s+/ the appended id is
+    // never separated from the pre-existing ones and the notice vanishes.
+    const { dom, option } = disabledDom();
+    describeStatically(dom, option, "decoy-a", "Pro is the highest reasoning tier");
+    describeStatically(dom, option, "decoy-b", "Keyboard shortcut");
+    option.setAttribute("aria-describedby", "decoy-a \t decoy-b");
+    appendTooltipOnHover(
+      dom,
+      option,
+      "tier-notice",
+      "Limit reached. Try again after Aug 16, 2026.",
+    );
+    await expect(run(dom.documentStub, "pro", "gpt-5.5-pro")).resolves.toMatchObject({
+      status: "option-disabled",
+      notice: "Limit reached. Try again after Aug 16, 2026.",
+    });
+  });
+
+  it("prefers the tooltip this hover appended over a static description", async () => {
+    // Radix keeps an app-supplied description and appends its own id, so mere
+    // presence of aria-describedby proves the ROW but not the REASON. Returning the
+    // static blurb would hand the caller a confident wrong answer.
+    const { dom, option } = disabledDom();
+    describeStatically(dom, option, "tier-help", "Pro is the highest reasoning tier");
+    appendTooltipOnHover(
+      dom,
+      option,
+      "tier-notice",
+      "Limit reached. Try again after Aug 16, 2026.",
+    );
+    await expect(run(dom.documentStub, "pro", "gpt-5.5-pro")).resolves.toMatchObject({
+      status: "option-disabled",
+      notice: "Limit reached. Try again after Aug 16, 2026.",
+    });
+  });
+
+  it("ignores an unrelated tooltip that opens during this hover", async () => {
+    const { dom, option } = disabledDom();
+    // Novelty is not ownership: another control's armed open-delay can fire inside
+    // this hover's window, and its date has nothing to do with this tier.
+    addUnrelatedTooltipOnHover(dom, option, "Limit reached. Try again after Dec 31, 2099.");
+    await expect(run(dom.documentStub, "pro", "gpt-5.5-pro")).resolves.toMatchObject({
+      status: "option-disabled",
+      notice: null,
+    });
+  });
+
+  it("lets the appended association win over a static title", async () => {
+    // title is consulted only after the association poll expires, so a permanent
+    // tooltip attribute cannot preempt the real reason while it is still mounting.
+    const { dom, option } = disabledDom();
+    option.setAttribute("title", "Highest reasoning tier");
+    // polls high enough that the association is still mounting across several poll
+    // iterations: with a lower value the tooltip resolves inside the first
+    // iteration and the test could not detect a title that preempts it.
+    appendTooltipOnHover(
+      dom,
+      option,
+      "tier-notice",
+      "Limit reached. Try again after Aug 16, 2026.",
+      {
+        polls: 6,
+      },
+    );
+    await expect(run(dom.documentStub, "pro", "gpt-5.5-pro")).resolves.toMatchObject({
+      status: "option-disabled",
+      notice: "Limit reached. Try again after Aug 16, 2026.",
+    });
+  });
+
+  it("falls back to the row's title attribute when nothing associates", async () => {
+    const { dom, option } = disabledDom();
+    option.setAttribute("title", "Limit reached. Try again after Aug 16, 2026.");
+    await expect(run(dom.documentStub, "pro", "gpt-5.5-pro")).resolves.toMatchObject({
+      status: "option-disabled",
+      notice: "Limit reached. Try again after Aug 16, 2026.",
+    });
+  });
+
+  it("redacts the disabled row's label", async () => {
+    const { dom, option } = disabledDom();
+    option.textContent = "Pro  contact\nsupport@example.com now";
+    const result = (await run(dom.documentStub, "pro", "gpt-5.5-pro")) as DisabledProbeResult;
+    expect(result.label).toBe("Pro contact [redacted-email] now");
+  });
+
+  it('treats data-disabled="false" as enabled and still clicks the row', async () => {
+    const dom = buildDom("High");
+    const option = dom.tierRows[4]!;
+    option.setAttribute("data-disabled", "false");
+    const result = (await run(dom.documentStub, "pro", "gpt-5.5-pro")) as DisabledProbeResult;
+    expect(result.status).not.toBe("option-disabled");
+    expect(option.clicks).toBe(1);
+  });
+
+  it("refuses a row that is disabled even while it is the selected effort", async () => {
+    // Deliberate ordering: disabled wins over already-selected. Being checked does
+    // not prove the tier is still usable, and refusing costs nothing, while
+    // submitting may spend a request and come back silently degraded. A future
+    // cleanup that hoists the selected check above the disabled check must fail
+    // here.
+    const dom = buildDom("Pro");
+    const option = dom.tierRows[4]!;
+    option.setAttribute("aria-disabled", "true");
+    const result = (await run(dom.documentStub, "pro", "gpt-5.5-pro")) as DisabledProbeResult;
+    expect(result.status).toBe("option-disabled");
+    expect(option.clicks).toBe(0);
+  });
+  it("returns a null notice when no tooltip renders", async () => {
+    const { dom } = disabledDom();
+    await expect(run(dom.documentStub, "pro", "gpt-5.5-pro")).resolves.toMatchObject({
+      status: "option-disabled",
+      notice: null,
+    });
+  });
+
+  it("includes disabled state attributes in picker diagnostics", async () => {
+    const { dom } = disabledDom();
+    const result = (await run(dom.documentStub, "pro", "gpt-5.5-pro")) as DisabledProbeResult;
+    // The effort rows live in the submenu, so scan every captured menu: the
+    // assertion is about the disabled attributes reaching the diagnostic, not
+    // about which menu index the harness happens to expose them under.
+    const items = (result.diagnostic?.menus ?? []).flatMap((menu) => menu.items ?? []);
+    const item = items.find((entry) => entry.ariaDisabled === "true");
+    expect(item).toMatchObject({ ariaDisabled: "true", dataDisabled: null, disabled: true });
+  });
+
+  it("throws ThinkingTierUnavailableError when disabled Pro is requested", async () => {
+    const runtime = {
+      evaluate: async () => ({
+        result: {
+          value: {
+            status: "option-disabled",
+            label: "Pro",
+            notice: "Limit reached. Try again after Aug 16, 2026.",
+          },
+        },
+      }),
+    };
+    const strictSelection = ensureThinkingTime(
+      runtime as never,
+      "pro",
+      (() => {}) as never,
+      "gpt-5.5-pro",
+    );
+    await expect(strictSelection).rejects.toBeInstanceOf(ThinkingTierUnavailableError);
+    await expect(strictSelection).rejects.toMatchObject({
+      name: "ThinkingTierUnavailableError",
+      message:
+        "Thinking time: Pro is unavailable on this account (Limit reached. Try again after Aug 16, 2026.); refusing to submit without confirmed Pro.",
+      requestedLevel: "pro",
+      requestedLabel: "Pro",
+      optionLabel: "Pro",
+      notice: "Limit reached. Try again after Aug 16, 2026.",
+      confirmedTarget: "Pro",
+    });
+
+    const logs: string[] = [];
+    await expect(
+      ensureThinkingTime(
+        runtime as never,
+        "extended",
+        ((line: string) => logs.push(line)) as never,
+        null,
+      ),
+    ).resolves.toBeUndefined();
+    expect(logs.join(" ")).toContain("Limit reached. Try again after Aug 16, 2026.");
+  });
+
+  it("names the requested tier, not a hard-coded one, in the strict error", async () => {
+    // Extended on a Pro model is the other strict path, and its confirmation
+    // target must follow the request instead of being spelled out for Pro alone.
+    const runtime = {
+      evaluate: async () => ({
+        result: {
+          value: {
+            status: "option-disabled",
+            label: "Pro Extended",
+            notice: "Unavailable on this plan.",
+          },
+        },
+      }),
+    };
+    await expect(
+      ensureThinkingTime(runtime as never, "extended", (() => {}) as never, "gpt-5.5-pro"),
+    ).rejects.toMatchObject({
+      name: "ThinkingTierUnavailableError",
+      requestedLevel: "extended",
+      confirmedTarget: "Pro Extended",
+      message: expect.stringContaining("refusing to submit without confirmed Pro Extended"),
+    });
+  });
+
+  it("keeps the current effort when IfAvailable sees a disabled row", async () => {
+    const runtime = {
+      evaluate: async () => ({
+        result: {
+          value: {
+            status: "option-disabled",
+            label: "Pro",
+            notice: "Limit reached. Try again after Aug 16, 2026.",
+          },
+        },
+      }),
+    };
+    const logs: string[] = [];
+    await expect(
+      ensureThinkingTimeIfAvailable(
+        runtime as never,
+        "pro",
+        ((line: string) => logs.push(line)) as never,
+        "gpt-5.5-pro",
+      ),
+    ).resolves.toBe(false);
+    const logged = logs.join(" ");
+    expect(logged).toContain("keeping the effort already selected in ChatGPT");
+    expect(logged).not.toContain("continuing with default");
   });
 });

--- a/tests/browser/thinkingTime.test.ts
+++ b/tests/browser/thinkingTime.test.ts
@@ -3463,6 +3463,7 @@ describe("unified Intelligence picker with Advanced -> Effort submenu", () => {
     await expect(strictSelection).rejects.toBeInstanceOf(ThinkingTierUnavailableError);
     await expect(strictSelection).rejects.toMatchObject({
       name: "ThinkingTierUnavailableError",
+      category: "browser-automation",
       message:
         "Thinking time: Pro is unavailable on this account (Limit reached. Try again after Aug 16, 2026.); refusing to submit without confirmed Pro.",
       requestedLevel: "pro",
@@ -3470,6 +3471,14 @@ describe("unified Intelligence picker with Advanced -> Effort submenu", () => {
       optionLabel: "Pro",
       notice: "Limit reached. Try again after Aug 16, 2026.",
       confirmedTarget: "Pro",
+      details: {
+        stage: "thinking-tier-unavailable",
+        requestedLevel: "pro",
+        requestedLabel: "Pro",
+        optionLabel: "Pro",
+        notice: "Limit reached. Try again after Aug 16, 2026.",
+        confirmedTarget: "Pro",
+      },
     });
 
     const logs: string[] = [];


### PR DESCRIPTION
## Summary

- carry @enieuwy's #376 commit intact so disabled ChatGPT effort tiers are detected before click and report their row-owned notice
- preserve fail-closed behavior for strict Pro requests and best-effort behavior for optional selection
- classify the new unavailable-tier error as browser automation and persist its structured stage/details through Oracle's session and MCP boundary
- add contributor credit under 0.17.4 Unreleased

## Why this branch

The contributor patch is well-designed and has credible capped-account browser proof. The maintainer commit completes its structured-error contract: the original subclass was a plain `Error`, so normal Oracle session serialization dropped the new fields and classified the failure as internal. It now extends the existing browser-automation error owner while preserving the message and direct properties.

## Verification

- `pnpm vitest run tests/browser/thinkingTime.test.ts tests/browser/chatgptImages.test.ts` — 73 passed
- `pnpm test` — 1,756 passed, 43 skipped
- `pnpm run check`
- `pnpm run build`
- `pnpm run docs:check`
- source-blind built-library validation for strict, best-effort, and missing-notice outcomes
- structured P1 full-branch and maintainer-delta reviews: clean

The original macOS failure was an unrelated 10-second timeout in `chatgptImages.test.ts`; that test passes alongside the touched picker test and in the full local suite on this exact stack. This replacement PR provides a fresh CI run.

Supersedes #376 for landing while preserving its commit history, live proof, and author credit.
