### PR TITLE
fix(browser): block sends while attachments are uploading

### DIFF
--- a/docs/manual-tests.md
+++ b/docs/manual-tests.md
@@ -22,7 +22,7 @@ Run `pnpm build && node scripts/attachment-send-proof.mjs` with Chrome installed
 
 The disposable profile and fixtures live in a temporary, non-hidden directory under your home directory and are removed afterward. This lets Snap Chromium read the same files as Node instead of looking in its private `/tmp`. An optional directory argument retains the fixtures for manual testing; that directory must also be readable by the selected browser.
 
-The attachment proof also holds composer upload progress active for longer than three seconds, verifies completion and send both refuse it without input, then clears it and verifies one successful send despite unrelated page progress. Readiness uses explicit loading/busy state and native/ARIA progress controls; filenames and status prose alone cannot establish an active transfer.
+The attachment proof also holds composer upload progress active for longer than three seconds inside a non-editable attachment widget nested in a rich-text editor, verifies completion and send both refuse it without input, then clears it and verifies one successful send despite unrelated page progress. Readiness uses explicit loading/busy state and native/ARIA progress controls; filenames and status prose alone cannot establish an active transfer.
 
 ### Quick browser port smoke
 

--- a/docs/manual-tests.md
+++ b/docs/manual-tests.md
@@ -22,6 +22,8 @@ Run `pnpm build && node scripts/attachment-send-proof.mjs` with Chrome installed
 
 The disposable profile and fixtures live in a temporary, non-hidden directory under your home directory and are removed afterward. This lets Snap Chromium read the same files as Node instead of looking in its private `/tmp`. An optional directory argument retains the fixtures for manual testing; that directory must also be readable by the selected browser.
 
+The attachment proof also holds composer upload progress active for longer than three seconds, verifies completion and send both refuse it without input, then clears it and verifies one successful send despite unrelated page progress.
+
 ### Quick browser port smoke
 
 - `pnpm test:browser` — launches headful Chrome and checks the DevTools endpoint is reachable. Set `ORACLE_BROWSER_PORT` (or `ORACLE_BROWSER_DEBUG_PORT`) to reuse a fixed port when you’ve already opened a firewall rule.

--- a/docs/manual-tests.md
+++ b/docs/manual-tests.md
@@ -22,7 +22,7 @@ Run `pnpm build && node scripts/attachment-send-proof.mjs` with Chrome installed
 
 The disposable profile and fixtures live in a temporary, non-hidden directory under your home directory and are removed afterward. This lets Snap Chromium read the same files as Node instead of looking in its private `/tmp`. An optional directory argument retains the fixtures for manual testing; that directory must also be readable by the selected browser.
 
-The attachment proof also holds composer upload progress active for longer than three seconds, verifies completion and send both refuse it without input, then clears it and verifies one successful send despite unrelated page progress.
+The attachment proof also holds composer upload progress active for longer than three seconds, verifies completion and send both refuse it without input, then clears it and verifies one successful send despite unrelated page progress. Readiness uses explicit loading/busy state and native/ARIA progress controls; filenames and status prose alone cannot establish an active transfer.
 
 ### Quick browser port smoke
 

--- a/scripts/attachment-send-proof.mjs
+++ b/scripts/attachment-send-proof.mjs
@@ -175,6 +175,30 @@ try {
       /Attachments never reached a clickable send button/,
     );
     assert.equal(await evaluate("window.proof.clicks + window.proof.enters"), 0);
