### PR TITLE
fix(release): upload and verify GitHub release assets before the Homebrew tap dispatch

### DIFF
--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -14,9 +14,14 @@ permissions:
   contents: read
 
 jobs:
+  # Preflight release assets before dispatching the tap update (fixes #443).
   update-homebrew-tap:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
       - name: Resolve release tag
         id: release
         shell: bash
@@ -29,6 +34,12 @@ jobs:
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "request_id=oracle-${tag}-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: scripts/verify-release-assets.sh "${{ steps.release.outputs.tag }}"
 
       - name: Dispatch tap update
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Release: attach the npm tarball and its checksums to the GitHub Release and verify them before the Homebrew tap updates, so the formula no longer points at a missing asset. Fixes #443.
+
 ## 0.18.1 - 2026-09-05
 
 **Highlights:** More reliable browser uploads, strict remote-tab isolation, and broader support for ChatGPT's current thinking controls.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,6 +1,6 @@
 # Release Checklist (npm + Homebrew)
 
-> For a guarded, phased flow, run `./scripts/release.sh <phase>` (gates | artifacts | publish | smoke | tag | all); it stops on the first error so you can resume after fixing issues.
+> For a guarded, phased flow, run `./scripts/release.sh <phase>` (gates | artifacts | publish | smoke | tag | github-release | all); it stops on the first error so you can resume after fixing issues.
 
 1. **Version & metadata**
    - [ ] Update `package.json` version (e.g., `1.0.0`).
@@ -9,13 +9,12 @@
    - [ ] If dependencies changed, run `pnpm install` so `pnpm-lock.yaml` is current.
    - [ ] Source `~/.profile` so codesign/notary env vars are available before building the notifier.
 2. **Artifacts**
-   - [ ] Run `pnpm run build` (ensure `dist/` is current).
+   - [ ] Run `./scripts/release.sh artifacts` (builds `dist/`, packs npm, and generates checksums).
    - [ ] Verify `bin` mapping in `package.json` points to `dist/bin/oracle-cli.js`.
 
-- [ ] Produce npm tarball and checksums:
-  - `npm pack --pack-destination /tmp` (after build)
-  - Move the tarball into repo root (e.g., `oracle-<version>.tgz`) and generate `*.sha1` / `*.sha256`.
-  - Keep these files handy for the GitHub release; do **not** commit them.
+- [ ] Keep the generated `.release-artifacts/oracle-<version>.tgz{,.sha1,.sha256}` for the GitHub release.
+  - `.release-artifacts/` is gitignored; do **not** commit these files.
+  - Set `ARTIFACT_DIR` to override the artifact directory; use the same directory for `github-release`.
 - [ ] Rebuild macOS notifier helper with signing + notarization:
   - `cd vendor/oracle-notifier && ./build-notifier.sh` (requires `CODESIGN_ID` and `APP_STORE_CONNECT_*`).
   - Signing inputs (same as Trimmy): `CODESIGN_ID="Developer ID Application: Peter Steinberger (Y5PE65HELJ)"` plus notary env vars `APP_STORE_CONNECT_API_KEY_P8`, `APP_STORE_CONNECT_KEY_ID`, and `APP_STORE_CONNECT_ISSUER_ID`.
@@ -49,8 +48,8 @@
    - [ ] `npm view @steipete/oracle version` (and optionally `npm view @steipete/oracle time`) to confirm the registry shows the new version.
    - [ ] Verify positional prompt still works: `npx -y @steipete/oracle "Test prompt" --dry-run`.
 6. **Homebrew (tap)**
