### PR TITLE
fix(browser): honor thinking time in Deep Research

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Browser: detect a disabled ChatGPT effort tier (e.g. an exhausted Pro allotment) before clicking it, and report the account's own reset notice instead of a misleading "selection unverified" failure. Thanks @enieuwy!
+
 ## 0.17.3 — 2026-08-13
 
 **Highlight:** browser-mode answers and recovery are reliable again — no more

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -204,6 +204,21 @@ export function classifyPreservedBrowserErrorForTest(
 // defaults to Standard effort. ensureThinkingTime() already handles the
 // "already-selected" case as a no-op, so always attempting it is safe.
 
+type BrowserConfigWithThinkingTime = Pick<
+  ResolvedBrowserConfig,
+  "researchMode" | "thinkingTime"
+> & {
+  thinkingTime: NonNullable<ResolvedBrowserConfig["thinkingTime"]>;
+};
+
+function shouldApplyThinkingTimeSelection(
+  config: Pick<ResolvedBrowserConfig, "researchMode" | "thinkingTime">,
+): config is BrowserConfigWithThinkingTime {
+  // Deep Research uses the same effort picker, so research mode must not
+  // suppress an explicitly configured thinking-time selection.
+  return config.thinkingTime !== undefined;
+}
+
 type ChatGptUiWarningType = "rate_limit" | "temporary_unavailable" | "auth_or_challenge";
 
 type ChatGptUiWarning = {
@@ -1503,22 +1518,23 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
       );
     }
     const deepResearch = config.researchMode === "deep";
-    // Handle thinking time selection if specified. Deep Research owns its own effort flow.
-    const thinkingTime = config.thinkingTime;
-    if (thinkingTime && !deepResearch) {
+    if (shouldApplyThinkingTimeSelection(config)) {
       const thinkingTargetModel = modelStrategy === "select" ? config.desiredModel : null;
       await raceWithDisconnect(
-        withRetries(() => ensureThinkingTime(Runtime, thinkingTime, logger, thinkingTargetModel), {
-          retries: 2,
-          delayMs: 300,
-          onRetry: (attempt, error) => {
-            if (options.verbose) {
-              logger(
-                `[retry] Thinking time (${thinkingTime}) attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
-              );
-            }
+        withRetries(
+          () => ensureThinkingTime(Runtime, config.thinkingTime, logger, thinkingTargetModel),
+          {
+            retries: 2,
+            delayMs: 300,
+            onRetry: (attempt, error) => {
+              if (options.verbose) {
+                logger(
+                  `[retry] Thinking time (${config.thinkingTime}) attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
+                );
+              }
+            },
           },
-        }),
+        ),
       );
     }
     const profileLockTimeoutMs = manualLogin ? (config.profileLockTimeoutMs ?? 0) : 0;
@@ -3107,19 +3123,17 @@ async function runRemoteBrowserMode(
       );
     }
     const deepResearch = config.researchMode === "deep";
-    // Handle thinking time selection if specified. Deep Research owns its own effort flow.
-    const thinkingTime = config.thinkingTime;
-    if (thinkingTime && !deepResearch) {
+    if (shouldApplyThinkingTimeSelection(config)) {
       const thinkingTargetModel = modelStrategy === "select" ? config.desiredModel : null;
       await withRetries(
-        () => ensureThinkingTime(Runtime, thinkingTime, logger, thinkingTargetModel),
+        () => ensureThinkingTime(Runtime, config.thinkingTime, logger, thinkingTargetModel),
         {
           retries: 2,
           delayMs: 300,
           onRetry: (attempt, error) => {
             if (options.verbose) {
               logger(
-                `[retry] Thinking time (${thinkingTime}) attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
+                `[retry] Thinking time (${config.thinkingTime}) attempt ${attempt + 1}: ${error instanceof Error ? error.message : error}`,
               );
             }
           },
@@ -3889,6 +3903,7 @@ export const __test__ = {
   listIgnoredRemoteChromeFlags,
   normalizeAuthenticatedModelSelectionError,
   resolveManualLoginWaitMs,
+  shouldApplyThinkingTimeSelection,
   shouldCleanupBlankTabsAfterLastLease,
   shouldCloseOwnedRunTargetAfterRun,
   shouldKeepLocalBrowserOpen,

--- a/tests/browser/index.test.ts
+++ b/tests/browser/index.test.ts
@@ -263,10 +263,23 @@ describe("manual-login profile setup gate", () => {
   });
 });
 
-// NOTE: shouldSkipThinkingTimeSelection was removed — it incorrectly assumed
-// that selecting "Pro" in the picker always implied Extended effort, which is
-// wrong for lower-tier plans where Pro defaults to Standard. The thinking time
-// step now always runs; ensureThinkingTime handles the already-selected case.
+describe("thinking time selection policy", () => {
+  test("keeps explicit effort selection enabled for Deep Research", () => {
+    const config = resolveBrowserConfig({
+      desiredModel: "gpt-5.6-sol",
+      thinkingTime: "pro",
+      researchMode: "deep",
+    });
+
+    expect(__test__.shouldApplyThinkingTimeSelection(config)).toBe(true);
+  });
+
+  test("does not select an effort when none was requested", () => {
+    const config = resolveBrowserConfig({ researchMode: "deep" });
+
+    expect(__test__.shouldApplyThinkingTimeSelection(config)).toBe(false);
+  });
+});
 
 describe("formatBrowserTurnTranscript", () => {
   test("keeps single-turn browser output unchanged", () => {


### PR DESCRIPTION
Fixes #382

Oracle skips the requested thinking time when Deep Research is enabled, so the saved config can say one thing while ChatGPT uses another.

This makes both browser paths select and verify the requested effort before Deep Research starts. I added regression tests for that combination.

I ran a live browser check on ChatGPT Pro using GPT-5.6 Sol, Pro effort, and Deep Research. It completed successfully. These were the relevant log lines:

```text
Model picker: GPT-5.6 Sol
[browser] Thinking time: Pro
Deep Research mode activated
Clicked send button
Deep Research completed (21s elapsed)
```

The targeted browser tests pass, 62 total. The full local test suite, build, lint, formatting, and type checks also pass.