### PR TITLE
fix(browser): match ChatGPT collision-renamed attachment names

### DIFF
--- a/src/browser/actions/attachments.ts
+++ b/src/browser/actions/attachments.ts
@@ -6,6 +6,17 @@ import { delay } from "../utils.js";
 import { logDomFailure } from "../domDebug.js";
 import { transferAttachmentViaDataTransfer } from "./attachmentDataTransfer.js";
 
+export function buildCollisionRenamedAttachmentPattern(expectedName: string): RegExp | null {
+  const baseName = expectedName.split("/").pop()?.split("\\").pop() ?? expectedName;
+  const normalizedExpected = baseName.toLowerCase().replace(/\s+/g, " ").trim();
+  const extensionIndex = normalizedExpected.lastIndexOf(".");
+  if (extensionIndex <= 0 || extensionIndex === normalizedExpected.length - 1) return null;
+  const escape = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const stem = escape(normalizedExpected.slice(0, extensionIndex));
+  const extension = escape(normalizedExpected.slice(extensionIndex + 1));
+  return new RegExp(`^${stem}(?:\\([0-9-]+\\))?\\.${extension}$`, "i");
+}
+
 export async function uploadAttachmentFile(
   deps: {
     runtime: ChromeClient["Runtime"];
@@ -26,16 +37,20 @@ export async function uploadAttachmentFile(
       : 0;
 
   const readAttachmentSignals = async (name: string) => {
+    const collisionPattern = buildCollisionRenamedAttachmentPattern(name);
     const check = await runtime.evaluate({
       expression: `(() => {
         const expected = ${JSON.stringify(name)};
         const normalizedExpected = String(expected || '').toLowerCase().replace(/\\s+/g, ' ').trim();
         const expectedNoExt = normalizedExpected.replace(/\\.[a-z0-9]{1,10}$/i, '');
+        const collisionPatternSource = ${JSON.stringify(collisionPattern?.source ?? "")};
+        const collisionPattern = collisionPatternSource ? new RegExp(collisionPatternSource, 'i') : null;
         const normalize = (value) => String(value || '').toLowerCase().replace(/\\s+/g, ' ').trim();
         const matchesExpected = (value) => {
           const text = normalize(value);
           if (!text) return false;
           if (text.includes(normalizedExpected)) return true;
+          if (collisionPattern?.test(text)) return true;
           if (expectedNoExt.length >= 6 && text.includes(expectedNoExt)) return true;
           if (text.includes('…') || text.includes('...')) {
             const marker = text.includes('…') ? '…' : '...';
@@ -374,10 +389,12 @@ export async function uploadAttachmentFile(
   const expectedName = path.basename(attachment.path);
   const expectedNameLower = normalizeForMatch(expectedName);
   const expectedNameNoExt = expectedNameLower.replace(/\.[a-z0-9]{1,10}$/i, "");
+  const expectedCollisionPattern = buildCollisionRenamedAttachmentPattern(expectedNameLower);
   const matchesExpectedName = (value: string): boolean => {
     const normalized = normalizeForMatch(value);
     if (!normalized) return false;
     if (normalized.includes(expectedNameLower)) return true;
+    if (expectedCollisionPattern?.test(normalized)) return true;
     if (expectedNameNoExt.length >= 6 && normalized.includes(expectedNameNoExt)) return true;
     return false;
   };
@@ -1603,8 +1620,10 @@ export async function waitForAttachmentCompletion(
         const baseName = expected.split("/").pop()?.split("\\").pop() ?? expected;
         const normalizedExpected = baseName.toLowerCase().replace(/\s+/g, " ").trim();
         const expectedNoExt = normalizedExpected.replace(/\.[a-z0-9]{1,10}$/i, "");
+        const collisionPattern = buildCollisionRenamedAttachmentPattern(normalizedExpected);
         return attachedNames.some((raw) => {
           if (raw.includes(normalizedExpected)) return true;
+          if (collisionPattern?.test(raw)) return true;
           if (expectedNoExt.length >= 6 && raw.includes(expectedNoExt)) return true;
           if (raw.includes("…") || raw.includes("...")) {
             const marker = raw.includes("…") ? "…" : "...";

--- a/src/browser/actions/attachments.ts
+++ b/src/browser/actions/attachments.ts
@@ -14,7 +14,10 @@ export function buildCollisionRenamedAttachmentPattern(expectedName: string): Re
   const escape = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const stem = escape(normalizedExpected.slice(0, extensionIndex));
   const extension = escape(normalizedExpected.slice(extensionIndex + 1));
-  return new RegExp(`^${stem}(?:\\([0-9-]+\\))?\\.${extension}$`, "i");
+  return new RegExp(
+    `(?:^|[^a-z0-9._-])${stem}(?:\\([0-9-]+\\))?\\.${extension}(?:$|[^a-z0-9._-])`,
+    "i",
+  );
 }
 
 export async function uploadAttachmentFile(

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -13,6 +13,7 @@ import {
 } from "../conversationTurns.js";
 import { delay } from "../utils.js";
 import { logDomFailure } from "../domDebug.js";
+import { buildCollisionRenamedAttachmentPattern } from "./attachments.js";
 import { buildClickDispatcher } from "./domEvents.js";
 import { BrowserAutomationError } from "../../oracle/errors.js";
 
@@ -358,6 +359,7 @@ function buildAttachmentReadyExpression(attachmentNames: AttachmentReadyInput[])
       name: normalized,
       stem: normalized.replace(/\.[a-z0-9]{1,10}$/i, ""),
       extension: normalized.match(/(\.[a-z0-9]{1,10})$/i)?.[1] ?? "",
+      collisionPattern: buildCollisionRenamedAttachmentPattern(normalized)?.source ?? "",
       generatedBundle: typeof attachment === "object" && attachment.generatedBundle === true,
     };
   });
@@ -427,6 +429,13 @@ function buildAttachmentReadyExpression(attachmentNames: AttachmentReadyInput[])
       const text = normalize(value);
       if (!text) return false;
       if (hasNameBoundary(text, item.name)) return true;
+      const collisionPattern = item.collisionPattern ? new RegExp(item.collisionPattern, 'i') : null;
+      if (
+        collisionPattern &&
+        String(value || '').split('\\n').some((candidate) => collisionPattern.test(normalize(candidate)))
+      ) {
+        return true;
+      }
       if (item.generatedBundle && hasBareStemBoundary(text, item.stem)) return true;
       if (
         item.stem &&
@@ -532,7 +541,7 @@ function buildAttachmentReadyExpression(attachmentNames: AttachmentReadyInput[])
       };
       pushAttrs(node);
       pushText(node);
-      return pieces.join(' ').toLowerCase();
+      return pieces.join('\\n').toLowerCase();
     };
     const collectLabelHaystack = (node) => {
       if (!node) return '';
@@ -545,7 +554,7 @@ function buildAttachmentReadyExpression(attachmentNames: AttachmentReadyInput[])
       push(parent);
       const grandparent = parent?.parentElement;
       push(grandparent);
-      return pieces.join(' ').toLowerCase();
+      return pieces.join('\\n').toLowerCase();
     };
     const attachmentRoots = Array.from(new Set([composer])).filter(Boolean);
     const collectChipNodes = () => {

--- a/tests/browser/attachmentsCompletion.test.ts
+++ b/tests/browser/attachmentsCompletion.test.ts
@@ -3,6 +3,7 @@ import {
   waitForAttachmentCompletion,
   waitForUserTurnAttachments,
 } from "../../src/browser/pageActions.js";
+import * as attachments from "../../src/browser/actions/attachments.js";
 import type { ChromeClient } from "../../src/browser/types.js";
 
 const useFakeTime = () => {
@@ -13,6 +14,64 @@ const useFakeTime = () => {
 const useRealTime = () => {
   vi.useRealTimers();
 };
+
+const buildCollisionPattern = (expectedName: string): RegExp | null => {
+  const builder = (
+    attachments as unknown as {
+      buildCollisionRenamedAttachmentPattern?: (name: string) => RegExp | null;
+    }
+  ).buildCollisionRenamedAttachmentPattern;
+  return builder?.(expectedName) ?? null;
+};
+
+describe("collision-renamed attachment names", () => {
+  test.each([
+    ["01.jpg", "01(5).jpg"],
+    ["document.md", "document(20260818-145702).md"],
+    ["document.md", "document.md"],
+    ["a+b.jpg", "a+b(2).jpg"],
+  ])("matches %s to %s", (expectedName, actualName) => {
+    expect(buildCollisionPattern(expectedName)?.test(actualName) ?? false).toBe(true);
+  });
+
+  test.each([
+    ["01.jpg", "010.jpg"],
+    ["01.jpg", "02(5).jpg"],
+  ])("does not match %s to %s", (expectedName, actualName) => {
+    expect(buildCollisionPattern(expectedName)?.test(actualName) ?? false).toBe(false);
+  });
+
+  test("waitForAttachmentCompletion resolves for a collision-renamed short filename", async () => {
+    useFakeTime();
+
+    const runtime = {
+      evaluate: vi.fn().mockResolvedValue({
+        result: {
+          value: {
+            state: "ready",
+            uploading: false,
+            filesAttached: true,
+            attachedNames: ["01(5).jpg"],
+            inputNames: [],
+            fileCount: 0,
+          },
+        },
+      }),
+    } as unknown as ChromeClient["Runtime"];
+
+    try {
+      const promise = waitForAttachmentCompletion(runtime, 3_000, ["01.jpg"]);
+      const resolved = promise.then(
+        () => true,
+        () => false,
+      );
+      await vi.advanceTimersByTimeAsync(4_000);
+      expect(await resolved).toBe(true);
+    } finally {
+      useRealTime();
+    }
+  });
+});
 
 describe("attachment completion fallbacks", () => {
   test("waitForAttachmentCompletion resolves when ready file input contains expected name (no UI chip)", async () => {

--- a/tests/browser/attachmentsCompletion.test.ts
+++ b/tests/browser/attachmentsCompletion.test.ts
@@ -30,6 +30,10 @@ describe("collision-renamed attachment names", () => {
     ["document.md", "document(20260818-145702).md"],
     ["document.md", "document.md"],
     ["a+b.jpg", "a+b(2).jpg"],
+    ["01.jpg", "remove file 1: 01.jpg"],
+    ["01.jpg", "remove file 2: 01(1).jpg"],
+    ["01.jpg", "remove file 2: 01(5).jpg"],
+    ["document.md", "remove file 1: document(20260818-145702).md"],
   ])("matches %s to %s", (expectedName, actualName) => {
     expect(buildCollisionPattern(expectedName)?.test(actualName) ?? false).toBe(true);
   });
@@ -37,6 +41,13 @@ describe("collision-renamed attachment names", () => {
   test.each([
     ["01.jpg", "010.jpg"],
     ["01.jpg", "02(5).jpg"],
+    ["01.jpg", "remove file 1: 001.jpg"],
+    ["01.jpg", "remove file 1: x01.jpg"],
+    ["01.jpg", "remove file 1: 01.jpeg"],
+    ["01.jpg", "remove file 1: photo01.jpg"],
+    ["attachments-bundle.txt", "not-attachments-bundle.txt"],
+    ["report.pdf", "remove file 1: my_report.pdf"],
+    ["report.pdf", "remove file 1: report.pdf.bak"],
   ])("does not match %s to %s", (expectedName, actualName) => {
     expect(buildCollisionPattern(expectedName)?.test(actualName) ?? false).toBe(false);
   });

--- a/tests/browser/pageActions.test.ts
+++ b/tests/browser/pageActions.test.ts
@@ -1817,6 +1817,8 @@ describe("uploadAttachmentFile", () => {
 
     expect(capturedPresenceExpression).toContain("text.includes('…')");
     expect(capturedPresenceExpression).toContain("text.includes('...')");
+    expect(capturedPresenceExpression).toContain("collisionPattern");
+    expect(capturedPresenceExpression).toContain("[0-9-]+");
     expect(dom.getDocument).not.toHaveBeenCalled();
     expect(dom.setFileInputFiles).not.toHaveBeenCalled();
     expect(logger).toHaveBeenCalledWith(expect.stringMatching(/Attachment already present/i));

--- a/tests/browser/promptComposerExpressions.test.ts
+++ b/tests/browser/promptComposerExpressions.test.ts
@@ -253,6 +253,40 @@ describe("prompt composer attachment expressions", () => {
     expect(evaluateAttachmentReadyExpression(["README.md"], document)).toBe(true);
   });
 
+  test.each([
+    ["01.jpg", "01(5).jpg"],
+    ["document.md", "document(20260818-145702).md"],
+    ["document.md", "document.md"],
+    ["a+b.jpg", "a+b(2).jpg"],
+  ])("attachment ready check matches %s to %s", (expectedName, actualName) => {
+    const document = new FakeDocument([
+      new FakeElement("div", { "data-testid": "unified-composer" }, [
+        new FakeElement("div", { "data-testid": "attachment-chip" }, [
+          new FakeElement("span", {}, [], actualName),
+          new FakeElement("button", { "aria-label": `Remove file 1: ${actualName}` }),
+        ]),
+      ]),
+    ]);
+
+    expect(evaluateAttachmentReadyExpression([expectedName], document)).toBe(true);
+  });
+
+  test.each(["010.jpg", "02(5).jpg"])(
+    "attachment ready check does not match 01.jpg to %s",
+    (actualName) => {
+      const document = new FakeDocument([
+        new FakeElement("div", { "data-testid": "unified-composer" }, [
+          new FakeElement("div", { "data-testid": "attachment-chip" }, [
+            new FakeElement("span", {}, [], actualName),
+            new FakeElement("button", { "aria-label": `Remove file 1: ${actualName}` }),
+          ]),
+        ]),
+      ]);
+
+      expect(evaluateAttachmentReadyExpression(["01.jpg"], document)).toBe(false);
+    },
+  );
+
   test("attachment ready check accepts generated bundle chips that expose only the bundle stem", () => {
     const document = new FakeDocument([
       new FakeElement("div", { "data-testid": "unified-composer" }, [


### PR DESCRIPTION
Fixes #393.

## Problem

ChatGPT renames a colliding upload. Issue #393 reports two forms:

```
01.jpg      -> 01(5).jpg
document.md -> document(20260818-145702).md
```

Oracle keeps waiting for a chip that carries the original name. Three matchers accept a renamed chip only when the extension-stripped stem is long enough:

| matcher | gate |
|---|---|
| `src/browser/actions/attachments.ts`, in-page matcher | `expectedNoExt.length >= 6` |
| `src/browser/actions/attachments.ts`, `matchesExpectedName` | `expectedNameNoExt.length >= 6` |
| `src/browser/actions/promptComposer.ts`, `matchesExpected` | `item.stem.length >= 4` |

For `01.jpg` the stem is `01`, which is 2 characters. All three reject the chip, and `"01(5).jpg".includes("01.jpg")` is false. The run then fails with "Attachments did not finish uploading before timeout.", although the chips exist and Send is enabled.

`document.md` passes today only because its stem is 8 characters. That is why a markdown-only upload usually works and adding `01.jpg` breaks the run.

## Change

One helper builds an escaped, case-insensitive pattern:

```
(?:^|[^a-z0-9._-])<stem>(?:\([0-9-]+\))?\.<ext>(?:$|[^a-z0-9._-])
```

The suffix accepts digits and hyphens, so it covers the counter form and the timestamp form. The stem and the extension are escaped, so a filename that contains regex metacharacters is safe.

The pattern matches on non-alphanumeric boundaries rather than on string anchors, because every caller tests it against chip text, not against a bare filename. The boundary excludes `.`, `_` and `-`, which matches the character test the existing `promptComposer` boundary helpers already use. That keeps a stem from matching inside a longer filename.

All three matchers use this pattern. The in-page matcher cannot import a TypeScript helper, so the pattern source is interpolated into the injected script. There is one source of truth.

Every existing check stays in place. Matching is not widened in any other way.

## Correction to the first version of this PR

The first version anchored the pattern with `^` and `$`. That version did not fix the issue.

Every caller tests the pattern against the chip text, which is the remove-button label, not a bare filename. The anchors could never match that text. The unit tests fed bare filenames, a shape no caller passes, so they passed while the fix did not work.

I measured the first version against real chip text captured from a signed-in ChatGPT composer:

| chip text | `includes` original name | collision pattern | matched |
|---|---|---|---|
| `remove file 1: 01.jpg` | true | false | yes, by the existing check |
| `remove file 2: 01(1).jpg` | false | false | **no** |

The renamed chip stayed unmatched, which is the exact failure in #393. This version fixes that and adds tests in the real chip-text shape.

## Proof

Live run. I uploaded two files both named `01.jpg` into a signed-in ChatGPT composer and read the attachment chip labels from the DOM:

```
Remove file 1: 01.jpg
Remove file 2: 01(1).jpg
```

That is the rename this PR targets. Running this version's pattern against those two exact strings matches both. Running the previous anchored version matches only the first.

Negative controls against the same pattern, all rejected:

```
expected 01.jpg                 vs  remove file 1: 001.jpg          no match
expected 01.jpg                 vs  remove file 1: x01.jpg          no match
expected 01.jpg                 vs  remove file 1: 01.jpeg          no match
expected 01.jpg                 vs  remove file 1: photo01.jpg      no match
expected report.pdf             vs  remove file 1: my_report.pdf    no match
expected report.pdf             vs  remove file 1: report.pdf.bak   no match
expected attachments-bundle.txt vs  not-attachments-bundle.txt      no match
```

The last row is the case that `promptComposerExpressions.test.ts` already protects. A boundary of `[^a-z0-9]` alone would break it, because `-` satisfies that class. `[^a-z0-9._-]` keeps it rejected.

Tests:

```
$ ./node_modules/.bin/vitest run tests/browser/
Test Files  48 passed (48)
     Tests  877 passed | 1 skipped (878)
```

Anchored pattern restored, tests kept:

```
FAIL  matches 01.jpg to remove file 1: 01.jpg
FAIL  matches 01.jpg to remove file 2: 01(1).jpg
FAIL  matches 01.jpg to remove file 2: 01(5).jpg
FAIL  matches document.md to remove file 1: document(20260818-145702).md
Tests  4 failed | 29 passed (33)
```

The four new cases fail on the anchored pattern and pass on this one, so they are not vacuous.

`tsc -p tsconfig.build.json --noEmit`: exit 0.
