### PR TITLE
fix(remote): allocate distinct upload basenames after sanitization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Remote: allocate unique upload basenames for primary and fallback attachments that collide after sanitization, preserving original display paths and every payload. Fixes #387. Thanks @postoso!
 - Browser: attach to running Chrome when `DevToolsActivePort` metadata is absent, with IPv6 support and bounded endpoint retries that include response-body reads. Fixes #414. Thanks @devYRPauli!
 - Browser: recognize collision-renamed attachment chips, including short filenames, while keeping Unicode filename boundaries and visible extensions distinct across upload and send checks. Fixes #393. Thanks @devYRPauli!
 - Browser: select and verify thinking effort in ChatGPT's direct-slider picker without an Advanced submenu, keeping explicit Pro requests fail-closed. Fixes #422.

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -7,6 +7,8 @@ Oracle’s bridge workflow lets you keep an authenticated ChatGPT session on a W
 - **Host (Windows)**: runs `oracle bridge host` and holds the signed-in ChatGPT session.
 - **Client (Linux)**: stores the host connection once and routes browser runs (and MCP browser runs) through the host.
 
+The host sanitizes incoming attachment filenames for staging. If names collide after sanitization (or differ only by case), later uploads receive a unique numeric suffix before the extension, while their original display paths and payload order are retained. This applies to both primary uploads and prompt-size fallback uploads. Non-colliding filenames are unchanged; supplied names such as `a_b-2.txt` are reserved before suffix allocation.
+
 ## Generated artifact transfer
 
 Bridge runs now keep the Windows browser host and Linux client separated while still returning ChatGPT-generated files, such as ZIP, CSV, PDF, wheels, and source distributions, to a cloud-readable path. The host advertises artifact-transfer support from the token-protected `GET /health` response. The Linux client uses that capability signal in `oracle bridge client --test` and `oracle bridge doctor`; older hosts remain usable for text responses, but generated files require manual copy from the Windows browser until both sides are upgraded.

--- a/src/remote/server.ts
+++ b/src/remote/server.ts
@@ -15,6 +15,7 @@ import type { BrowserRunResult } from "../browserMode.js";
 import type {
   RemoteArtifactCapabilities,
   RemoteArtifactDescriptor,
+  RemoteAttachmentPayload,
   RemoteRunPayload,
   RemoteRunEvent,
 } from "./types.js";
