### PR TITLE
test(browser): guard archive expression locale labels against silent drift

### DIFF
--- a/tests/browser/archiveConversation.test.ts
+++ b/tests/browser/archiveConversation.test.ts
@@ -171,12 +171,43 @@ describe("archiveChatGptConversation", () => {
   });
 });
 
-// Every locale label this matcher relies on, one line per literal. A future PR that
-// silently drops or renames one of these (while adding a new locale, for example)
-// fails here instead of only showing up as a live-account regression report — see
-// docs/browser-mode.md's "self check" ask and the localized-controls history in #407/#405.
+// Every locale label this matcher relies on, one line per literal, checked against the
+// SPECIFIC matcher function that consumes it (not the whole serialized expression) — a
+// global `expression.toContain(label)` would still pass if a label were deleted from one
+// matcher while an identical label happened to survive in a sibling matcher, since several
+// of these labels (e.g. "archive", "アーカイブ") are deliberately repeated across matchers.
+// Labels are matched as quoted literals (`'label'`), not bare substrings: "アーカイブ" is
+// itself a substring of "アーカイブする", so a bare check would stay green even after the
+// standalone "アーカイブ" literal is deleted, as long as "アーカイブする" still exists.
+// A future PR that silently drops or renames a label now fails here instead of only
+// showing up as a live-account regression report — see docs/browser-mode.md's "self check"
+// ask and the localized-controls history in #407/#405.
 describe("archive expression locale label inventory", () => {
   const expression = buildArchiveConversationExpressionForTest();
+  const quoted = (label: string) => `'${label}'`;
+
+  // Slice out one matcher function's own source, bounded by the next function's start,
+  // so an assertion against the slice can only be satisfied by that matcher's own labels.
+  const matcherSlice = (startMarker: string, endMarker: string): string => {
+    const start = expression.indexOf(startMarker);
+    if (start === -1) {
+      throw new Error(`matcher start marker not found in expression: ${startMarker}`);
+    }
+    const end = expression.indexOf(endMarker, start + startMarker.length);
+    if (end === -1) {
+      throw new Error(`matcher end marker not found in expression: ${endMarker}`);
+    }
+    return expression.slice(start, end);
+  };
+
+  const menuButtonSlice = matcherSlice("findConversationMenuButton", "visibleMenuCandidates");
+  const archiveItemSlice = matcherSlice("findArchiveMenuItem", "findArchiveConfirmationButton");
+  const confirmButtonSlice = matcherSlice("findArchiveConfirmationButton", "hasUnarchiveMenuItem");
+  const unarchiveMenuSlice = matcherSlice("hasUnarchiveMenuItem", "hasArchiveConfirmation");
+  const confirmationToastSlice = matcherSlice(
+    "hasArchiveConfirmation",
+    "waitForArchiveConfirmation",
+  );
 
   test("conversation menu ('more options') labels are present", () => {
     for (const label of [
@@ -188,11 +219,17 @@ describe("archive expression locale label inventory", () => {
       "その他",
       "会話オプション",
     ]) {
-      expect(expression).toContain(label);
+      expect(menuButtonSlice).toContain(quoted(label));
     }
   });
 
-  test("archive menu-item and confirmation-button labels are present", () => {
+  test("archive menu-item labels are present", () => {
+    for (const label of ["archive", "archiwizuj", "アーカイブ", "アーカイブする"]) {
+      expect(archiveItemSlice).toContain(quoted(label));
+    }
+  });
+
+  test("archive confirmation-button labels are present", () => {
     for (const label of [
       "archive",
       "archiwizuj",
@@ -200,13 +237,19 @@ describe("archive expression locale label inventory", () => {
       "アーカイブする",
       "archive conversation",
     ]) {
-      expect(expression).toContain(label);
+      expect(confirmButtonSlice).toContain(quoted(label));
     }
   });
 
-  test("unarchive/restore exclusion labels are present", () => {
-    for (const label of ["unarchive", "restore", "przywróć", "przywroc", "アーカイブを解除"]) {
-      expect(expression).toContain(label);
+  test("unarchive/restore exclusion labels are present in every matcher that excludes them", () => {
+    for (const label of ["unarchive", "restore", "アーカイブを解除"]) {
+      expect(archiveItemSlice).toContain(quoted(label));
+      expect(confirmButtonSlice).toContain(quoted(label));
+      expect(unarchiveMenuSlice).toContain(quoted(label));
+    }
+    // Polish restore/unarchive words only appear in the standalone unarchive-detection matcher.
+    for (const label of ["przywróć", "przywroc"]) {
+      expect(unarchiveMenuSlice).toContain(quoted(label));
     }
   });
 
@@ -220,7 +263,7 @@ describe("archive expression locale label inventory", () => {
       "アーカイブしました",
       "アーカイブされました",
     ]) {
-      expect(expression).toContain(label);
+      expect(confirmationToastSlice).toContain(quoted(label));
     }
   });
 });

--- a/tests/browser/archiveConversation.test.ts
+++ b/tests/browser/archiveConversation.test.ts
@@ -170,3 +170,57 @@ describe("archiveChatGptConversation", () => {
     expect(expression).toContain("アーカイブしました");
   });
 });
+
+// Every locale label this matcher relies on, one line per literal. A future PR that
+// silently drops or renames one of these (while adding a new locale, for example)
+// fails here instead of only showing up as a live-account regression report — see
+// docs/browser-mode.md's "self check" ask and the localized-controls history in #407/#405.
+describe("archive expression locale label inventory", () => {
+  const expression = buildArchiveConversationExpressionForTest();
+
+  test("conversation menu ('more options') labels are present", () => {
+    for (const label of [
+      "more",
+      "conversation options",
+      "open menu",
+      "więcej",
+      "opcje",
+      "その他",
+      "会話オプション",
+    ]) {
+      expect(expression).toContain(label);
+    }
+  });
+
+  test("archive menu-item and confirmation-button labels are present", () => {
+    for (const label of [
+      "archive",
+      "archiwizuj",
+      "アーカイブ",
+      "アーカイブする",
+      "archive conversation",
+    ]) {
+      expect(expression).toContain(label);
+    }
+  });
+
+  test("unarchive/restore exclusion labels are present", () => {
+    for (const label of ["unarchive", "restore", "przywróć", "przywroc", "アーカイブを解除"]) {
+      expect(expression).toContain(label);
+    }
+  });
+
+  test("post-archive confirmation toast labels are present", () => {
+    for (const label of [
+      "archived",
+      "conversation archived",
+      "chat archived",
+      "zarchiwizowano",
+      "archiwum",
+      "アーカイブしました",
+      "アーカイブされました",
+    ]) {
+      expect(expression).toContain(label);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add a locale-label drift guard for the ChatGPT archive-conversation matcher (`buildArchiveConversationExpression`).
- Test-only. No production code changed.

## Problem

`docs/browser-mode.md` names this gap directly:

> Model picker drift – we rely on heuristics… Consider snapshot tests or a small "self check" command.

The archive matcher is the clearest recent example. It carries four separate per-locale label lists (menu "more options", archive item/confirm, unarchive/restore exclusion, confirmation toast), each independently extended locale-by-locale (#407 added Japanese; Polish predates that). Nothing asserted the full set together — only a handful of Japanese literals were spot-checked. A future PR touching any one of these `.includes(...)` chains could silently drop or mistype an existing locale's label, and it would only surface later as a live-account regression report.

## Change

`tests/browser/archiveConversation.test.ts`: one inventory test per matcher (menu, archive action, unarchive exclusion, confirmation toast), asserting every locale label currently in `buildArchiveConversationExpression` is present. A drop or typo in any of them now fails CI at review time instead of live.

## Update: scoped assertions per matcher (addresses review feedback)

The first version checked each label against the *whole* serialized expression. Several labels ("archive", "アーカイブ") are legitimately repeated across `findArchiveMenuItem` and `findArchiveConfirmationButton`, so a global `toContain(label)` stayed green even when a label was deleted from just one of them — reviewed and flagged correctly.

Fixed: the expression is now sliced per matcher function before asserting, so a check can only be satisfied by that matcher's own labels. Labels are also matched as quoted literals (`'label'`) rather than bare substrings — "アーカイブ" is itself a substring of "アーカイブする", so a bare check would still pass after the standalone literal is removed as long as the longer one survives.

Verified against exactly the flagged scenario: removed the `'アーカイブ'` exact-match line from `findArchiveConfirmationButton` only (left it in `findArchiveMenuItem`). First attempt (unquoted slice check) stayed green — a false negative, confirming the substring issue above. Fixed to quoted matching, reran: failed on exactly that label. Restored the source, confirmed green again (14/14).

Original drift-catch proof (still holds against the current version): temporarily removed one Polish literal (`opcje`), reran, restored:

```
FAIL  tests/browser/archiveConversation.test.ts > archive expression locale label inventory > conversation menu ('more options') labels are present
AssertionError: ...to contain '\'opcje\''
```

`git diff --stat src/browser/actions/archiveConversation.ts` → no diff after both restores; production code was never touched.

## Checks

- `pnpm vitest run tests/browser/archiveConversation.test.ts` — 14 passed
- `pnpm test` — 152 files / 1795 passed / 44 skipped (unchanged skip count)
- `pnpm run typecheck` — clean
- `npx oxlint tests/browser/archiveConversation.test.ts` — clean
- `npx oxfmt --check` — clean

`CHANGELOG.md` left as-is (mis-formatted on main; release owner per #349).

## Scope note

This is a pilot on one file to establish the pattern before extending it — `thinkingTime.ts` (behind #405's effort-label locale fixes) and the other action files with per-locale matchers are natural next candidates, as follow-up PRs.

