### PR TITLE
fix(cli): honor configured remote Chrome defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- CLI: inherit browser.remoteChrome from user configuration, matching MCP behavior while preserving explicit connection choices.
+- CLI: inherit browser.remoteChrome from user configuration, matching MCP behavior while preserving explicit connection choices; thanks @ShunmeiCho.
 - Azure: ignore generic base URLs during model metadata resolution as well as request dispatch, preventing OpenRouter catalog lookups with Azure credentials.
 - Browser: retain per-file attachment evidence through local/remote upload and send checks, including filename-less images; activate and stabilize the send target without replaying a dispatched prompt. Fixes #418. Thanks @hubofvalley!
 - Remote: allocate unique upload basenames for primary and fallback attachments that collide after sanitization, preserving original display paths and every payload. Fixes #387. Thanks @postoso!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- CLI: inherit browser.remoteChrome from user configuration, matching MCP behavior while preserving explicit connection choices.
 - Azure: ignore generic base URLs during model metadata resolution as well as request dispatch, preventing OpenRouter catalog lookups with Azure credentials.
 - Browser: retain per-file attachment evidence through local/remote upload and send checks, including filename-less images; activate and stabilize the send target without replaying a dispatched prompt. Fixes #418. Thanks @hubofvalley!
 - Remote: allocate unique upload basenames for primary and fallback attachments that collide after sanitization, preserving original display paths and every payload. Fixes #387. Thanks @postoso!

