### PR TITLE
fix(serve): stage remote attachments under unique paths

### DIFF
--- a/src/remote/server.ts
+++ b/src/remote/server.ts
@@ -229,7 +229,9 @@ export async function createRemoteServer(
       const attachmentsPayload = Array.isArray(payload.attachments) ? payload.attachments : [];
       for (const [index, attachment] of attachmentsPayload.entries()) {
         const safeName = sanitizeName(attachment.fileName ?? `attachment-${index + 1}`);
-        const filePath = path.join(attachmentDir, safeName);
+        const stagingDir = path.join(attachmentDir, String(index));
+        await mkdir(stagingDir, { recursive: true });
+        const filePath = path.join(stagingDir, safeName);
         await writeFile(filePath, Buffer.from(attachment.contentBase64, "base64"));
         attachments.push({
           path: filePath,
@@ -247,7 +249,9 @@ export async function createRemoteServer(
           : [];
         for (const [index, attachment] of fallbackPayload.entries()) {
           const safeName = sanitizeName(attachment.fileName ?? `fallback-attachment-${index + 1}`);
-          const filePath = path.join(fallbackAttachmentDir, safeName);
+          const stagingDir = path.join(fallbackAttachmentDir, String(index));
+          await mkdir(stagingDir, { recursive: true });
+          const filePath = path.join(stagingDir, safeName);
           await writeFile(filePath, Buffer.from(attachment.contentBase64, "base64"));
           fallbackAttachments.push({
             path: filePath,

--- a/tests/remote/server.test.ts
+++ b/tests/remote/server.test.ts
@@ -149,6 +149,45 @@ describe("remote browser service", () => {
   );
 
   test.skipIf(!CAN_LISTEN_LOCALHOST)(
+    "stages colliding primary attachment names without losing payloads",
+    async () => {
+      await expectRemoteAttachmentStaging({
+        location: "primary",
+        files: [
+          { fileName: "a b.txt", content: "primary with space", stagedName: "a_b.txt" },
+          { fileName: "a_b.txt", content: "primary with underscore", stagedName: "a_b.txt" },
+        ],
+      });
+    },
+  );
+
+  test.skipIf(!CAN_LISTEN_LOCALHOST)(
+    "stages colliding fallback attachment names without losing payloads",
+    async () => {
+      await expectRemoteAttachmentStaging({
+        location: "fallback",
+        files: [
+          { fileName: "a b.txt", content: "fallback with space", stagedName: "a_b.txt" },
+          { fileName: "a_b.txt", content: "fallback with underscore", stagedName: "a_b.txt" },
+        ],
+      });
+    },
+  );
+
+  test.skipIf(!CAN_LISTEN_LOCALHOST)(
+    "preserves ordinary non-colliding attachment names and payload order",
+    async () => {
+      await expectRemoteAttachmentStaging({
+        location: "primary",
+        files: [
+          { fileName: "alpha.txt", content: "first", stagedName: "alpha.txt" },
+          { fileName: "beta.md", content: "second", stagedName: "beta.md" },
+        ],
+      });
+    },
+  );
+
+  test.skipIf(!CAN_LISTEN_LOCALHOST)(
     "keeps manual-login Chrome but requests completed run-tab cleanup",
     async () => {
       const manualLoginProfileDir = "/tmp/oracle-manual-login-profile-test";
@@ -449,6 +488,80 @@ describe("remote browser service", () => {
     },
   );
 });
+
+async function expectRemoteAttachmentStaging({
+  location,
+  files,
+}: {
+  location: "primary" | "fallback";
+  files: Array<{ fileName: string; content: string; stagedName: string }>;
+}): Promise<void> {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "oracle-remote-staging-test-"));
+  const sourceAttachments = [];
+  for (const file of files) {
+    const sourcePath = path.join(tmpDir, file.fileName);
+    await writeFile(sourcePath, file.content, "utf8");
+    sourceAttachments.push({
+      path: sourcePath,
+      displayPath: file.fileName,
+      sizeBytes: Buffer.byteLength(file.content),
+    });
+  }
+
+  const server = await createRemoteServer(
+    { host: "127.0.0.1", port: 0, token: "secret", logger: () => {} },
+    {
+      runBrowser: async (options) => {
+        const stagedAttachments =
+          location === "primary" ? options.attachments : options.fallbackSubmission?.attachments;
+        expect(stagedAttachments).toHaveLength(files.length);
+        if (!stagedAttachments) {
+          throw new Error(`missing ${location} attachments`);
+        }
+
+        const stagedPaths = stagedAttachments.map((attachment) => attachment.path);
+        expect(new Set(stagedPaths).size).toBe(files.length);
+        expect(stagedAttachments.map((attachment) => path.basename(attachment.path))).toEqual(
+          files.map((file) => file.stagedName),
+        );
+        expect(stagedAttachments.map((attachment) => attachment.displayPath)).toEqual(
+          files.map((file) => file.fileName),
+        );
+        await expect(
+          Promise.all(stagedPaths.map((stagedPath) => readFile(stagedPath, "utf8"))),
+        ).resolves.toEqual(files.map((file) => file.content));
+
+        return {
+          answerText: "done",
+          answerMarkdown: "done",
+          tookMs: 1,
+          answerTokens: 1,
+          answerChars: 4,
+        };
+      },
+    },
+  );
+
+  try {
+    const executor = createRemoteBrowserExecutor({
+      host: `127.0.0.1:${server.port}`,
+      token: "secret",
+    });
+    const result = await executor({
+      prompt: "remote attachment staging",
+      attachments: location === "primary" ? sourceAttachments : [],
+      fallbackSubmission:
+        location === "fallback"
+          ? { prompt: "fallback attachment staging", attachments: sourceAttachments }
+          : undefined,
+      config: {},
+    });
+    expect(result.answerText).toBe("done");
+  } finally {
+    await server.close();
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
 
 function createArtifactDescriptor(
   payload: Buffer,


### PR DESCRIPTION
Fixes #387.

Remote-host attachments whose names differ only in characters the server sanitizes are staged to the same path, so one payload overwrites the other before upload. `sanitizeName` maps everything outside `[a-zA-Z0-9._-]` to `_`, so `a b.txt` and `a_b.txt` both become `a_b.txt`, `writeFile` overwrites the first, and both attachment entries end up referencing the survivor. The run reports the full file count and succeeds.

Both staging loops had the defect: the primary loop and the fallback-submission loop.

## Approach

Each attachment stages under its own index-scoped directory:

```
attachments/<index>/<sanitized-basename>
fallback-attachments/<index>/<sanitized-basename>
```

Uniqueness is structural rather than a suffixing heuristic, and the sanitized basename is unchanged, so the filename the browser ultimately sees is exactly what it was before. Payload order is preserved.

## Real behavior proof

A real `oracle serve` instance on localhost, a real client run over HTTP with `--remote-host`, two files whose names collide only after sanitization, each carrying a distinct sentinel. The staging directory was captured during the run.

**Before (unmodified `main`):**

```
attachments/a_b.txt  ==>  SENTINEL-BETA-underscore-version
```

One file. The alpha payload is gone, overwritten by beta under the shared sanitized name. The client reported `files=2` and the run completed successfully in 34.0s, which is what makes this silent.

**After (this branch):**

```
attachments/0/a_b.txt  ==>  SENTINEL-ALPHA-space-version
attachments/1/a_b.txt  ==>  SENTINEL-BETA-underscore-version
```

Both payloads survive with distinct staged paths and the sanitized basename preserved. Client reported `files=2`, run completed in 39.9s.

Same harness, same two files, same transport; the only difference is the patch.

## Tests

`tests/remote/server.test.ts` gains coverage for colliding names in the primary loop, the same in the fallback loop, and a non-colliding control asserting ordinary behavior and order are unchanged. Each asserts distinct staged paths, expected sanitized basenames, preserved display paths, and that both distinct payloads survive on disk.

The fallback test fails without the fallback-loop half of the fix (`expected 1 to be 2`) and passes with it, so the loop that is easy to miss is covered by proof rather than inspection.

## Checks

`pnpm vitest run tests/remote/server.test.ts`, `pnpm lint`, `pnpm test` (1764 passed, 43 skipped), `pnpm build`, and `pnpm docs:check` all pass.

`pnpm check` reports a pre-existing `CHANGELOG.md` formatting issue that reproduces on an untouched `main` worktree at `083bba7e` and is not in `ci.yml`.

## Changed since first review

Dropped the `CHANGELOG.md` entry per review; changelog left to the release owner. The user-visible change is described above.

## Interaction worth flagging

While capturing the before case I ran it against a build carrying the #388 browser-side guard. On unmodified staging both attachments resolve to the same path, so `runBrowserMode` receives two entries with an identical basename and #388's boundary check rejects the run with a clear error rather than uploading a duplicated payload. The two fixes compose: #388 turns this failure loud at the browser boundary, and #389 removes the collision at its source so the run proceeds with both payloads intact.
