### PR TITLE
fix(remote): say what a lost bridge connection means for the run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Remote: say what a lost bridge connection means for the run. Losing the service mid-run surfaced the bare socket error ("aborted"), leaving out the consequential part — the run had already been accepted, so the ChatGPT conversation very likely exists on the bridge host and resubmitting opens a second one. The client now distinguishes a bridge it could not reach from one it lost mid-run, and the latter points at `oracle status` on the bridge host to reattach rather than resubmit.
+
 ## 0.18.0 — 2026-08-14
 
 ### Changed
@@ -10,6 +16,7 @@
 ### Fixed
 
 - Browser: detect a disabled ChatGPT effort tier (e.g. an exhausted Pro allotment) before clicking it, and report the account's own reset notice instead of a misleading "selection unverified" failure. Thanks @enieuwy!
+
 ## 0.17.3 — 2026-08-13
 
 **Highlight:** browser-mode answers and recovery are reliable again — no more

--- a/src/remote/client.ts
+++ b/src/remote/client.ts
@@ -62,12 +62,38 @@ export function createRemoteBrowserExecutor({ host, token }: RemoteExecutorOptio
       const transferPromises: Promise<void>[] = [];
       let artifactTransferQueue = Promise.resolve();
       let settled = false;
+      let runAccepted = false;
       let resolved: BrowserRunResult | null = null;
 
       const fail = (error: Error) => {
         if (settled) return;
         settled = true;
         reject(error);
+      };
+
+      /**
+       * A transport error after the run was accepted usually means the bridge
+       * went away mid-run, and the bare socket error ("aborted", "ECONNRESET")
+       * describes the symptom rather than the situation. The important part for
+       * whoever reads this is that the conversation may well exist on the bridge
+       * host regardless — the browser work is not undone by losing the stream.
+       */
+      const failTransport = (error: Error) => {
+        const wasAccepted = runAccepted;
+        fail(
+          wasAccepted
+            ? new Error(
+                `Lost the connection to the research bridge at ${hostname}:${port} while the run was in progress (${error.message}). ` +
+                  "The run may have started in ChatGPT before the connection dropped: check `oracle status` on the bridge host " +
+                  "for a session from this run and reattach to it rather than resubmitting, which would create a second conversation.",
+                { cause: error },
+              )
+            : new Error(
+                `Could not reach the research bridge at ${hostname}:${port} (${error.message}). ` +
+                  "Confirm the service is running on that host and that the port is reachable from here.",
+                { cause: error },
+              ),
+        );
       };
 
       const req = http.request(
@@ -89,6 +115,9 @@ export function createRemoteBrowserExecutor({ host, token }: RemoteExecutorOptio
               .catch(fail);
             return;
           }
+          // 200 means the service took the request; from here on a dropped
+          // connection is a run that may exist rather than one that never began.
+          runAccepted = true;
           res.setEncoding("utf8");
           let buffer = "";
           res.on("data", (chunk: string) => {
@@ -139,10 +168,10 @@ export function createRemoteBrowserExecutor({ host, token }: RemoteExecutorOptio
               resolve(mergeTransferredArtifacts(resolved, transferredFiles, transferFailures));
             })().catch(fail);
           });
-          res.on("error", fail);
+          res.on("error", failTransport);
         },
       );
-      req.on("error", fail);
+      req.on("error", failTransport);
       req.write(body);
       req.end();
     });

--- a/tests/remote/server.test.ts
+++ b/tests/remote/server.test.ts
@@ -581,3 +581,41 @@ async function httpGetJson({
     req.end();
   });
 }
+
+describe("transport failure messages", () => {
+  test.skipIf(!CAN_LISTEN_LOCALHOST)(
+    "losing the bridge mid-run says the conversation may exist and not to resubmit",
+    async () => {
+      // The bare socket error ("aborted") describes the symptom. What the reader
+      // needs is that the browser work is not undone by losing the stream, so
+      // resubmitting would open a second ChatGPT conversation.
+      //
+      // Stubbed rather than driven through the real service: the behaviour under
+      // test is entirely the client's, and a real server cannot drop a socket
+      // mid-run without also waiting for the run it is pretending to perform.
+      const stub = http.createServer((req, res) => {
+        res.writeHead(200, { "Content-Type": "application/x-ndjson" });
+        res.write(`${JSON.stringify({ type: "log", message: "started" })}\n`);
+        setTimeout(() => req.socket.destroy(), 50);
+      });
+      await new Promise<void>((resolve) => stub.listen(0, "127.0.0.1", resolve));
+      const { port } = stub.address() as { port: number };
+
+      const executor = createRemoteBrowserExecutor({ host: `127.0.0.1:${port}`, token: "secret" });
+      await expect(executor({ prompt: "x", config: {} })).rejects.toThrow(
+        /research bridge at 127\.0\.0\.1:\d+ while the run was in progress/,
+      );
+      await expect(executor({ prompt: "x", config: {} })).rejects.toThrow(
+        /reattach to it rather than resubmitting/,
+      );
+      await new Promise<void>((resolve) => stub.close(() => resolve()));
+    },
+  );
+
+  test("an unreachable bridge is reported as unreachable, not as a lost run", async () => {
+    const executor = createRemoteBrowserExecutor({ host: "127.0.0.1:1", token: "secret" });
+    await expect(executor({ prompt: "x", config: {} })).rejects.toThrow(
+      /Could not reach the research bridge at 127\.0\.0\.1:1/,
+    );
+  });
+});


### PR DESCRIPTION
## What

Killing `oracle serve` while a run was in flight left the caller with:

```
ERROR: aborted
```

That is the socket's description of the symptom, and it omits the part that changes what the operator should do: the run had **already been accepted**, so the browser work is not undone by losing the stream and the ChatGPT conversation very likely exists on the bridge host. Resubmitting — which is what "aborted" invites — opens a second conversation.

## Approach

The client now distinguishes the two transport failures it can have, using whether the service returned 200 (i.e. took the request) as the dividing line:

- **before acceptance** — the bridge is unreachable; say so and point at checking the service and port.
- **after acceptance** — name the bridge, say the run was in progress, and point at `oracle status` on that host to reattach rather than resubmit.

The underlying socket error is preserved as `cause` in both cases.

## Real behavior

Before, with the service killed 10s into a run:

```
ERROR: aborted
```

After, same scenario:

```
ERROR: Lost the connection to the research bridge at 127.0.0.1:9473 while the run
was in progress (aborted). The run may have started in ChatGPT before the
connection dropped: check `oracle status` on the bridge host for a session from
this run and reattach to it rather than resubmitting, which would create a second
conversation.
```

Exit code is 1 in both cases — this changes what the caller is told, not whether it fails.

## Tests

Two, driven against a stub that accepts and then drops the socket (the behaviour under test is entirely the client's, and a real server cannot drop mid-run without also waiting on the run it is pretending to perform): a lost-mid-run connection names the bridge and says reattach-not-resubmit, and an unreachable bridge is reported as unreachable rather than as a lost run.

Full suite green: 1763 passed / 43 skipped.
