### PR TITLE
fix(browser): probe the DevTools endpoint when attach discovery finds nothing

### DIFF
--- a/src/browser/attachRunning.ts
+++ b/src/browser/attachRunning.ts
@@ -1,6 +1,7 @@
 import type { BrowserLogger, ResolvedBrowserConfig } from "./types.js";
 import {
   discoverDevToolsActivePortCandidates,
+  resolveDevToolsActivePortDiscoveryRoots,
   type DevToolsActivePortCandidate,
 } from "./detect.js";
 
@@ -8,7 +9,7 @@ export interface AttachRunningConnectionInfo {
   host: string;
   port: number;
   browserWSEndpoint: string;
-  profileRoot: string;
+  profileRoot: string | null;
 }
 
 export async function resolveAttachRunningConnection(
@@ -32,8 +33,18 @@ export async function resolveAttachRunningConnection(
     .sort(compareDevToolsCandidates);
 
   if (candidates.length === 0) {
+    const probe = await probeDevToolsBrowserWSEndpoint({ host, port });
+    if (probe.ok) {
+      return {
+        host,
+        port,
+        browserWSEndpoint: probe.browserWSEndpoint,
+        profileRoot: null,
+      };
+    }
+    const discoveryRoots = resolveDevToolsActivePortDiscoveryRoots();
     throw new Error(
-      `No running browser with attach metadata matched ${host}:${port}. Enable remote debugging in chrome://inspect/#remote-debugging first.`,
+      `No running browser matched ${host}:${port}. DevToolsActivePort discovery searched ${discoveryRoots.join(", ") || "no roots"}, and endpoint probe http://${host}:${port}/json/version failed: ${probe.error}.`,
     );
   }
   const candidate = candidates[0];
@@ -44,6 +55,47 @@ export async function resolveAttachRunningConnection(
     browserWSEndpoint: candidate.browserWSEndpoint,
     profileRoot: candidate.profileRoot,
   };
+}
+
+async function probeDevToolsBrowserWSEndpoint({
+  host,
+  port,
+  attempts = 2,
+  timeoutMs = 1000,
+}: {
+  host: string;
+  port: number;
+  attempts?: number;
+  timeoutMs?: number;
+}): Promise<
+  | { ok: true; browserWSEndpoint: string }
+  | { ok: false; error: string }
+> {
+  const versionUrl = `http://${host}:${port}/json/version`;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), timeoutMs);
+      const response = await fetch(versionUrl, { signal: controller.signal });
+      clearTimeout(timeout);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const version = (await response.json()) as { webSocketDebuggerUrl?: unknown };
+      if (typeof version.webSocketDebuggerUrl !== "string" || !version.webSocketDebuggerUrl) {
+        throw new Error("response did not include webSocketDebuggerUrl");
+      }
+      return { ok: true, browserWSEndpoint: version.webSocketDebuggerUrl };
+    } catch (error) {
+      if (attempt < attempts - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 500 * (attempt + 1)));
+        continue;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      return { ok: false, error: message };
+    }
+  }
+  return { ok: false, error: "unreachable" };
 }
 
 function compareDevToolsCandidates(

--- a/src/browser/attachRunning.ts
+++ b/src/browser/attachRunning.ts
@@ -1,6 +1,7 @@
 import type { BrowserLogger, ResolvedBrowserConfig } from "./types.js";
 import {
   discoverDevToolsActivePortCandidates,
+  formatWebSocketHost,
   resolveDevToolsActivePortDiscoveryRoots,
   type DevToolsActivePortCandidate,
 } from "./detect.js";
@@ -44,7 +45,7 @@ export async function resolveAttachRunningConnection(
     }
     const discoveryRoots = resolveDevToolsActivePortDiscoveryRoots();
     throw new Error(
-      `No running browser matched ${host}:${port}. DevToolsActivePort discovery searched ${discoveryRoots.join(", ") || "no roots"}, and endpoint probe http://${host}:${port}/json/version failed: ${probe.error}.`,
+      `No running browser matched ${host}:${port}. DevToolsActivePort discovery searched ${discoveryRoots.join(", ") || "no roots"}, and endpoint probe http://${formatWebSocketHost(host)}:${port}/json/version failed: ${probe.error}.`,
     );
   }
   const candidate = candidates[0];
