### PR TITLE
fix(browser): verify localized effort labels with Unicode boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Browser: recognize collision-renamed attachment chips, including short filenames, while keeping Unicode filename boundaries and visible extensions distinct across upload and send checks. Fixes #393. Thanks @devYRPauli!
 - Browser: select and verify thinking effort in ChatGPT's direct-slider picker without an Advanced submenu, keeping explicit Pro requests fail-closed. Fixes #422.
 - Browser: preserve Hangul and recognize Korean model/effort picker labels, distinguishing High from Extra High and keeping Pro verification strict. Fixes #423.
+- Browser: verify direct-slider effort labels without depending on locale-specific announcement punctuation or ordinal grammar. Fixes #440.
 - Browser: restore locally launched macOS Chrome windows to their prior placement for visible runs only when Oracle recorded the window before a `--browser-hide-window` run; unmarked windows remain untouched.
 - Browser: archive completed ChatGPT conversations when the interface is Japanese by recognizing the current `その他`, `アーカイブ`, and `アーカイブを解除する` controls.
 - Browser: apply the configured input timeout to prompt preparation so stalled local file assembly fails clearly before launching Chrome. Fixes #381.

--- a/src/browser/actions/thinkingTime.ts
+++ b/src/browser/actions/thinkingTime.ts
@@ -1064,17 +1064,38 @@ function buildThinkingTimeExpression(
         const thumb = slider?.querySelector?.('[role="slider"]');
         if (!control || !thumb || !isVisible(control)) return null;
         const levels = ['light', 'standard', 'extended', 'extra-high', 'pro'];
-        const labels = describedIds(control)
-          .map((id) => (document.getElementById?.(id)?.textContent ?? '').split(/[,，]/)[0].trim())
-          .filter((label) => levels.some((level) => TARGET_LEVEL_TOKENS[level].some((token) => normalize(token) === normalize(label))));
-        if (labels.length !== 1) return null;
-        const label = labels[0];
-        const index = levels.findIndex((level) => TARGET_LEVEL_TOKENS[level].some((token) => normalize(token) === normalize(label)));
+        // The selected label leads localized aria-describedby prose, while punctuation
+        // and ordinal grammar vary by locale. Match only that leading label and let
+        // the thumb's numeric ARIA state independently prove its position.
+        const readLeadingLevel = (description) => {
+          const value = (description ?? '').normalize('NFC').trim();
+          if (!value) return null;
+          const matches = levels.flatMap((level, index) => {
+            const token = [...TARGET_LEVEL_TOKENS[level]]
+              .sort((left, right) => right.length - left.length)
+              .find((candidate) => {
+                const normalizedCandidate = candidate.normalize('NFC');
+                const prefix = value.slice(0, normalizedCandidate.length);
+                if (normalize(prefix) !== normalize(normalizedCandidate)) return false;
+                const next = normalize(value.slice(prefix.length, prefix.length + 1));
+                return !next;
+              });
+            return token
+              ? [{ level, index, label: value.slice(0, token.normalize('NFC').length) }]
+              : [];
+          });
+          return matches.length === 1 ? matches[0] : null;
+        };
+        const selections = describedIds(control)
+          .map((id) => readLeadingLevel(document.getElementById?.(id)?.textContent ?? ''))
+          .filter(Boolean);
+        if (selections.length !== 1) return null;
+        const { label, index, level } = selections[0];
         // This adapter owns the observed five-tier layout only. A different range
         // or contradictory announcement must not turn a numeric guess into proof.
         if (thumb.getAttribute('aria-valuemin') !== '0' || thumb.getAttribute('aria-valuemax') !== '4' ||
             thumb.getAttribute('aria-valuenow') !== String(index)) return null;
-        return { control, label, index, level: levels[index] };
+        return { control, label, index, level };
       };
       let current = resolve();
       const finish = (result) => { closeOpenMenus(); return result; };