+    await evaluate('document.querySelector("#upload-progress").style.opacity = "0"');
+    assert.equal(await evaluate(buildAttachmentReadyExpressionForTest(names)), true);
+    await evaluate('document.querySelector("#upload-progress").style.opacity = "1"');
+    assert.equal(await evaluate(buildAttachmentReadyExpressionForTest(names)), false);
+    await evaluate(`(() => {
+      document.querySelector('#upload-progress').remove();
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svg.id = 'upload-progress'; svg.setAttribute('role', 'progressbar');
+      svg.setAttribute('aria-valuenow', '50'); svg.setAttribute('width', '20'); svg.setAttribute('height', '20');
+      document.querySelector('form').append(svg);
+    })()`);
+    assert.equal(await evaluate(buildAttachmentReadyExpressionForTest(names)), false);
+    await evaluate(
+      'document.querySelector("#upload-progress").setAttribute("aria-valuenow", "100")',
+    );
+    assert.equal(await evaluate(buildAttachmentReadyExpressionForTest(names)), true);
+    await evaluate(`(() => {
+      document.querySelector('#upload-progress').remove();
+      const progress = document.createElement('progress'); progress.id = 'upload-progress';
+      progress.value = 50; progress.max = 100; document.querySelector('form').append(progress);
+    })()`);
+    assert.equal(await evaluate(buildAttachmentReadyExpressionForTest(names)), false);
+    await evaluate('document.querySelector("#upload-progress").value = 100');
+    assert.equal(await evaluate(buildAttachmentReadyExpressionForTest(names)), true);
     await evaluate(`(() => {
       document.querySelector('#upload-progress').remove();
       const unrelated = document.createElement('div'); unrelated.dataset.state = 'uploading';

--- a/scripts/attachment-send-proof.mjs
+++ b/scripts/attachment-send-proof.mjs
@@ -149,6 +149,37 @@ try {
       await evaluate('document.querySelector("#chips").innerText.includes("case418.jpg")'),
       false,
     );
+    await evaluate(`(() => {
+      const progress = document.createElement('div'); progress.id = 'upload-progress';
+      progress.dataset.state = 'uploading'; progress.textContent = 'Uploading 50%';
+      document.querySelector('form').append(progress);
+    })()`);
+    await assert.rejects(
+      waitForAttachmentCompletion(Runtime, 4500, names, logger),
+      /did not finish uploading/,
+    );
+    assert.equal(await evaluate(buildAttachmentReadyExpressionForTest(names)), false);
+    await assert.rejects(
+      submitPrompt(
+        {
+          runtime: Runtime,
+          input: Input,
+          page: Page,
+          attachmentNames: names,
+          attachmentTimeoutMs: 1000,
+          baselineTurns: 0,
+        },
+        "Do not send while a file is still uploading.",
+        logger,
+      ),
+      /Attachments never reached a clickable send button/,
+    );
+    assert.equal(await evaluate("window.proof.clicks + window.proof.enters"), 0);
+    await evaluate(`(() => {
+      document.querySelector('#upload-progress').remove();
+      const unrelated = document.createElement('div'); unrelated.dataset.state = 'uploading';
+      unrelated.textContent = 'Uploading another conversation'; document.querySelector('aside').append(unrelated);
+    })()`);
     await waitForAttachmentCompletion(Runtime, 4000, names, logger);
     assert.equal(await evaluate(buildAttachmentReadyExpressionForTest(names)), true);
     const bytes = await evaluate(
@@ -227,7 +258,15 @@ try {
       false,
     ]);
     console.log(
-      JSON.stringify({ mode, filenameLessImage: true, elapsedMs, events, payloads, ...state }),
+      JSON.stringify({
+        mode,
+        uploadProgressBlocksSend: true,
+        filenameLessImage: true,
+        elapsedMs,
+        events,
+        payloads,
+        ...state,
+      }),
     );
   }
   await reset(true);

--- a/scripts/attachment-send-proof.mjs
+++ b/scripts/attachment-send-proof.mjs
@@ -152,7 +152,9 @@ try {
     await evaluate(`(() => {
       const progress = document.createElement('div'); progress.id = 'upload-progress';
       progress.dataset.state = 'uploading'; progress.textContent = 'Uploading 50%';
-      document.querySelector('form').append(progress);
+      const editor = document.createElement('div'); editor.contentEditable = 'true';
+      const widget = document.createElement('div'); widget.contentEditable = 'false';
+      widget.append(progress); editor.append(widget); document.querySelector('form').append(editor);
     })()`);
     await assert.rejects(
       waitForAttachmentCompletion(Runtime, 4500, names, logger),

--- a/src/browser/actions/attachmentProgress.ts
+++ b/src/browser/actions/attachmentProgress.ts
@@ -4,11 +4,17 @@ export function buildAttachmentProgressExpression(composerExpression: string): s
     const root = ${composerExpression};
     if (!root || root === document || root === document.body) return false;
     // Text can name a file or describe a completed operation; only explicit state blocks sending.
-    const selectors = ['[data-state="loading"]', '[data-state="uploading"]', '[data-state="pending"]', '[aria-busy="true"]', '[role="progressbar"]', 'progress'];
+    const selectors = ['[data-state="loading"]', '[data-state="uploading"]', '[data-state="pending"]', '[aria-busy="true"]', '[role~="progressbar"]', 'progress'];
     const candidates = new Set(selectors.flatMap(selector => Array.from(root.querySelectorAll(selector))));
     if (selectors.some(selector => root.matches?.(selector))) candidates.add(root);
     return Array.from(candidates).some(node => {
-      if (typeof node.getBoundingClientRect !== 'function' || node.closest('textarea,input,[contenteditable="true"]')) return false;
+      if (typeof node.getBoundingClientRect !== 'function') return false;
+      const editor = node.closest('textarea,[contenteditable=""],[contenteditable="true" i],[contenteditable="plaintext-only" i]');
+      if (editor && editor !== node) return false;
+      const state = node.getAttribute('data-state');
+      const pending = node.getAttribute('aria-busy') === 'true' || ['loading', 'uploading', 'pending'].includes(state);
+      // File inputs and backing editors may be hidden behind the visible composer.
+      if (pending && (node.matches('input[type="file"]') || editor === node)) return true;
       const rect = node.getBoundingClientRect();
       if (rect.width <= 0 || rect.height <= 0) return false;
       for (let ancestor = node; ancestor && typeof ancestor.getBoundingClientRect === 'function'; ancestor = ancestor.parentElement) {
@@ -18,10 +24,9 @@ export function buildAttachmentProgressExpression(composerExpression: string): s
         if (clip?.length === 4 && clip.every(Number.isFinite) && (clip[2] <= clip[0] || clip[1] <= clip[3])) return false;
         if (style.clipPath === 'inset(50%)') return false;
       }
-      const state = node.getAttribute('data-state');
-      if (node.getAttribute('aria-busy') === 'true' || ['loading', 'uploading', 'pending'].includes(state)) return true;
+      if (pending) return true;
       const nativeProgress = node.matches('progress');
-      if (nativeProgress || node.getAttribute('role') === 'progressbar') {
+      if (nativeProgress || node.matches('[role~="progressbar"]')) {
         const current = nativeProgress
           ? (node.hasAttribute('value') ? node.value : NaN)
           : Number.parseFloat(node.getAttribute('aria-valuenow'));

--- a/src/browser/actions/attachmentProgress.ts
+++ b/src/browser/actions/attachmentProgress.ts
@@ -5,18 +5,33 @@ export function buildAttachmentProgressExpression(composerExpression: string): s
   return String.raw`(() => {
     const root = ${composerExpression};
     if (!root || root === document || root === document.body) return false;
-    const selectors = ${JSON.stringify(UPLOAD_STATUS_SELECTORS)};
+    const selectors = ${JSON.stringify([...UPLOAD_STATUS_SELECTORS, '[aria-busy="true"]', '[role="status"]', '[role="progressbar"]', "progress"])};
     const candidates = new Set(selectors.flatMap(selector => Array.from(root.querySelectorAll(selector))));
     if (selectors.some(selector => root.matches?.(selector))) candidates.add(root);
     return Array.from(candidates).some(node => {
-      if (!(node instanceof HTMLElement) || node.closest('textarea,input,[contenteditable="true"]')) return false;
+      if (typeof node.getBoundingClientRect !== 'function' || node.closest('textarea,input,[contenteditable="true"]')) return false;
       const rect = node.getBoundingClientRect();
       if (rect.width <= 0 || rect.height <= 0) return false;
-      const style = typeof window === 'undefined' ? {} : window.getComputedStyle(node);
-      if (style.display === 'none' || style.visibility === 'hidden') return false;
+      for (let ancestor = node; ancestor && typeof ancestor.getBoundingClientRect === 'function'; ancestor = ancestor.parentElement) {
+        const style = typeof window === 'undefined' ? {} : window.getComputedStyle(ancestor);
+        if (style.display === 'none' || style.visibility === 'hidden' || Number.parseFloat(style.opacity) === 0) return false;
+      }
       const state = node.getAttribute('data-state');
       if (node.getAttribute('aria-busy') === 'true' || ['loading', 'uploading', 'pending'].includes(state)) return true;
-      return /^\s*(?:uploading|processing)(?:\s|…|\.{2,}|$)/i.test(node.textContent ?? '');
+      const nativeProgress = node.matches('progress');
+      if (nativeProgress || node.getAttribute('role') === 'progressbar') {
+        const current = nativeProgress
+          ? (node.hasAttribute('value') ? node.value : NaN)
+          : Number.parseFloat(node.getAttribute('aria-valuenow'));
+        const maximum = nativeProgress ? node.max : Number.parseFloat(node.getAttribute('aria-valuemax') ?? '100');
+        return !Number.isFinite(current) || !Number.isFinite(maximum) || current < maximum;
+      }
+      // Attachment labels are filenames, not status announcements.
+      if (!node.matches('[aria-live="polite"],[aria-live="assertive"],[role="status"],[role="progressbar"],[data-testid*="progress"],[data-testid*="status"]')) return false;
+      const text = [node.textContent, node.getAttribute('aria-label')].filter(Boolean).join(' ')
+        .replace(/\b(?:uploading|processing)\s+(?:is\s+)?(?:complete[ds]?|finished|done)\b/gi, '')
+        .replace(/\b(?:complete[ds]?|finished|done)\s+(?:uploading|processing)\b/gi, '');
+      return /(?:^|[^\p{L}\p{N}\p{M}])(?:uploading|processing)(?=$|[^\p{L}\p{N}\p{M}])/iu.test(text);
     });
   })()`;
 }

--- a/src/browser/actions/attachmentProgress.ts
+++ b/src/browser/actions/attachmentProgress.ts
@@ -1,0 +1,22 @@
+import { UPLOAD_STATUS_SELECTORS } from "../constants.js";
+
+// Use the same composer-scoped signal at completion and immediately before send.
+export function buildAttachmentProgressExpression(composerExpression: string): string {
+  return String.raw`(() => {
+    const root = ${composerExpression};
+    if (!root || root === document || root === document.body) return false;
+    const selectors = ${JSON.stringify(UPLOAD_STATUS_SELECTORS)};
+    const candidates = new Set(selectors.flatMap(selector => Array.from(root.querySelectorAll(selector))));
+    if (selectors.some(selector => root.matches?.(selector))) candidates.add(root);
+    return Array.from(candidates).some(node => {
+      if (!(node instanceof HTMLElement) || node.closest('textarea,input,[contenteditable="true"]')) return false;
+      const rect = node.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) return false;
+      const style = typeof window === 'undefined' ? {} : window.getComputedStyle(node);
+      if (style.display === 'none' || style.visibility === 'hidden') return false;
+      const state = node.getAttribute('data-state');
+      if (node.getAttribute('aria-busy') === 'true' || ['loading', 'uploading', 'pending'].includes(state)) return true;
+      return /^\s*(?:uploading|processing)(?:\s|…|\.{2,}|$)/i.test(node.textContent ?? '');
+    });
+  })()`;
+}

--- a/src/browser/actions/attachmentProgress.ts
+++ b/src/browser/actions/attachmentProgress.ts
@@ -9,7 +9,9 @@ export function buildAttachmentProgressExpression(composerExpression: string): s
     if (selectors.some(selector => root.matches?.(selector))) candidates.add(root);
     return Array.from(candidates).some(node => {
       if (typeof node.getBoundingClientRect !== 'function') return false;
-      const editor = node.closest('textarea,[contenteditable=""],[contenteditable="true" i],[contenteditable="plaintext-only" i]');
+      // Non-editable widgets inside rich-text editors own their upload controls.
+      const boundary = node.closest('textarea,[contenteditable=""],[contenteditable="true" i],[contenteditable="plaintext-only" i],[contenteditable="false" i]');
+      const editor = boundary?.matches('[contenteditable="false" i]') ? null : boundary;
       if (editor && editor !== node) return false;
       const state = node.getAttribute('data-state');
       const pending = node.getAttribute('aria-busy') === 'true' || ['loading', 'uploading', 'pending'].includes(state);

--- a/src/browser/actions/attachmentProgress.ts
+++ b/src/browser/actions/attachmentProgress.ts
@@ -1,11 +1,10 @@
-import { UPLOAD_STATUS_SELECTORS } from "../constants.js";
-
 // Use the same composer-scoped signal at completion and immediately before send.
 export function buildAttachmentProgressExpression(composerExpression: string): string {
   return String.raw`(() => {
     const root = ${composerExpression};
     if (!root || root === document || root === document.body) return false;
-    const selectors = ${JSON.stringify([...UPLOAD_STATUS_SELECTORS, '[aria-busy="true"]', '[role="status"]', '[role="progressbar"]', "progress"])};
+    // Text can name a file or describe a completed operation; only explicit state blocks sending.
+    const selectors = ['[data-state="loading"]', '[data-state="uploading"]', '[data-state="pending"]', '[aria-busy="true"]', '[role="progressbar"]', 'progress'];
     const candidates = new Set(selectors.flatMap(selector => Array.from(root.querySelectorAll(selector))));
     if (selectors.some(selector => root.matches?.(selector))) candidates.add(root);
     return Array.from(candidates).some(node => {
@@ -15,6 +14,9 @@ export function buildAttachmentProgressExpression(composerExpression: string): s
       for (let ancestor = node; ancestor && typeof ancestor.getBoundingClientRect === 'function'; ancestor = ancestor.parentElement) {
         const style = typeof window === 'undefined' ? {} : window.getComputedStyle(ancestor);
         if (style.display === 'none' || style.visibility === 'hidden' || Number.parseFloat(style.opacity) === 0) return false;
+        const clip = style.clip?.match(/^rect\((.*)\)$/)?.[1].split(/[,\s]+/).filter(Boolean).map(Number.parseFloat);
+        if (clip?.length === 4 && clip.every(Number.isFinite) && (clip[2] <= clip[0] || clip[1] <= clip[3])) return false;
+        if (style.clipPath === 'inset(50%)') return false;
       }
       const state = node.getAttribute('data-state');
       if (node.getAttribute('aria-busy') === 'true' || ['loading', 'uploading', 'pending'].includes(state)) return true;
@@ -26,12 +28,7 @@ export function buildAttachmentProgressExpression(composerExpression: string): s
         const maximum = nativeProgress ? node.max : Number.parseFloat(node.getAttribute('aria-valuemax') ?? '100');
         return !Number.isFinite(current) || !Number.isFinite(maximum) || current < maximum;
       }
-      // Attachment labels are filenames, not status announcements.
-      if (!node.matches('[aria-live="polite"],[aria-live="assertive"],[role="status"],[role="progressbar"],[data-testid*="progress"],[data-testid*="status"]')) return false;
-      const text = [node.textContent, node.getAttribute('aria-label')].filter(Boolean).join(' ')
-        .replace(/\b(?:uploading|processing)\s+(?:is\s+)?(?:complete[ds]?|finished|done)\b/gi, '')
-        .replace(/\b(?:complete[ds]?|finished|done)\s+(?:uploading|processing)\b/gi, '');
-      return /(?:^|[^\p{L}\p{N}\p{M}])(?:uploading|processing)(?=$|[^\p{L}\p{N}\p{M}])/iu.test(text);
+      return false;
     });
   })()`;
 }

--- a/src/browser/actions/attachments.ts
+++ b/src/browser/actions/attachments.ts
@@ -5,6 +5,7 @@ import { buildConversationTurnListExpression } from "../conversationTurns.js";
 import { delay } from "../utils.js";
 import { logDomFailure } from "../domDebug.js";
 import { transferAttachmentViaDataTransfer } from "./attachmentDataTransfer.js";
+import { buildAttachmentProgressExpression } from "./attachmentProgress.js";
 import {
   beginAttachmentEvidence,
   confirmAttachmentEvidence,
@@ -1446,19 +1447,7 @@ export async function waitForAttachmentCompletion(
         button.getAttribute('data-disabled') === 'true' ||
         window.getComputedStyle(button).pointerEvents === 'none'
       : null;
-    const uploadingSelectors = ${JSON.stringify(UPLOAD_STATUS_SELECTORS)};
-    const uploading = uploadingSelectors.some((selector) => {
-      return Array.from(document.querySelectorAll(selector)).some((node) => {
-        const ariaBusy = node.getAttribute?.('aria-busy');
-        const dataState = node.getAttribute?.('data-state');
-        if (ariaBusy === 'true' || dataState === 'loading' || dataState === 'uploading' || dataState === 'pending') {
-          return true;
-        }
-        // Avoid false positives from user prompts ("upload:") or generic UI copy; only treat explicit progress strings as uploading.
-        const text = node.textContent?.toLowerCase?.() ?? '';
-        return /\buploading\b/.test(text) || /\bprocessing\b/.test(text);
-      });
-    });
+    const uploading = ${buildAttachmentProgressExpression("composerRoot")};
     const attachmentChipSelectors = [
       '[data-testid*="chip"]',
       '[data-testid*="attachment"]',
@@ -1630,6 +1619,14 @@ export async function waitForAttachmentCompletion(
           );
         }
       }
+      if (value.uploading) {
+        attachmentMatchSince = null;
+        inputMatchSince = null;
+        inputOnlyReadySince = null;
+        inputOnlySignature = "";
+        await delay(250);
+        continue;
+      }
       const attachedNames = (value.attachedNames ?? [])
         .map((name) => name.toLowerCase().replace(/\s+/g, " ").trim())
         .filter(Boolean);
@@ -1660,7 +1657,7 @@ export async function waitForAttachmentCompletion(
       };
       const missing = expectedNormalized.filter((expected) => !matchesExpected(expected));
       if (missing.length === 0) {
-        const stableThresholdMs = value.uploading ? 3000 : 1500;
+        const stableThresholdMs = 1500;
         if (attachmentMatchSince === null) {
           attachmentMatchSince = Date.now();
         }
@@ -1710,7 +1707,7 @@ export async function waitForAttachmentCompletion(
       const inputStateOk = value.state === "ready" || value.state === "missing";
       const inputSeenNow = inputOnlyNamesSatisfied;
       const inputEvidenceOk = inputSeenNow;
-      const stableThresholdMs = value.uploading ? 3000 : 1500;
+      const stableThresholdMs = 1500;
       if (inputSeenNow && inputStateOk && inputEvidenceOk) {
         if (inputMatchSince === null) {
           inputMatchSince = Date.now();

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -17,6 +17,7 @@ import { buildAttachmentNamePattern } from "./attachments.js";
 import { buildClickDispatcher } from "./domEvents.js";
 import { BrowserAutomationError } from "../../oracle/errors.js";
 import { buildAttachmentEvidenceExpression } from "./attachmentEvidence.js";
+import { buildAttachmentProgressExpression } from "./attachmentProgress.js";
 
 const ENTER_KEY_EVENT = {
   key: "Enter",
@@ -536,7 +537,7 @@ function buildAttachmentReadyExpression(attachmentNames: AttachmentReadyInput[])
         ),
       ),
     );
-    return chipsReady || inputsReady;
+    return (chipsReady || inputsReady) && !${buildAttachmentProgressExpression("composer")};
   })()`;
 }
 