@@ -213,13 +214,11 @@ export async function createRemoteServer(
     // Each run gets an isolated temp dir so attachments/logs don't collide.
     const runDir = await mkdtemp(path.join(os.tmpdir(), `oracle-serve-${runId}-`));
     const attachmentDir = path.join(runDir, "attachments");
-    await mkdir(attachmentDir, { recursive: true });
 
     const sendEvent = (event: RemoteRunEvent) => {
       res.write(`${JSON.stringify(event)}\n`);
     };
 
-    const attachments: BrowserAttachment[] = [];
     let fallbackSubmission:
       | {
           prompt: string;
@@ -228,34 +227,22 @@ export async function createRemoteServer(
       | undefined;
     try {
       const attachmentsPayload = Array.isArray(payload.attachments) ? payload.attachments : [];
-      for (const [index, attachment] of attachmentsPayload.entries()) {
-        const safeName = sanitizeName(attachment.fileName ?? `attachment-${index + 1}`);
-        const filePath = path.join(attachmentDir, safeName);
-        await writeFile(filePath, Buffer.from(attachment.contentBase64, "base64"));
-        attachments.push({
-          path: filePath,
-          displayPath: attachment.displayPath,
-          sizeBytes: attachment.sizeBytes,
-        });
-      }
+      const attachments = await stageRemoteAttachments(
+        attachmentsPayload,
+        attachmentDir,
+        "attachment",
+      );
 
       if (payload.fallbackSubmission) {
         const fallbackAttachmentDir = path.join(runDir, "fallback-attachments");
-        await mkdir(fallbackAttachmentDir, { recursive: true });
-        const fallbackAttachments: BrowserAttachment[] = [];
         const fallbackPayload = Array.isArray(payload.fallbackSubmission.attachments)
           ? payload.fallbackSubmission.attachments
           : [];
-        for (const [index, attachment] of fallbackPayload.entries()) {
-          const safeName = sanitizeName(attachment.fileName ?? `fallback-attachment-${index + 1}`);
-          const filePath = path.join(fallbackAttachmentDir, safeName);
-          await writeFile(filePath, Buffer.from(attachment.contentBase64, "base64"));
-          fallbackAttachments.push({
-            path: filePath,
-            displayPath: attachment.displayPath,
-            sizeBytes: attachment.sizeBytes,
-          });
-        }
+        const fallbackAttachments = await stageRemoteAttachments(
+          fallbackPayload,
+          fallbackAttachmentDir,
+          "fallback-attachment",
+        );
         fallbackSubmission = {
           prompt: payload.fallbackSubmission.prompt,
           attachments: fallbackAttachments,
@@ -771,8 +758,43 @@ export function pickClientBrowserConfig(
   return accepted;
 }
 
-function sanitizeName(raw: string): string {
-  return raw.replace(/[^a-zA-Z0-9._-]/g, "_");
+async function stageRemoteAttachments(
+  payload: RemoteAttachmentPayload[],
+  directory: string,
+  defaultPrefix: string,
+): Promise<BrowserAttachment[]> {
+  await mkdir(directory, { recursive: true });
+  const names = payload.map((attachment, index) => {
+    const fallback = `${defaultPrefix}-${index + 1}`;
+    const sanitized = (attachment.fileName ?? fallback).replace(/[^a-zA-Z0-9._-]/g, "_");
+    return !sanitized || sanitized === "." || sanitized === ".." ? fallback : sanitized;
+  });
+  // Reserve future names too, and honor case-insensitive host filesystems.
+  const reserved = new Set(names.map((name) => name.toLowerCase()));
+  const used = new Set<string>();
+  const attachments: BrowserAttachment[] = [];
+  for (const [index, attachment] of payload.entries()) {
+    const original = names[index]!;
+    let name = original;
+    if (used.has(name.toLowerCase())) {
+      const extension = path.extname(original);
+      const stem = original.slice(0, original.length - extension.length);
+      let suffix = 2;
+      do {
+        name = `${stem}-${suffix++}${extension}`;
+      } while (reserved.has(name.toLowerCase()));
+    }
+    used.add(name.toLowerCase());
+    reserved.add(name.toLowerCase());
+    const filePath = path.join(directory, name);
+    await writeFile(filePath, Buffer.from(attachment.contentBase64, "base64"), { flag: "wx" });
+    attachments.push({
+      path: filePath,
+      displayPath: attachment.displayPath,
+      sizeBytes: attachment.sizeBytes,
+    });
+  }
+  return attachments;
 }
 
 function sanitizeResult(

--- a/tests/remote/server.test.ts
+++ b/tests/remote/server.test.ts
@@ -10,6 +10,8 @@ import { createRemoteBrowserExecutor } from "../../src/remote/client.js";
 import type { BrowserRunResult } from "../../src/browserMode.js";
 import type { RemoteArtifactDescriptor } from "../../src/remote/types.js";
 import { setOracleHomeDirOverrideForTest } from "../../src/oracleHome.js";
+import { runBrowserMode, runSubmissionWithRecoveryForTest } from "../../src/browser/index.js";
+import { BrowserAutomationError } from "../../src/oracle/errors.js";
 
 const CAN_LISTEN_LOCALHOST =
   spawnSync(
@@ -145,6 +147,60 @@ describe("remote browser service", () => {
 
       await server.close();
       await rm(tmpDir, { recursive: true, force: true });
+    },
+  );
+
+  test.skipIf(!CAN_LISTEN_LOCALHOST)(
+    "stages colliding primary attachment names without losing payloads",
+    async () => {
+      await expectRemoteAttachmentStaging({
+        location: "primary",
+        files: [
+          { fileName: "a b.txt", content: "primary with space", stagedName: "a_b.txt" },
+          { fileName: "a_b.txt", content: "primary with underscore", stagedName: "a_b-2.txt" },
+        ],
+      });
+    },
+  );
+
+  test.skipIf(!CAN_LISTEN_LOCALHOST)(
+    "stages colliding fallback attachment names without losing payloads",
+    async () => {
+      await expectRemoteAttachmentStaging({
+        location: "fallback",
+        files: [
+          { fileName: "a b.txt", content: "fallback with space", stagedName: "a_b.txt" },
+          { fileName: "a_b.txt", content: "fallback with underscore", stagedName: "a_b-2.txt" },
+        ],
+      });
+    },
+  );
+
+  test.skipIf(!CAN_LISTEN_LOCALHOST)(
+    "preserves ordinary non-colliding attachment names and payload order",
+    async () => {
+      await expectRemoteAttachmentStaging({
+        location: "primary",
+        files: [
+          { fileName: "alpha.txt", content: "first", stagedName: "alpha.txt" },
+          { fileName: "beta.md", content: "second", stagedName: "beta.md" },
+        ],
+      });
+    },
+  );
+
+  test.skipIf(!CAN_LISTEN_LOCALHOST).each(["primary", "fallback"] as const)(
+    "reserves supplied suffixes and case-folded basenames in %s staging",
+    async (location) => {
+      await expectRemoteAttachmentStaging({
+        location,
+        files: [
+          { fileName: "a b.txt", content: "space", stagedName: "a_b.txt" },
+          { fileName: "a_b.txt", content: "underscore", stagedName: "a_b-3.txt" },
+          { fileName: "a_b-2.txt", content: "reserved suffix", stagedName: "a_b-2.txt" },
+          { fileName: "A_B.TXT", content: "uppercase", stagedName: "A_B-4.TXT" },
+        ],
+      });
     },
   );
 
@@ -449,6 +505,118 @@ describe("remote browser service", () => {
     },
   );
 });
+
+async function expectRemoteAttachmentStaging({
+  location,
+  files,
+}: {
+  location: "primary" | "fallback";
+  files: Array<{ fileName: string; content: string; stagedName: string }>;
+}): Promise<void> {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "oracle-remote-staging-test-"));
+  const sourceAttachments = [];
+  for (const [index, file] of files.entries()) {
+    const sourceDir = path.join(tmpDir, String(index));
+    await mkdir(sourceDir);
+    const sourcePath = path.join(sourceDir, file.fileName);
+    await writeFile(sourcePath, file.content, "utf8");
+    sourceAttachments.push({
+      path: sourcePath,
+      displayPath: file.fileName,
+      sizeBytes: Buffer.byteLength(file.content),
+    });
+  }
+
+  const server = await createRemoteServer(
+    { host: "127.0.0.1", port: 0, token: "secret", logger: () => {} },
+    {
+      runBrowser: async (options) => {
+        const stagedAttachments =
+          location === "primary" ? options.attachments : options.fallbackSubmission?.attachments;
+        expect(stagedAttachments).toHaveLength(files.length);
+        if (!stagedAttachments) {
+          throw new Error(`missing ${location} attachments`);
+        }
+
+        const stagedPaths = stagedAttachments.map((attachment) => attachment.path);
+        expect(new Set(stagedPaths).size).toBe(files.length);
+        expect(stagedAttachments.map((attachment) => path.basename(attachment.path))).toEqual(
+          files.map((file) => file.stagedName),
+        );
+        expect(stagedAttachments.map((attachment) => attachment.displayPath)).toEqual(
+          files.map((file) => file.fileName),
+        );
+        await expect(
+          Promise.all(stagedPaths.map((stagedPath) => readFile(stagedPath, "utf8"))),
+        ).resolves.toEqual(files.map((file) => file.content));
+
+        if (location === "primary") {
+          // Reach the real browser guard, then stop at a later config check before Chrome starts.
+          await expect(
+            runBrowserMode({
+              prompt: options.prompt,
+              attachments: stagedAttachments,
+              config: {
+                copyProfileSource: "/unused-test-profile",
+                remoteChrome: { host: "127.0.0.1", port: 1 },
+              },
+            }),
+          ).rejects.toMatchObject({ details: { stage: "profile-config" } });
+        } else {
+          let submissions = 0;
+          let prepared = false;
+          await runSubmissionWithRecoveryForTest({
+            prompt: options.prompt,
+            attachments: [],
+            fallbackSubmission: options.fallbackSubmission,
+            submit: async (_prompt, uploaded) => {
+              if (submissions++ === 0) {
+                throw new BrowserAutomationError("prompt too large", { code: "prompt-too-large" });
+              }
+              expect(uploaded).toEqual(stagedAttachments);
+              return { baselineTurns: null, baselineAssistantText: null };
+            },
+            prepareFallbackSubmission: async () => {
+              prepared = true;
+            },
+            reloadPromptComposer: async () => {},
+            logger: () => {},
+          });
+          expect(submissions).toBe(2);
+          expect(prepared).toBe(true);
+        }
+
+        return {
+          answerText: "done",
+          answerMarkdown: "done",
+          tookMs: 1,
+          answerTokens: 1,
+          answerChars: 4,
+        };
+      },
+    },
+  );
+
+  try {
+    const executor = createRemoteBrowserExecutor({
+      host: `127.0.0.1:${server.port}`,
+      token: "secret",
+    });
+    const result = await executor({
+      prompt: "remote attachment staging",
+      attachments: location === "primary" ? sourceAttachments : [],
+      fallbackSubmission:
+        location === "fallback"
+          ? { prompt: "fallback attachment staging", attachments: sourceAttachments }
+          : undefined,
+      config: {},
+    });
+    expect(result.answerText).toBe("done");
+  } finally {
+    await server.close();
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
 
 function createArtifactDescriptor(
   payload: Buffer,


### PR DESCRIPTION
The remote server could map distinct client filenames such as `a b.txt` and `a_b.txt` onto the same staging path, overwriting the first payload. #389 separated the directories but left duplicate upload basenames, which the current browser runner correctly rejects.

This reviewed integration supersedes #389 and credits @postoso for the original fix and regression coverage. Both primary and fallback staging now use one allocator. It preserves non-colliding names, reserves all supplied names before allocating suffixes, compares names without case to protect Windows/macOS hosts, and retains original display paths, payload order, and extensions. Exclusive writes provide a final no-overwrite guard. The browser's collision guard is unchanged.

Proof:

- Four regression cases fail on main; 78 focused remote-server/browser-boundary tests pass with the patch.
- A real HTTP client/server run crossed the production primary and fallback browser guards, then used the built data-transfer function against real Chrome. All eight File objects retained the expected names and distinct contents: four per staging path, 136 bytes total.
- Formatting, typecheck/lint, build, docs/help consistency, docs site, and packed built-CLI help passed. Native MCP initialization and tool listing also passed.
- Codex autoreview passed at its configured P0 threshold.

The first local full-suite run hit two timing failures. A lower-concurrency rerun passed 1,884 tests and skipped 44, with only the MCP smoke suite's 30-second built-CLI import hook failing. Search persistence passed on retry, and native MCP initialization/tool listing passed. The same smoke on unmodified main took 29.44 seconds, just below its cutoff. No timeout limits were changed. All four GitHub CI jobs passed on this exact PR head: https://github.com/steipete/oracle/actions/runs/33188415616 .

The browser proof uses a synthetic local Chrome page, not an authenticated ChatGPT consultation.

Fixes #387.
