### PR TITLE
fix(cli): keep dry-run side-effect free

### DIFF
--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -1875,8 +1875,10 @@ async function runRootCommand(options: CliOptions): Promise<void> {
   }
 
   const retentionHours = typeof options.retainHours === "number" ? options.retainHours : undefined;
-  await sessionStore.ensureStorage();
-  await pruneOldSessions(retentionHours, (message) => console.log(chalk.dim(message)));
+  if (!previewMode) {
+    await sessionStore.ensureStorage();
+    await pruneOldSessions(retentionHours, (message) => console.log(chalk.dim(message)));
+  }
   if (providerMode === "openai") {
     if (hasExplicitAzureOption(optionUsesDefault)) {
       throw new Error("--provider openai/--no-azure cannot be combined with Azure options.");

--- a/tests/cli/integrationCli.test.ts
+++ b/tests/cli/integrationCli.test.ts
@@ -156,6 +156,60 @@ describe("oracle CLI integration", () => {
   );
 
   test(
+    "does not prune stored sessions during a dry-run",
+    async () => {
+      const oracleHome = await mkdtemp(path.join(os.tmpdir(), "oracle-dry-run-retention-"));
+      const oldSessionDir = path.join(oracleHome, "sessions", "old-neutral-session");
+      try {
+        await mkdir(oldSessionDir, { recursive: true });
+        await writeFile(
+          path.join(oldSessionDir, "meta.json"),
+          JSON.stringify({
+            id: "old-neutral-session",
+            createdAt: "2020-01-01T00:00:00.000Z",
+            status: "completed",
+            mode: "browser",
+            options: {},
+          }),
+          "utf8",
+        );
+
+        const result = await execCli(
+          [
+            "--dry-run",
+            "summary",
+            "--retain-hours",
+            "1",
+            "--engine",
+            "browser",
+            "--prompt",
+            "Neutral dry-run retention check",
+          ],
+          {
+            env: {
+              ...process.env,
+              // biome-ignore lint/style/useNamingConvention: env var name
+              ORACLE_HOME_DIR: oracleHome,
+              // biome-ignore lint/style/useNamingConvention: env var name
+              ORACLE_DISABLE_KEYTAR: "1",
+            },
+            timeout: INTEGRATION_TIMEOUT,
+          },
+        );
+
+        expect(result.code).toBe(0);
+        expect(result.stdout).not.toContain("Pruned");
+        await expect(readFile(path.join(oldSessionDir, "meta.json"), "utf8")).resolves.toContain(
+          "old-neutral-session",
+        );
+      } finally {
+        await rm(oracleHome, { recursive: true, force: true });
+      }
+    },
+    INTEGRATION_TIMEOUT,
+  );
+
+  test(
     "SIGINT exits promptly",
     async () => {
       const oracleHome = await mkdtemp(path.join(os.tmpdir(), "oracle-sigint-"));


### PR DESCRIPTION
## Summary

- keep `--dry-run` side-effect free with respect to session storage
- skip retention pruning during previews while preserving normal-run cleanup
- cover the behavior with an isolated expired-session fixture

## Problem

Root command startup initialized the session store and ran retention pruning before the preview branch returned. As a result, `--dry-run --retain-hours ...` could delete stored sessions even though no model run was requested.

## Fix

Run storage initialization and retention pruning only when `previewMode` is false. Route, preflight, and every non-preview execution path retain their existing behavior.

## Verification

Exact head: `dcc4475c94098a823b6c1454359d9aeb3ffc36e2`

- focused regression: 1 passed
- full suite: 1757 passed, 48 skipped
- `pnpm run lint`
- `pnpm run build`
- `pnpm run docs:check`
- changed-file `oxfmt --check`
- `git diff --check`

An exact-head CLI proof used an isolated Oracle home containing a completed session dated 2020, then ran a dry-run with one-hour retention. The preview completed, emitted no pruning message, and the old session remained present.

### Inspectable exact-head terminal receipt

The local wrapper and temporary-directory prefixes are normalized below; the command arguments and output are otherwise unchanged.

```text
$ git rev-parse HEAD
dcc4475c94098a823b6c1454359d9aeb3ffc36e2

$ ORACLE_HOME_DIR=/tmp/oracle-dry-run-proof oracle \
    --dry-run summary \
    --retain-hours 1 \
    --engine browser \
    --model gpt-5-pro \
    --prompt "Neutral exact-head dry-run retention proof"
🧿 oracle 0.18.0 — Less lorem, more logic.
[preview] Oracle (0.18.0) browser mode (target=GPT-5.6 Sol; requested=gpt-5-pro) with ~14 tokens.
[preview] Browser control: launch visible Chrome; may focus/control the browser UI.
[preview] Browser guidance: A visible automation Chrome window may take focus while Oracle controls ChatGPT.
[preview] Browser guidance: Use --browser-hide-window, --browser-attach-running, or --remote-chrome to reduce desktop disruption.
[preview] Cookies: Chrome copy disabled (use --browser-manual-login, inline cookies, or --browser-cookie-sync).
[preview] No files attached.

$ test -f /tmp/oracle-dry-run-proof/sessions/old-neutral-session/meta.json \
    && jq -r '.id' /tmp/oracle-dry-run-proof/sessions/old-neutral-session/meta.json
old-neutral-session
```

There is no `Pruned` line in the preview output, and the command after it proves that the expired fixture remained readable on the same exact head.

The exact upstream base currently reports unrelated `CHANGELOG.md` drift under whole-repository `format:check`; this PR does not touch that file, and both changed files pass the pinned formatter.

## Safety

No browser, network, provider credential, or real session content is needed for the regression. Non-preview retention behavior is unchanged.