--- a/tests/browser/attachmentProgress.test.ts
+++ b/tests/browser/attachmentProgress.test.ts
@@ -6,6 +6,49 @@ import { FakeDocument, FakeElement, FakeInputElement } from "./domFixture.js";
 
 afterEach(() => vi.useRealTimers());
 
+test.each(["input", "textarea", "contenteditable", "hidden-input", "hidden-textarea"])(
+  "explicit busy state on %s blocks completion and send",
+  async (kind) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const progress = new FakeElement(
+      "div",
+      kind === "contenteditable" ? { contenteditable: "true", "aria-busy": "true" } : {},
+    );
+    const { evaluate, runtime, form } = fixture(progress);
+    if (kind !== "contenteditable") {
+      const control = form.querySelector(kind.replace("hidden-", ""))!;
+      const get = control.getAttribute.bind(control);
+      control.getAttribute = (name) => (name === "aria-busy" ? "true" : get(name));
+      if (kind.startsWith("hidden-"))
+        control.getBoundingClientRect = () => ({ width: 0, height: 0 });
+    }
+    expect(evaluate(buildAttachmentReadyExpressionForTest(["a.txt", "b.txt"]))).toBe(false);
+    const outcome = waitForAttachmentCompletion(runtime, 5_000, ["a.txt", "b.txt"]).then(
+      () => "resolved",
+      () => "timed-out",
+    );
+    await vi.advanceTimersByTimeAsync(6_000);
+    expect(await outcome).toBe("timed-out");
+  },
+);
+
+test.each(["", "true", "plaintext-only", "TRUE"])(
+  "markup inside contenteditable=%s cannot assert upload state",
+  async (value) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const editor = new FakeElement("div", { contenteditable: value }, [
+      new FakeElement("span", { "data-state": "uploading" }),
+    ]);
+    const { evaluate, runtime } = fixture(editor);
+    expect(evaluate(buildAttachmentReadyExpressionForTest(["a.txt", "b.txt"]))).toBe(true);
+    const completion = waitForAttachmentCompletion(runtime, 5_000, ["a.txt", "b.txt"]);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await completion;
+  },
+);
+
 test.each([0.5, 1, null])(
   "native progress value %s has matching completion and send state",
   async (value) => {
@@ -63,6 +106,8 @@ test.each([
   ["loading state", { "data-state": "loading" }, ""],
   ["ARIA busy", { "aria-busy": "true" }, ""],
   ["ARIA progress", { role: "progressbar", "aria-valuenow": "50" }, ""],
+  ["ARIA role tokens", { role: "progressbar status", "aria-valuenow": "50" }, ""],
+  ["ARIA role whitespace", { role: " progressbar ", "aria-valuenow": "50" }, ""],
   ["indeterminate ARIA progress", { role: "progressbar" }, ""],
 ] as const)(
   "completion and final send reject active %s beyond three seconds",

--- a/tests/browser/attachmentProgress.test.ts
+++ b/tests/browser/attachmentProgress.test.ts
@@ -41,7 +41,7 @@ function fixture(progress: FakeElement, outside = false) {
   ]);
   if (!outside) form.append(progress);
   const document = new FakeDocument(outside ? [progress, form] : [form]);
-  const styles = new Map<FakeElement, { opacity: string }>();
+  const styles = new Map<FakeElement, Record<string, string>>();
   const evaluate = (expression: string) =>
     new Function("document", "HTMLElement", "HTMLInputElement", "window", `return ${expression};`)(
       document,
@@ -60,14 +60,10 @@ function fixture(progress: FakeElement, outside = false) {
 test.each([
   ["upload state", { "data-state": "uploading" }, ""],
   ["pending state", { "data-state": "pending" }, ""],
+  ["loading state", { "data-state": "loading" }, ""],
+  ["ARIA busy", { "aria-busy": "true" }, ""],
   ["ARIA progress", { role: "progressbar", "aria-valuenow": "50" }, ""],
   ["indeterminate ARIA progress", { role: "progressbar" }, ""],
-  ["progress text", { "aria-live": "polite" }, "Uploading 50%"],
-  ["filename-prefixed progress", { "aria-live": "polite" }, "a.txt — Uploading 50%"],
-  ["colon progress", { "aria-live": "polite" }, "Uploading: 50%"],
-  ["dash progress", { "aria-live": "polite" }, "Uploading—50%"],
-  ["mixed status", { role: "status" }, "Processing complete. Uploading: 50%"],
-  ["processing text", { "data-testid": "attachment-status" }, "Processing…"],
 ] as const)(
   "completion and final send reject active %s beyond three seconds",
   async (_, attrs, text) => {
@@ -195,3 +191,42 @@ test.each(["Processing complete", "Finished uploading", "Processing is complete"
     await completion;
   },
 );
+
+test.each(["one-pixel", "offscreen", "clip", "clip-path"])(
+  "visually hidden %s status does not block attachments",
+  async (kind) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const progress = new FakeElement(
+      "div",
+      kind.startsWith("clip") ? { "data-state": "uploading" } : { role: "status" },
+      [],
+      "Uploading",
+    );
+    const { evaluate, runtime, styles } = fixture(progress);
+    if (kind === "one-pixel") progress.getBoundingClientRect = () => ({ width: 1, height: 1 });
+    if (kind === "offscreen")
+      progress.getBoundingClientRect = () => ({ width: 100, height: 20, bottom: -1, right: -1 });
+    if (kind === "clip") styles.set(progress, { clip: "rect(0px, 0px, 0px, 0px)" });
+    if (kind === "clip-path") styles.set(progress, { clipPath: "inset(50%)" });
+    expect(evaluate(buildAttachmentReadyExpressionForTest(["a.txt", "b.txt"]))).toBe(true);
+    const completion = waitForAttachmentCompletion(runtime, 5_000, ["a.txt", "b.txt"]);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await completion;
+  },
+);
+
+test("explicit upload state remains blocking when the attachment is below the viewport", async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+  const progress = new FakeElement("div", { "data-state": "uploading" });
+  progress.getBoundingClientRect = () => ({ width: 100, height: 20, bottom: -1, right: -1 });
+  const { evaluate, runtime } = fixture(progress);
+  expect(evaluate(buildAttachmentReadyExpressionForTest(["a.txt", "b.txt"]))).toBe(false);
+  const outcome = waitForAttachmentCompletion(runtime, 5_000, ["a.txt", "b.txt"]).then(
+    () => "resolved",
+    () => "timed-out",
+  );
+  await vi.advanceTimersByTimeAsync(6_000);
+  expect(await outcome).toBe("timed-out");
+});

--- a/tests/browser/attachmentProgress.test.ts
+++ b/tests/browser/attachmentProgress.test.ts
@@ -49,6 +49,50 @@ test.each(["", "true", "plaintext-only", "TRUE"])(
   },
 );
 
+test.each(["false", "FALSE"])(
+  "non-editable attachment widgets inside an editor retain upload state (%s)",
+  async (value) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const progress = new FakeElement("div", { "data-state": "uploading" });
+    const editor = new FakeElement("div", { contenteditable: "true" }, [
+      new FakeElement("div", { contenteditable: value }, [progress]),
+    ]);
+    const { evaluate, runtime } = fixture(editor);
+    expect(evaluate(buildAttachmentReadyExpressionForTest(["a.txt", "b.txt"]))).toBe(false);
+    const outcome = waitForAttachmentCompletion(runtime, 5_000, ["a.txt", "b.txt"]).then(
+      () => "resolved",
+      () => "timed-out",
+    );
+    await vi.advanceTimersByTimeAsync(6_000);
+    expect(await outcome).toBe("timed-out");
+  },
+);
+
+test("hidden file inputs inside non-editable attachment widgets remain authoritative", () => {
+  const input = new FakeInputElement([]);
+  const get = input.getAttribute.bind(input);
+  input.getAttribute = (name) => (name === "aria-busy" ? "true" : get(name));
+  input.getBoundingClientRect = () => ({ width: 0, height: 0 });
+  const editor = new FakeElement("div", { contenteditable: "true" }, [
+    new FakeElement("div", { contenteditable: "false" }, [input]),
+  ]);
+  const { evaluate } = fixture(editor);
+  expect(evaluate(buildAttachmentReadyExpressionForTest(["a.txt", "b.txt"]))).toBe(false);
+});
+
+test("a nested editable host inside an attachment widget still excludes prompt markup", () => {
+  const editor = new FakeElement("div", { contenteditable: "true" }, [
+    new FakeElement("div", { contenteditable: "false" }, [
+      new FakeElement("div", { contenteditable: "true" }, [
+        new FakeElement("span", { "data-state": "uploading" }),
+      ]),
+    ]),
+  ]);
+  const { evaluate } = fixture(editor);
+  expect(evaluate(buildAttachmentReadyExpressionForTest(["a.txt", "b.txt"]))).toBe(true);
+});
+
 test.each([0.5, 1, null])(
   "native progress value %s has matching completion and send state",
   async (value) => {

--- a/tests/browser/attachmentProgress.test.ts
+++ b/tests/browser/attachmentProgress.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { waitForAttachmentCompletion } from "../../src/browser/actions/attachments.js";
+import { buildAttachmentReadyExpressionForTest } from "../../src/browser/actions/promptComposer.js";
+import type { ChromeClient } from "../../src/browser/types.js";
+import { FakeDocument, FakeElement, FakeInputElement } from "./domFixture.js";
+
+afterEach(() => vi.useRealTimers());
+
+function fixture(progress: FakeElement, outside = false) {
+  const form = new FakeElement("form", { "data-testid": "composer" }, [
+    new FakeElement("textarea", { id: "prompt-textarea" }),
+    new FakeInputElement([{ name: "a.txt" }, { name: "b.txt" }]),
+    ...["a.txt", "b.txt"].map(
+      (name) =>
+        new FakeElement("div", { "data-testid": "attachment-chip" }, [
+          new FakeElement("button", { "aria-label": `Remove file: ${name}` }),
+        ]),
+    ),
+    new FakeElement("button", { "data-testid": "send-button" }),
+  ]);
+  if (!outside) form.append(progress);
+  const document = new FakeDocument(outside ? [progress, form] : [form]);
+  const evaluate = (expression: string) =>
+    new Function("document", "HTMLElement", "HTMLInputElement", "window", `return ${expression};`)(
+      document,
+      FakeElement,
+      FakeInputElement,
+      { getComputedStyle: () => ({ pointerEvents: "auto" }) },
+    );
+  const runtime = {
+    evaluate: vi.fn(async ({ expression }: { expression: string }) => ({
+      result: { value: evaluate(expression) },
+    })),
+  } as unknown as ChromeClient["Runtime"];
+  return { evaluate, runtime, form };
+}
+
+test.each([
+  ["upload state", { "data-state": "uploading" }, ""],
+  ["pending state", { "data-state": "pending" }, ""],
+  ["progress text", { "aria-live": "polite" }, "Uploading 50%"],
+  ["processing text", { "data-testid": "attachment-status" }, "Processing…"],
+] as const)(
+  "completion and final send reject active %s beyond three seconds",
+  async (_, attrs, text) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const { evaluate, runtime } = fixture(new FakeElement("div", attrs, [], text));
+    expect(evaluate(buildAttachmentReadyExpressionForTest(["a.txt", "b.txt"]))).toBe(false);
+    const outcome = waitForAttachmentCompletion(runtime, 5_000, ["a.txt", "b.txt"]).then(
+      () => "resolved",
+      () => "timed-out",
+    );
+    await vi.advanceTimersByTimeAsync(6_000);
+    expect(await outcome).toBe("timed-out");
+  },
+);
+
+test.each(["outside", "hidden", "filename"])(
+  "unrelated %s progress does not block completed files",
+  async (kind) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const progress =
+      kind === "filename"
+        ? new FakeElement("div", { "data-testid": "attachment-chip" }, [], "processing.ts")
+        : new FakeElement("div", { "data-state": "uploading" });
+    if (kind === "hidden") progress.getBoundingClientRect = () => ({ width: 0, height: 0 });
+    const { evaluate, runtime } = fixture(progress, kind === "outside");
+    expect(evaluate(buildAttachmentReadyExpressionForTest(["a.txt", "b.txt"]))).toBe(true);
+    const completion = waitForAttachmentCompletion(runtime, 5_000, ["a.txt", "b.txt"]);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await completion;
+  },
+);
+
+test("completion waits for progress to clear and restarts its stability window", async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+  const progress = new FakeElement("div", { "data-state": "uploading" });
+  const { evaluate, runtime } = fixture(progress);
+  let completed = false;
+  const completion = waitForAttachmentCompletion(runtime, 9_000, ["a.txt", "b.txt"]).then(() => {
+    completed = true;
+  });
+  await vi.advanceTimersByTimeAsync(4_000);
+  expect(completed).toBe(false);
+  progress.remove();
+  expect(evaluate(buildAttachmentReadyExpressionForTest(["a.txt", "b.txt"]))).toBe(true);
+  await vi.advanceTimersByTimeAsync(1_000);
+  expect(completed).toBe(false);
+  await vi.advanceTimersByTimeAsync(2_000);
+  await completion;
+  expect(completed).toBe(true);
+});
+
+test("a missing send button cannot bypass active upload progress", async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+  const { form, runtime } = fixture(new FakeElement("div", { "data-state": "uploading" }));
+  form.querySelector('[data-testid="send-button"]')?.remove();
+  const outcome = waitForAttachmentCompletion(runtime, 5_000, ["a.txt", "b.txt"]).then(
+    () => "resolved",
+    () => "timed-out",
+  );
+  await vi.advanceTimersByTimeAsync(6_000);
+  expect(await outcome).toBe("timed-out");
+});

