### PR TITLE
fix(browser): preserve latest-turn identity in virtualized chats

### DIFF
--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -903,6 +903,13 @@ async function verifyPromptCommitted(
     if (matchesPrompt && (baselineUnknown || info?.hasNewTurn)) {
       return typeof turnsCount === "number" && Number.isFinite(turnsCount) ? turnsCount : null;
     }
+    const virtualizedActiveCommit =
+      info?.composerCleared &&
+      info.inConversation &&
+      Boolean(info.lastMatched || (info.prefixMatched && info.stopVisible));
+    if (virtualizedActiveCommit) {
+      return typeof turnsCount === "number" && Number.isFinite(turnsCount) ? turnsCount : null;
+    }
     const fallbackCommit =
       info?.composerCleared &&
       Boolean(info?.hasNewTurn) &&

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -257,12 +257,19 @@ async function readLatestUserTurnText(Runtime: ChromeClient["Runtime"]): Promise
         document.querySelectorAll('[data-message-author-role="user"], [data-turn="user"]'),
       );
       const latest = nodes[nodes.length - 1];
-      if (!latest) return '';
-      return latest.innerText ?? latest.textContent ?? '';
+      if (!latest) return { found: false, text: '' };
+      return { found: true, text: latest.innerText ?? latest.textContent ?? '' };
     })()`,
     returnByValue: true,
   });
-  return typeof result?.value === "string" ? result.value : null;
+  const value = result?.value as { found?: unknown; text?: unknown } | undefined;
+  if (value?.found === false) {
+    return "";
+  }
+  if (value?.found !== true || typeof value.text !== "string" || !value.text.trim()) {
+    return null;
+  }
+  return value.text;
 }
 
 export async function clearPromptComposer(Runtime: ChromeClient["Runtime"], logger: BrowserLogger) {
@@ -1031,6 +1038,7 @@ function summarizeCommitProbe(probe: CommitProbeState): Record<string, unknown> 
 // biome-ignore lint/style/useNamingConvention: test-only export used in vitest suite
 export const __test__ = {
   attemptSendButton,
+  readLatestUserTurnText,
   sendButtonTimeoutMs,
   verifyPromptCommitted,
 };

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -213,6 +213,7 @@ export async function submitPrompt(
     );
   }
 
+  const baselineLastUserText = await readLatestUserTurnText(runtime).catch(() => null);
   const clicked = await attemptSendButton(
     runtime,
     input,
@@ -245,7 +246,23 @@ export async function submitPrompt(
     commitTimeoutMs,
     logger,
     deps.baselineTurns ?? undefined,
+    baselineLastUserText,
   );
+}
+
+async function readLatestUserTurnText(Runtime: ChromeClient["Runtime"]): Promise<string | null> {
+  const { result } = await Runtime.evaluate({
+    expression: `(() => {
+      const nodes = Array.from(
+        document.querySelectorAll('[data-message-author-role="user"], [data-turn="user"]'),
+      );
+      const latest = nodes[nodes.length - 1];
+      if (!latest) return '';
+      return latest.innerText ?? latest.textContent ?? '';
+    })()`,
+    returnByValue: true,
+  });
+  return typeof result?.value === "string" ? result.value : null;
 }
 
 export async function clearPromptComposer(Runtime: ChromeClient["Runtime"], logger: BrowserLogger) {
@@ -787,6 +804,7 @@ async function verifyPromptCommitted(
   timeoutMs: number,
   logger?: BrowserLogger,
   baselineTurns?: number,
+  baselineLastUserText?: string | null,
 ): Promise<number | null> {
   const deadline = Date.now() + timeoutMs;
   const encodedPrompt = JSON.stringify(prompt.trim());
@@ -814,6 +832,8 @@ async function verifyPromptCommitted(
     }
   }
   const baselineLiteral = baseline ?? -1;
+  const baselineLastUserKnownLiteral = typeof baselineLastUserText === "string";
+  const baselineLastUserTextLiteral = JSON.stringify(baselineLastUserText ?? "");
   // Learned: ChatGPT can echo/format text; normalize markdown and use prefix matches to detect the sent prompt.
   const script = `(() => {
 		    const editor = document.querySelector(${primarySelectorLiteral});
@@ -829,8 +849,21 @@ async function verifyPromptCommitted(
 	    };
 	    const normalizedPrompt = normalize(${encodedPrompt});
 	    const normalizedPromptPrefix = normalizedPrompt.slice(0, 120);
+	    const baselineLastUserKnown = ${baselineLastUserKnownLiteral};
+	    const baselineLastUserText = normalize(${baselineLastUserTextLiteral});
 	    const articles = ${buildConversationTurnListExpression()};
 	    const normalizedTurns = articles.map((node) => normalize(node?.innerText));
+	    const userTurns = Array.from(
+	      document.querySelectorAll('[data-message-author-role="user"], [data-turn="user"]'),
+	    );
+	    const latestUserNode = userTurns[userTurns.length - 1];
+	    const latestUserText = normalize(latestUserNode?.innerText ?? latestUserNode?.textContent);
+	    const latestUserChanged =
+	      baselineLastUserKnown && latestUserText.length > 0 && latestUserText !== baselineLastUserText;
+	    const latestUserMatched =
+	      normalizedPrompt.length > 0 &&
+	      (latestUserText.includes(normalizedPrompt) ||
+	        (normalizedPromptPrefix.length > 30 && latestUserText.includes(normalizedPromptPrefix)));
 	    const readValue = (node) => {
 	      if (!node) return '';
 	      if (node instanceof HTMLTextAreaElement) return node.value ?? '';
@@ -876,6 +909,8 @@ async function verifyPromptCommitted(
 	      userMatched,
 	      prefixMatched,
 	      lastMatched,
+	      latestUserChanged,
+	      latestUserMatched,
 	      hasNewTurn,
 	      stopVisible,
       assistantVisible,
@@ -906,7 +941,9 @@ async function verifyPromptCommitted(
     const virtualizedActiveCommit =
       info?.composerCleared &&
       info.inConversation &&
-      Boolean(info.lastMatched || (info.prefixMatched && info.stopVisible));
+      info.stopVisible &&
+      info.latestUserChanged &&
+      info.latestUserMatched;
     if (virtualizedActiveCommit) {
       return typeof turnsCount === "number" && Number.isFinite(turnsCount) ? turnsCount : null;
     }
@@ -957,6 +994,8 @@ interface CommitProbeState {
   userMatched?: boolean;
   prefixMatched?: boolean;
   lastMatched?: boolean;
+  latestUserChanged?: boolean;
+  latestUserMatched?: boolean;
   hasNewTurn?: boolean;
   stopVisible?: boolean;
   assistantVisible?: boolean;
@@ -977,6 +1016,8 @@ function summarizeCommitProbe(probe: CommitProbeState): Record<string, unknown> 
     userMatched: probe.userMatched,
     prefixMatched: probe.prefixMatched,
     lastMatched: probe.lastMatched,
+    latestUserChanged: probe.latestUserChanged,
+    latestUserMatched: probe.latestUserMatched,
     hasNewTurn: probe.hasNewTurn,
     stopVisible: probe.stopVisible,
     assistantVisible: probe.assistantVisible,

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -213,7 +213,10 @@ export async function submitPrompt(
     );
   }
 
-  const baselineLastUserText = await readLatestUserTurnText(runtime).catch(() => null);
+  const baselineLastUserTurn = await readLatestUserTurnSnapshot(runtime).catch(() => ({
+    text: null,
+    messageId: null,
+  }));
   const clicked = await attemptSendButton(
     runtime,
     input,
@@ -246,30 +249,62 @@ export async function submitPrompt(
     commitTimeoutMs,
     logger,
     deps.baselineTurns ?? undefined,
-    baselineLastUserText,
+    baselineLastUserTurn.text,
+    baselineLastUserTurn.messageId,
   );
 }
 
-async function readLatestUserTurnText(Runtime: ChromeClient["Runtime"]): Promise<string | null> {
+interface LatestUserTurnSnapshot {
+  text: string | null;
+  messageId: string | null;
+}
+
+async function readLatestUserTurnSnapshot(
+  Runtime: ChromeClient["Runtime"],
+): Promise<LatestUserTurnSnapshot> {
   const { result } = await Runtime.evaluate({
     expression: `(() => {
       const nodes = Array.from(
         document.querySelectorAll('[data-message-author-role="user"], [data-turn="user"]'),
       );
       const latest = nodes[nodes.length - 1];
-      if (!latest) return { found: false, text: '' };
-      return { found: true, text: latest.innerText ?? latest.textContent ?? '' };
+      if (!latest) return { found: false, text: '', messageId: '' };
+      const messageId =
+        latest.getAttribute?.('data-message-id') ??
+        latest.closest?.('[data-message-id]')?.getAttribute?.('data-message-id') ??
+        latest.querySelector?.('[data-message-id]')?.getAttribute?.('data-message-id') ??
+        '';
+      return {
+        found: true,
+        text: latest.innerText ?? latest.textContent ?? '',
+        messageId,
+      };
     })()`,
     returnByValue: true,
   });
-  const value = result?.value as { found?: unknown; text?: unknown } | undefined;
+  const value = result?.value as
+    | { found?: unknown; text?: unknown; messageId?: unknown }
+    | undefined;
   if (value?.found === false) {
-    return "";
+    return { text: "", messageId: null };
   }
+  const messageId =
+    typeof value?.messageId === "string" && value.messageId.trim() ? value.messageId : null;
   if (value?.found !== true || typeof value.text !== "string" || !value.text.trim()) {
-    return null;
+    return { text: null, messageId };
   }
-  return value.text;
+  return { text: value.text, messageId };
+}
+
+async function readLatestUserTurnText(Runtime: ChromeClient["Runtime"]): Promise<string | null> {
+  return (await readLatestUserTurnSnapshot(Runtime)).text;
+}
+
+function didUserTurnMessageIdChange(
+  baselineMessageId: string | null | undefined,
+  latestMessageId: string | null | undefined,
+): boolean {
+  return Boolean(baselineMessageId && latestMessageId && baselineMessageId !== latestMessageId);
 }
 
 export async function clearPromptComposer(Runtime: ChromeClient["Runtime"], logger: BrowserLogger) {
@@ -812,6 +847,7 @@ async function verifyPromptCommitted(
   logger?: BrowserLogger,
   baselineTurns?: number,
   baselineLastUserText?: string | null,
+  baselineLastUserMessageId?: string | null,
 ): Promise<number | null> {
   const deadline = Date.now() + timeoutMs;
   const encodedPrompt = JSON.stringify(prompt.trim());
@@ -945,12 +981,19 @@ async function verifyPromptCommitted(
     if (matchesPrompt && (baselineUnknown || info?.hasNewTurn)) {
       return typeof turnsCount === "number" && Number.isFinite(turnsCount) ? turnsCount : null;
     }
+    let latestUserIdentityChanged = false;
+    const virtualizedActiveCandidate =
+      info?.composerCleared && info.inConversation && info.stopVisible && info.latestUserMatched;
+    if (virtualizedActiveCandidate && !info.latestUserChanged) {
+      const latestUserTurn = await readLatestUserTurnSnapshot(Runtime).catch(() => null);
+      latestUserIdentityChanged = didUserTurnMessageIdChange(
+        baselineLastUserMessageId,
+        latestUserTurn?.messageId,
+      );
+      info.latestUserIdentityChanged = latestUserIdentityChanged;
+    }
     const virtualizedActiveCommit =
-      info?.composerCleared &&
-      info.inConversation &&
-      info.stopVisible &&
-      info.latestUserChanged &&
-      info.latestUserMatched;
+      virtualizedActiveCandidate && (info.latestUserChanged || latestUserIdentityChanged);
     if (virtualizedActiveCommit) {
       return typeof turnsCount === "number" && Number.isFinite(turnsCount) ? turnsCount : null;
     }
@@ -1002,6 +1045,7 @@ interface CommitProbeState {
   prefixMatched?: boolean;
   lastMatched?: boolean;
   latestUserChanged?: boolean;
+  latestUserIdentityChanged?: boolean;
   latestUserMatched?: boolean;
   hasNewTurn?: boolean;
   stopVisible?: boolean;
@@ -1024,6 +1068,7 @@ function summarizeCommitProbe(probe: CommitProbeState): Record<string, unknown> 
     prefixMatched: probe.prefixMatched,
     lastMatched: probe.lastMatched,
     latestUserChanged: probe.latestUserChanged,
+    latestUserIdentityChanged: probe.latestUserIdentityChanged,
     latestUserMatched: probe.latestUserMatched,
     hasNewTurn: probe.hasNewTurn,
     stopVisible: probe.stopVisible,
@@ -1038,6 +1083,8 @@ function summarizeCommitProbe(probe: CommitProbeState): Record<string, unknown> 
 // biome-ignore lint/style/useNamingConvention: test-only export used in vitest suite
 export const __test__ = {
   attemptSendButton,
+  didUserTurnMessageIdChange,
+  readLatestUserTurnSnapshot,
   readLatestUserTurnText,
   sendButtonTimeoutMs,
   verifyPromptCommitted,

--- a/src/cli/browserTabs.ts
+++ b/src/cli/browserTabs.ts
@@ -21,6 +21,8 @@ import { resolveOutputPath } from "./writeOutputPath.js";
 
 const LIVE_POLL_MS = 2000;
 const DEFAULT_STALL_THRESHOLD_MS = 60_000;
+const HARVEST_FRESHNESS_TIMEOUT_MS = 5_000;
+const HARVEST_FRESHNESS_POLL_MS = 250;
 
 function isRecoverableMissingTabError(message: string): boolean {
   return (
@@ -47,6 +49,53 @@ function finishRecoveredChrome(
   } catch {
     // best-effort cleanup
   }
+}
+
+function normalizePromptText(value: unknown): string {
+  return String(value ?? "")
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function harvestMatchesSessionPrompt(
+  harvested: ChatGptTabSummary,
+  expectedPrompt: string | undefined,
+): boolean {
+  const assistantText = harvested.lastAssistantMarkdown ?? harvested.lastAssistantText;
+  if (harvested.assistantFollowsLatestUser !== true || !assistantText?.trim()) {
+    return false;
+  }
+  const expected = normalizePromptText(expectedPrompt);
+  if (!expected) {
+    return true;
+  }
+  const observed = normalizePromptText(harvested.lastUserText);
+  if (!observed) {
+    return false;
+  }
+  const prefix = expected.slice(0, Math.min(120, expected.length));
+  return observed.startsWith(expected) || observed.startsWith(prefix);
+}
+
+async function harvestSessionPrompt(
+  meta: SessionMetadata,
+  options: Parameters<typeof harvestChatGptTab>[0],
+): Promise<ChatGptTabSummary> {
+  const expectedPrompt =
+    typeof meta.options?.prompt === "string" ? meta.options.prompt.trim() : undefined;
+  const deadline = Date.now() + HARVEST_FRESHNESS_TIMEOUT_MS;
+  let harvested = await harvestChatGptTab(options);
+  while (!harvestMatchesSessionPrompt(harvested, expectedPrompt) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, HARVEST_FRESHNESS_POLL_MS));
+    harvested = await harvestChatGptTab(options);
+  }
+  if (!harvestMatchesSessionPrompt(harvested, expectedPrompt)) {
+    throw new Error(
+      "Latest ChatGPT turn did not contain an assistant answer paired with this session prompt after 5s; refusing to harvest stale output.",
+    );
+  }
+  return harvested;
 }
 
 export interface BrowserHarvestOptions {
@@ -276,7 +325,7 @@ export async function harvestSessionBrowserOutput(
   try {
     let harvested: ChatGptTabSummary;
     try {
-      harvested = await harvestChatGptTab({
+      harvested = await harvestSessionPrompt(meta, {
         host: initialEndpoint.host,
         port: initialEndpoint.port,
         ref,
@@ -296,7 +345,7 @@ export async function harvestSessionBrowserOutput(
         existingEndpoint: recordedEndpoint ?? undefined,
       });
       recoveredChrome = recovered.chrome;
-      harvested = await harvestChatGptTab({
+      harvested = await harvestSessionPrompt(meta, {
         host: recovered.host,
         port: recovered.port,
         ref: recovered.ref,

--- a/src/cli/browserTabs.ts
+++ b/src/cli/browserTabs.ts
@@ -91,8 +91,10 @@ function expectedLatestUserPrompt(meta: SessionMetadata): {
       }
     }
   }
+  const system = typeof meta.options?.system === "string" ? meta.options.system.trim() : "";
+  const prompt = typeof meta.options?.prompt === "string" ? meta.options.prompt.trim() : "";
   return {
-    text: typeof meta.options?.prompt === "string" ? meta.options.prompt.trim() : undefined,
+    text: [system, prompt].filter(Boolean).join("\n\n") || undefined,
     exact: false,
   };
 }

--- a/src/cli/browserTabs.ts
+++ b/src/cli/browserTabs.ts
@@ -61,13 +61,13 @@ function normalizePromptText(value: unknown): string {
 
 function harvestMatchesSessionPrompt(
   harvested: ChatGptTabSummary,
-  expectedPrompt: string | undefined,
+  expectedPrompt: { text: string | undefined; exact: boolean },
 ): boolean {
   const assistantText = harvested.lastAssistantMarkdown ?? harvested.lastAssistantText;
   if (harvested.assistantFollowsLatestUser !== true || !assistantText?.trim()) {
     return false;
   }
-  const expected = normalizePromptText(expectedPrompt);
+  const expected = normalizePromptText(expectedPrompt.text);
   if (!expected) {
     return true;
   }
@@ -75,15 +75,33 @@ function harvestMatchesSessionPrompt(
   if (!observed) {
     return false;
   }
-  return observed.startsWith(expected);
+  return expectedPrompt.exact ? observed === expected : observed.startsWith(expected);
+}
+
+function expectedLatestUserPrompt(meta: SessionMetadata): {
+  text: string | undefined;
+  exact: boolean;
+} {
+  const followUps = meta.options?.browserFollowUps;
+  if (Array.isArray(followUps)) {
+    for (let index = followUps.length - 1; index >= 0; index -= 1) {
+      const followUp = followUps[index];
+      if (typeof followUp === "string" && followUp.trim()) {
+        return { text: followUp.trim(), exact: true };
+      }
+    }
+  }
+  return {
+    text: typeof meta.options?.prompt === "string" ? meta.options.prompt.trim() : undefined,
+    exact: false,
+  };
 }
 
 async function harvestSessionPrompt(
   meta: SessionMetadata,
   options: Parameters<typeof harvestChatGptTab>[0],
 ): Promise<ChatGptTabSummary> {
-  const expectedPrompt =
-    typeof meta.options?.prompt === "string" ? meta.options.prompt.trim() : undefined;
+  const expectedPrompt = expectedLatestUserPrompt(meta);
   const deadline = Date.now() + HARVEST_FRESHNESS_TIMEOUT_MS;
   let harvested = await harvestChatGptTab(options);
   while (!harvestMatchesSessionPrompt(harvested, expectedPrompt) && Date.now() < deadline) {

--- a/src/cli/browserTabs.ts
+++ b/src/cli/browserTabs.ts
@@ -52,10 +52,11 @@ function finishRecoveredChrome(
 }
 
 function normalizePromptText(value: unknown): string {
-  return String(value ?? "")
-    .toLowerCase()
-    .replace(/\s+/g, " ")
-    .trim();
+  let text = String(value ?? "").toLowerCase();
+  text = text.replace(/```[^\n]*\n([\s\S]*?)```/g, " $1 ");
+  text = text.replace(/```/g, " ");
+  text = text.replace(/`([^`]*)`/g, "$1");
+  return text.replace(/\s+/g, " ").trim();
 }
 
 function harvestMatchesSessionPrompt(
@@ -74,8 +75,7 @@ function harvestMatchesSessionPrompt(
   if (!observed) {
     return false;
   }
-  const prefix = expected.slice(0, Math.min(120, expected.length));
-  return observed.startsWith(expected) || observed.startsWith(prefix);
+  return observed.startsWith(expected);
 }
 
 async function harvestSessionPrompt(

--- a/tests/browser/promptComposer.test.ts
+++ b/tests/browser/promptComposer.test.ts
@@ -324,4 +324,78 @@ describe("promptComposer", () => {
       vi.useRealTimers();
     }
   });
+
+  test("accepts a matched prompt when conversation virtualization keeps the turn count stable", async () => {
+    const runtime = {
+      evaluate: vi.fn().mockResolvedValue({
+        result: {
+          value: {
+            baseline: 6,
+            turnsCount: 6,
+            userMatched: false,
+            prefixMatched: true,
+            lastMatched: false,
+            hasNewTurn: false,
+            stopVisible: true,
+            assistantVisible: true,
+            composerCleared: true,
+            composerMatchesPrompt: false,
+            inConversation: true,
+          },
+        },
+      }),
+    } as unknown as {
+      evaluate: (args: { expression: string; returnByValue?: boolean }) => Promise<unknown>;
+    };
+
+    await expect(
+      promptComposer.verifyPromptCommitted(
+        runtime as never,
+        "A neutral prompt long enough for reliable prefix matching in a virtualized conversation.",
+        150,
+        undefined,
+        6,
+      ),
+    ).resolves.toBe(6);
+  });
+
+  test("does not accept a historical prefix match without an active response", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtime = {
+        evaluate: vi.fn().mockResolvedValue({
+          result: {
+            value: {
+              baseline: 6,
+              turnsCount: 6,
+              userMatched: false,
+              prefixMatched: true,
+              lastMatched: false,
+              hasNewTurn: false,
+              stopVisible: false,
+              assistantVisible: true,
+              composerCleared: true,
+              composerMatchesPrompt: false,
+              inConversation: true,
+            },
+          },
+        }),
+      } as unknown as {
+        evaluate: (args: { expression: string; returnByValue?: boolean }) => Promise<unknown>;
+      };
+
+      const promise = promptComposer.verifyPromptCommitted(
+        runtime as never,
+        "A historical neutral prompt that remains visible in a virtualized conversation.",
+        150,
+        undefined,
+        6,
+      );
+      const assertion = expect(promise).rejects.toThrow(/prompt did not appear/i);
+      await vi.advanceTimersByTimeAsync(250);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/tests/browser/promptComposer.test.ts
+++ b/tests/browser/promptComposer.test.ts
@@ -26,6 +26,34 @@ describe("promptComposer", () => {
     ).resolves.toBeNull();
   });
 
+  test("captures a stable message id for the latest user turn", async () => {
+    const runtime = {
+      evaluate: vi.fn().mockResolvedValue({
+        result: {
+          value: {
+            found: true,
+            text: "Repeated neutral prompt",
+            messageId: "message-new",
+          },
+        },
+      }),
+    };
+
+    await expect(promptComposer.readLatestUserTurnSnapshot(runtime as never)).resolves.toEqual({
+      text: "Repeated neutral prompt",
+      messageId: "message-new",
+    });
+    const expression = runtime.evaluate.mock.calls[0]?.[0]?.expression ?? "";
+    expect(expression).toContain("data-message-id");
+  });
+
+  test("requires two distinct non-empty message ids to prove a structural change", () => {
+    expect(promptComposer.didUserTurnMessageIdChange("message-old", "message-new")).toBe(true);
+    expect(promptComposer.didUserTurnMessageIdChange("message-old", "message-old")).toBe(false);
+    expect(promptComposer.didUserTurnMessageIdChange(null, "message-new")).toBe(false);
+    expect(promptComposer.didUserTurnMessageIdChange("message-old", null)).toBe(false);
+  });
+
   test("fails composer clearing when stale text remains", async () => {
     const runtime = {
       evaluate: vi.fn().mockResolvedValue({
@@ -456,6 +484,105 @@ describe("promptComposer", () => {
       const assertion = expect(promise).rejects.toThrow(/prompt did not appear/i);
       await vi.advanceTimersByTimeAsync(250);
       await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("accepts a repeated prompt when the latest user turn has a new structural identity", async () => {
+    const probe = {
+      baseline: 6,
+      turnsCount: 6,
+      userMatched: true,
+      prefixMatched: true,
+      lastMatched: true,
+      hasNewTurn: false,
+      stopVisible: true,
+      assistantVisible: true,
+      composerCleared: true,
+      inConversation: true,
+      latestUserChanged: false,
+      latestUserMatched: true,
+    };
+    const runtime = {
+      evaluate: vi
+        .fn()
+        .mockResolvedValueOnce({ result: { value: probe } })
+        .mockResolvedValueOnce({
+          result: {
+            value: {
+              found: true,
+              text: "A repeated neutral prompt that is already the latest visible user turn.",
+              messageId: "message-new",
+            },
+          },
+        }),
+    } as unknown as {
+      evaluate: (args: { expression: string; returnByValue?: boolean }) => Promise<unknown>;
+    };
+
+    await expect(
+      promptComposer.verifyPromptCommitted(
+        runtime as never,
+        "A repeated neutral prompt that is already the latest visible user turn.",
+        150,
+        undefined,
+        6,
+        "A repeated neutral prompt that is already the latest visible user turn.",
+        "message-old",
+      ),
+    ).resolves.toBe(6);
+    expect(probe).toMatchObject({ latestUserIdentityChanged: true });
+  });
+
+  test("does not accept a repeated prompt when its message id appears only after baseline", async () => {
+    vi.useFakeTimers();
+    try {
+      const probe = {
+        baseline: 6,
+        turnsCount: 6,
+        userMatched: true,
+        prefixMatched: true,
+        lastMatched: true,
+        hasNewTurn: false,
+        stopVisible: true,
+        assistantVisible: true,
+        composerCleared: true,
+        inConversation: true,
+        latestUserChanged: false,
+        latestUserMatched: true,
+      };
+      const runtime = {
+        evaluate: vi.fn(async ({ expression }: { expression: string }) =>
+          expression.includes("if (!latest) return { found: false")
+            ? {
+                result: {
+                  value: {
+                    found: true,
+                    text: "A repeated neutral prompt that is already the latest visible user turn.",
+                    messageId: "message-hydrated",
+                  },
+                },
+              }
+            : { result: { value: probe } },
+        ),
+      } as unknown as {
+        evaluate: (args: { expression: string; returnByValue?: boolean }) => Promise<unknown>;
+      };
+
+      const promise = promptComposer.verifyPromptCommitted(
+        runtime as never,
+        "A repeated neutral prompt that is already the latest visible user turn.",
+        150,
+        undefined,
+        6,
+        "A repeated neutral prompt that is already the latest visible user turn.",
+        null,
+      );
+      const assertion = expect(promise).rejects.toThrow(/prompt did not appear/i);
+      await vi.advanceTimersByTimeAsync(250);
+      await assertion;
+      expect(probe).toMatchObject({ latestUserIdentityChanged: false });
     } finally {
       vi.useRealTimers();
     }

--- a/tests/browser/promptComposer.test.ts
+++ b/tests/browser/promptComposer.test.ts
@@ -10,6 +10,22 @@ import {
 } from "../../src/browser/constants.js";
 
 describe("promptComposer", () => {
+  test("distinguishes a new conversation from an unhydrated latest user turn", async () => {
+    const emptyConversationRuntime = {
+      evaluate: vi.fn().mockResolvedValue({ result: { value: { found: false, text: "" } } }),
+    };
+    const unhydratedTurnRuntime = {
+      evaluate: vi.fn().mockResolvedValue({ result: { value: { found: true, text: "" } } }),
+    };
+
+    await expect(
+      promptComposer.readLatestUserTurnText(emptyConversationRuntime as never),
+    ).resolves.toBe("");
+    await expect(
+      promptComposer.readLatestUserTurnText(unhydratedTurnRuntime as never),
+    ).resolves.toBeNull();
+  });
+
   test("fails composer clearing when stale text remains", async () => {
     const runtime = {
       evaluate: vi.fn().mockResolvedValue({

--- a/tests/browser/promptComposer.test.ts
+++ b/tests/browser/promptComposer.test.ts
@@ -341,6 +341,8 @@ describe("promptComposer", () => {
             composerCleared: true,
             composerMatchesPrompt: false,
             inConversation: true,
+            latestUserChanged: true,
+            latestUserMatched: true,
           },
         },
       }),
@@ -377,6 +379,8 @@ describe("promptComposer", () => {
               composerCleared: true,
               composerMatchesPrompt: false,
               inConversation: true,
+              latestUserChanged: true,
+              latestUserMatched: true,
             },
           },
         }),
@@ -387,6 +391,48 @@ describe("promptComposer", () => {
       const promise = promptComposer.verifyPromptCommitted(
         runtime as never,
         "A historical neutral prompt that remains visible in a virtualized conversation.",
+        150,
+        undefined,
+        6,
+      );
+      const assertion = expect(promise).rejects.toThrow(/prompt did not appear/i);
+      await vi.advanceTimersByTimeAsync(250);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("does not accept a repeated historical prompt when turn count is virtualized", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtime = {
+        evaluate: vi.fn().mockResolvedValue({
+          result: {
+            value: {
+              baseline: 6,
+              turnsCount: 6,
+              userMatched: true,
+              prefixMatched: true,
+              lastMatched: true,
+              hasNewTurn: false,
+              stopVisible: true,
+              assistantVisible: true,
+              composerCleared: true,
+              composerMatchesPrompt: false,
+              inConversation: true,
+              latestUserChanged: false,
+              latestUserMatched: true,
+            },
+          },
+        }),
+      } as unknown as {
+        evaluate: (args: { expression: string; returnByValue?: boolean }) => Promise<unknown>;
+      };
+
+      const promise = promptComposer.verifyPromptCommitted(
+        runtime as never,
+        "A repeated neutral prompt that is already the latest visible user turn.",
         150,
         undefined,
         6,

--- a/tests/cli/browserTabsRecover.test.ts
+++ b/tests/cli/browserTabsRecover.test.ts
@@ -291,6 +291,93 @@ describe("harvestSessionBrowserOutput recovery fallback", () => {
     expect(result.lastAssistantMarkdown).toBe(completedHarvest.lastAssistantMarkdown);
   });
 
+  test("matches recovery against the final non-empty browser follow-up", async () => {
+    const finalFollowUp = "Give the final neutral decision";
+    const harvestChatGptTab = vi.fn().mockResolvedValue({
+      ...completedHarvest,
+      lastUserText: finalFollowUp,
+      lastUserSnippet: finalFollowUp,
+    });
+
+    vi.doMock("../../src/browser/liveTabs.js", () => ({
+      collectChatGptTabs: vi.fn(),
+      DEFAULT_REMOTE_CHROME_HOST: "127.0.0.1",
+      DEFAULT_REMOTE_CHROME_PORT: 9222,
+      extractConversationIdFromUrl: () => "saved-conversation",
+      formatBrowserTabState: () => "completed",
+      harvestChatGptTab,
+      sessionMatchesTab: () => false,
+    }));
+    vi.doMock("../../src/browser/recoverConversation.js", () => ({
+      recoverConversationTab: vi.fn(),
+    }));
+    vi.doMock("../../src/sessionStore.js", () => ({
+      sessionStore: {
+        readSession: async () => ({
+          ...baseMeta,
+          options: {
+            prompt: "Initial neutral request",
+            browserFollowUps: ["Challenge the recommendation", finalFollowUp, "  "],
+          },
+        }),
+        updateSession: async () => {},
+      },
+    }));
+
+    const { harvestSessionBrowserOutput } = await import("../../src/cli/browserTabs.js");
+    const result = await harvestSessionBrowserOutput("sess-recover", { quietOutput: true });
+
+    expect(harvestChatGptTab).toHaveBeenCalledTimes(1);
+    expect(result.lastAssistantMarkdown).toBe(completedHarvest.lastAssistantMarkdown);
+  });
+
+  test("requires an exact latest-user match for a short browser follow-up", async () => {
+    const staleHarvest = {
+      ...completedHarvest,
+      lastUserText: "Yesterday's unrelated neutral request",
+      lastUserSnippet: "Yesterday's unrelated neutral request",
+      lastAssistantText: "Unrelated answer",
+      lastAssistantMarkdown: "Unrelated answer",
+    };
+    const freshHarvest = {
+      ...completedHarvest,
+      lastUserText: "Yes",
+      lastUserSnippet: "Yes",
+    };
+    const harvestChatGptTab = vi
+      .fn()
+      .mockResolvedValueOnce(staleHarvest)
+      .mockResolvedValueOnce(freshHarvest);
+
+    vi.doMock("../../src/browser/liveTabs.js", () => ({
+      collectChatGptTabs: vi.fn(),
+      DEFAULT_REMOTE_CHROME_HOST: "127.0.0.1",
+      DEFAULT_REMOTE_CHROME_PORT: 9222,
+      extractConversationIdFromUrl: () => "saved-conversation",
+      formatBrowserTabState: () => "completed",
+      harvestChatGptTab,
+      sessionMatchesTab: () => false,
+    }));
+    vi.doMock("../../src/browser/recoverConversation.js", () => ({
+      recoverConversationTab: vi.fn(),
+    }));
+    vi.doMock("../../src/sessionStore.js", () => ({
+      sessionStore: {
+        readSession: async () => ({
+          ...baseMeta,
+          options: { prompt: "Initial neutral request", browserFollowUps: ["Yes"] },
+        }),
+        updateSession: async () => {},
+      },
+    }));
+
+    const { harvestSessionBrowserOutput } = await import("../../src/cli/browserTabs.js");
+    const result = await harvestSessionBrowserOutput("sess-recover", { quietOutput: true });
+
+    expect(harvestChatGptTab).toHaveBeenCalledTimes(2);
+    expect(result.lastAssistantMarkdown).toBe(completedHarvest.lastAssistantMarkdown);
+  });
+
   test("fails closed when the latest assistant never pairs with the session prompt", async () => {
     vi.useFakeTimers();
     try {

--- a/tests/cli/browserTabsRecover.test.ts
+++ b/tests/cli/browserTabsRecover.test.ts
@@ -331,6 +331,54 @@ describe("harvestSessionBrowserOutput recovery fallback", () => {
     expect(result.lastAssistantMarkdown).toBe(completedHarvest.lastAssistantMarkdown);
   });
 
+  test("matches initial-turn recovery against the stored system and user prompt", async () => {
+    vi.useFakeTimers();
+    try {
+      const harvestChatGptTab = vi.fn().mockResolvedValue({
+        ...completedHarvest,
+        lastUserText:
+          "Use the public context only\n\nInitial neutral request\n\nAttached public file context",
+        lastUserSnippet: "Use the public context only",
+      });
+
+      vi.doMock("../../src/browser/liveTabs.js", () => ({
+        collectChatGptTabs: vi.fn(),
+        DEFAULT_REMOTE_CHROME_HOST: "127.0.0.1",
+        DEFAULT_REMOTE_CHROME_PORT: 9222,
+        extractConversationIdFromUrl: () => "saved-conversation",
+        formatBrowserTabState: () => "completed",
+        harvestChatGptTab,
+        sessionMatchesTab: () => false,
+      }));
+      vi.doMock("../../src/browser/recoverConversation.js", () => ({
+        recoverConversationTab: vi.fn(),
+      }));
+      vi.doMock("../../src/sessionStore.js", () => ({
+        sessionStore: {
+          readSession: async () => ({
+            ...baseMeta,
+            options: {
+              prompt: "Initial neutral request",
+              system: "Use the public context only",
+            },
+          }),
+          updateSession: async () => {},
+        },
+      }));
+
+      const { harvestSessionBrowserOutput } = await import("../../src/cli/browserTabs.js");
+      const promise = harvestSessionBrowserOutput("sess-recover", { quietOutput: true });
+      const assertion = expect(promise).resolves.toMatchObject({
+        lastAssistantMarkdown: completedHarvest.lastAssistantMarkdown,
+      });
+      await vi.advanceTimersByTimeAsync(5_250);
+      await assertion;
+      expect(harvestChatGptTab).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("requires an exact latest-user match for a short browser follow-up", async () => {
     const staleHarvest = {
       ...completedHarvest,

--- a/tests/cli/browserTabsRecover.test.ts
+++ b/tests/cli/browserTabsRecover.test.ts
@@ -336,4 +336,51 @@ describe("harvestSessionBrowserOutput recovery fallback", () => {
       vi.useRealTimers();
     }
   });
+
+  test("does not match a stale user turn that only shares the prompt prefix", async () => {
+    const commonPrefix = "Shared neutral review preamble with stable wrapper context. ".repeat(3);
+    const currentPrompt = `${commonPrefix}Current constraints.`;
+    const staleHarvest = {
+      ...completedHarvest,
+      lastUserText: `${commonPrefix}Older constraints.`,
+      lastUserSnippet: "Shared neutral review preamble",
+      lastAssistantText: "Older answer",
+      lastAssistantMarkdown: "Older answer",
+      assistantFollowsLatestUser: true,
+    };
+    const freshHarvest = {
+      ...completedHarvest,
+      lastUserText: currentPrompt,
+      lastUserSnippet: "Shared neutral review preamble",
+    };
+    const harvestChatGptTab = vi
+      .fn()
+      .mockResolvedValueOnce(staleHarvest)
+      .mockResolvedValueOnce(freshHarvest);
+
+    vi.doMock("../../src/browser/liveTabs.js", () => ({
+      collectChatGptTabs: vi.fn(),
+      DEFAULT_REMOTE_CHROME_HOST: "127.0.0.1",
+      DEFAULT_REMOTE_CHROME_PORT: 9222,
+      extractConversationIdFromUrl: () => "saved-conversation",
+      formatBrowserTabState: () => "completed",
+      harvestChatGptTab,
+      sessionMatchesTab: () => false,
+    }));
+    vi.doMock("../../src/browser/recoverConversation.js", () => ({
+      recoverConversationTab: vi.fn(),
+    }));
+    vi.doMock("../../src/sessionStore.js", () => ({
+      sessionStore: {
+        readSession: async () => ({ ...baseMeta, options: { prompt: currentPrompt } }),
+        updateSession: async () => {},
+      },
+    }));
+
+    const { harvestSessionBrowserOutput } = await import("../../src/cli/browserTabs.js");
+    const result = await harvestSessionBrowserOutput("sess-recover", { quietOutput: true });
+
+    expect(harvestChatGptTab).toHaveBeenCalledTimes(2);
+    expect(result.lastAssistantMarkdown).toBe(completedHarvest.lastAssistantMarkdown);
+  });
 });

--- a/tests/cli/browserTabsRecover.test.ts
+++ b/tests/cli/browserTabsRecover.test.ts
@@ -242,4 +242,98 @@ describe("harvestSessionBrowserOutput recovery fallback", () => {
     ).rejects.toThrow(/explicit-ref/);
     expect(recoverConversationTab).not.toHaveBeenCalled();
   });
+
+  test("waits for the assistant paired with the session prompt instead of harvesting a stale turn", async () => {
+    const staleHarvest = {
+      ...completedHarvest,
+      lastUserText: "Current neutral request with the latest constraints",
+      lastUserSnippet: "Current neutral request",
+      lastAssistantText: "Older answer",
+      lastAssistantMarkdown: "Older answer",
+      assistantFollowsLatestUser: false,
+    };
+    const freshHarvest = {
+      ...completedHarvest,
+      lastUserText: "Current neutral request with the latest constraints",
+      lastUserSnippet: "Current neutral request",
+    };
+    const harvestChatGptTab = vi
+      .fn()
+      .mockResolvedValueOnce(staleHarvest)
+      .mockResolvedValueOnce(freshHarvest);
+
+    vi.doMock("../../src/browser/liveTabs.js", () => ({
+      collectChatGptTabs: vi.fn(),
+      DEFAULT_REMOTE_CHROME_HOST: "127.0.0.1",
+      DEFAULT_REMOTE_CHROME_PORT: 9222,
+      extractConversationIdFromUrl: () => "saved-conversation",
+      formatBrowserTabState: () => "completed",
+      harvestChatGptTab,
+      sessionMatchesTab: () => false,
+    }));
+    vi.doMock("../../src/browser/recoverConversation.js", () => ({
+      recoverConversationTab: vi.fn(),
+    }));
+    vi.doMock("../../src/sessionStore.js", () => ({
+      sessionStore: {
+        readSession: async () => ({
+          ...baseMeta,
+          options: { prompt: "Current neutral request with the latest constraints" },
+        }),
+        updateSession: async () => {},
+      },
+    }));
+
+    const { harvestSessionBrowserOutput } = await import("../../src/cli/browserTabs.js");
+    const result = await harvestSessionBrowserOutput("sess-recover", { quietOutput: true });
+
+    expect(harvestChatGptTab).toHaveBeenCalledTimes(2);
+    expect(result.lastAssistantMarkdown).toBe(completedHarvest.lastAssistantMarkdown);
+  });
+
+  test("fails closed when the latest assistant never pairs with the session prompt", async () => {
+    vi.useFakeTimers();
+    try {
+      const staleHarvest = {
+        ...completedHarvest,
+        lastUserText: "An older neutral request",
+        lastUserSnippet: "An older neutral request",
+        lastAssistantText: "Older answer",
+        lastAssistantMarkdown: "Older answer",
+        assistantFollowsLatestUser: true,
+      };
+      const harvestChatGptTab = vi.fn().mockResolvedValue(staleHarvest);
+
+      vi.doMock("../../src/browser/liveTabs.js", () => ({
+        collectChatGptTabs: vi.fn(),
+        DEFAULT_REMOTE_CHROME_HOST: "127.0.0.1",
+        DEFAULT_REMOTE_CHROME_PORT: 9222,
+        extractConversationIdFromUrl: () => "saved-conversation",
+        formatBrowserTabState: () => "completed",
+        harvestChatGptTab,
+        sessionMatchesTab: () => false,
+      }));
+      vi.doMock("../../src/browser/recoverConversation.js", () => ({
+        recoverConversationTab: vi.fn(),
+      }));
+      vi.doMock("../../src/sessionStore.js", () => ({
+        sessionStore: {
+          readSession: async () => ({
+            ...baseMeta,
+            options: { prompt: "Current neutral request with the latest constraints" },
+          }),
+          updateSession: async () => {},
+        },
+      }));
+
+      const { harvestSessionBrowserOutput } = await import("../../src/cli/browserTabs.js");
+      const promise = harvestSessionBrowserOutput("sess-recover", { quietOutput: true });
+      const assertion = expect(promise).rejects.toThrow(/refusing to harvest stale output/i);
+      await vi.advanceTimersByTimeAsync(5_250);
+      await assertion;
+      expect(harvestChatGptTab).toHaveBeenCalledTimes(21);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- recognize committed prompts when ChatGPT virtualizes the visible turn count
- require a real latest-user-turn transition before accepting the stable-count path
- match recovery to the final non-empty follow-up in multi-turn browser sessions
- reconstruct the initial system-plus-user prefix used by the browser composer
- wait for an assistant answer paired with the expected latest user turn before harvest persists or prints output
- use the stored browser input timeout for bounded recovery hydration
- fail closed with a bounded error instead of returning an older answer

## Problem

In long reused conversations, ChatGPT can replace visible DOM turns while keeping the visible count stable. A submitted prompt may clear the composer and begin streaming while `turnsCount` remains equal to the baseline, producing a false `prompt-commit-timeout`.

The inverse race also exists during harvest: the new user turn may be visible while the assistant selector still points at the previous answer. A single snapshot can therefore return stale output.

## Fix

Before dispatch, capture the latest visible user turn. The stable-count commit path now requires:

- a known pre-submit user-turn state and a latest user turn matching the submitted prompt
- either changed normalized text or two known, distinct native `data-message-id` values
- a cleared composer, active Stop control, and conversation URL

An existing but empty user node is treated as unhydrated/unknown, not as a new conversation. A missing message ID, an ID that appears only after dispatch, or the same ID on both snapshots cannot prove a repeated prompt was committed and therefore fails closed. Raw message IDs stay in memory and are not persisted or logged.

Harvest now polls within the session's resolved `browser.config.inputTimeoutMs` and accepts output only when the assistant follows the latest user turn. This reuses the existing configured/default 60-second input budget instead of introducing a new hardcoded deadline. Single-turn recovery matches the full normalized initial prompt as a prefix so attachment context remains compatible. Multi-turn recovery selects the final non-empty configured follow-up and requires an exact normalized match; browser follow-ups are sent without attachments. If identity cannot be established, Oracle returns an explicit stale-output error and does not persist or print the candidate answer.

When stored run options contain a custom system prompt, initial-turn recovery reconstructs the same trimmed `system`, blank line, and trimmed user prompt prefix that browser prompt assembly sends. The current 0.18.0 CLI does not expose a `--system` flag; this preserves stored/programmatic compatibility rather than claiming a new CLI workflow.

## Verification

Exact head: `c3095c3f9f153b61e1009c9328c6f9b2bae8b24c`

- focused prompt/harvest suite: 29 passed
- full suite: 1771 passed, 48 skipped
- `pnpm run lint`
- `pnpm run build`
- `pnpm run docs:check`
- changed-file `oxfmt --check`
- `git diff --check`

Independent Claude Opus 5 review identified concrete false-positive states across the review cycles: repeated historical prompts, different prompts sharing the first 120 normalized characters, a short follow-up such as `Yes` matching an unrelated latest user turn, and a partial structural identity changing when an old node hydrates. Each accepted finding was reproduced as a red test and repaired. The structural repair now compares only two non-empty native message IDs through a pure tested helper; it does not use virtualized turn indexes. Two conditional concerns were resolved by source inspection: the browser runner uses the same trim-and-filter rule for follow-ups, and browser mode rejects an empty initial prompt before dispatch. One bounded structural repair run exhausted its tool-turn limit and is not counted as approval. A separate focused Opus 5 review of the final system-prefix repair completed with verified model and verdict `proceed`; its only residual request was real-DOM evidence for a CLI path that 0.18.0 does not currently expose.

An exact-head GPT-5.6 Sol repeated-turn proof completed without API fallback:

- one public `package.json` attachment was delivered inline
- the initial prompt and configured follow-up used the same exact text
- both turns returned exactly `UPSTREAM_REPEAT_TURN_OK` in 32.8 seconds
- model selection was verified as GPT-5.6 Sol, `promptSubmitted=true`, and both session/model statuses were `completed`
- no stale-output timeout occurred

On the preceding reviewed head, a distinct multi-turn run completed in 20.3 seconds and `session --harvest --write-output` then recovered the exact final follow-up after the original CDP port disappeared. The current focused suite preserves that recovery coverage.

The custom-system regression uses the exact browser composer ordering and separator, then adds trailing inline-file context to the harvested DOM text. It failed through the five-second stale-output boundary before the repair and now succeeds on the first harvest. No live `--system` receipt is claimed because that flag is not present in the current CLI.

The timeout regression keeps a stale DOM response for 6.25 seconds under a configured 10-second input timeout. The previous hardcoded deadline rejected it; the current head recovers the fresh turn on poll 26. A second regression configures 750 ms and proves a permanent mismatch still fails closed after four polls, so the repair remains bounded and operator-configurable.

The tab lease registry ended with zero leases and zero waiters.

## Compatibility

Historical sessions without a stored prompt still require a non-empty assistant answer paired with the latest visible user turn. When the stored prompt exists but the DOM cannot prove its full identity, harvest fails closed rather than returning potentially stale content.

PR #386 also touches prompt commit verification for Pro-specific durable receipts. This change is generic to ChatGPT DOM virtualization and CLI harvest freshness; it does not depend on the Pro receipt format, although a small conflict resolution may be needed if #386 lands first.

The exact upstream base currently reports unrelated `CHANGELOG.md` drift under whole-repository `format:check`; this PR does not touch that file, and all changed files pass the pinned formatter.