-   - [ ] The `Update Homebrew Tap` workflow dispatches `steipete/homebrew-tap` after the GitHub release is published.
-   - [ ] If needed, run `.github/workflows/update-homebrew-tap.yml` manually with the release tag after assets are live.
+   - [ ] The `Update Homebrew Tap` workflow preflights the tarball and both checksum assets after the GitHub release is published: it verifies their hashes and the public tarball URL before dispatching `steipete/homebrew-tap`.
+   - [ ] Missing assets or failed verification stop the job before dispatch. Run `./scripts/release.sh github-release`, then re-run `.github/workflows/update-homebrew-tap.yml` via `workflow_dispatch` with the release tag (`tag=vX.Y.Z`). For an older release, do not rebuild: download the published npm tarball (`npm view @steipete/oracle@X.Y.Z dist.tarball`), verify it against `dist.integrity`, place it in `ARTIFACT_DIR` as `oracle-X.Y.Z.tgz` with `.sha1`/`.sha256` files, and run the phase with `VERSION=X.Y.Z`.
    - [ ] Confirm the tap workflow updated `Formula/oracle.rb` to the GitHub release asset and committed the SHA256.
    - [ ] Verify install:
      - `brew uninstall oracle || true`
@@ -60,18 +59,12 @@
      - `brew uninstall oracle`
 7. **Post-publish**
 
-- [ ] Verify GitHub release exists for `vX.Y.Z` and has the intended assets (tarball + checksums if produced). Add missing assets before announcing.
+- [ ] Run `./scripts/release.sh tag` so `vX.Y.Z` exists on origin (always tag each release).
+- [ ] Run `./scripts/release.sh github-release`: create a draft with title `X.Y.Z` and the full version's changelog section (without its heading), upload the tarball and both checksums, verify the downloads, publish, and re-verify the public tarball URL. Publishing triggers the Homebrew tap workflow, which also waits for that URL to become available.
+  - Existing releases keep their notes; identical assets are skipped, and conflicting assets fail without overwriting.
 - [ ] Confirm the GitHub release body exactly matches the `CHANGELOG.md` section for `X.Y.Z` (full bullet list). If not, update with `gh release edit vX.Y.Z --notes-file <file>`.
 - [ ] Confirm npm shows the new version: `npm view @steipete/oracle version` and `npx -y @steipete/oracle@X.Y.Z --version`.
 - [ ] Promote desired dist-tag (e.g., `npm dist-tag add @steipete/oracle@X.Y.Z latest`).
-- [ ] `git tag vX.Y.Z && git push origin vX.Y.Z` (always tag each release).
-- [ ] `git tag vX.Y.Z && git push --tags`
-- [ ] Create GitHub release for tag `vX.Y.Z`:
-  - Title = `X.Y.Z` (just the version, no “Oracle”, no date).
-- Body = product-facing bullet list for that version (copy from changelog bullets only; omit the heading and the word “changelog”). Always paste the full Added/Changed/Fixed bullets (no trimming) to keep npm/GitHub notes in sync.
-  - Upload assets: `oracle-<version>.tgz`, `oracle-<version>.tgz.sha1`, `oracle-<version>.tgz.sha256`.
-  - Confirm the auto `Source code (zip|tar.gz)` assets are present.
 - [ ] From a clean temp directory (no package.json/node_modules), run `npx @steipete/oracle@X.Y.Z "Smoke from empty dir" --dry-run` to confirm the package installs/executes via npx.
-- [ ] After uploading assets, verify they are reachable (e.g., `curl -I <GitHub-asset-URL>` or download and re-check SHA).
-- [ ] After verification, remove the untracked tarball/checksum assets from the repo root (`trash oracle-<version>.tgz*`).
+- [ ] After verification, remove the generated tarball/checksum assets (`trash .release-artifacts`, or the overridden `ARTIFACT_DIR`).
 - [ ] Announce / share release notes.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,12 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Oracle release helper (npm)
-# Phases: gates | artifacts | publish | smoke | tag | all
+# Oracle release helper (npm + GitHub)
+# Phases: gates | artifacts | publish | smoke | tag | github-release | all
 # Defaults to using the guardrail runner (MCP_RUNNER or ./runner).
 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
 RUNNER="${MCP_RUNNER:-./runner}"