--- a/tests/browser/thinkingTime.test.ts
+++ b/tests/browser/thinkingTime.test.ts
@@ -3117,6 +3117,47 @@ describe("unified Intelligence picker with Advanced -> Effort submenu", () => {
   });
 
   it.each([
+    ["Portuguese", "Pro, 5 de 5."],
+    ["Japanese", "Pro、5件中5件目。"],
+    ["Unicode punctuation", "Pro — position 5 of 5"],
+    ["whitespace", "Pro 5/5"],
+  ])(
+    "verifies Pro through a %s direct-slider announcement",
+    async (_locale: string, announcement: string) => {
+      const dom = buildDirectSlider(4);
+      dom.announcement.textContent = announcement;
+
+      await expect(run(dom.documentStub, "pro")).resolves.toEqual({
+        status: "already-selected",
+        label: "Pro",
+      });
+      expect(dom.keys).toEqual([]);
+    },
+  );
+
+  it("verifies a localized non-Pro label without a comma delimiter", async () => {
+    const dom = buildDirectSlider(3, ["Sofort", "Mittel", "Hoch", "Sehr hoch", "Pro"]);
+    dom.announcement.textContent = "Sehr hoch – 4 von 5";
+
+    await expect(run(dom.documentStub, "extra-high")).resolves.toEqual({
+      status: "already-selected",
+      label: "Sehr hoch",
+    });
+    expect(dom.keys).toEqual([]);
+  });
+
+  it.each(["Professional, 5 of 5", "Selected Pro, 5 of 5", "Pro5/5", "5 of 5"])(
+    "does not infer Pro from the direct-slider announcement %j",
+    async (announcement: string) => {
+      const dom = buildDirectSlider(4);
+      dom.announcement.textContent = announcement;
+
+      expect((await run(dom.documentStub, "pro")).status).toBe("selection-unverified");
+      expect(dom.keys).toEqual([]);
+    },
+  );
+
+  it.each([
     ["light", "Instant", 4],
     ["standard", "Medium", 3],
     ["extended", "High", 2],


### PR DESCRIPTION
The direct effort slider announces the selected tier using localized text, such as Japanese `Pro、5件中5件目。`. Main splits that announcement only at ASCII/fullwidth commas, so it cannot verify this Japanese form or navigate through Japanese announcements. Match a known label at the start of the announcement, independently verify the five-tier numeric ARIA position, and allow whitespace, Unicode punctuation, or end-of-string after the label.

The boundary check must inspect the original Unicode suffix. Normalizing a single UTF-16 code unit erases characters such as `é`, Cyrillic letters, astral digits, combining marks and symbols; that incorrectly verifies `Proé` as Pro. This candidate rejects those continuations and retains the existing fail-closed behavior for missing labels, stale/contradictory state, invalid ranges and position-only announcements. The false positives also reproduce on main; they are not attributed solely to the initial PR.

This preserves @Gabrielgvl's implementation and commit history, incorporates @kiyo-e's Japanese reproduction, and merges current main without rewriting contributor commits. Thanks to both contributors. The narrower #438 overlaps with the Japanese coverage here and remains open pending maintainer disposition.

## Real browser proof

A local synthetic page exercised the production selection expression in the existing Chrome browser through the allowed Chrome extension. The corrected expression came from the built package. No DOM stubs, timer substitutions, provider requests, signed-in ChatGPT changes, or isolated-browser substitution were used for this proof.

| Candidate | Expected outcomes |
| --- | --- |
| Current main | 3 / 11 |
| Initial PR #441 | 6 / 11 |
| Corrected candidate | 11 / 11 |

The matrix verifies Japanese already-selected Pro and two ArrowRight movements from High through Extra High to Pro with Japanese announcements, Portuguese and whitespace forms, Unicode continuation rejection, numeric contradiction, and position-only rejection. This proves the changed locale parsing and keyboard behavior on the documented synthetic DOM shape; it does not claim a new live ChatGPT consultation.

Before (main):

![Main rejects Japanese announcements and accepts malformed Unicode continuations](https://github.com/user-attachments/assets/2ebde9fd-56f6-4da4-b3bc-cec6b4971aa8)

After:

![Corrected built parser passes all eleven synthetic real-Chrome cases](https://github.com/user-attachments/assets/ef7adafa-6695-4e68-a626-4ab876d020a0)

## Validation

- Six added Unicode regression cases failed against the original PR and passed after correction.
- `pnpm test`: 154 files / 1,938 tests passed, 18 files / 43 tests skipped. Existing stale-state, malformed-range, non-Pro and multilingual tests remain green.
- `pnpm run check`, `pnpm run build`, `pnpm run docs:check`, `pnpm run docs:site`, and `pnpm run test:packed-cli` passed.
- Full candidate P0–P2 Codex review: scoped-clean, no actionable findings.

Closes #440.