--- a/tests/browser/attachmentProgress.test.ts
+++ b/tests/browser/attachmentProgress.test.ts
@@ -6,6 +6,27 @@ import { FakeDocument, FakeElement, FakeInputElement } from "./domFixture.js";
 
 afterEach(() => vi.useRealTimers());
 
+test.each([0.5, 1, null])(
+  "native progress value %s has matching completion and send state",
+  async (value) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const attributes: Record<string, string> = value === null ? {} : { value: String(value) };
+    const progress = Object.assign(new FakeElement("progress", attributes), {
+      value: value ?? 0,
+      max: 1,
+    });
+    const { evaluate, runtime } = fixture(progress);
+    expect(evaluate(buildAttachmentReadyExpressionForTest(["a.txt", "b.txt"]))).toBe(value === 1);
+    const outcome = waitForAttachmentCompletion(runtime, 5_000, ["a.txt", "b.txt"]).then(
+      () => "resolved",
+      () => "timed-out",
+    );
+    await vi.advanceTimersByTimeAsync(6_000);
+    expect(await outcome).toBe(value === 1 ? "resolved" : "timed-out");
+  },
+);
+
 function fixture(progress: FakeElement, outside = false) {
   const form = new FakeElement("form", { "data-testid": "composer" }, [
     new FakeElement("textarea", { id: "prompt-textarea" }),
@@ -20,25 +41,32 @@ function fixture(progress: FakeElement, outside = false) {
   ]);
   if (!outside) form.append(progress);
   const document = new FakeDocument(outside ? [progress, form] : [form]);
+  const styles = new Map<FakeElement, { opacity: string }>();
   const evaluate = (expression: string) =>
     new Function("document", "HTMLElement", "HTMLInputElement", "window", `return ${expression};`)(
       document,
       FakeElement,
       FakeInputElement,
-      { getComputedStyle: () => ({ pointerEvents: "auto" }) },
+      { getComputedStyle: (node: FakeElement) => ({ pointerEvents: "auto", ...styles.get(node) }) },
     );
   const runtime = {
     evaluate: vi.fn(async ({ expression }: { expression: string }) => ({
       result: { value: evaluate(expression) },
     })),
   } as unknown as ChromeClient["Runtime"];
-  return { evaluate, runtime, form };
+  return { evaluate, runtime, form, styles };
 }
 
 test.each([
   ["upload state", { "data-state": "uploading" }, ""],
   ["pending state", { "data-state": "pending" }, ""],
+  ["ARIA progress", { role: "progressbar", "aria-valuenow": "50" }, ""],
+  ["indeterminate ARIA progress", { role: "progressbar" }, ""],
   ["progress text", { "aria-live": "polite" }, "Uploading 50%"],
+  ["filename-prefixed progress", { "aria-live": "polite" }, "a.txt — Uploading 50%"],
+  ["colon progress", { "aria-live": "polite" }, "Uploading: 50%"],
+  ["dash progress", { "aria-live": "polite" }, "Uploading—50%"],
+  ["mixed status", { role: "status" }, "Processing complete. Uploading: 50%"],
   ["processing text", { "data-testid": "attachment-status" }, "Processing…"],
 ] as const)(
   "completion and final send reject active %s beyond three seconds",
@@ -106,3 +134,64 @@ test("a missing send button cannot bypass active upload progress", async () => {
   await vi.advanceTimersByTimeAsync(6_000);
   expect(await outcome).toBe("timed-out");
 });
+
+test.each(["self", "parent"])(
+  "faded progress on %s does not block ready attachments",
+  async (kind) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const progress = new FakeElement("div", { "data-state": "uploading" });
+    const wrapper = new FakeElement("div", {}, [progress]);
+    const { evaluate, runtime, styles } = fixture(wrapper);
+    styles.set(kind === "self" ? progress : wrapper, { opacity: "0" });
+    expect(evaluate(buildAttachmentReadyExpressionForTest(["a.txt", "b.txt"]))).toBe(true);
+    const completion = waitForAttachmentCompletion(runtime, 5_000, ["a.txt", "b.txt"]);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await completion;
+  },
+);
+
+test.each(["processing", "uploading", "processing notes.txt"])(
+  "filename %s is not an upload status",
+  async (name) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const { evaluate, runtime } = fixture(
+      new FakeElement("div", { "data-testid": "attachment-chip" }, [], name),
+    );
+    expect(evaluate(buildAttachmentReadyExpressionForTest(["a.txt", "b.txt"]))).toBe(true);
+    const completion = waitForAttachmentCompletion(runtime, 5_000, ["a.txt", "b.txt"]);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await completion;
+  },
+);
+
+test("completed ARIA progress does not block ready attachments", async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+  const { evaluate, runtime } = fixture(
+    new FakeElement(
+      "div",
+      { role: "progressbar", "aria-valuenow": "1", "aria-valuemax": "1" },
+      [],
+      "Uploading 100%",
+    ),
+  );
+  expect(evaluate(buildAttachmentReadyExpressionForTest(["a.txt", "b.txt"]))).toBe(true);
+  const completion = waitForAttachmentCompletion(runtime, 5_000, ["a.txt", "b.txt"]);
+  await vi.advanceTimersByTimeAsync(2_000);
+  await completion;
+});
+
+test.each(["Processing complete", "Finished uploading", "Processing is complete"])(
+  "terminal status %s does not block ready attachments",
+  async (text) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const { evaluate, runtime } = fixture(new FakeElement("div", { role: "status" }, [], text));
+    expect(evaluate(buildAttachmentReadyExpressionForTest(["a.txt", "b.txt"]))).toBe(true);
+    const completion = waitForAttachmentCompletion(runtime, 5_000, ["a.txt", "b.txt"]);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await completion;
+  },
+);

