### PR TITLE
fix(browser): stop remote runs when isolated tab creation fails

### DIFF
--- a/src/browser/chromeLifecycle.ts
+++ b/src/browser/chromeLifecycle.ts
@@ -396,6 +396,7 @@ export async function connectToRemoteChrome(
   browserWSEndpoint?: string,
   options?: {
     approvalWaitMs?: number;
+    fallbackToDefault?: boolean;
   },
 ): Promise<RemoteChromeConnection> {
   if (browserWSEndpoint) {
@@ -406,13 +407,15 @@ export async function connectToRemoteChrome(
       approvalWaitMs: options?.approvalWaitMs,
     });
   }
-  if (targetUrl) {
-    const targetConnection = await connectToNewTarget(host, port, targetUrl, logger, {
-      opened: () => `Opened dedicated remote Chrome tab targeting ${targetUrl}`,
+  const newTargetUrl =
+    targetUrl || (options?.fallbackToDefault === false ? "about:blank" : undefined);
+  if (newTargetUrl) {
+    const targetConnection = await connectToNewTarget(host, port, newTargetUrl, logger, {
+      opened: () => `Opened dedicated remote Chrome tab targeting ${newTargetUrl}`,
       openFailed: (message) =>
-        `Failed to open dedicated remote Chrome tab (${message}); falling back to first target.`,
+        `Failed to open dedicated remote Chrome tab (${message}); ${options?.fallbackToDefault === false ? "refusing to reuse an unrelated tab" : "falling back to first target"}.`,
       attachFailed: (targetId, message) =>
-        `Failed to attach to dedicated remote Chrome tab ${targetId} (${message}); falling back to first target.`,
+        `Failed to attach to dedicated remote Chrome tab ${targetId} (${message}); ${options?.fallbackToDefault === false ? "refusing to reuse an unrelated tab" : "falling back to first target"}.`,
       closeFailed: (targetId, message) =>
         `Failed to close unused remote Chrome tab ${targetId}: ${message}`,
     });
@@ -425,6 +428,11 @@ export async function connectToRemoteChrome(
           await closeRemoteChromeTarget(host, port, targetConnection.targetId, logger);
         },
       };
+    }
+    if (options?.fallbackToDefault === false) {
+      throw new Error(
+        "Unable to create a dedicated remote Chrome tab; refusing to reuse an unrelated conversation.",
+      );
     }
   }
   const fallbackClient = await CDP({ host, port });

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -3036,6 +3036,7 @@ async function runRemoteBrowserMode(
         browserWSEndpoint,
         {
           approvalWaitMs: config.attachRunning && browserWSEndpoint ? 20_000 : undefined,
+          fallbackToDefault: false,
         },
       );
       client = connection.client;

--- a/tests/browser/chromeLifecycle.test.ts
+++ b/tests/browser/chromeLifecycle.test.ts
@@ -399,6 +399,104 @@ describe("connectWithNewTab", () => {
     expect(cdpMock).not.toHaveBeenCalled();
   });
 
+  test("remote new-task failure never attaches an unrelated conversation", async () => {
+    cdpNewMock.mockRejectedValue(new Error("cannot create tab"));
+    const { connectToRemoteChrome } = await import("../../src/browser/chromeLifecycle.js");
+    await expect(
+      connectToRemoteChrome(
+        "127.0.0.1",
+        9222,
+        vi.fn<(message: string) => void>(),
+        "about:blank",
+        undefined,
+        {
+          fallbackToDefault: false,
+        },
+      ),
+    ).rejects.toThrow(/unrelated conversation/);
+    expect(cdpMock).not.toHaveBeenCalled();
+  });
+
+  test("strict remote mode also forbids default-target fallback when the URL is omitted", async () => {
+    cdpNewMock.mockRejectedValue(new Error("cannot create tab"));
+    const { connectToRemoteChrome } = await import("../../src/browser/chromeLifecycle.js");
+    await expect(
+      connectToRemoteChrome(
+        "127.0.0.1",
+        9222,
+        vi.fn<(message: string) => void>(),
+        undefined,
+        undefined,
+        { fallbackToDefault: false },
+      ),
+    ).rejects.toThrow(/unrelated conversation/);
+    expect(cdpNewMock).toHaveBeenCalledWith({ host: "127.0.0.1", port: 9222, url: "about:blank" });
+    expect(cdpMock).not.toHaveBeenCalled();
+  });
+
+  test("strict remote attachment failure closes only its new target", async () => {
+    cdpNewMock.mockResolvedValue({ id: "owned-new-tab" });
+    cdpMock.mockRejectedValueOnce(new Error("attach failed"));
+    cdpCloseMock.mockResolvedValue(undefined);
+    const { connectToRemoteChrome } = await import("../../src/browser/chromeLifecycle.js");
+    await expect(
+      connectToRemoteChrome(
+        "127.0.0.1",
+        9222,
+        vi.fn<(message: string) => void>(),
+        "about:blank",
+        undefined,
+        { fallbackToDefault: false },
+      ),
+    ).rejects.toThrow(/unrelated conversation/);
+    expect(cdpMock).toHaveBeenCalledTimes(1);
+    expect(cdpMock).toHaveBeenCalledWith(expect.objectContaining({ target: "owned-new-tab" }));
+    expect(cdpCloseMock).toHaveBeenCalledWith({
+      host: "127.0.0.1",
+      port: 9222,
+      id: "owned-new-tab",
+    });
+  });
+
+  test("strict remote connection returns its dedicated target when available", async () => {
+    cdpNewMock.mockResolvedValue({ id: "owned-success" });
+    const client = { close: vi.fn().mockResolvedValue(undefined) };
+    cdpMock.mockResolvedValue(client);
+    cdpCloseMock.mockResolvedValue(undefined);
+    const { connectToRemoteChrome } = await import("../../src/browser/chromeLifecycle.js");
+    const result = await connectToRemoteChrome(
+      "127.0.0.1",
+      9222,
+      vi.fn<(message: string) => void>(),
+      "about:blank",
+      undefined,
+      { fallbackToDefault: false },
+    );
+    expect(result.targetId).toBe("owned-success");
+    expect(result.client).toBe(client);
+    await result.close();
+    expect(client.close).toHaveBeenCalledTimes(1);
+    expect(cdpCloseMock).toHaveBeenCalledWith({
+      host: "127.0.0.1",
+      port: 9222,
+      id: "owned-success",
+    });
+  });
+
+  test("ordinary remote runs never connect to the default tab after target creation fails", async () => {
+    cdpNewMock.mockRejectedValue(new Error("cannot create tab"));
+    const { runBrowserMode } = await import("../../src/browser/index.js");
+    await expect(
+      runBrowserMode({
+        prompt: "A new isolated task",
+        config: { remoteChrome: { host: "127.0.0.1", port: 9222 }, manualLogin: false },
+        log: vi.fn<(message: string) => void>(),
+      }),
+    ).rejects.toThrow(/unrelated conversation/);
+    expect(cdpNewMock).toHaveBeenCalled();
+    expect(cdpMock).not.toHaveBeenCalled();
+  });
+
   test("returns isolated target when attach succeeds", async () => {
     cdpNewMock.mockResolvedValue({ id: "target-2" });
     cdpMock.mockResolvedValue({});


### PR DESCRIPTION
Ordinary remote browser runs now stop if their dedicated tab cannot be created or attached. Previously, the connection helper could fall back to a default target, leaving subsequent navigation pointed at an unrelated conversation.

Add opt-in `fallbackToDefault: false` and enable it for ordinary remote runs. Strict calls without a target URL create `about:blank`; callers that omit the option retain their existing helper behavior. Cleanup remains scoped to newly created targets.

## Real Chrome evidence

[Protocol and scope](https://github.com/ShunmeiCho/oracle/blob/aaf9fe90de0b34dcc8e07599dc00e269cf28fd6b/docs/evidence/pr-review/README.md) · [candidate results](https://github.com/ShunmeiCho/oracle/blob/aaf9fe90de0b34dcc8e07599dc00e269cf28fd6b/docs/evidence/pr-review/452/candidate.json) · [baseline results](https://github.com/ShunmeiCho/oracle/blob/aaf9fe90de0b34dcc8e07599dc00e269cf28fd6b/docs/evidence/pr-review/452/baseline.json) · [reproduction script](https://github.com/ShunmeiCho/oracle/blob/aaf9fe90de0b34dcc8e07599dc00e269cf28fd6b/scripts/remote-tab-isolation-proof.mjs)

This uses an independent temporary Chrome 137/Linux profile and real HTTP/WebSocket transport. A loopback proxy injects target-creation HTTP 500 or a new target's WS-handshake HTTP 502; it does not mock the CDP client. The matrix covers a fresh profile and the same running browser after another protected page exists.

| Scenario, in both setups | Baseline `be6c92a` | Candidate `7f8e619` |
| --- | --- | --- |
| Creation failure | Connects to protected sentinel | Rejects; zero sentinel WS connections |
| Attachment failure | Connects to protected sentinel | Rejects; closes only newly created target |
| Normal connection/cleanup | Dedicated target works | Dedicated target works; only its own target closes |

Candidate passes all six cases. The identical strict assertions fail on the four baseline fallback cases. Records include module hashes, actual WS target counts, unchanged sentinel URL/nonce/DOM hashes, zero sentinel navigations, and restored target sets. Success also executes and verifies a title update on the new target. Cleanup completes before the final success marker. No ChatGPT login or model request is involved.

## Compatibility and validation

Accepting the change means ordinary runs that previously depended on accidental default-tab fallback will now fail before navigation. Operators should fix dedicated-target access, or use explicit `--browser-tab` when reuse is intentional. Maintainer acceptance of that behavior remains outstanding; this evidence does not establish authenticated-profile migration, other OSes or the separate browser-level WS endpoint path.

Regression tests cover creation/attachment failure, strict omitted-URL behavior, success cleanup, and the actual `runBrowserMode` call path. Typecheck/lint/format and non-live suites were checked, including the post-build MCP rerun. Complementary to #445 (shared-process/lease lifecycle) and #431 (attachment navigation/dispatch checks); no dependency on those PRs or #448.

## Restack verification

Rebased independently onto main at 748193758d54e43779ab93e94fac23cbc6c9e421. Current head: 8e49a387dc812188dcd44647bbde9af04190bfd3. The diff contains only the two production files and lifecycle test file; all three are byte-identical to the previously proven head 84f98b8f2b6fb710ff9f2765219bc7b1255f53fe. CHANGELOG coverage and contributor thanks are consolidated in #455.

Fresh validation: 33 lifecycle tests passed; typecheck, lint and formatting passed. Branch autoreview against origin/main is scoped-clean through P2. The independently repeated [real Chrome proof](https://github.com/steipete/oracle/pull/452#issuecomment-5554803748) remains applicable because the code is unchanged. Exact-head CI is recorded in the final proof comment. No merge performed.
