### PR TITLE
fix(browser): reject colliding attachment basenames before upload

### DIFF
--- a/src/browser/attachmentValidation.ts
+++ b/src/browser/attachmentValidation.ts
@@ -1,0 +1,85 @@
+import path from "node:path";
+import type { BrowserAttachment } from "./types.js";
+
+export interface AttachmentBasenameCollision {
+  basename: string;
+  attachments: BrowserAttachment[];
+}
+
+export interface AttachmentBasenameCollisionDetail {
+  basename: string;
+  files: string[];
+}
+
+export interface AttachmentBasenameCollisionDetails {
+  collisions: AttachmentBasenameCollisionDetail[];
+  files: string[];
+}
+
+function compareStrings(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+export function findAttachmentBasenameCollisions(
+  attachments: BrowserAttachment[],
+): AttachmentBasenameCollision[] {
+  const attachmentsByBasename = new Map<string, BrowserAttachment[]>();
+  for (const attachment of attachments) {
+    const basename = path.basename(attachment.path);
+    const matchingAttachments = attachmentsByBasename.get(basename) ?? [];
+    matchingAttachments.push(attachment);
+    attachmentsByBasename.set(basename, matchingAttachments);
+  }
+
+  return [...attachmentsByBasename.entries()]
+    .filter(([, matchingAttachments]) => matchingAttachments.length > 1)
+    .sort(([leftBasename], [rightBasename]) => compareStrings(leftBasename, rightBasename))
+    .map(([basename, matchingAttachments]) => ({
+      basename,
+      attachments: [...matchingAttachments].sort(
+        (left, right) =>
+          compareStrings(left.displayPath, right.displayPath) ||
+          compareStrings(left.path, right.path),
+      ),
+    }));
+}
+
+export function buildAttachmentBasenameCollisionDetails(
+  collisions: AttachmentBasenameCollision[],
+  displayFile: (attachment: BrowserAttachment) => string,
+): AttachmentBasenameCollisionDetails {
+  const collisionDetails = collisions.map((collision) => ({
+    basename: collision.basename,
+    files: collision.attachments.map(displayFile),
+  }));
+  return {
+    collisions: collisionDetails,
+    files: collisionDetails.flatMap((collision) => collision.files),
+  };
+}
+
+export function formatAttachmentBasenameCollisionMessage(
+  subject: string,
+  collisions: AttachmentBasenameCollisionDetail[],
+): string {
+  const collisionLines =
+    collisions.length === 1
+      ? [
+          `${subject} cannot safely include multiple files named "${collisions[0]!.basename}":`,
+          ...collisions[0]!.files.map((file) => `- ${file}`),
+        ]
+      : [
+          `${subject} cannot safely include files with colliding basenames:`,
+          ...collisions.flatMap((collision) => [
+            `Files named "${collision.basename}":`,
+            ...collision.files.map((file) => `- ${file}`),
+          ]),
+        ];
+
+  return [
+    ...collisionLines,
+    "Use --browser-bundle-files (and --browser-bundle-format zip for raw or binary files), or choose unique names before retrying.",
+  ].join("\n");
+}

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -60,6 +60,11 @@ import type { BrowserModelSelectionEvidence } from "../sessionStore.js";
 import { CHATGPT_URL, DEFAULT_MODEL_STRATEGY } from "./constants.js";
 import type { LaunchedChrome } from "chrome-launcher";
 import { BrowserAutomationError } from "../oracle/errors.js";
+import {
+  buildAttachmentBasenameCollisionDetails,
+  findAttachmentBasenameCollisions,
+  formatAttachmentBasenameCollisionMessage,
+} from "./attachmentValidation.js";
 import { alignPromptEchoPair, buildPromptEchoMatcher } from "./reattachHelpers.js";
 import { buildConversationTurnCountExpression } from "./conversationTurns.js";
 import type { ProfileRunLock } from "./profileState.js";
@@ -509,6 +514,27 @@ function hasBrowserErrorCode(error: unknown, code: string): boolean {
   );
 }
 
