### PR TITLE
fix(browser): recognize renamed Japanese effort label 思考量

### DIFF
--- a/src/browser/actions/thinkingTime.ts
+++ b/src/browser/actions/thinkingTime.ts
@@ -947,7 +947,7 @@ function buildThinkingTimeExpression(
       'avanzado', 'avancado', 'avance',
     ];
     const EFFORT_WORDS = [
-      'effort', 'aufwand', '强度', '努力', '推論レベル',
+      'effort', 'aufwand', '强度', '努力', '推論レベル', '思考量',
       'esfuerzo', 'esforco', 'sforzo', 'inspanning', 'wysilek',
     ];
     const containsAny = (label, words) => words.some((word) => label.includes(word));

--- a/tests/browser/thinkingTime.test.ts
+++ b/tests/browser/thinkingTime.test.ts
@@ -80,6 +80,7 @@ describe("browser thinking-time selection expression", () => {
     expect(expression).toContain("\\u4e00-\\u9fff");
     expect(expression).toContain("'极高'");
     expect(expression).toContain("'推論レベル'");
+    expect(expression).toContain("'思考量'");
   });
 
   it("infers target model kind with token matching", () => {
@@ -2989,6 +2990,23 @@ describe("unified Intelligence picker with Advanced -> Effort submenu", () => {
     const result = await run(dom.documentStub, "pro");
     expect(dom.advancedToggle.clicks).toBeGreaterThan(0);
     expect(dom.modelOpener.clicks).toBe(0);
+    expect(dom.effortOpener.clicks).toBeGreaterThan(0);
+    expect(result).toEqual({
+      status: "switched",
+      label: "Pro",
+    });
+    expect(dom.getSelectedTier()).toBe("Pro");
+  });
+
+  it("selects Pro through the renamed Japanese effort label", async () => {
+    const dom = buildDom("High");
+    dom.advancedToggle.textContent = "詳細設定";
+    dom.effortOpener.textContent = "思考量High";
+    ["最速", "中程度", "高い", "非常に高い", "Pro"].forEach((label, index) => {
+      dom.tierRows[index]!.textContent = label;
+    });
+
+    const result = await run(dom.documentStub, "pro");
     expect(dom.effortOpener.clicks).toBeGreaterThan(0);
     expect(result).toEqual({
       status: "switched",


### PR DESCRIPTION
## Summary
- ChatGPT's Japanese UI renamed the Intelligence picker effort label from `推論レベル` to `思考量`, so explicit effort selection (e.g. `--browser-thinking-time pro`) started failing closed.
- Add `思考量` to `EFFORT_WORDS` alongside the existing Japanese word, keeping the fail-closed guard for unknown languages intact.

## Testing
- `pnpm vitest run tests/browser/thinkingTime.test.ts` — 60 passed (includes a new case selecting Pro through a `思考量High` opener).
- `pnpm lint` (tsc + oxlint) clean.

Follow-up to #377 / commit a3c8b0cd which added the original Japanese labels.