@@ -67,17 +68,18 @@ async function probeDevToolsBrowserWSEndpoint({
   port: number;
   attempts?: number;
   timeoutMs?: number;
-}): Promise<
-  | { ok: true; browserWSEndpoint: string }
-  | { ok: false; error: string }
-> {
-  const versionUrl = `http://${host}:${port}/json/version`;
+}): Promise<{ ok: true; browserWSEndpoint: string } | { ok: false; error: string }> {
+  const versionUrl = `http://${formatWebSocketHost(host)}:${port}/json/version`;
   for (let attempt = 0; attempt < attempts; attempt++) {
     try {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), timeoutMs);
-      const response = await fetch(versionUrl, { signal: controller.signal });
-      clearTimeout(timeout);
+      let response: Response;
+      try {
+        response = await fetch(versionUrl, { signal: controller.signal });
+      } finally {
+        clearTimeout(timeout);
+      }
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);
       }

--- a/src/browser/detect.ts
+++ b/src/browser/detect.ts
@@ -362,7 +362,7 @@ function deriveDevToolsProfileRoot(activePortPath: string): string {
   return parentDir;
 }
 
-function formatWebSocketHost(host: string): string {
+export function formatWebSocketHost(host: string): string {
   if (host.includes(":") && !host.startsWith("[") && !host.endsWith("]")) {
     return `[${host}]`;
   }

--- a/tests/browser/attachRunning.test.ts
+++ b/tests/browser/attachRunning.test.ts
@@ -94,7 +94,8 @@ describe("resolveAttachRunningConnection", () => {
   });
 
   test("probes the endpoint when DevToolsActivePort discovery finds nothing", async () => {
-    vi.doMock("../../src/browser/detect.js", () => ({
+    vi.doMock("../../src/browser/detect.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("../../src/browser/detect.js")>()),
       discoverDevToolsActivePortCandidates: vi.fn(async () => []),
     }));
     const fetchMock = vi.fn().mockResolvedValue(
@@ -129,8 +130,85 @@ describe("resolveAttachRunningConnection", () => {
     });
   });
 
+  test("brackets an IPv6 host when probing the endpoint", async () => {
+    vi.doMock("../../src/browser/detect.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("../../src/browser/detect.js")>()),
+      discoverDevToolsActivePortCandidates: vi.fn(async () => []),
+    }));
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          webSocketDebuggerUrl: "ws://[::1]:9222/devtools/browser/probed",
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { resolveAttachRunningConnection } = await import("../../src/browser/attachRunning.js");
+    const logger = vi.fn() as BrowserLogger;
+
+    const result = await resolveAttachRunningConnection(
+      {
+        chromePath: null,
+        remoteChrome: { host: "::1", port: 9222 },
+      },
+      logger,
+    );
+
+    expect(result).toEqual({
+      host: "::1",
+      port: 9222,
+      browserWSEndpoint: "ws://[::1]:9222/devtools/browser/probed",
+      profileRoot: null,
+    });
+    expect(fetchMock).toHaveBeenCalledWith("http://[::1]:9222/json/version", {
+      signal: expect.any(AbortSignal),
+    });
+    const [versionUrl] = fetchMock.mock.calls[0] as [string];
+    expect(() => new URL(versionUrl)).not.toThrow();
+  });
+
+  test("keeps an IPv4 host unchanged when probing the endpoint", async () => {
+    vi.doMock("../../src/browser/detect.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("../../src/browser/detect.js")>()),
+      discoverDevToolsActivePortCandidates: vi.fn(async () => []),
+    }));
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/browser/probed",
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { resolveAttachRunningConnection } = await import("../../src/browser/attachRunning.js");
+    const logger = vi.fn() as BrowserLogger;
+
+    const result = await resolveAttachRunningConnection(
+      {
+        chromePath: null,
+        remoteChrome: { host: "127.0.0.1", port: 9222 },
+      },
+      logger,
+    );
+
+    expect(result).toEqual({
+      host: "127.0.0.1",
+      port: 9222,
+      browserWSEndpoint: "ws://127.0.0.1:9222/devtools/browser/probed",
+      profileRoot: null,
+    });
+    expect(fetchMock).toHaveBeenCalledWith("http://127.0.0.1:9222/json/version", {
+      signal: expect.any(AbortSignal),
+    });
+  });
+
   test("reports discovery roots and a failed endpoint probe", async () => {
-    vi.doMock("../../src/browser/detect.js", () => ({
+    vi.doMock("../../src/browser/detect.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("../../src/browser/detect.js")>()),
       discoverDevToolsActivePortCandidates: vi.fn(async () => []),
       resolveDevToolsActivePortDiscoveryRoots: vi.fn(() => ["/profiles/search-root"]),
     }));
@@ -152,5 +230,36 @@ describe("resolveAttachRunningConnection", () => {
       /DevToolsActivePort discovery searched \/profiles\/search-root, and endpoint probe http:\/\/127\.0\.0\.1:63332\/json\/version failed: connection refused/i,
     );
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("clears the abort timer after every rejected endpoint probe", async () => {
+    vi.doMock("../../src/browser/detect.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("../../src/browser/detect.js")>()),
+      discoverDevToolsActivePortCandidates: vi.fn(async () => []),
+      resolveDevToolsActivePortDiscoveryRoots: vi.fn(() => ["/profiles/search-root"]),
+    }));
+    const fetchMock = vi.fn().mockRejectedValue(new Error("connection refused"));
+    vi.stubGlobal("fetch", fetchMock);
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+
+    try {
+      const { resolveAttachRunningConnection } = await import("../../src/browser/attachRunning.js");
+      const logger = vi.fn() as BrowserLogger;
+
+      await expect(
+        resolveAttachRunningConnection(
+          {
+            chromePath: null,
+            remoteChrome: { host: "127.0.0.1", port: 9222 },
+          },
+          logger,
+        ),
+      ).rejects.toThrow(/endpoint probe .* failed: connection refused/i);
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(clearTimeoutSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      clearTimeoutSpy.mockRestore();
+    }
   });
 });

--- a/tests/browser/attachRunning.test.ts
+++ b/tests/browser/attachRunning.test.ts
@@ -1,9 +1,13 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { BrowserLogger } from "../../src/browser/types.js";
 
 describe("resolveAttachRunningConnection", () => {
   beforeEach(() => {
     vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   test("defaults attach-running discovery to 127.0.0.1:9222", async () => {
@@ -18,6 +22,8 @@ describe("resolveAttachRunningConnection", () => {
         },
       ]),
     }));
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
 
     const { resolveAttachRunningConnection } = await import("../../src/browser/attachRunning.js");
     const logger = vi.fn();
@@ -39,6 +45,7 @@ describe("resolveAttachRunningConnection", () => {
     expect(logger).toHaveBeenCalledWith(
       "Selected attach-running browser metadata from /profiles/default/DevToolsActivePort",
     );
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("uses remote-chrome as the attach-running hint and prefers the newest candidate", async () => {
@@ -86,10 +93,49 @@ describe("resolveAttachRunningConnection", () => {
     );
   });
 
-  test("rejects attach-running when no local DevToolsActivePort matches the selected port", async () => {
+  test("probes the endpoint when DevToolsActivePort discovery finds nothing", async () => {
     vi.doMock("../../src/browser/detect.js", () => ({
       discoverDevToolsActivePortCandidates: vi.fn(async () => []),
     }));
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          webSocketDebuggerUrl: "ws://127.0.0.1:63332/devtools/browser/probed",
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { resolveAttachRunningConnection } = await import("../../src/browser/attachRunning.js");
+    const logger = vi.fn() as BrowserLogger;
+
+    const result = await resolveAttachRunningConnection(
+      {
+        chromePath: null,
+        remoteChrome: { host: "127.0.0.1", port: 63332 },
+      },
+      logger,
+    );
+
+    expect(result).toEqual({
+      host: "127.0.0.1",
+      port: 63332,
+      browserWSEndpoint: "ws://127.0.0.1:63332/devtools/browser/probed",
+      profileRoot: null,
+    });
+    expect(fetchMock).toHaveBeenCalledWith("http://127.0.0.1:63332/json/version", {
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  test("reports discovery roots and a failed endpoint probe", async () => {
+    vi.doMock("../../src/browser/detect.js", () => ({
+      discoverDevToolsActivePortCandidates: vi.fn(async () => []),
+      resolveDevToolsActivePortDiscoveryRoots: vi.fn(() => ["/profiles/search-root"]),
+    }));
+    const fetchMock = vi.fn().mockRejectedValue(new Error("connection refused"));
+    vi.stubGlobal("fetch", fetchMock);
 
     const { resolveAttachRunningConnection } = await import("../../src/browser/attachRunning.js");
     const logger = vi.fn() as BrowserLogger;
@@ -102,6 +148,9 @@ describe("resolveAttachRunningConnection", () => {
         },
         logger,
       ),
-    ).rejects.toThrow(/No running browser with attach metadata matched 127\.0\.0\.1:63332/i);
+    ).rejects.toThrow(
+      /DevToolsActivePort discovery searched \/profiles\/search-root, and endpoint probe http:\/\/127\.0\.0\.1:63332\/json\/version failed: connection refused/i,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
Fixes #414.

## Problem

`resolveAttachRunningConnection` finds the browser only by file discovery. `discoverDevToolsActivePortCandidates` walks the platform root from `resolveDevToolsActivePortDiscoveryRoots` (`~/Library/Application Support` on macOS) looking for `DevToolsActivePort` files.

Chrome 151 does not write that file. So `candidates` is empty and attach throws, even when the endpoint is live. The old message also sends the user to `chrome://inspect`, where remote debugging is already enabled.

## Change

File discovery runs first and is unchanged. When it finds a candidate the behaviour is identical to before, including the `profileRoot` it returns.

Only when discovery finds nothing, read `webSocketDebuggerUrl` from `http://host:port/json/version` and attach to that. This is the case that fails outright today, so nothing that works now takes a new path.

`AttachRunningConnectionInfo.profileRoot` becomes `string | null`. The probe cannot supply a profile root, and the only consumer already accepts null: `src/browser/index.ts` assigns it to `config.remoteChromeProfileRoot`, which is typed `string | null`, defaults to `null`, and is read as `?? undefined`.

Two review findings are also fixed in `edf26a08`:

- **IPv6 hosts are bracketed before probing.** `parseRemoteChromeTarget` accepts `[::1]:9222` and stores the host as `::1`, so the probe built `http://::1:9222/json/version`. `new URL()` rejects that with `ERR_INVALID_URL`, so the fallback failed on the IPv6 path it exists to serve. The probe URL and the error message now use `formatWebSocketHost`, the helper `detect.ts` already had for this.
- **The abort timer is cleared on a rejected probe.** `clearTimeout` sat after the `await`, so a rejected fetch skipped it and left a live timer per attempt. It now runs in a `finally`.

When both discovery and the probe fail, the error names what was searched:

```
No running browser matched 127.0.0.1:63332. DevToolsActivePort discovery searched
/profiles/search-root, and endpoint probe http://127.0.0.1:63332/json/version failed:
connection refused.
```

## Real behaviour, Chrome 151.0.7922.174

Chrome started with a dedicated profile under `~/Library/Application Support`:

```
$ "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
    --remote-debugging-port=9222 --user-data-dir="<profile>" --no-first-run

$ curl -s http://127.0.0.1:9222/json/version
  Browser: Chrome/151.0.7922.174
  ws:      ws://127.0.0.1:9222/devtools/browser/<id>

$ find ~/Library/Application\ Support -maxdepth 3 -name DevToolsActivePort
  (no output)
```

The endpoint is live and no `DevToolsActivePort` file exists anywhere. That is the reported condition.

**Before, on `main`:**

```
$ oracle --engine browser --browser-attach-running --remote-chrome 127.0.0.1:9222 -p "..."
ERROR: No running browser with attach metadata matched 127.0.0.1:9222. Enable remote
debugging in chrome://inspect/#remote-debugging first.
```

**After, same browser, same command:**

```
$ oracle --engine browser --browser-attach-running --remote-chrome 127.0.0.1:9222 \
    -p "Reply with exactly: ATTACH OK"
[browser] Browser control: attach to an already-running local Chrome session
[browser] Browser guidance: Oracle opens a dedicated tab and leaves the existing browser process alone.
[browser] Thinking time: Pro
[browser] Archived ChatGPT conversation after saving local artifacts.
[browser] Model selection evidence: target=GPT-5.5; resolvedLabel=GPT-5.5; status=switched;
          strategy=select; verified=yes; source=chatgpt-model-picker
Answer:
ATTACH OK

22.8s - GPT-5.5[browser] - up 14 down 3
exit 0
```

Attach recovers, the model picker resolves, and the run completes.

## Tests

`vitest run tests/browser/attachRunning.test.ts`: 7 passed. Browser suite: 49 files, 882 passed, 1 skipped. `oxlint` clean, `tsc -p tsconfig.build.json --noEmit` exit 0.

Each new test fails against the code it guards:

```
probe removed        -> FAIL probes the endpoint when DevToolsActivePort discovery finds nothing
brackets removed     -> FAIL brackets an IPv6 host when probing the endpoint  (IPv4 control still passes)
finally removed      -> FAIL clears the abort timer after every rejected endpoint probe
```

Two pre-existing mocks in that file replaced the whole `detect` module, so they had to grow the new export. They now spread `importOriginal`, matching the other mocks in the file.

## One thing left alone

`src/browser/profileState.ts:317` (`verifyDevToolsReachable`) has both of the same defects: it builds `http://${host}:${port}/json/version` without brackets, and clears its timer after the `await`. That is pre-existing and outside this fix, so it is untouched here. Happy to send it as a follow-up.
