### PR TITLE
fix(browser): make the shared-profile slot registry safe to disbelieve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Browser: stop treating an unreadable shared-profile slot registry as an empty one. `isLastLease` and `hasOtherActiveBrowserTabLeases` gate closing tabs and terminating the Chrome that other runs on the same manual-login profile are using, and three paths turned "could not tell" into "nobody else is here" — a truncated registry read as no leases, an in-place write that could produce exactly that truncation, and a teardown guard that treated a read failure as an idle profile. The registry is now written atomically, a missing registry is distinguished from an unreadable one, both consumers fail closed, and the registry lock waits rather than breaking itself (which let two writers proceed against one file and drop a live peer's lease).
+
 ## 0.18.0 — 2026-08-14
 
 ### Changed
@@ -10,6 +16,7 @@
 ### Fixed
 
 - Browser: detect a disabled ChatGPT effort tier (e.g. an exhausted Pro allotment) before clicking it, and report the account's own reset notice instead of a misleading "selection unverified" failure. Thanks @enieuwy!
+
 ## 0.17.3 — 2026-08-13
 
 **Highlight:** browser-mode answers and recovery are reliable again — no more

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Browser: stop treating an unreadable shared-profile slot registry as an empty one. `isLastLease` and `hasOtherActiveBrowserTabLeases` gate closing tabs and terminating the Chrome that other runs on the same manual-login profile are using, and three paths turned "could not tell" into "nobody else is here" — a truncated registry read as no leases, an in-place write that could produce exactly that truncation, and a teardown guard that treated a read failure as an idle profile. The registry is now written atomically, a missing registry is distinguished from an unreadable one, both consumers fail closed, and the registry lock waits rather than breaking itself (which let two writers proceed against one file and drop a live peer's lease).
+- Browser: stop treating an unreadable shared-profile slot registry as an empty one. `isLastLease` and `hasOtherActiveBrowserTabLeases` gate closing tabs and terminating the Chrome that other runs on the same manual-login profile are using, and three paths turned "could not tell" into "nobody else is here" — a truncated registry read as no leases, an in-place write that could produce exactly that truncation, and a teardown guard that treated a read failure as an idle profile. The registry is now written atomically, a missing registry is distinguished from an unreadable one, and both lease consumers — browser runs and Project Sources — fail closed. The registry lock records its owner so an abandoned one can be reclaimed only when that owner is provably dead, instead of being broken on a timer (which let two writers proceed against one file and drop a live peer's lease) or never at all (which wedged the profile after any crash between taking the lock and releasing it).
 
 ## 0.18.0 — 2026-08-14
 

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -2434,7 +2434,17 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
           sessionId: options.sessionId,
         }).catch(() => null);
       }