-VERSION="${VERSION:-$(node -p "require('./package.json').version")}" 
+VERSION="${VERSION:-$(node -p "require('./package.json').version")}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-$ROOT_DIR/.release-artifacts}"
+TGZ="oracle-${VERSION}.tgz"
+REPO="${REPO:-steipete/oracle}"
+
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+  echo "Invalid VERSION: expected a version such as 0.18.1 or 0.18.1-beta.1." >&2
+  exit 1
+fi
 
 if [[ "${CODEX_MANAGED_BY_NPM:-}" == "1" ]]; then
   export NPM_CONFIG_PROGRESS=false
@@ -14,7 +24,7 @@ if [[ "${CODEX_MANAGED_BY_NPM:-}" == "1" ]]; then
 fi
 
 banner() { printf "\n==== %s ====" "$1"; printf "\n"; }
-run() { echo ">> $*"; "$@"; }
+run() { echo ">> $*" >&2; "$@"; }
 
 phase_gates() {
   banner "Gates (check/lint/test/build)"
@@ -24,28 +34,39 @@ phase_gates() {
   run "$RUNNER" pnpm run build
 }
 
-phase_artifacts() {
+phase_artifacts() (
   banner "Artifacts (npm pack + checksums)"
   run "$RUNNER" pnpm run build
-  run "$RUNNER" npm pack --pack-destination /tmp
+  local packdir packed
+  packdir=$(mktemp -d)
+  trap 'rm -rf "$packdir"' EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+  chmod 700 "$packdir"
+  # shellcheck disable=SC2016 # Template literals must expand in JavaScript, not Bash.
+  packed=$(run "$RUNNER" npm pack --json --pack-destination "$packdir" | node -e '
+    const fs = require("node:fs");
+    const path = require("node:path");
+    // npm <= 11 prints an array; npm >= 12 prints an object keyed by package name.
+    const parsed = JSON.parse(fs.readFileSync(0, "utf8"));
+    const pack = Array.isArray(parsed) ? parsed[0] : parsed["@steipete/oracle"];
+    if (pack?.name !== "@steipete/oracle" || pack?.version !== process.argv[1]) {
+      throw new Error(`Unexpected npm pack metadata: ${pack?.name}@${pack?.version}; expected @steipete/oracle@${process.argv[1]}`);
+    }
+    if (typeof pack.filename !== "string" || !pack.filename.endsWith(".tgz") || path.basename(pack.filename) !== pack.filename) {
+      throw new Error("npm pack did not return a tarball basename");
+    }
+    process.stdout.write(pack.filename);
+  ' "$VERSION")
 
-  # npm pack tarballs are not consistent for scoped packages:
-  # - @scope/name -> scope-name-x.y.z.tgz
-  # - name        -> name-x.y.z.tgz
-  local packed
-  packed=$(ls -1 "/tmp/"*"${VERSION}.tgz" 2>/dev/null | head -n1 || true)
-  if [[ -z "${packed:-}" ]]; then
-    echo "No tgz found in /tmp after npm pack" >&2
-    exit 1
-  fi
-
-  local tgz="oracle-${VERSION}.tgz"
-  mv "$packed" "$tgz"
-  run shasum "$tgz"
-  shasum "$tgz" > "${tgz}.sha1"
-  run shasum -a 256 "$tgz"
-  shasum -a 256 "$tgz" > "${tgz}.sha256"
-}
+  mkdir -p "$ARTIFACT_DIR"
+  rm -f "$ARTIFACT_DIR/$TGZ"*
+  mv "$packdir/$packed" "$ARTIFACT_DIR/$TGZ"
+  cd "$ARTIFACT_DIR"
+  shasum -a 1 "$TGZ" > "$TGZ.sha1"
+  shasum -a 256 "$TGZ" > "$TGZ.sha256"
+  cat "$TGZ.sha1" "$TGZ.sha256"
+)
 
 phase_publish() {
   banner "Publish to npm"
@@ -67,21 +88,128 @@ phase_tag() {
   git push --tags
 }
 
+extract_release_notes() {
+  # shellcheck disable=SC2016 # Template literals must expand in JavaScript, not Bash.
+  node -e '
+    const fs = require("node:fs");
+    const version = process.argv[1];
+    const lines = fs.readFileSync("CHANGELOG.md", "utf8").split(/\r?\n/);
+    const heading = `## ${version}`;
+    const start = lines.findIndex((line) => line === heading || line.startsWith(`${heading} `));
+    if (start < 0) throw new Error(`Missing CHANGELOG.md section for ${version}`);
+    let end = start + 1;
+    while (end < lines.length && !lines[end].startsWith("## ")) end++;
+    const body = lines.slice(start + 1, end);
+    while (body.length && !body[0].trim()) body.shift();
+    while (body.length && !body[body.length - 1].trim()) body.pop();
+    if (!body.length) throw new Error(`Empty CHANGELOG.md section for ${version}`);
+    process.stdout.write(`${body.join("\n")}\n`);
+  ' "$VERSION"
+}
+
+phase_github_release() (
+  banner "GitHub Release (upload, verify, publish)"
+  run gh auth status
+  local tag="v$VERSION" asset tmp release_info is_draft local_sha256 remote_sha256 local_asset_sha256
+  local assets=("$TGZ" "$TGZ.sha1" "$TGZ.sha256")
+  for asset in "${assets[@]}"; do
+    if [[ ! -f "$ARTIFACT_DIR/$asset" ]]; then
+      echo "Missing artifact: $ARTIFACT_DIR/$asset; run scripts/release.sh artifacts first." >&2
+      exit 1
+    fi
+  done
+  (cd "$ARTIFACT_DIR" && shasum -a 256 -c "$TGZ.sha256" && shasum -a 1 -c "$TGZ.sha1")
+  local_sha256=$(shasum -a 256 "$ARTIFACT_DIR/$TGZ")
+  local_sha256="${local_sha256%% *}"
+  if ! git ls-remote --exit-code --tags origin "refs/tags/$tag"; then
+    echo "Tag $tag must exist on origin; run scripts/release.sh tag first." >&2
+    exit 1
+  fi
+
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+  chmod 700 "$tmp"
+  extract_release_notes > "$tmp/notes.md"
+  if release_info=$(gh release view "$tag" --repo "$REPO" --json isDraft,assets --jq '.isDraft, .assets[].name' 2> "$tmp/release-error"); then
+    is_draft="${release_info%%$'\n'*}"
+    [[ "$is_draft" == true || "$is_draft" == false ]] || { echo 'Invalid release metadata from gh.' >&2; exit 1; }
+    echo "Reusing existing release $tag without changing its notes."
+  else
+    # Only a missing release permits creation; auth/network failures must stop here.
+    cat "$tmp/release-error" >&2
+    if [[ "$(cat "$tmp/release-error")" != *"release not found"* ]]; then
+      echo "Unable to inspect release $tag; refusing to create it." >&2
+      exit 1
+    fi
+    local create_args=(--draft --verify-tag --title "$VERSION" --notes-file "$tmp/notes.md")
+    if [[ "$VERSION" == *-* ]]; then
+      create_args+=(--prerelease)
+    fi
+    run gh release create "$tag" --repo "$REPO" "${create_args[@]}"
+    is_draft=true
+    release_info=true
+  fi
+
+  local uploads=()
+  for asset in "${assets[@]}"; do
+    if [[ $'\n'"$release_info"$'\n' == *$'\n'"$asset"$'\n'* ]]; then
+      gh release download "$tag" --repo "$REPO" --dir "$tmp" --pattern "$asset"
+      remote_sha256=$(shasum -a 256 "$tmp/$asset")
+      remote_sha256="${remote_sha256%% *}"
+      local_asset_sha256=$(shasum -a 256 "$ARTIFACT_DIR/$asset")
+      local_asset_sha256="${local_asset_sha256%% *}"
+      if [[ "$remote_sha256" != "$local_asset_sha256" ]]; then
+        printf 'Error: existing asset %s differs.\n  local sha256: %s\n  remote sha256: %s\n' "$asset" "$local_asset_sha256" "$remote_sha256" >&2
+        # shellcheck disable=SC2016 # Backticks quote a suggested command, not command substitution.
+        printf 'Delete it manually with `gh release delete-asset %s %s --repo %s`, then rerun this phase.\n' "$tag" "$asset" "$REPO" >&2
+        exit 1
+      fi
+      echo "Identical asset already uploaded; skipping $asset."
+    else
+      uploads+=("$ARTIFACT_DIR/$asset")
+    fi
+  done
+  if [[ ${#uploads[@]} -gt 0 ]]; then
+    run gh release upload "$tag" --repo "$REPO" "${uploads[@]}"
+  fi
+
+  # A failed download/hash check exits before the draft can be published.
+  REPO="$REPO" RELEASE_ASSET_PUBLIC_URL_CHECK=0 RELEASE_ASSET_EXPECT_SHA256="$local_sha256" \
+    "$ROOT_DIR/scripts/verify-release-assets.sh" "$tag"
+  if [[ "$is_draft" == true ]]; then
+    if [[ "$VERSION" == *-* ]]; then
+      run gh release edit "$tag" --repo "$REPO" --draft=false
+    else
+      run gh release edit "$tag" --repo "$REPO" --draft=false --latest
+    fi
+  else
+    echo "Release $tag is already published; skipping publication."
+  fi
+  # The publish event starts the tap workflow, whose own preflight also waits for the CDN.
+  REPO="$REPO" RELEASE_ASSET_PUBLIC_URL_CHECK=1 RELEASE_ASSET_EXPECT_SHA256="$local_sha256" \
+    "$ROOT_DIR/scripts/verify-release-assets.sh" "$tag"
+)
+
 usage() {
   cat <<'EOF'
 Usage: scripts/release.sh [phase]
 
 Phases (run individually or all):
-  gates      pnpm check, lint, test, build
-  artifacts  npm pack + sha1/sha256
-  publish    pnpm publish --tag latest --access public, verify npm view
-  smoke      empty-dir npx @steipete/oracle@<version> --dry-run
-  tag        git tag v<version> && push tags
-  all        run everything in order
+  gates          pnpm check, lint, test, build
+  artifacts      npm pack + sha1/sha256 in ARTIFACT_DIR
+  publish        pnpm publish --tag latest --access public, verify npm view
+  smoke          empty-dir npx @steipete/oracle@<version> --dry-run
+  tag            git tag v<version> && push tags
+  github-release upload/verify assets, publish GitHub Release (triggers Homebrew tap), verify public URL
+  all            gates, artifacts, publish, smoke, tag, github-release
 
 Environment:
   MCP_RUNNER (default ./runner) - guardrail wrapper
   VERSION    (default from package.json)
+  ARTIFACT_DIR (default .release-artifacts/ under the repo root)
+  REPO       (default steipete/oracle) - GitHub release repository
 EOF
 }
 
@@ -93,9 +221,12 @@ main() {
     publish) phase_publish ;;
     smoke) phase_smoke ;;
     tag) phase_tag ;;
-    all) phase_gates; phase_artifacts; phase_publish; phase_smoke; phase_tag ;;
+    github-release) phase_github_release ;;
+    all) phase_gates; phase_artifacts; phase_publish; phase_smoke; phase_tag; phase_github_release ;;
     *) usage; exit 1 ;;
   esac
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/scripts/verify-release-assets.sh
+++ b/scripts/verify-release-assets.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() { printf 'Error: %s\n' "$*" >&2; exit 1; }
+
+if [[ $# -ne 1 || ! "$1" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+  fail 'Usage: scripts/verify-release-assets.sh <tag>; tag must have the form v0.18.0 or v0.18.0-beta.1 (v prefix required).'
+fi
+
+tag="$1"
+version="${tag#v}"
+REPO="${REPO:-steipete/oracle}"
+attempts="${RELEASE_ASSET_ATTEMPTS:-12}"
+delay="${RELEASE_ASSET_DELAY:-15}"
+public_check="${RELEASE_ASSET_PUBLIC_URL_CHECK:-1}"
+expected_sha256="${RELEASE_ASSET_EXPECT_SHA256:-}"
+[[ "$attempts" =~ ^[1-9][0-9]*$ ]] || fail 'RELEASE_ASSET_ATTEMPTS must be a positive integer.'
+[[ "$delay" =~ ^[0-9]+([.][0-9]+)?$ ]] || fail 'RELEASE_ASSET_DELAY must be a nonnegative number of seconds.'
+[[ "$public_check" == 0 || "$public_check" == 1 ]] || fail 'RELEASE_ASSET_PUBLIC_URL_CHECK must be 0 or 1.'
+if [[ -n "$expected_sha256" && ! "$expected_sha256" =~ ^[[:xdigit:]]{64}$ ]]; then
+  fail 'RELEASE_ASSET_EXPECT_SHA256 must be a 64-character hex digest.'
+fi
+for tool in gh shasum; do
+  command -v "$tool" >/dev/null 2>&1 || fail "$tool is required."
+done
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+chmod 700 "$tmp"
+tgz="oracle-${version}.tgz"
+assets=("$tgz" "$tgz.sha1" "$tgz.sha256")
+url="https://github.com/$REPO/releases/download/$tag/$tgz"
+
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+  missing=()
+  if release_info=$(gh release view "$tag" --repo "$REPO" --json isDraft,assets --jq '.isDraft, .assets[].name'); then
+    is_draft="${release_info%%$'\n'*}"
+    [[ "$is_draft" == true || "$is_draft" == false ]] || fail 'Invalid release metadata from gh.'
+    for asset in "${assets[@]}"; do
+      if [[ $'\n'"$release_info"$'\n' != *$'\n'"$asset"$'\n'* ]]; then
+        missing+=("$asset")
+      fi
+    done
+  else
+    printf 'Release %s/%s is not yet available (attempt %s/%s).\n' "$REPO" "$tag" "$attempt" "$attempts" >&2
+    missing=("${assets[@]}")
+  fi
+  if [[ ${#missing[@]} -eq 0 ]]; then
+    break
+  fi
+  printf 'Missing assets (attempt %s/%s):\n' "$attempt" "$attempts" >&2
+  printf '  %s\n' "${missing[@]}" >&2
+  if (( attempt == attempts )); then
+    printf 'Release assets unavailable for %s/%s after %s attempts.\nMissing assets:\n' "$REPO" "$tag" "$attempts" >&2
+    printf '  %s\n' "${missing[@]}" >&2
+    # shellcheck disable=SC2016 # Backticks quote suggested commands, not command substitution.
+    printf 'Remediation: run `scripts/release.sh github-release` (or `gh release upload %s <files>`) and re-run the Update Homebrew Tap workflow via workflow_dispatch with tag=%s\n' "$tag" "$tag" >&2
+    exit 1
+  fi
+  sleep "$delay"
+done
+
+# Asset downloads go through the release-assets CDN, which can time out transiently; retry with the same bounds.
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+  if gh release download "$tag" --repo "$REPO" --dir "$tmp" --pattern "$tgz*" --clobber; then
+    break
+  fi
+  printf 'Asset download failed (attempt %s/%s).\n' "$attempt" "$attempts" >&2
+  if (( attempt == attempts )); then
+    fail "Could not download release assets for $REPO/$tag after $attempts attempts."
+  fi
+  sleep "$delay"
+done
+for asset in "${assets[@]}"; do
+  [[ -f "$tmp/$asset" ]] || fail "Downloaded assets do not include $asset."
+done
+
+# Checksum files are either a bare digest (older releases) or `digest  filename` as written by shasum.
+verify_checksum() {
+  local algorithm="$1" suffix="$2" length="$3" line pattern expected observed
+  line=$(tr -d '\r' < "$tmp/$tgz.$suffix")
+  pattern="^([[:xdigit:]]{$length})( [ *]([^[:space:]]+))?$"
+  if [[ ! "$line" =~ $pattern ]]; then
+    fail "$tgz.$suffix must contain exactly one $suffix digest, optionally followed by the filename $tgz."
+  fi
+  expected=$(printf '%s' "${BASH_REMATCH[1]}" | tr '[:upper:]' '[:lower:]')
+  if [[ -n "${BASH_REMATCH[3]:-}" && "$(basename "${BASH_REMATCH[3]}")" != "$tgz" ]]; then
+    fail "$tgz.$suffix references ${BASH_REMATCH[3]} instead of $tgz."
+  fi
+  observed=$(shasum -a "$algorithm" "$tmp/$tgz")
+  observed="${observed%% *}"
+  if [[ "$observed" != "$expected" ]]; then
+    printf 'Error: %s mismatch for %s\n  expected: %s\n  observed: %s\n' "$suffix" "$tgz" "$expected" "$observed" >&2
+    exit 1
+  fi
+  printf '%s: %s OK\n' "$tgz" "$suffix"
+}
+
+verify_checksum 256 sha256 64
+verify_checksum 1 sha1 40
+tarball_sha256=$(shasum -a 256 "$tmp/$tgz")
+tarball_sha256="${tarball_sha256%% *}"
+if [[ -n "$expected_sha256" ]]; then
+  expected_sha256=$(printf '%s' "$expected_sha256" | tr '[:upper:]' '[:lower:]')
+  if [[ "$tarball_sha256" != "$expected_sha256" ]]; then
+    printf 'Error: RELEASE_ASSET_EXPECT_SHA256 mismatch for %s\n  expected: %s\n  observed: %s\n' "$tgz" "$expected_sha256" "$tarball_sha256" >&2
+    exit 1
+  fi
+fi
+
+if [[ "$is_draft" == false && "$public_check" == 1 ]]; then
+  command -v curl >/dev/null 2>&1 || fail 'curl is required for the public URL check.'
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    if http_code=$(curl -fsSIL --connect-timeout 15 --max-time 60 -o /dev/null -w '%{http_code}' "$url") && [[ "$http_code" == 200 ]]; then
+      break
+    fi
+    printf 'Public URL not ready (attempt %s/%s, HTTP %s): %s\n' "$attempt" "$attempts" "${http_code:-unknown}" "$url" >&2
+    if (( attempt == attempts )); then
+      fail "Public release URL never returned HTTP 200 after $attempts attempts: $url"
+    fi
+    sleep "$delay"
+  done
+fi
+
+for asset in "${assets[@]}"; do
+  size=$(wc -c < "$tmp/$asset" | tr -d '[:space:]')
+  printf '%s: %s bytes' "$asset" "$size"
+  if [[ "$asset" == "$tgz" ]]; then
+    printf ', sha256 %s' "$tarball_sha256"
+  fi
+  printf '\n'
+done
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  printf 'tarball_sha256=%s\ntarball_url=%s\n' "$tarball_sha256" "$url" >> "$GITHUB_OUTPUT"
+fi
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    printf '### Release assets verified: %s\n\n' "$tag"
+    printf 'Tarball and both checksum files verified for [%s](%s).\n\n' "$REPO/$tag" "$url"
+    # shellcheck disable=SC2016 # Backticks are literal Markdown code delimiters.
+    printf 'SHA256: `%s`\n' "$tarball_sha256"
+    if [[ "$is_draft" == false && "$public_check" == 1 ]]; then
+      printf '\nPublic download URL returned HTTP 200.\n'
+    else
+      printf '\nPublic download URL check skipped (draft release or disabled).\n'
+    fi
+  } >> "$GITHUB_STEP_SUMMARY"
+fi


### PR DESCRIPTION
## Problem

`Update Homebrew Tap` runs on `release.published` and dispatches `steipete/homebrew-tap` with the asset URL `releases/download/{tag}/oracle-{version}.tgz`, but nothing in `scripts/release.sh` or the workflows ever uploads that asset (the workflow only has `contents: read`). Publishing v0.18.0 without assets therefore triggered a tap update against a missing file and Homebrew got a 404 (#443). The asset was attached by hand afterwards; this PR closes the gap in the tooling.

## Changes

- **New `scripts/verify-release-assets.sh`**: given a `vX.Y.Z` tag, waits with bounded retries (default 12 x 15s) until `oracle-X.Y.Z.tgz`, `.sha1`, and `.sha256` exist on the release, downloads them, checks the tarball against both checksum files (accepts the bare-digest format of older releases and the `digest  filename` format of newer ones), optionally compares against an expected SHA-256, and confirms the exact public download URL the tap fetches returns HTTP 200. Hash mismatches fail immediately with expected/observed digests; missing assets fail after the retry budget with the remediation spelled out.
- **`update-homebrew-tap.yml`**: checks out the default branch and runs the verifier before the tap dispatch, so a release without verified assets fails the job clearly instead of pushing a broken formula. Permissions stay `contents: read`.
- **`scripts/release.sh`**:
  - `artifacts` now packs with `npm pack --json` into a private temp dir (no more `/tmp/*VERSION.tgz` glob), asserts the packed name/version, normalizes to `.release-artifacts/oracle-<version>.tgz` (gitignored) and writes `.sha1`/`.sha256` with bare filenames. Handles both the npm <= 11 array and npm 12 object JSON shapes.
  - new `github-release` phase: requires the artifacts and the pushed tag, extracts the version's `CHANGELOG.md` section as release notes, creates a **draft** release (or reuses an existing one without touching its notes), uploads the three assets (identical existing assets are skipped, differing ones fail rather than being clobbered), verifies the draft via the verifier script with the local SHA-256, and only then publishes and re-verifies the public URL. Publishing is what triggers the tap workflow, so the dispatch is now downstream of a verified upload.
  - `all` runs `gates, artifacts, publish, smoke, tag, github-release`.
- **`docs/RELEASING.md`** updated to the new phases and the tap preflight; **`CHANGELOG.md`** gets an Unreleased entry.

## Proof

- `bash -n`, `shellcheck` (both scripts), `actionlint` (workflow), `oxfmt --check` on touched md/yml, `pnpm run lint`: clean.
- `./scripts/release.sh artifacts` on npm 12.0.2 produced `.release-artifacts/oracle-0.18.1.tgz{,.sha1,.sha256}`; `shasum -c` on both checksum files: OK.
- Verifier against real releases (read-only): `v0.18.0` (shasum-format checksums, with `RELEASE_ASSET_EXPECT_SHA256=9bc8d08c…`) exit 0; `v0.17.3` (bare-digest checksums) exit 0, including a transient CDN timeout that the retry loop absorbed.
- Negative paths: bare tag `0.18.0` -> usage error; non-existent `v9.9.9` -> bounded retries then a clear missing-assets message with remediation; wrong expected SHA-256 -> mismatch error with both digests.
- Checksum parser exercised against bare / `digest  file` / `digest *file` / path-prefixed / CRLF / uppercase inputs (all accepted) and wrong filename / wrong digest / garbage / two-line inputs (all rejected).

Nothing was tagged, uploaded, or published while building this.

Fixes #443.