--- a/tests/browser/attachmentsCompletion.test.ts
+++ b/tests/browser/attachmentsCompletion.test.ts
@@ -186,9 +186,9 @@ describe("attachment completion fallbacks", () => {
       }),
     } as unknown as ChromeClient["Runtime"];
 
-    const promise = waitForAttachmentCompletion(runtime, 800, ["oracle-attach-verify.txt"]);
+    const promise = waitForAttachmentCompletion(runtime, 5_000, ["oracle-attach-verify.txt"]);
     const assertion = expect(promise).rejects.toThrow(/did not finish uploading/i);
-    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(6_000);
     await assertion;
     useRealTime();
   });

--- a/tests/browser/domFixture.ts
+++ b/tests/browser/domFixture.ts
@@ -111,13 +111,17 @@ function matchesSingleSelector(element: FakeElement, selector: string): boolean 
   const id = normalized.match(/#([a-z0-9_-]+)/i)?.[1];
   if (id && element.getAttribute("id") !== id) return false;
 
-  const attrPattern = /\[([^\]\s~|^$*!=]+)([*^$]?=)?(?:"([^"]*)"|'([^']*)')?\s*i?\]/g;
+  const attrPattern = /\[([^\]\s~|^$*!=]+)([*^$~]?=)?(?:"([^"]*)"|'([^']*)')?\s*(i)?\]/g;
   for (const match of normalized.matchAll(attrPattern)) {
-    const [, name, operator, doubleQuotedValue, singleQuotedValue] = match;
+    const [, name, operator, doubleQuotedValue, singleQuotedValue, insensitive] = match;
     const expected = doubleQuotedValue ?? singleQuotedValue ?? "";
     const actual = element.getAttribute(name);
     if (actual === null) return false;
-    if (operator === "=" && actual !== expected) return false;
+    const equal = insensitive
+      ? actual.toLowerCase() === expected.toLowerCase()
+      : actual === expected;
+    if (operator === "=" && !equal) return false;
+    if (operator === "~=" && !actual.split(/\s+/).includes(expected)) return false;
     if (operator === "*=" && !actual.toLowerCase().includes(expected.toLowerCase())) return false;
     if (operator === "^=" && !actual.toLowerCase().startsWith(expected.toLowerCase())) return false;
     if (operator === "$=" && !actual.toLowerCase().endsWith(expected.toLowerCase())) return false;


### PR DESCRIPTION
Attachment completion could succeed after three seconds while the DOM still reported an upload in progress. The final send gate checked attachment identity but did not recheck progress, permitting an early send.

Use one composer-scoped structured-state detector at completion and final send readiness. Explicit loading/busy states and incomplete native/ARIA progress controls block sending and reset stability windows. Busy state on hidden file inputs or backing editors remains authoritative. Respect the nearest editing boundary so non-editable attachment widgets nested inside a rich-text editor retain their upload state, while prompt-owned editable markup is excluded. Filenames and status prose are not used to infer transfer state.

Fixes #446; thanks @HJC704.

Independently rebased onto main at 748193758d54e43779ab93e94fac23cbc6c9e421. Current head: 4f207cb0ad5e8f350759005bf7599b2075b91282. This PR has no CHANGELOG.md diff; #455 owns its release-note coverage and contributor thanks. The restack preserved the existing source; subsequent autoreview exposed the non-editable-widget edge case, reproduced in three new tests and in the built real-Chrome proof before correction.

Fresh validation on Node 24.20.0/macOS: 179 attachment/composer tests passed; typecheck, lint, formatting, build and built CLI docs/help checks passed. The updated real-Chrome proof (`node scripts/attachment-send-proof.mjs` after building) passed for local and remote three-file uploads, filename-less image evidence, active/completed SVG/native progress, opacity and offscreen recovery. Holding upload state active inside a non-editable rich-editor widget for 4.5 seconds blocks completion; attempted send produces zero clicks/Enter events. Clearing state permits exactly one trusted click and one committed turn with byte-identical attachments. This is controlled browser-runtime proof, not a claim about current signed-in ChatGPT race frequency.

The staged candidate passed autoreview through P2. Exact-head branch review and CI results are recorded in the final proof comment. No merge performed.