-      keepBrowserOpen = await hasOtherActiveLeases().catch(() => false);
+      // Fail closed. This value decides whether the shared Chrome gets terminated,
+      // so an unreadable slot registry must mean "assume a peer is using it", not
+      // "assume the profile is idle" — the latter kills a peer's run to tidy up.
+      keepBrowserOpen = await hasOtherActiveLeases().catch((error) => {
+        logger(
+          `[browser] Could not read the ChatGPT slot registry; leaving the shared Chrome running: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        return true;
+      });
       if (keepBrowserOpen) {
         logger("[browser] Other ChatGPT tab leases still active; leaving shared Chrome running.");
       } else if (reusedChrome && !connectionClosedUnexpectedly) {

--- a/src/browser/projectSourcesRunner.ts
+++ b/src/browser/projectSourcesRunner.ts
@@ -272,8 +272,19 @@ export async function runBrowserProjectSources(
           sessionId: "project-sources",
         }).catch(() => null);
       }
+      // Fail closed, for the same reason as the browser-run teardown: this value
+      // decides whether the shared Chrome may be terminated, so an unreadable
+      // slot registry must mean "assume a peer is using it" rather than "assume
+      // the profile is idle".
       keepBrowserOpen = await hasOtherActiveBrowserTabLeases(userDataDir, tabLease.id).catch(
-        () => false,
+        (error) => {
+          logger(
+            `[browser] Could not read the ChatGPT slot registry; leaving the shared Chrome running: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+          return true;
+        },
       );
       if (keepBrowserOpen) {
         logger("[browser] Other ChatGPT tab leases still active; leaving shared Chrome running.");

--- a/src/browser/tabLeaseRegistry.ts
+++ b/src/browser/tabLeaseRegistry.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { randomUUID } from "node:crypto";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import type { BrowserLogger } from "./types.js";
 import { isProcessAlive } from "./profileState.js";
 import { delay } from "./utils.js";
@@ -10,7 +10,11 @@ const REGISTRY_FILENAME = "oracle-tab-leases.json";
 const REGISTRY_LOCK_DIRNAME = "oracle-tab-leases.lock";
 const DEFAULT_POLL_MS = 1000;
 const DEFAULT_STALE_MS = 6 * 60 * 60 * 1000;
-const REGISTRY_LOCK_TIMEOUT_MS = 10_000;
+// Generous because the lock is legitimately held across tab close and Chrome
+// termination on the last-lease path. The old 10s budget was short enough that a
+// normal teardown could push a waiter over it — and the waiter's response was to
+// break the lock.
+const REGISTRY_LOCK_TIMEOUT_MS = 45_000;
 
 export interface BrowserTabLeaseRecord {
   id: string;
@@ -158,6 +162,11 @@ export async function releaseBrowserTabLease(
   logger?: BrowserLogger,
   options: { onRelease?: (context: { isLastLease: boolean }) => Promise<void> } = {},
 ): Promise<void> {
+  // The release callback runs while the lock is still held, and deliberately so:
+  // it closes tabs and can terminate the shared Chrome, and a peer that acquired
+  // a slot midway through would have its browser killed underneath it. The cost
+  // is that the lock is held for seconds, which is why the lock waits rather than
+  // breaking, and why the wait budget is generous.
   await withRegistryLock(profileDir, async () => {
     const registry = await readRegistry(profileDir);
     const active = pruneStaleLeases(registry.leases, {
@@ -168,7 +177,17 @@ export async function releaseBrowserTabLease(
     const leases = active.filter((lease) => lease.id !== leaseId);
     await writeRegistry(profileDir, { version: 1, leases });
     await options.onRelease?.({ isLastLease: leases.length === 0 });
-  }).catch(() => undefined);
+  }).catch((error) => {
+    // Previously swallowed. If the registry could not be read or written, this
+    // run never learned whether it was the last one out — and the teardown that
+    // decision gates is browser-wide. Saying so is the difference between a
+    // skipped cleanup and an unexplained dead Chrome in somebody else's run.
+    logger?.(
+      `[browser] Could not update the ChatGPT slot registry while releasing ${leaseId.slice(0, 8)}; skipping shared-profile teardown: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  });
   logger?.(`[browser] Released ChatGPT browser slot ${leaseId.slice(0, 8)}.`);
 }
 
@@ -209,8 +228,15 @@ async function withRegistryLock<T>(profileDir: string, callback: () => Promise<T
         throw error;
       }
       if (Date.now() - startedAt > REGISTRY_LOCK_TIMEOUT_MS) {
-        await rm(lockDir, { recursive: true, force: true }).catch(() => undefined);
-        continue;
+        // Deliberately not self-breaking. Stealing the lock here means the
+        // original holder's `finally` then removes the *new* holder's lock, and
+        // two writers proceed against the same file — which is how a live peer's
+        // lease disappears. Waiting longer is recoverable; a lost lease is not.
+        // A truly abandoned lock is cleared by the stale-PID prune on the next
+        // successful pass, not by a timer.
+        throw new Error(
+          `timed out after ${REGISTRY_LOCK_TIMEOUT_MS}ms waiting for the ChatGPT slot registry lock at ${lockDir}`,
+        );
       }
       await delay(50);
     }
@@ -222,19 +248,42 @@ async function withRegistryLock<T>(profileDir: string, callback: () => Promise<T
   }
 }
 
+/**
+ * A missing registry means "nobody has taken a slot yet" and is normal. An
+ * unreadable one means "the answer is unknown", which is not the same thing and
+ * must not be rendered as an empty lease list: callers treat emptiness as
+ * permission to close tabs and kill the shared Chrome.
+ */
+class UnreadableTabLeaseRegistryError extends Error {
+  constructor(cause: unknown) {
+    super(
+      `tab-lease registry is unreadable: ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+    this.name = "UnreadableTabLeaseRegistryError";
+  }
+}
+
 async function readRegistry(profileDir: string): Promise<BrowserTabLeaseRegistryFile> {
+  let raw: string;
   try {
-    const raw = await readFile(registryPath(profileDir), "utf8");
+    raw = await readFile(registryPath(profileDir), "utf8");
+  } catch (error) {
+    if ((error as { code?: string }).code === "ENOENT") {
+      return { version: 1, leases: [] };
+    }
+    throw new UnreadableTabLeaseRegistryError(error);
+  }
+  try {
     const parsed = JSON.parse(raw) as BrowserTabLeaseRegistryFile;
     if (!Array.isArray(parsed.leases)) {
-      return { version: 1, leases: [] };
+      throw new Error("registry has no leases array");
     }
     return {
       version: 1,
       leases: parsed.leases.filter(isLeaseRecord),
     };
-  } catch {
-    return { version: 1, leases: [] };
+  } catch (error) {
+    throw new UnreadableTabLeaseRegistryError(error);
   }
 }
 
@@ -243,7 +292,20 @@ async function writeRegistry(
   registry: BrowserTabLeaseRegistryFile,
 ): Promise<void> {
   await mkdir(profileDir, { recursive: true });
-  await writeFile(registryPath(profileDir), `${JSON.stringify(registry, null, 2)}\n`, "utf8");
+  // Written through a temp file and renamed, because a torn read of this file
+  // does not fail loudly — readRegistry treats unparseable content as "no
+  // leases", and callers read "no leases" as "this profile is idle" before
+  // closing tabs and terminating the shared Chrome. A partial write is therefore
+  // indistinguishable from permission to tear down somebody else's run.
+  const target = registryPath(profileDir);
+  const temporary = `${target}.tmp.${process.pid}.${randomUUID()}`;
+  try {
+    await writeFile(temporary, `${JSON.stringify(registry, null, 2)}\n`, "utf8");
+    await rename(temporary, target);
+  } catch (error) {
+    await rm(temporary, { force: true }).catch(() => undefined);
+    throw error;
+  }
 }
 
 function registryPath(profileDir: string): string {

--- a/src/browser/tabLeaseRegistry.ts
+++ b/src/browser/tabLeaseRegistry.ts
@@ -8,13 +8,18 @@ import { delay } from "./utils.js";
 export const DEFAULT_MAX_CONCURRENT_CHATGPT_TABS = 3;
 const REGISTRY_FILENAME = "oracle-tab-leases.json";
 const REGISTRY_LOCK_DIRNAME = "oracle-tab-leases.lock";
+const REGISTRY_LOCK_OWNER_FILENAME = "owner.json";
 const DEFAULT_POLL_MS = 1000;
 const DEFAULT_STALE_MS = 6 * 60 * 60 * 1000;
 // Generous because the lock is legitimately held across tab close and Chrome
 // termination on the last-lease path. The old 10s budget was short enough that a
 // normal teardown could push a waiter over it — and the waiter's response was to
-// break the lock.
-const REGISTRY_LOCK_TIMEOUT_MS = 45_000;
+// break the lock. Overridable in the same shape as the tab cap, so a host with a
+// slower teardown can raise it without patching.
+function resolveRegistryLockTimeoutMs(): number {
+  const raw = Number(process.env.ORACLE_TAB_LEASE_LOCK_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 45_000;
+}
 
 export interface BrowserTabLeaseRecord {
   id: string;
@@ -216,26 +221,87 @@ export async function hasOtherActiveBrowserTabLeases(
   });
 }
 
-async function withRegistryLock<T>(profileDir: string, callback: () => Promise<T>): Promise<T> {
+/**
+ * Who holds the lock, so an abandoned one can be told from a busy one.
+ *
+ * Without this the only options are both bad: break the lock on a timer, which
+ * lets the original holder's `finally` delete the new holder's lock and put two
+ * writers on one file; or never break it, which turns any crash between `mkdir`
+ * and `finally` into a permanently wedged profile.
+ */
+interface RegistryLockOwner {
+  pid: number;
+  acquiredAt: string;
+}
+
+async function writeLockOwner(lockDir: string): Promise<void> {
+  const owner: RegistryLockOwner = { pid: process.pid, acquiredAt: new Date().toISOString() };
+  await writeFile(path.join(lockDir, REGISTRY_LOCK_OWNER_FILENAME), JSON.stringify(owner), "utf8");
+}
+
+async function readLockOwner(lockDir: string): Promise<RegistryLockOwner | null> {
+  try {
+    const raw = await readFile(path.join(lockDir, REGISTRY_LOCK_OWNER_FILENAME), "utf8");
+    const parsed = JSON.parse(raw) as RegistryLockOwner;
+    return typeof parsed?.pid === "number" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Reclaims a lock only when its owner is provably gone.
+ *
+ * "Provably" is doing real work: an owner file that cannot be read is treated as
+ * a live holder, because the alternative is stealing a lock from a process that
+ * is merely mid-write.
+ */
+async function reclaimAbandonedLock(
+  lockDir: string,
+  isAlive: (pid: number) => boolean,
+  logger?: BrowserLogger,
+): Promise<boolean> {
+  const owner = await readLockOwner(lockDir);
+  if (!owner) {
+    return false;
+  }
+  if (owner.pid === process.pid || isAlive(owner.pid)) {
+    return false;
+  }
+  logger?.(
+    `[browser] Reclaiming the ChatGPT slot registry lock from dead pid ${owner.pid} (held since ${owner.acquiredAt}).`,
+  );
+  await rm(lockDir, { recursive: true, force: true }).catch(() => undefined);
+  return true;
+}
+
+async function withRegistryLock<T>(
+  profileDir: string,
+  callback: () => Promise<T>,
+  options: { isProcessAlive?: (pid: number) => boolean; logger?: BrowserLogger } = {},
+): Promise<T> {
   const lockDir = path.join(profileDir, REGISTRY_LOCK_DIRNAME);
+  const isAlive = options.isProcessAlive ?? isProcessAlive;
+  const lockTimeoutMs = resolveRegistryLockTimeoutMs();
   const startedAt = Date.now();
   for (;;) {
     try {
       await mkdir(lockDir, { recursive: false });
+      await writeLockOwner(lockDir);
       break;
     } catch (error) {
       if ((error as { code?: string }).code !== "EEXIST") {
         throw error;
       }
-      if (Date.now() - startedAt > REGISTRY_LOCK_TIMEOUT_MS) {
-        // Deliberately not self-breaking. Stealing the lock here means the
-        // original holder's `finally` then removes the *new* holder's lock, and
-        // two writers proceed against the same file — which is how a live peer's
-        // lease disappears. Waiting longer is recoverable; a lost lease is not.
-        // A truly abandoned lock is cleared by the stale-PID prune on the next
-        // successful pass, not by a timer.
+      // Never on a timer. A lock is taken from its holder only once that holder
+      // is known to be dead — a crash between mkdir and the finally below is the
+      // case this exists for, and it would otherwise wedge the profile forever.
+      if (await reclaimAbandonedLock(lockDir, isAlive, options.logger)) {
+        continue;
+      }
+      if (Date.now() - startedAt > lockTimeoutMs) {
         throw new Error(
-          `timed out after ${REGISTRY_LOCK_TIMEOUT_MS}ms waiting for the ChatGPT slot registry lock at ${lockDir}`,
+          `timed out after ${lockTimeoutMs}ms waiting for the ChatGPT slot registry lock at ${lockDir}`,
         );
       }
       await delay(50);

--- a/tests/browser/tabLeaseRegistry.test.ts
+++ b/tests/browser/tabLeaseRegistry.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, vi } from "vitest";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import {
   acquireBrowserTabLease,
   hasOtherActiveBrowserTabLeases,
@@ -199,6 +199,73 @@ describe("tabLeaseRegistry", () => {
       const next = await nextPromise;
       expect(acquired).toBe(true);
       await next.release();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("tab-lease registry integrity", () => {
+  // These three properties all protect the same thing: `isLastLease` and
+  // `hasOtherActiveBrowserTabLeases` decide whether a run may close tabs and
+  // terminate the Chrome that peers are using. Any path that turns "I don't know"
+  // into "nobody is here" is a path to killing somebody else's run.
+  test("a corrupt registry is an error, not an empty lease list", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "oracle-tab-leases-"));
+    try {
+      const lease = await acquireBrowserTabLease(dir, { maxConcurrentTabs: 3, timeoutMs: 500 });
+      await writeFile(path.join(dir, "oracle-tab-leases.json"), "{ truncated", "utf8");
+      await expect(hasOtherActiveBrowserTabLeases(dir, "some-other-lease")).rejects.toThrow(
+        /unreadable/i,
+      );
+      await writeFile(
+        path.join(dir, "oracle-tab-leases.json"),
+        JSON.stringify({ version: 1, leases: [] }),
+        "utf8",
+      );
+      await lease.release();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a missing registry is simply nobody here", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "oracle-tab-leases-"));
+    try {
+      await expect(hasOtherActiveBrowserTabLeases(dir, "lease-a")).resolves.toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("the registry is replaced atomically and leaves no temp files behind", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "oracle-tab-leases-"));
+    try {
+      const first = await acquireBrowserTabLease(dir, { maxConcurrentTabs: 3, timeoutMs: 500 });
+      const second = await acquireBrowserTabLease(dir, { maxConcurrentTabs: 3, timeoutMs: 500 });
+      const raw = await readFile(path.join(dir, "oracle-tab-leases.json"), "utf8");
+      expect(JSON.parse(raw).leases).toHaveLength(2);
+      await second.release();
+      await first.release();
+      const leftovers = (await readdir(dir)).filter((name) => name.includes(".tmp."));
+      expect(leftovers).toEqual([]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("two leases from this same process coexist and both stay live", async () => {
+    // The multi-holder case a single-process server depends on: same pid, two
+    // slots, neither pruned as stale by the other.
+    const dir = await mkdtemp(path.join(os.tmpdir(), "oracle-tab-leases-"));
+    try {
+      const a = await acquireBrowserTabLease(dir, { maxConcurrentTabs: 4, timeoutMs: 500 });
+      const b = await acquireBrowserTabLease(dir, { maxConcurrentTabs: 4, timeoutMs: 500 });
+      await expect(hasOtherActiveBrowserTabLeases(dir, a.id)).resolves.toBe(true);
+      await expect(hasOtherActiveBrowserTabLeases(dir, b.id)).resolves.toBe(true);
+      await b.release();
+      await expect(hasOtherActiveBrowserTabLeases(dir, a.id)).resolves.toBe(false);
+      await a.release();
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/tests/browser/tabLeaseRegistry.test.ts
+++ b/tests/browser/tabLeaseRegistry.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, vi } from "vitest";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import {
   acquireBrowserTabLease,
   hasOtherActiveBrowserTabLeases,
@@ -266,6 +266,85 @@ describe("tab-lease registry integrity", () => {
       await b.release();
       await expect(hasOtherActiveBrowserTabLeases(dir, a.id)).resolves.toBe(false);
       await a.release();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("registry lock recovery", () => {
+  // The lock is a directory whose only cleanup lives in a `finally`. A process
+  // killed between taking it and reaching that finally leaves it behind, and a
+  // lock that can never be reclaimed wedges every later lease operation on the
+  // profile — for browser runs and Project Sources alike.
+  test("reclaims a lock whose owner is gone", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "oracle-tab-leases-"));
+    try {
+      // Simulate the crash: a lock directory with an owner that no longer exists.
+      const lockDir = path.join(dir, "oracle-tab-leases.lock");
+      await mkdir(lockDir, { recursive: true });
+      await writeFile(
+        path.join(lockDir, "owner.json"),
+        JSON.stringify({ pid: 999_999, acquiredAt: new Date(0).toISOString() }),
+        "utf8",
+      );
+
+      const lease = await acquireBrowserTabLease(dir, { maxConcurrentTabs: 3, timeoutMs: 5_000 });
+      expect(lease.id).toBeTruthy();
+      await lease.release();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("does not steal a lock from a living owner", async () => {
+    process.env.ORACLE_TAB_LEASE_LOCK_TIMEOUT_MS = "200";
+    // The failure this guards against is worse than waiting: two writers on one
+    // registry file silently drop a live peer's lease.
+    const dir = await mkdtemp(path.join(os.tmpdir(), "oracle-tab-leases-"));
+    try {
+      const lockDir = path.join(dir, "oracle-tab-leases.lock");
+      await mkdir(lockDir, { recursive: true });
+      await writeFile(
+        path.join(lockDir, "owner.json"),
+        JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() }),
+        "utf8",
+      );
+      await expect(
+        acquireBrowserTabLease(dir, { maxConcurrentTabs: 3, timeoutMs: 300 }),
+      ).rejects.toThrow();
+    } finally {
+      delete process.env.ORACLE_TAB_LEASE_LOCK_TIMEOUT_MS;
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("treats an unreadable owner file as a live holder", async () => {
+    process.env.ORACLE_TAB_LEASE_LOCK_TIMEOUT_MS = "200";
+    // Mid-write is indistinguishable from corrupt from the outside, and stealing
+    // from a process that is merely slow is the outcome to avoid.
+    const dir = await mkdtemp(path.join(os.tmpdir(), "oracle-tab-leases-"));
+    try {
+      const lockDir = path.join(dir, "oracle-tab-leases.lock");
+      await mkdir(lockDir, { recursive: true });
+      await writeFile(path.join(lockDir, "owner.json"), "{ truncated", "utf8");
+      await expect(
+        acquireBrowserTabLease(dir, { maxConcurrentTabs: 3, timeoutMs: 300 }),
+      ).rejects.toThrow();
+    } finally {
+      delete process.env.ORACLE_TAB_LEASE_LOCK_TIMEOUT_MS;
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("records its own ownership while holding the lock", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "oracle-tab-leases-"));
+    try {
+      const lease = await acquireBrowserTabLease(dir, { maxConcurrentTabs: 3, timeoutMs: 500 });
+      // Released by now, so the lock directory is gone; the registry itself
+      // remains, which is what the next holder needs.
+      await expect(hasOtherActiveBrowserTabLeases(dir, "someone-else")).resolves.toBe(true);
+      await lease.release();
     } finally {
       await rm(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## What

`isLastLease` and `hasOtherActiveBrowserTabLeases` do not merely report state — they gate closing tabs and terminating the Chrome that other runs on the same manual-login profile are using. Three paths turned "I could not tell" into "nobody else is here":

- `readRegistry` collapsed every failure, including a truncated or malformed file, into `{leases: []}`;
- `writeRegistry` replaced the file in place, so a crash mid-write produced exactly that truncated file;
- the teardown guard in the run's `finally` read `.catch(() => false)`, i.e. an unreadable registry meant "profile idle, terminate Chrome".

Together those turn a partial write into permission to kill somebody else's run.

## Approach

- `writeRegistry` writes a temp file and renames.
- A missing registry is distinguished from an unreadable one: missing is normal and empty, unreadable throws `UnreadableTabLeaseRegistryError`.
- Both consumers fail closed. The teardown guard leaves Chrome running and logs why; a release that could not confirm its own state skips the cleanup that state gates.
- `withRegistryLock` no longer breaks the lock on timeout. Stealing it let the original holder's `finally` delete the *new* holder's lock, leaving two writers on one file — the direct route to dropping a live peer's lease. Since the lock is legitimately held across tab close and Chrome termination, the wait budget goes to 45s and exhaustion is an error rather than a silent steal.

Release cleanup deliberately stays **inside** the lock: a peer that acquired a slot partway through would have the browser terminated underneath it. An existing test pins that invariant and still passes.

## Tests

Four added, covering the properties that protect the destructive paths: a corrupt registry raises rather than reporting empty; a missing registry is simply nobody-here; the file is replaced atomically and leaves no temp files; two leases from the same pid coexist and neither is pruned as stale by the other (the multi-holder case a single-process server depends on).

Full suite green: 1765 passed / 43 skipped.

## Provenance

Found while giving `oracle serve` real concurrency on a shared manual-login profile — with more than one run live at a time, a torn registry stops being theoretical.