--- a/src/cli/browserDefaults.ts
+++ b/src/cli/browserDefaults.ts
@@ -65,7 +65,6 @@ export function applyBrowserDefaultsFromConfig(
     options.browserModelStrategy === "current" && getSource("browserModelStrategy") === "cli";
 
   if (
-    !attachRunningRequested &&
     !options.copyProfile &&
     isUnset("remoteChrome") &&
     options.remoteChrome === undefined &&

--- a/src/cli/browserDefaults.ts
+++ b/src/cli/browserDefaults.ts
@@ -10,6 +10,8 @@ import type {
 } from "../browser/types.js";
 
 export interface BrowserDefaultsOptions {
+  remoteChrome?: string;
+  copyProfile?: string;
   chatgptUrl?: string;
   browserUrl?: string;
   browserChromeProfile?: string;
@@ -61,6 +63,17 @@ export function applyBrowserDefaultsFromConfig(
     (isUnset("browserAttachRunning") && browser.attachRunning === true);
   const currentModelRequestedByCli =
     options.browserModelStrategy === "current" && getSource("browserModelStrategy") === "cli";
+
+  if (
+    !attachRunningRequested &&
+    !options.copyProfile &&
+    isUnset("remoteChrome") &&
+    options.remoteChrome === undefined &&
+    browser.remoteChrome
+  ) {
+    const { host, port } = browser.remoteChrome;
+    options.remoteChrome = `${host.includes(":") && !host.startsWith("[") ? `[${host}]` : host}:${port}`;
+  }
 
   const configuredChatgptUrl = browser.chatgptUrl ?? browser.url;
   const cliChatgptSet = options.chatgptUrl !== undefined || options.browserUrl !== undefined;

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@ export interface NotifyConfig {
 }
 
 export interface BrowserConfigDefaults {
+  remoteChrome?: { host: string; port: number } | null;
   chromeProfile?: string | null;
   chromePath?: string | null;
   chromeCookiePath?: string | null;

--- a/tests/cli/browserDefaults.test.ts
+++ b/tests/cli/browserDefaults.test.ts
@@ -9,6 +9,75 @@ import type { UserConfig } from "../../src/config.js";
 const source = (_key: keyof BrowserDefaultsOptions) => undefined;
 
 describe("applyBrowserDefaultsFromConfig", () => {
+  test("uses the same configured remote Chrome as MCP unless CLI overrides it", () => {
+    const options: BrowserDefaultsOptions = {};
+    const config: UserConfig = { browser: { remoteChrome: { host: "127.0.0.1", port: 9222 } } };
+    applyBrowserDefaultsFromConfig(options, config, source);
+    expect(options.remoteChrome).toBe("127.0.0.1:9222");
+    options.remoteChrome = "another-host:9444";
+    applyBrowserDefaultsFromConfig(options, config, () => "cli");
+    expect(options.remoteChrome).toBe("another-host:9444");
+  });
+
+  test("formats IPv6 remote Chrome defaults for the existing target parser", () => {
+    for (const host of ["::1", "[::1]"]) {
+      const options: BrowserDefaultsOptions = {};
+      applyBrowserDefaultsFromConfig(
+        options,
+        { browser: { remoteChrome: { host, port: 9222 } } },
+        source,
+      );
+      expect(options.remoteChrome).toBe("[::1]:9222");
+    }
+  });
+
+  test("uses the configured host/port and respects non-CLI endpoint overrides", () => {
+    const config: UserConfig = {
+      browser: { remoteChrome: { host: "devbox.example", port: 9444 } },
+    };
+    const options: BrowserDefaultsOptions = {};
+    applyBrowserDefaultsFromConfig(options, config, source);
+    expect(options.remoteChrome).toBe("devbox.example:9444");
+    options.remoteChrome = "programmatic.example:9555";
+    applyBrowserDefaultsFromConfig(options, config, source);
+    expect(options.remoteChrome).toBe("programmatic.example:9555");
+  });
+
+  test("respects configured attach-running unless the CLI explicitly turns it off", () => {
+    const config: UserConfig = {
+      browser: { attachRunning: true, remoteChrome: { host: "remote.example", port: 9444 } },
+    };
+    const inherited: BrowserDefaultsOptions = {};
+    applyBrowserDefaultsFromConfig(inherited, config, source);
+    expect(inherited.remoteChrome).toBeUndefined();
+    const explicit: BrowserDefaultsOptions = { browserAttachRunning: false };
+    applyBrowserDefaultsFromConfig(explicit, config, (key) =>
+      key === "browserAttachRunning" ? "cli" : undefined,
+    );
+    expect(explicit.remoteChrome).toBe("remote.example:9444");
+  });
+
+  test("preserves explicit attach-running and copy-profile connection choices", () => {
+    for (const options of [
+      { browserAttachRunning: true },
+      { copyProfile: "/profile" },
+    ] as BrowserDefaultsOptions[]) {
+      applyBrowserDefaultsFromConfig(
+        options,
+        { browser: { remoteChrome: { host: "127.0.0.1", port: 9222 } } },
+        source,
+      );
+      expect(options.remoteChrome).toBeUndefined();
+    }
+  });
+
+  test("leaves an unset or null remote Chrome configuration local", () => {
+    for (const config of [{}, { browser: { remoteChrome: null } }]) {
+      const options: BrowserDefaultsOptions = {};
+      applyBrowserDefaultsFromConfig(options, config, source);
+      expect(options.remoteChrome).toBeUndefined();
+    }
+  });
   test("applies chatgptUrl from user config when flags are absent", () => {
     const options: BrowserDefaultsOptions = {};
     const config: UserConfig = {

--- a/tests/cli/browserDefaults.test.ts
+++ b/tests/cli/browserDefaults.test.ts
@@ -5,6 +5,7 @@ import {
   type BrowserDefaultsOptions,
 } from "../../src/cli/browserDefaults.js";
 import type { UserConfig } from "../../src/config.js";
+import { buildBrowserConfig } from "../../src/cli/browserConfig.js";
 
 const source = (_key: keyof BrowserDefaultsOptions) => undefined;
 
@@ -43,13 +44,20 @@ describe("applyBrowserDefaultsFromConfig", () => {
     expect(options.remoteChrome).toBe("programmatic.example:9555");
   });
 
-  test("respects configured attach-running unless the CLI explicitly turns it off", () => {
+  test("retains the configured endpoint as the attach-running destination", async () => {
     const config: UserConfig = {
       browser: { attachRunning: true, remoteChrome: { host: "remote.example", port: 9444 } },
     };
     const inherited: BrowserDefaultsOptions = {};
     applyBrowserDefaultsFromConfig(inherited, config, source);
-    expect(inherited.remoteChrome).toBeUndefined();
+    expect(inherited.remoteChrome).toBe("remote.example:9444");
+    const resolved = await buildBrowserConfig({
+      model: "gpt-5.6-sol",
+      browserAttachRunning: inherited.browserAttachRunning,
+      remoteChrome: inherited.remoteChrome,
+    });
+    expect(resolved.attachRunning).toBe(true);
+    expect(resolved.remoteChrome).toEqual({ host: "remote.example", port: 9444 });
     const explicit: BrowserDefaultsOptions = { browserAttachRunning: false };
     applyBrowserDefaultsFromConfig(explicit, config, (key) =>
       key === "browserAttachRunning" ? "cli" : undefined,
@@ -57,18 +65,24 @@ describe("applyBrowserDefaultsFromConfig", () => {
     expect(explicit.remoteChrome).toBe("remote.example:9444");
   });
 
-  test("preserves explicit attach-running and copy-profile connection choices", () => {
-    for (const options of [
-      { browserAttachRunning: true },
-      { copyProfile: "/profile" },
-    ] as BrowserDefaultsOptions[]) {
-      applyBrowserDefaultsFromConfig(
-        options,
-        { browser: { remoteChrome: { host: "127.0.0.1", port: 9222 } } },
-        source,
-      );
-      expect(options.remoteChrome).toBeUndefined();
-    }
+  test("preserves the configured endpoint with an explicit attach-running flag", () => {
+    const options: BrowserDefaultsOptions = { browserAttachRunning: true };
+    applyBrowserDefaultsFromConfig(
+      options,
+      { browser: { remoteChrome: { host: "explicit.example", port: 9555 } } },
+      source,
+    );
+    expect(options.remoteChrome).toBe("explicit.example:9555");
+  });
+
+  test("does not inject remote Chrome into an explicit copy-profile launch", () => {
+    const options: BrowserDefaultsOptions = { copyProfile: "/profile" };
+    applyBrowserDefaultsFromConfig(
+      options,
+      { browser: { remoteChrome: { host: "127.0.0.1", port: 9222 } } },
+      source,
+    );
+    expect(options.remoteChrome).toBeUndefined();
   });
 
   test("leaves an unset or null remote Chrome configuration local", () => {


### PR DESCRIPTION
Browser CLI runs now inherit `browser.remoteChrome`, so CLI and MCP use the same configured endpoint. Explicit CLI/programmatic endpoints remain authoritative; an explicit copy-profile launch is not given a remote endpoint.

The review correction preserves `remoteChrome` when attaching to a running browser. `attachRunning` and `remoteChrome` are compatible: the endpoint is the attachment destination, not a conflicting local-launch option. Regression coverage now carries the values through `applyBrowserDefaultsFromConfig` into `buildBrowserConfig`.

Validation: the review regression fails on the previous PR revision; 99 defaults/configuration/attach-running tests pass after the correction, along with typecheck and lint. The original patch's before/after default-inheritance regressions, IPv6 and explicit endpoint cases remain covered. No live model inference was used for these deterministic routing checks.
