### PR TITLE
fix(browser): direct effort slider fails selection-unverified on ja-JP (ideographic comma in announcement)

### DIFF
--- a/src/browser/actions/thinkingTime.ts
+++ b/src/browser/actions/thinkingTime.ts
@@ -1065,7 +1065,7 @@ function buildThinkingTimeExpression(
         if (!control || !thumb || !isVisible(control)) return null;
         const levels = ['light', 'standard', 'extended', 'extra-high', 'pro'];
         const labels = describedIds(control)
-          .map((id) => (document.getElementById?.(id)?.textContent ?? '').split(/[,，]/)[0].trim())
+          .map((id) => (document.getElementById?.(id)?.textContent ?? '').split(/[,，、]/)[0].trim())
           .filter((label) => levels.some((level) => TARGET_LEVEL_TOKENS[level].some((token) => normalize(token) === normalize(label))));
         if (labels.length !== 1) return null;
         const label = labels[0];

--- a/tests/browser/thinkingTime.test.ts
+++ b/tests/browser/thinkingTime.test.ts
@@ -3191,6 +3191,23 @@ describe("unified Intelligence picker with Advanced -> Effort submenu", () => {
     expect(dom.keys).toEqual([]);
   });
 
+  it("verifies Pro through a Japanese ideographic-comma announcement", async () => {
+    // ja-JP announces "Pro、5件中5件目。" — U+3001 is neither "," nor "，".
+    const dom = buildDirectSlider(4, ["最速", "中程度", "高い", "非常に高い", "Pro"]);
+    dom.announcement.textContent = "Pro、5件中5件目。";
+    dom.control.dispatchEvent = (event: unknown) => {
+      const key = (event as { key?: string }).key;
+      if (key !== "ArrowLeft" && key !== "ArrowRight") return true;
+      dom.keys.push(key);
+      return true;
+    };
+    await expect(run(dom.documentStub, "pro")).resolves.toEqual({
+      status: "already-selected",
+      label: "Pro",
+    });
+    expect(dom.keys).toEqual([]);
+  });
+
   it("selects Pro through the Effort submenu", async () => {
     const dom = buildDom("High");
     await expect(run(dom.documentStub, "pro")).resolves.toEqual({


### PR DESCRIPTION
## Summary

On the ja-JP ChatGPT UI, the direct thinking-effort slider (PR #424 layout) always fails verification with `selection-unverified`, even when Pro is already selected. The slider announcement in Japanese reads `Pro、5件中5件目。` — the separator is the ideographic comma `、` (U+3001), which the announcement parser does not split on. The label resolves to the whole string, matches no tier token, and `resolve()` returns `null` before the slider position is ever inspected.

## Repro

On a ja-JP account with the direct-slider layout (observed 2026-08-31):

```
oracle --engine browser -m gpt-5.6-sol --browser-thinking-time pro "..."
```

fails with `thinking time verification failed (requested Pro): selection-unverified`, regardless of the slider's actual position (including `aria-valuenow="4"` with a visible Pro label).

Observed DOM (via CDP, ja-JP locale):

- control: `[role="menuitem"][aria-label="パワー"]` with `aria-describedby="_r_4i_ _r_4j_"`
- `#_r_4i_` textContent: `Pro、5件中5件目。`
- `#_r_4j_` textContent: `左右の矢印キーでパワーを調整します。`
- thumb: `[role="slider"]` with `aria-valuemin="0" aria-valuemax="4" aria-valuenow="4"`

## Where it comes from

`src/browser/actions/thinkingTime.ts`, in `selectDirectEffortSlider`'s `resolve()`:

```js
const labels = describedIds(control)
  .map((id) => (document.getElementById?.(id)?.textContent ?? '').split(/[,，]/)[0].trim())
```

The split handles ASCII `,` and fullwidth `，` (U+FF0C), but Japanese slider announcements use the ideographic comma `、` (U+3001): `Pro、5件中5件目。`. The un-split string doesn't normalize to any `TARGET_LEVEL_TOKENS` entry, `labels.length !== 1` fails, `resolve()` returns `null`, and the flow ends in `failure('selection-unverified')` — a hard failure on every ja-JP direct-slider account.

## Fix

Add `、` to the separator class: `split(/[,，、]/)`. Position labels like `5件中5件目` contain no tier token, so the existing single-label filter still holds.

Includes a regression test with the verbatim ja-JP announcement (`Pro、5件中5件目。`); it fails on `main` and passes with the one-character fix. Full `tests/browser/thinkingTime.test.ts` suite passes (86 tests).