+function assertUniqueAttachmentBasenames(
+  attachments: BrowserAttachment[],
+  options: { stage: string; subject: string },
+): void {
+  const collisions = findAttachmentBasenameCollisions(attachments);
+  if (collisions.length === 0) return;
+
+  const collisionDetails = buildAttachmentBasenameCollisionDetails(
+    collisions,
+    (attachment) => attachment.displayPath || attachment.path,
+  );
+  throw new BrowserAutomationError(
+    formatAttachmentBasenameCollisionMessage(options.subject, collisionDetails.collisions),
+    {
+      stage: options.stage,
+      code: "attachment-basename-collision",
+      ...collisionDetails,
+    },
+  );
+}
+
 async function saveOptionalArtifact<T>(
   operation: () => Promise<T | null>,
   logger: BrowserLogger,
@@ -790,6 +816,10 @@ async function runSubmissionWithRecovery({
 
       const isPromptTooLarge = hasBrowserErrorCode(error, "prompt-too-large");
       if (fallbackSubmission && isPromptTooLarge && !usedFallbackSubmission) {
+        assertUniqueAttachmentBasenames(fallbackSubmission.attachments, {
+          stage: "upload-fallback",
+          subject: "The inline prompt was too large, but its upload fallback",
+        });
         usedFallbackSubmission = true;
         logger("[browser] Inline prompt too large; retrying with file uploads.");
         await prepareFallbackSubmission();
@@ -912,12 +942,17 @@ function buildSkippedModelSelectionEvidence(
 }
 
 export async function runBrowserMode(options: BrowserRunOptions): Promise<BrowserRunResult> {
+  const attachments: BrowserAttachment[] = options.attachments ?? [];
+  assertUniqueAttachmentBasenames(attachments, {
+    stage: "upload",
+    subject: "Browser upload",
+  });
+
   const promptText = options.prompt?.trim();
   if (!promptText) {
     throw new Error("Prompt text is required when using browser mode.");
   }
 
-  const attachments: BrowserAttachment[] = options.attachments ?? [];
   const fallbackSubmission = options.fallbackSubmission;
 
   let config = resolveBrowserConfig(options.config);

--- a/src/browser/prompt.ts
+++ b/src/browser/prompt.ts
@@ -15,6 +15,11 @@ import { buildPromptMarkdown } from "../oracle/promptAssembly.js";
 import type { BrowserAttachment } from "./types.js";
 import { buildAttachmentPlan } from "./policies.js";
 import { createStoredZip } from "./zipBundle.js";
+import {
+  buildAttachmentBasenameCollisionDetails,
+  findAttachmentBasenameCollisions,
+  formatAttachmentBasenameCollisionMessage,
+} from "./attachmentValidation.js";
 
 const DEFAULT_BROWSER_INLINE_CHAR_BUDGET = 60_000;
 const MAX_BROWSER_ATTACHMENTS = 10;
@@ -191,6 +196,19 @@ function assertAttachmentCount(
   if (attachments.length <= MAX_BROWSER_ATTACHMENTS) return;
   throw new Error(
     `Browser upload has ${attachments.length} attachments after applying bundle format "${format}". Use --browser-bundle-format auto or zip to stay within the ${MAX_BROWSER_ATTACHMENTS}-attachment limit.`,
+  );
+}
+
+function assertUniqueAttachmentBasenames(attachments: BrowserAttachment[], cwd: string): void {
+  const collisions = findAttachmentBasenameCollisions(attachments);
+  if (collisions.length === 0) return;
+
+  const details = buildAttachmentBasenameCollisionDetails(collisions, (attachment) =>
+    path.isAbsolute(attachment.path) ? attachment.path : path.resolve(cwd, attachment.path),
+  );
+  throw new FileValidationError(
+    formatAttachmentBasenameCollisionMessage("Browser upload", details.collisions),
+    { ...details },
   );
 }
 
@@ -380,6 +398,7 @@ export async function assembleBrowserPrompt(
     bundled = writtenBundle.metadata;
   }
   assertAttachmentCount(attachments, resolvedBundleFormat);
+  assertUniqueAttachmentBasenames(attachments, cwd);
 
   const inlineFileCount = shouldBundle ? 0 : selectedPlan.inlineFileCount;
   const modelConfig = isKnownModel(runOptions.model)

--- a/tests/browser/index.test.ts
+++ b/tests/browser/index.test.ts
@@ -540,6 +540,30 @@ describe("ChatGPT UI warning detection", () => {
 });
 
 describe("browser follow-ups", () => {
+  test("rejects direct attachment basename collisions before launching Chrome", async () => {
+    await expect(
+      runBrowserMode({
+        prompt: "test",
+        attachments: [
+          { path: "/tmp/first/SKILL.md", displayPath: "first/SKILL.md" },
+          { path: "/tmp/second/SKILL.md", displayPath: "second/SKILL.md" },
+        ],
+      }),
+    ).rejects.toMatchObject({
+      details: {
+        stage: "upload",
+        code: "attachment-basename-collision",
+        collisions: [
+          {
+            basename: "SKILL.md",
+            files: ["first/SKILL.md", "second/SKILL.md"],
+          },
+        ],
+        files: ["first/SKILL.md", "second/SKILL.md"],
+      },
+    });
+  });
+
   test("rejects copy-profile with manual-login before launching Chrome", async () => {
     await expect(
       runBrowserMode({
@@ -772,6 +796,52 @@ describe("shouldPreferSystemTmpDirForTest", () => {
 });
 
 describe("runSubmissionWithRecoveryForTest", () => {
+  test("rejects colliding fallback basenames before preparing or submitting fallback", async () => {
+    const submit = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new BrowserAutomationError("prompt too large", { code: "prompt-too-large" }),
+      );
+    const prepareFallbackSubmission = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      runSubmissionWithRecoveryForTest({
+        prompt: "inline prompt",
+        attachments: [],
+        fallbackSubmission: {
+          prompt: "fallback prompt",
+          attachments: [
+            { path: "/tmp/first/SKILL.md", displayPath: "first/SKILL.md", sizeBytes: 5 },
+            { path: "/tmp/second/SKILL.md", displayPath: "second/SKILL.md", sizeBytes: 6 },
+          ],
+        },
+        submit,
+        reloadPromptComposer: vi.fn().mockResolvedValue(undefined),
+        prepareFallbackSubmission,
+        logger: vi.fn<(message: string) => void>(),
+      }),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining(
+        'inline prompt was too large, but its upload fallback cannot safely include multiple files named "SKILL.md"',
+      ),
+      details: {
+        stage: "upload-fallback",
+        code: "attachment-basename-collision",
+        collisions: [
+          {
+            basename: "SKILL.md",
+            files: ["first/SKILL.md", "second/SKILL.md"],
+          },
+        ],
+        files: ["first/SKILL.md", "second/SKILL.md"],
+      },
+    });
+
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(submit).toHaveBeenCalledWith("inline prompt", []);
+    expect(prepareFallbackSubmission).not.toHaveBeenCalled();
+  });
+
   test("preserves prompt-too-large fallback after a dead-composer retry", async () => {
     const submit = vi
       .fn()

--- a/tests/browser/prompt.test.ts
+++ b/tests/browser/prompt.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, test } from "vitest";
 import { assembleBrowserPrompt, isRawUploadFile } from "../../src/browser/prompt.js";
+import { findAttachmentBasenameCollisions } from "../../src/browser/attachmentValidation.js";
 import { createStoredZip } from "../../src/browser/zipBundle.js";
 import { DEFAULT_SYSTEM_PROMPT, type MODEL_CONFIGS } from "../../src/oracle.js";
 import type { RunOracleOptions } from "../../src/oracle.js";
@@ -70,6 +71,35 @@ function readStoredZipEntries(zip: Buffer): Map<string, Buffer> {
 
   return entries;
 }
+
+describe("findAttachmentBasenameCollisions", () => {
+  test("returns every collision sorted by basename and display path", () => {
+    const collisions = findAttachmentBasenameCollisions([
+      { path: "/repo/z/SKILL.md", displayPath: "z/SKILL.md" },
+      { path: "/repo/b/README.md", displayPath: "b/README.md" },
+      { path: "/repo/a/SKILL.md", displayPath: "a/SKILL.md" },
+      { path: "/repo/a/README.md", displayPath: "a/README.md" },
+      { path: "/repo/unique.txt", displayPath: "unique.txt" },
+    ]);
+
+    expect(collisions).toEqual([
+      {
+        basename: "README.md",
+        attachments: [
+          { path: "/repo/a/README.md", displayPath: "a/README.md" },
+          { path: "/repo/b/README.md", displayPath: "b/README.md" },
+        ],
+      },
+      {
+        basename: "SKILL.md",
+        attachments: [
+          { path: "/repo/a/SKILL.md", displayPath: "a/SKILL.md" },
+          { path: "/repo/z/SKILL.md", displayPath: "z/SKILL.md" },
+        ],
+      },
+    ]);
+  });
+});
 
 describe("assembleBrowserPrompt", () => {
   test("builds markdown bundle with system/user/file blocks", async () => {
@@ -167,6 +197,172 @@ describe("assembleBrowserPrompt", () => {
     expect(tokenizedContents).toContain("### File: a.txt\n```\ntiny\n```");
     expect(tokenizedContents.some((content) => content.includes("1 | tiny"))).toBe(false);
     expect(result.fallback).toBeNull();
+  });
+
+  test("always mode rejects upload attachments with the same basename", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-duplicate-basename-"));
+    const firstPath = path.join(tempDir, "first", "SKILL.md");
+    const secondPath = path.join(tempDir, "second", "SKILL.md");
+    try {
+      await fs.mkdir(path.dirname(firstPath), { recursive: true });
+      await fs.mkdir(path.dirname(secondPath), { recursive: true });
+      await fs.writeFile(firstPath, "first");
+      await fs.writeFile(secondPath, "second");
+
+      await expect(
+        assembleBrowserPrompt(
+          buildOptions({
+            file: [firstPath, secondPath],
+            browserAttachments: "always",
+          }),
+          { cwd: tempDir, tokenizeImpl: fastTokenizer },
+        ),
+      ).rejects.toMatchObject({
+        message: expect.stringContaining('multiple files named "SKILL.md"'),
+        details: {
+          collisions: [{ basename: "SKILL.md", files: [firstPath, secondPath] }],
+          files: [firstPath, secondPath],
+        },
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("auto mode rejects basename collisions when it selects upload", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-auto-upload-collision-"));
+    const firstPath = path.join(tempDir, "first", "SKILL.md");
+    const secondPath = path.join(tempDir, "second", "SKILL.md");
+    const firstUniquePath = path.join(tempDir, "first", "FIRST.md");
+    const secondUniquePath = path.join(tempDir, "second", "SECOND.md");
+    const largeContent = "x".repeat(31_000);
+    try {
+      await fs.mkdir(path.dirname(firstPath), { recursive: true });
+      await fs.mkdir(path.dirname(secondPath), { recursive: true });
+      await Promise.all([
+        fs.writeFile(firstPath, largeContent),
+        fs.writeFile(secondPath, largeContent),
+        fs.writeFile(firstUniquePath, largeContent),
+        fs.writeFile(secondUniquePath, largeContent),
+      ]);
+
+      const uploadControl = await assembleBrowserPrompt(
+        buildOptions({
+          file: [firstUniquePath, secondUniquePath],
+          browserAttachments: "auto",
+        }),
+        { cwd: tempDir, tokenizeImpl: fastTokenizer },
+      );
+      expect(uploadControl.attachmentMode).toBe("upload");
+      expect(uploadControl.fallback).toBeNull();
+
+      await expect(
+        assembleBrowserPrompt(
+          buildOptions({
+            file: [firstPath, secondPath],
+            browserAttachments: "auto",
+          }),
+          { cwd: tempDir, tokenizeImpl: fastTokenizer },
+        ),
+      ).rejects.toMatchObject({
+        details: {
+          collisions: [{ basename: "SKILL.md", files: [firstPath, secondPath] }],
+          files: [firstPath, secondPath],
+        },
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("auto mode keeps tiny duplicate-basename text files inline", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-auto-inline-collision-"));
+    const firstPath = path.join(tempDir, "first", "SKILL.md");
+    const secondPath = path.join(tempDir, "second", "SKILL.md");
+    try {
+      await fs.mkdir(path.dirname(firstPath), { recursive: true });
+      await fs.mkdir(path.dirname(secondPath), { recursive: true });
+      await fs.writeFile(firstPath, "first");
+      await fs.writeFile(secondPath, "second");
+
+      const result = await assembleBrowserPrompt(
+        buildOptions({
+          file: [firstPath, secondPath],
+          browserAttachments: "auto",
+        }),
+        { cwd: tempDir, tokenizeImpl: fastTokenizer },
+      );
+
+      expect(result.attachmentMode).toBe("inline");
+      expect(result.attachments).toEqual([]);
+      expect(result.composerText).toContain("### File: first/SKILL.md");
+      expect(result.composerText).toContain("1 | first");
+      expect(result.composerText).toContain("### File: second/SKILL.md");
+      expect(result.composerText).toContain("1 | second");
+      expect(result.fallback?.attachments).toHaveLength(2);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("never mode keeps duplicate-basename text files inline", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-never-inline-collision-"));
+    const firstPath = path.join(tempDir, "first", "SKILL.md");
+    const secondPath = path.join(tempDir, "second", "SKILL.md");
+    try {
+      await fs.mkdir(path.dirname(firstPath), { recursive: true });
+      await fs.mkdir(path.dirname(secondPath), { recursive: true });
+      await fs.writeFile(firstPath, "first");
+      await fs.writeFile(secondPath, "second");
+
+      const result = await assembleBrowserPrompt(
+        buildOptions({
+          file: [firstPath, secondPath],
+          browserAttachments: "never",
+        }),
+        { cwd: tempDir, tokenizeImpl: fastTokenizer },
+      );
+
+      expect(result.attachmentMode).toBe("inline");
+      expect(result.attachments).toEqual([]);
+      expect(result.composerText).toContain("### File: first/SKILL.md");
+      expect(result.composerText).toContain("1 | first");
+      expect(result.composerText).toContain("### File: second/SKILL.md");
+      expect(result.composerText).toContain("1 | second");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("bundling resolves duplicate attachment basenames", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-bundled-collision-"));
+    const firstPath = path.join(tempDir, "first", "SKILL.md");
+    const secondPath = path.join(tempDir, "second", "SKILL.md");
+    try {
+      await fs.mkdir(path.dirname(firstPath), { recursive: true });
+      await fs.mkdir(path.dirname(secondPath), { recursive: true });
+      await fs.writeFile(firstPath, "first");
+      await fs.writeFile(secondPath, "second");
+
+      const result = await assembleBrowserPrompt(
+        buildOptions({
+          file: [firstPath, secondPath],
+          browserAttachments: "always",
+          browserBundleFiles: true,
+        }),
+        { cwd: tempDir, tokenizeImpl: fastTokenizer },
+      );
+
+      expect(result.attachments).toHaveLength(1);
+      expect(result.bundled?.format).toBe("text");
+      const bundleText = await fs.readFile(result.attachments[0]!.path, "utf8");
+      expect(bundleText).toContain("### File: first/SKILL.md");
+      expect(bundleText).toContain("1 | first");
+      expect(bundleText).toContain("### File: second/SKILL.md");
+      expect(bundleText).toContain("1 | second");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   test("legacy browserInlineFiles forces inline and disables auto fallback", async () => {


### PR DESCRIPTION
Fixes #385.

Two `--file` attachments with different paths but the same basename silently lose one file's content on the upload path. `attachmentDataTransfer.ts` builds each browser `File` from `path.basename()`, so both enter ChatGPT under one name, ChatGPT's own dedupe renames one, and the survivor carries the second file's renamed filename with the first file's body. Oracle reports the full file count and exits 0.

## Approach

The guard is applied to every attachment set immediately before that set can be uploaded. Explicit and auto-selected upload primaries fail during prompt assembly, before Chrome starts. Auto-inline runs remain usable; if composer truncation activates their upload fallback, the fallback is checked before any fallback preparation or upload and fails with the same actionable collision error. No path can upload colliding basenames.

Placing the check at each set's point of use rather than at plan-construction time matters because `auto` builds an upload fallback that only activates on a `prompt-too-large` response. Validating that dormant plan eagerly would reject small `auto` runs that send every file inline and never upload anything, which is the path #385 itself documents as immune.

There is also a boundary check at `runBrowserMode` entry, since it is exported and the bridge server constructs options directly without going through prompt assembly.

## Real behavior proof

Two live runs on 0.17.3 against the built branch, same two files throughout: `alpha/SKILL.md` and `beta/SKILL.md`, carrying distinct sentinels.

**`--browser-attachments always` rejects before any browser work:**

```
User error (file-validation): Browser upload cannot safely include multiple files named "SKILL.md":
- .../pr388-live-proof/alpha/SKILL.md
- .../pr388-live-proof/beta/SKILL.md
Use --browser-bundle-files (and --browser-bundle-format zip for raw or binary files), or choose unique names before retrying.
```

Chrome is never launched; this fails during prompt assembly.

**`--browser-attachments auto` with the same two files completes normally, and both bodies reach the model.** Verbatim from the assistant's own answer:

```
I received two file entries in your message.

### File: `.../alpha/SKILL.md`
1 | SENTINEL-ALPHA-4417
2 | This is alpha SKILL.md.

### File: `.../beta/SKILL.md`
1 | SENTINEL-BETA-9925
2 | This is beta SKILL.md.

**I can see BOTH `SENTINEL-ALPHA-4417` and `SENTINEL-BETA-9925`.**
```

Run summary: `files=2`, exit 0. That is the case the eager-validation approach would have rejected, and it is the behavior #385 documents as already correct.

Also verified: unique basenames under `always` still upload normally (no false positive), and `--browser-bundle-files` resolves the collision as the error message advises, producing a single `attachments-bundle.txt`.

## Tests

Prompt assembly: `always` rejects duplicates; `auto` rejects when it genuinely selects upload (inline content over the 60k budget); `auto` allows a small duplicate-basename inline primary; `never` allows duplicates inline; bundling resolves the collision.

Recovery (`tests/browser/index.test.ts`): a fallback with colliding basenames plus a `prompt-too-large` primary failure produces the collision error, asserts `submit` was called exactly once, and asserts `prepareFallbackSubmission` was never called. That test fails without the transition check and passes with it.

## Checks

`pnpm vitest run` over the four browser test files, `pnpm lint`, `pnpm test` (1769 passed, 43 skipped), `pnpm build`, and `pnpm docs:check` all pass.

`pnpm check` reports a pre-existing `CHANGELOG.md` formatting issue that reproduces on unmodified `main` and is not in `ci.yml`. Left alone rather than mixing an unrelated reformat into this diff.

## Note on scope

Merging changes duplicate-basename uploads from a silent false success to an actionable failure. That is deliberate, and it is the shape the issue review asked for rather than automatic filename rewriting, which cannot be proven correct without live upload evidence.

Changelog left to the release owner.

## Adjacent, not fixed here

`src/remote/server.ts` stages every bridge attachment into one directory under a sanitized filename, so names differing only in sanitized characters overwrite each other. Same symptom, different mechanism, server-side fix. Filed as #387 and fixed separately in #389.
