### PR TITLE
chore(mcp): migrate to SDK v2 with legacy client compatibility

### DIFF
--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -3,12 +3,6 @@ import "dotenv/config";
 import { fileURLToPath } from "node:url";
 import { Command, Option } from "commander";
 import type { OptionValues } from "commander";
-// Allow `npx @steipete/oracle oracle-mcp` to resolve the MCP server even though npx runs the default binary.
-if (process.argv[2] === "oracle-mcp") {
-  const { startMcpServer } = await import("../src/mcp/server.js");
-  await startMcpServer();
-  process.exit(0);
-}
 import { resolveEngine, type EngineMode, defaultWaitPreference } from "../src/cli/engine.js";
 import { shouldRequirePrompt } from "../src/cli/promptRequirement.js";
 import { resolveDashPrompt } from "../src/cli/stdin.js";
@@ -2967,6 +2961,12 @@ program.action(async function (this: Command) {
 });
 
 async function main(): Promise<void> {
+  // npx runs the default binary; let the MCP transport own the alias lifetime.
+  if (process.argv[2] === "oracle-mcp") {
+    const { startMcpServer } = await import("../src/mcp/server.js");
+    await startMcpServer();
+    return;
+  }
   if (perfTraceArgs.error) {
     console.error(`error: ${perfTraceArgs.error}`);
     console.error("(use --help for usage)");

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -132,3 +132,14 @@ The MCP response includes `structuredContent.images[]` with the saved file path,
   - Claude Code with local macOS Chrome: `oracle bridge claude-config --local-browser > .mcp.json`
 - Tools and resources operate on the same session store as `oracle status|session`.
 - Defaults (model/engine/etc.) come from the effective Oracle CLI config; see `docs/configuration.md`, `~/.oracle/config.json`, and project `.oracle/config.json` files.
+
+### Lifecycle compatibility check
+
+After building, run `node scripts/mcp-lifecycle-proof.mjs` to exercise SDK v1,
+SDK v2 legacy, and SDK v2 modern clients through both executable entrypoints.
+It starts real detached CLI workers against a local API fixture and checks caller
+timeouts, request cancellation, transport reconnects, durable completion, and a
+single provider submission. The standard test suite also runs this matrix.
+For a real OpenAI run, add `--live-key-file <private-key-file>`; the harness uses
+an authenticated upstream request and delays its reply until the lifecycle
+assertions finish. This does not exercise signed-in browser execution.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -2,6 +2,8 @@
 
 `oracle-mcp` is a minimal MCP stdio server that mirrors the Oracle CLI. It shares session storage with the CLI (`~/.oracle/sessions` or `ORACLE_HOME_DIR`) so you can mix and match: run with the CLI, inspect or re-run via MCP, or vice versa.
 
+The server uses MCP SDK v2 and serves both modern and legacy protocol clients over stdio. Existing tool inputs, defaults, structured outputs, and `oracle-session://` resources are preserved. The SDK owns protocol negotiation and transport shutdown; the server definition is shared between protocol generations. HTTP transport, authentication, subscriptions, and protocol task APIs remain separate from this migration.
+
 ## Let Them Fight
 
 Claude Code can call `oracle-mcp` and ask a subscription-backed ChatGPT browser session for a second opinion. Use the `chatgpt-pro-heavy` preset when you want a compact MCP request that targets ChatGPT browser mode, the current Pro picker alias, and Pro Extended thinking time. The preset is intentionally boring at the API layer: it is a shortcut for existing browser-mode fields, not a new model id.

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@anthropic-ai/tokenizer": "^0.0.4",
     "@google/genai": "^2.21.0",
     "@google/generative-ai": "^0.24.1",
-    "@modelcontextprotocol/sdk": "^1.30.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "@steipete/sweet-cookie": "^0.4.2",
     "chalk": "^6.0.0",
     "chrome-launcher": "^1.2.1",
@@ -84,6 +84,8 @@
   },
   "devDependencies": {
     "@anthropic-ai/tokenizer": "^0.0.4",
+    "@modelcontextprotocol/client": "^2.0.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@types/chrome-remote-interface": "^0.34.0",
     "@types/inquirer": "^9.0.10",
     "@types/node": "^26.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,9 +25,9 @@ importers:
       '@google/generative-ai':
         specifier: ^0.24.1
         version: 0.24.1
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.30.0
-        version: 1.30.0(supports-color@10.2.2)(zod@4.5.4)
+      '@modelcontextprotocol/server':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@steipete/sweet-cookie':
         specifier: ^0.4.2
         version: 0.4.2
@@ -89,6 +89,12 @@ importers:
         specifier: ^4.5.4
         version: 4.5.4
     devDependencies:
+      '@modelcontextprotocol/client':
+        specifier: ^2.0.0
+        version: 2.0.0
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.30.0
+        version: 1.30.0(supports-color@10.2.2)(zod@4.5.4)
       '@types/chrome-remote-interface':
         specifier: ^0.34.0
         version: 0.34.0
@@ -474,6 +480,14 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@modelcontextprotocol/client@2.0.0':
+    resolution: {integrity: sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/core@2.0.0':
+    resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
+    engines: {node: '>=20'}
+
   '@modelcontextprotocol/sdk@1.30.0':
     resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
     engines: {node: '>=18'}
@@ -483,6 +497,10 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@modelcontextprotocol/server@2.0.0':
+    resolution: {integrity: sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==}
+    engines: {node: '>=20'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2721,6 +2739,20 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.6.0
 
+  '@modelcontextprotocol/client@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.1
+      jose: 6.2.10
+      pkce-challenge: 5.0.1
+      zod: 4.5.4
+
+  '@modelcontextprotocol/core@2.0.0':
+    dependencies:
+      zod: 4.5.4
+
   '@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.5.4)':
     dependencies:
       '@hono/node-server': 2.1.1(hono@4.13.5)
@@ -2742,6 +2774,11 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@4.5.4)
     transitivePeerDependencies:
       - supports-color
+
+  '@modelcontextprotocol/server@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      zod: 4.5.4
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:

--- a/scripts/mcp-lifecycle-proof.mjs
+++ b/scripts/mcp-lifecycle-proof.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+// Real built MCP/worker lifecycle matrix. Default: local Chat Completions fixture.
+// --live-key-file <path> forwards synthetic requests to OpenAI, holding replies
+// until the timeout/cancel/reconnect assertions have observed the live worker.
+import assert from "node:assert/strict";
+import http from "node:http";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client as LegacyClient } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport as LegacyTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { Client as ModernClient } from "@modelcontextprotocol/client";
+import { StdioClientTransport as ModernTransport } from "@modelcontextprotocol/client/stdio";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+const keyIndex = process.argv.indexOf("--live-key-file");
+const key =
+  keyIndex < 0 ? undefined : (await fs.readFile(process.argv[keyIndex + 1], "utf8")).trim();
+const clients = [
+  { name: "v1", Client: LegacyClient, Transport: LegacyTransport, modern: false },
+  { name: "v2-legacy", Client: ModernClient, Transport: ModernTransport, modern: false },
+  { name: "v2-modern", Client: ModernClient, Transport: ModernTransport, modern: true },
+];
+const results = [];
+for (const { name, Client, Transport, modern } of clients) {
+  for (const alias of [false, true]) {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-mcp-lifecycle-"));
+    let releaseResponse;
+    const responseGate = new Promise((resolve) => {
+      releaseResponse = resolve;
+    });
+    let receiveRequest;
+    let rejectRequest;
+    const requested = new Promise((resolve, reject) => {
+      receiveRequest = resolve;
+      rejectRequest = reject;
+    });
+    requested.catch(() => {});
+    let requests = 0;
+    let workerPid;
+    const marker = "ORACLE_MCP_LIFECYCLE_OK";
+    const server = http.createServer(async (req, res) => {
+      try {
+        assert.equal(req.url, "/v1/chat/completions");
+        assert.equal(req.method, "POST");
+        const chunks = [];
+        for await (const chunk of req) chunks.push(chunk);
+        const body = Buffer.concat(chunks).toString();
+        const request = JSON.parse(body);
+        assert.equal(request.model, "gpt-5.4");
+        assert.equal(request.stream, true);
+        requests += 1;
+        receiveRequest();
+        let responseBody;
+        let responseStatus = 200;
+        let contentType = "text/event-stream";
+        if (key) {
+          const upstream = await fetch("https://api.openai.com/v1/chat/completions", {
+            method: "POST",
+            signal: AbortSignal.timeout(60_000),
+            headers: { "Content-Type": "application/json", Authorization: `Bearer ${key}` },
+            body,
+          });
+          responseStatus = upstream.status;
+          contentType = upstream.headers.get("content-type") ?? contentType;
+          responseBody = Buffer.from(await upstream.arrayBuffer());
+        } else {
+          const chunk = {
+            id: "chatcmpl_fixture",
+            object: "chat.completion.chunk",
+            created: 1,
+            model: request.model,
+          };
+          responseBody =
+            [
+              {
+                ...chunk,
+                choices: [
+                  { index: 0, delta: { role: "assistant", content: marker }, finish_reason: null },
+                ],
+              },
+              {
+                ...chunk,
+                choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+                usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+              },
+            ]
+              .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+              .join("") + "data: [DONE]\n\n";
+        }
+        await responseGate;
+        res.writeHead(responseStatus, { "Content-Type": contentType });
+        res.end(responseBody);
+      } catch (error) {
+        rejectRequest(error);
+        res.writeHead(500);
+        res.end("Lifecycle proof upstream failed.");
+      }
+    });
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const env = Object.fromEntries(
+      Object.entries({
+        ...process.env,
+        ORACLE_HOME_DIR: home,
+        OPENAI_API_KEY: "synthetic-proof-key",
+        OPENAI_BASE_URL: `http://127.0.0.1:${server.address().port}/v1`,
+        ORACLE_DISABLE_KEYTAR: "1",
+        ORACLE_NO_DETACH: undefined,
+      }).filter(([, value]) => typeof value === "string"),
+    );
+    let client;
+    let transport;
+    const connect = async () => {
+      client = new Client(
+        { name: "oracle-lifecycle-proof", version: "1.0.0" },
+        modern ? { versionNegotiation: { mode: { pin: "2026-07-28" } } } : undefined,
+      );
+      transport = new Transport({
+        command: process.execPath,
+        args: alias
+          ? [path.join(root, "dist/bin/oracle-cli.js"), "oracle-mcp"]
+          : [path.join(root, "dist/bin/oracle-mcp.js")],
+        cwd: home,
+        env,
+        stderr: "pipe",
+      });
+      await client.connect(transport);
+      if (modern) assert.equal(client.getNegotiatedProtocolVersion(), "2026-07-28");
+      assert.ok((await client.listTools()).tools.some((tool) => tool.name === "wait"));
+    };
+    const call = (params, options) =>
+      name === "v1"
+        ? client.callTool(params, undefined, options)
+        : client.callTool(params, options);
+    try {
+      await connect();
+      const before = Date.now();
+      const started = await call({
+        name: "consult",
+        arguments: {
+          prompt: `Reply with exactly ${marker}.`,
+          model: "gpt-5.4",
+          engine: "api",
+          waitForCompletion: false,
+        },
+      });
+      assert.notEqual(started.isError, true, JSON.stringify(started));
+      assert.equal(started.structuredContent.detached, true);
+      const startMs = Date.now() - before;
+      const id = started.structuredContent.sessionId;
+      const readMeta = async () =>
+        JSON.parse(await fs.readFile(path.join(home, "sessions", id, "meta.json"), "utf8"));
+      workerPid = (await readMeta()).lifecycle.workerPid;
+      assert.ok(Number.isInteger(workerPid));
+      await Promise.race([
+        requested,
+        new Promise((_, reject) => {
+          const timer = setTimeout(
+            () => reject(new Error("Worker did not send its API request")),
+            15000,
+          );
+          timer.unref();
+        }),
+      ]);
+      const timeout = await call({ name: "wait", arguments: { id, timeoutMs: 20 } });
+      assert.equal(timeout.structuredContent.timedOut, true);
+      assert.equal((await readMeta()).status, "running");
+      const controller = new AbortController();
+      const cancelled = call(
+        { name: "wait", arguments: { id } },
+        {
+          signal: controller.signal,
+        },
+      );
+      const cancelledCheck = assert.rejects(cancelled);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      const abortStarted = Date.now();
+      controller.abort();
+      await cancelledCheck;
+      assert.ok(
+        Date.now() - abortStarted < 2000,
+        "Cancellation must not wait for the request timeout",
+      );
+      assert.equal((await readMeta()).status, "running");
+      process.kill(workerPid, 0);
+      // Closing while another waiter is pending must not take its worker down.
+      const interrupted = call({ name: "wait", arguments: { id } });
+      const interruptedCheck = assert.rejects(interrupted);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      await client.close();
+      await interruptedCheck;
+      process.kill(workerPid, 0);
+      assert.equal((await readMeta()).status, "running");
+      await connect();
+      releaseResponse();
+      const completed = await call(
+        { name: "wait", arguments: { id, timeoutMs: 120000 } },
+        { timeout: 130000 },
+      );
+      assert.equal(completed.structuredContent.status, "completed", JSON.stringify(completed));
+      assert.match(completed.structuredContent.output, new RegExp(marker));
+      assert.equal((await readMeta()).status, "completed");
+      assert.equal(requests, 1, "Timeout/cancellation/reconnect must not resubmit");
+      await client.close();
+      assert.equal(transport.pid, null);
+      results.push({
+        client: name,
+        entrypoint: alias ? "oracle oracle-mcp" : "oracle-mcp",
+        startMs,
+        waitTimeout: true,
+        cancellation: true,
+        reconnect: true,
+        completed: true,
+        requests,
+      });
+    } finally {
+      releaseResponse();
+      await client?.close();
+      if (workerPid) {
+        try {
+          process.kill(workerPid, "SIGTERM");
+        } catch {}
+      }
+      server.closeAllConnections();
+      await new Promise((resolve) => server.close(resolve));
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  }
+}
+console.log(
+  JSON.stringify(
+    {
+      provider: key ? "OpenAI via delayed-response proxy" : "local Chat Completions fixture",
+      results,
+    },
+    null,
+    2,
+  ),
+);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -2,8 +2,8 @@
 import "dotenv/config";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { McpServer } from "@modelcontextprotocol/server";
+import { serveStdio } from "@modelcontextprotocol/server/stdio";
 import { getCliVersion } from "../version.js";
 import { registerChatGptImageTool } from "./tools/chatgptImage.js";
 import { registerConsultTool } from "./tools/consult.js";
@@ -12,7 +12,7 @@ import { registerSessionsTool } from "./tools/sessions.js";
 import { registerWaitTool } from "./tools/wait.js";
 import { registerSessionResources } from "./tools/sessionResources.js";
 
-export async function startMcpServer(): Promise<void> {
+export function createMcpServer(): McpServer {
   const server = new McpServer(
     {
       name: "oracle-mcp",
@@ -31,20 +31,14 @@ export async function startMcpServer(): Promise<void> {
   registerSessionsTool(server);
   registerWaitTool(server);
   registerSessionResources(server);
+  return server;
+}
 
-  const transport = new StdioServerTransport();
-  transport.onerror = (error) => {
-    console.error("MCP transport error:", error);
-  };
-  const closed = new Promise<void>((resolve) => {
-    transport.onclose = () => {
-      resolve();
-    };
+export async function startMcpServer(): Promise<void> {
+  serveStdio(createMcpServer, {
+    legacy: "serve",
+    onerror: (error) => console.error("MCP transport error:", error),
   });
-
-  // Keep the process alive until the client closes the transport.
-  await server.connect(transport);
-  await closed;
 }
 
 export function shouldStartMcpServerFromModule(

--- a/src/mcp/tools/chatgptImage.ts
+++ b/src/mcp/tools/chatgptImage.ts
@@ -126,7 +126,7 @@ export function registerChatGptImageTool(server: McpServer): void {
       inputSchema: z.object(chatGptImageInputShape),
       outputSchema: z.object(chatGptImageOutputShape),
     },
-    async (input: unknown): Promise<CallToolResult> => {
+    async (input: unknown, context): Promise<CallToolResult> => {
       const textContent = (text: string) => [{ type: "text" as const, text }];
       let parsed;
       try {
@@ -138,7 +138,7 @@ export function registerChatGptImageTool(server: McpServer): void {
         };
       }
       const consultInput = buildChatGptImageConsultInput(parsed);
-      const result = await runConsultTool(consultInput, { server: server.server });
+      const result = await runConsultTool(consultInput, { log: context.mcpReq.log });
       if (result.isError || !result.structuredContent) {
         return result;
       }

--- a/src/mcp/tools/chatgptImage.ts
+++ b/src/mcp/tools/chatgptImage.ts
@@ -1,5 +1,4 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { McpServer, CallToolResult } from "@modelcontextprotocol/server";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
@@ -124,8 +123,8 @@ export function registerChatGptImageTool(server: McpServer): void {
       title: "Generate an image with ChatGPT",
       description:
         "Agent-friendly wrapper for ChatGPT browser image generation. It selects browser mode, enables the image-aware wait/download path, uploads reference files when provided, and returns saved image paths in structuredContent.images.",
-      inputSchema: chatGptImageInputShape,
-      outputSchema: chatGptImageOutputShape,
+      inputSchema: z.object(chatGptImageInputShape),
+      outputSchema: z.object(chatGptImageOutputShape),
     },
     async (input: unknown): Promise<CallToolResult> => {
       const textContent = (text: string) => [{ type: "text" as const, text }];

--- a/src/mcp/tools/consult.ts
+++ b/src/mcp/tools/consult.ts
@@ -1,10 +1,6 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, CallToolResult } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import { getCliVersion } from "../../version.js";
-import {
-  LoggingMessageNotificationParamsSchema,
-  type CallToolResult,
-} from "@modelcontextprotocol/sdk/types.js";
 import { ensureBrowserAvailable, mapConsultToRunOptions } from "../utils.js";
 import type { RunOracleOptions } from "../../oracle.js";
 import type { EngineMode } from "../../cli/engine.js";
@@ -46,7 +42,7 @@ import type { ThinkingTimeLevel } from "../../oracle/types.js";
 import { launchDetachedSession } from "../../cli/detachedSession.js";
 import { buildSessionLifecycle } from "../../cli/sessionLifecycle.js";
 
-// Use raw shapes so the MCP SDK (with its bundled Zod) wraps them and emits valid JSON Schema.
+// Shared fields are composed into explicit schemas when registering tools.
 const consultInputShape = {
   preset: z
     .enum(CONSULT_PRESETS)
@@ -592,12 +588,10 @@ export async function runConsultTool(
   const cwd = process.cwd();
   const sendLog = (text: string, level: "info" | "debug" = "info") =>
     server
-      .sendLoggingMessage(
-        LoggingMessageNotificationParamsSchema.parse({
-          level,
-          data: { text, bytes: Buffer.byteLength(text, "utf8") },
-        }),
-      )
+      .sendLoggingMessage({
+        level,
+        data: { text, bytes: Buffer.byteLength(text, "utf8") },
+      })
       .catch(() => {});
 
   const resolvedRemote = resolveRemoteServiceConfig({ userConfig, env: process.env });
@@ -851,9 +845,8 @@ export function registerConsultTool(server: McpServer): void {
       title: "Run an oracle session",
       description:
         'Run an Oracle session (API or ChatGPT browser automation). Use `files` to attach project context. If `engine` is omitted, Oracle follows CLI defaults: config/ORACLE_ENGINE first, then API when OPENAI_API_KEY is set, otherwise browser. Browser GPT-5.5 Pro consults can take many minutes; set `waitForCompletion:false` to return a durable sessionId immediately, then use `wait` to block without agent-side polling. Use `dryRun:true` first when configuring an agent and inspect `sessions`/`oracle status` before retrying. Browser manual-login uses a private Oracle Chrome profile separate from the user\'s normal Chrome; dry-run output includes first-time setup guidance when that path is active. For browser-based image/file uploads, set `browserAttachments:"always"`. For ChatGPT image generation, set `generateImage` to enable the same image wait/download path as CLI --generate-image and read returned paths from `images`. Browser consults can include `browserFollowUps` for a multi-turn ChatGPT review in one conversation. Sessions are stored under `ORACLE_HOME_DIR` (shared with the CLI).',
-      // Cast to any to satisfy SDK typings across differing Zod versions.
-      inputSchema: consultInputShape,
-      outputSchema: consultOutputShape,
+      inputSchema: z.object(consultInputShape),
+      outputSchema: z.object(consultOutputShape),
     },
     async (input: unknown) => runConsultTool(input, { server: server.server }),
   );

--- a/src/mcp/tools/consult.ts
+++ b/src/mcp/tools/consult.ts
@@ -516,7 +516,10 @@ export function formatConsultDryRunResolved(details: ConsultDryRunResolved): str
 
 export async function runConsultTool(
   input: unknown,
-  { log: requestLog, launchDetached = launchDetachedSession }: {
+  {
+    log: requestLog,
+    launchDetached = launchDetachedSession,
+  }: {
     log: ServerContext["mcpReq"]["log"];
     launchDetached?: typeof launchDetachedSession;
   },

--- a/src/mcp/tools/consult.ts
+++ b/src/mcp/tools/consult.ts
@@ -1,4 +1,4 @@
-import type { McpServer, CallToolResult } from "@modelcontextprotocol/server";
+import type { McpServer, CallToolResult, ServerContext } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import { getCliVersion } from "../../version.js";
 import { ensureBrowserAvailable, mapConsultToRunOptions } from "../utils.js";
@@ -514,15 +514,10 @@ export function formatConsultDryRunResolved(details: ConsultDryRunResolved): str
   return lines;
 }
 
-type McpLoggingServer = Pick<McpServer["server"], "sendLoggingMessage">;
-
 export async function runConsultTool(
   input: unknown,
-  {
-    server,
-    launchDetached = launchDetachedSession,
-  }: {
-    server: McpLoggingServer;
+  { log: requestLog, launchDetached = launchDetachedSession }: {
+    log: ServerContext["mcpReq"]["log"];
     launchDetached?: typeof launchDetachedSession;
   },
 ): Promise<CallToolResult> {
@@ -587,12 +582,7 @@ export async function runConsultTool(
   }
   const cwd = process.cwd();
   const sendLog = (text: string, level: "info" | "debug" = "info") =>
-    server
-      .sendLoggingMessage({
-        level,
-        data: { text, bytes: Buffer.byteLength(text, "utf8") },
-      })
-      .catch(() => {});
+    requestLog(level, { text, bytes: Buffer.byteLength(text, "utf8") }).catch(() => {});
 
   const resolvedRemote = resolveRemoteServiceConfig({ userConfig, env: process.env });
   const imageOutputPath = runOptions.generateImage ?? runOptions.outputPath;
@@ -848,6 +838,6 @@ export function registerConsultTool(server: McpServer): void {
       inputSchema: z.object(consultInputShape),
       outputSchema: z.object(consultOutputShape),
     },
-    async (input: unknown) => runConsultTool(input, { server: server.server }),
+    async (input: unknown, context) => runConsultTool(input, { log: context.mcpReq.log }),
   );
 }

--- a/src/mcp/tools/projectSources.ts
+++ b/src/mcp/tools/projectSources.ts
@@ -76,7 +76,7 @@ export function registerProjectSourcesTool(server: McpServer): void {
       inputSchema: z.object(projectSourcesInputShape),
       outputSchema: z.object(projectSourcesOutputShape),
     },
-    async (input: unknown) => {
+    async (input: unknown, context) => {
       const textContent = (text: string) => [{ type: "text" as const, text }];
       let parsed;
       try {
@@ -131,9 +131,7 @@ export function registerProjectSourcesTool(server: McpServer): void {
         dryRun: parsed.dryRun,
         config: browserConfig,
         log: (message) => {
-          server.server
-            .sendLoggingMessage({ level: "info", data: { text: message } })
-            .catch(() => undefined);
+          context.mcpReq.log("info", { text: message }).catch(() => undefined);
         },
       });
       const output =

--- a/src/mcp/tools/projectSources.ts
+++ b/src/mcp/tools/projectSources.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import { loadUserConfig } from "../../config.js";
 import { resolveRemoteServiceConfig } from "../../remote/remoteServiceConfig.js";
@@ -73,8 +73,8 @@ export function registerProjectSourcesTool(server: McpServer): void {
       title: "Manage ChatGPT Project Sources",
       description:
         "List or append files to a ChatGPT Project's persistent Sources tab. This is useful for Developer Mode workflows where chats do not share memory, but explicit project sources provide shared context. Destructive delete/replace/sync operations are intentionally not included in v1.",
-      inputSchema: projectSourcesInputShape,
-      outputSchema: projectSourcesOutputShape,
+      inputSchema: z.object(projectSourcesInputShape),
+      outputSchema: z.object(projectSourcesOutputShape),
     },
     async (input: unknown) => {
       const textContent = (text: string) => [{ type: "text" as const, text }];

--- a/src/mcp/tools/sessionResources.ts
+++ b/src/mcp/tools/sessionResources.ts
@@ -1,5 +1,4 @@
-import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ResourceTemplate, type McpServer } from "@modelcontextprotocol/server";
 import fs from "node:fs/promises";
 import { sessionStore } from "../../sessionStore.js";
 

--- a/src/mcp/tools/sessions.ts
+++ b/src/mcp/tools/sessions.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import { sessionStore } from "../../sessionStore.js";
 import { sessionsInputSchema } from "../types.js";
@@ -57,8 +57,8 @@ export function registerSessionsTool(server: McpServer): void {
       title: "List or fetch oracle sessions",
       description:
         "Inspect Oracle session history stored under `ORACLE_HOME_DIR` (shared with the CLI). List recent sessions or fetch one by id/slug (optionally including metadata + request + log).",
-      inputSchema: sessionsInputShape,
-      outputSchema: sessionsOutputShape,
+      inputSchema: z.object(sessionsInputShape),
+      outputSchema: z.object(sessionsOutputShape),
     },
     async (input: unknown) => {
       const textContent = (text: string) => [{ type: "text" as const, text }];

--- a/src/mcp/tools/wait.ts
+++ b/src/mcp/tools/wait.ts
@@ -1,8 +1,6 @@
 import { realpathSync, watch } from "node:fs";
 import type { FSWatcher } from "node:fs";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type { ServerNotification, ServerRequest } from "@modelcontextprotocol/sdk/types.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import type { SessionMetadata } from "../../sessionStore.js";
 import { sessionStore } from "../../sessionStore.js";
@@ -205,9 +203,7 @@ export async function waitForSessionTerminal(
   }
 }
 
-type McpToolExtra = RequestHandlerExtra<ServerRequest, ServerNotification>;
-
-export async function runWaitTool(input: unknown, extra?: Pick<McpToolExtra, "signal">) {
+export async function runWaitTool(input: unknown, extra?: { signal?: AbortSignal }) {
   const { id, timeoutMs } = waitInputSchema.parse(input);
   const result = await waitForSessionTerminal({ id, timeoutMs, signal: extra?.signal });
   const { metadata } = result;
@@ -236,9 +232,9 @@ export function registerWaitTool(server: McpServer): void {
       title: "Wait for an oracle session",
       description:
         "Wait for an existing Oracle session to reach a terminal state without agent-side polling. Omit timeoutMs to wait indefinitely, or set a bounded caller wait. Wait timeout or request cancellation never cancels the Oracle session; call wait again with the same id to continue waiting.",
-      inputSchema: waitInputShape,
-      outputSchema: waitOutputShape,
+      inputSchema: z.object(waitInputShape),
+      outputSchema: z.object(waitOutputShape),
     },
-    async (input: unknown, extra: McpToolExtra) => runWaitTool(input, extra),
+    async (input: unknown, context) => runWaitTool(input, { signal: context.mcpReq.signal }),
   );
 }

--- a/tests/mcp.integration.test.ts
+++ b/tests/mcp.integration.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { Client as LegacyClient } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport as LegacyTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { Client as ModernClient } from "@modelcontextprotocol/client";
+import { Client as ModernClient, LOG_LEVEL_META_KEY } from "@modelcontextprotocol/client";
 import { StdioClientTransport as ModernTransport } from "@modelcontextprotocol/client/stdio";
 
 describe.each([
@@ -65,6 +65,24 @@ describe.each([
       });
       expect(preview.isError).not.toBe(true);
       expect(preview.structuredContent).toMatchObject({ status: "dry-run", dryRun: true });
+      if (modern) {
+        const messages: unknown[] = [];
+        (client as ModernClient).setNotificationHandler("notifications/message", (notification) => {
+          messages.push(notification.params);
+        });
+        await client.callTool({
+          name: "consult",
+          arguments: { engine: "api", model: "gpt-5.4", prompt: "Quiet preview", dryRun: true },
+          _meta: { [LOG_LEVEL_META_KEY]: "error" },
+        });
+        expect(messages).toEqual([]);
+        await client.callTool({
+          name: "consult",
+          arguments: { engine: "api", model: "gpt-5.4", prompt: "Verbose preview", dryRun: true },
+          _meta: { [LOG_LEVEL_META_KEY]: "info" },
+        });
+        expect(messages.length).toBeGreaterThan(0);
+      }
       expect(await readdir(path.join(home, "sessions"))).toEqual(["compat-session"]);
       const templates = await client.listResourceTemplates();
       expect(templates.resourceTemplates.map((template) => template.uriTemplate)).toContain(

--- a/tests/mcp.integration.test.ts
+++ b/tests/mcp.integration.test.ts
@@ -1,39 +1,92 @@
-import { beforeAll, afterAll, describe, expect, it } from "vitest";
-import { spawn } from "node:child_process";
+import { describe, expect, test } from "vitest";
+import { mkdtemp, mkdir, writeFile, readdir, rm } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
-import { once } from "node:events";
+import { Client as LegacyClient } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport as LegacyTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { Client as ModernClient } from "@modelcontextprotocol/client";
+import { StdioClientTransport as ModernTransport } from "@modelcontextprotocol/client/stdio";
 
-function startOracleMcp(): { proc: ReturnType<typeof spawn>; waitReady: () => Promise<void> } {
-  const entry = path.join(process.cwd(), "dist/bin/oracle-mcp.js");
-  const proc = spawn(process.execPath, [entry], { stdio: ["pipe", "pipe", "pipe"] });
-  const waitReady = async () => {
-    // Give the stdio transport a moment to attach; MCP stdio has no explicit ready signal.
-    await new Promise((resolve) => setTimeout(resolve, 200));
-  };
-  return { proc, waitReady };
-}
-
-describe("oracle-mcp stdio smoke", () => {
-  let proc: ReturnType<typeof spawn>;
-
-  beforeAll(async () => {
-    // @ts-expect-error built artifact has no d.ts
-    await import("../dist/bin/oracle-mcp.js"); // ensure built artifacts exist
-    const started = startOracleMcp();
-    proc = started.proc;
-    await started.waitReady();
-  }, 30_000);
-
-  afterAll(async () => {
-    if (proc) {
-      const exitPromise = once(proc, "exit");
-      proc.kill("SIGTERM");
-      await Promise.race([exitPromise, new Promise((resolve) => setTimeout(resolve, 1000))]);
+describe.each([
+  { name: "SDK v1", Client: LegacyClient, Transport: LegacyTransport, modern: false },
+  { name: "SDK v2 legacy", Client: ModernClient, Transport: ModernTransport, modern: false },
+  { name: "SDK v2 modern", Client: ModernClient, Transport: ModernTransport, modern: true },
+])("oracle-mcp stdio compatibility: $name", ({ Client, Transport, modern }) => {
+  test("discovers tools, previews a consult, reads durable resources, and closes", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "oracle-mcp-compat-"));
+    const dir = path.join(home, "sessions", "compat-session");
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      path.join(dir, "meta.json"),
+      JSON.stringify({
+        id: "compat-session",
+        createdAt: new Date().toISOString(),
+        status: "completed",
+        model: "gpt-5.4",
+        mode: "api",
+        cwd: home,
+        options: { prompt: "Synthetic compatibility request", file: [], model: "gpt-5.4" },
+      }),
+    );
+    await writeFile(path.join(dir, "output.log"), "Synthetic compatibility answer\n");
+    await writeFile(
+      path.join(dir, "request.json"),
+      JSON.stringify({ prompt: "Synthetic compatibility request" }),
+    );
+    const client = new Client(
+      { name: "oracle-compatibility-proof", version: "1.0.0" },
+      modern ? { versionNegotiation: { mode: { pin: "2026-07-28" } } } : undefined,
+    );
+    const transport = new Transport({
+      command: process.execPath,
+      args: [path.join(process.cwd(), "dist/bin/oracle-mcp.js")],
+      env: { ...process.env, ORACLE_HOME_DIR: home, ORACLE_DISABLE_KEYTAR: "1" },
+      stderr: "pipe",
+    });
+    const errors: Error[] = [];
+    client.onerror = (error) => errors.push(error);
+    try {
+      await client.connect(transport);
+      if (modern) {
+        expect((client as ModernClient).getProtocolEra()).toBe("modern");
+        expect((client as ModernClient).getNegotiatedProtocolVersion()).toBe("2026-07-28");
+      }
+      const tools = await client.listTools();
+      expect(tools.tools.map((tool) => tool.name)).toEqual(
+        expect.arrayContaining(["consult", "chatgpt_image", "project_sources", "sessions"]),
+      );
+      for (const tool of tools.tools) {
+        expect(tool.inputSchema.type).toBe("object");
+        if (tool.outputSchema) expect(tool.outputSchema.type).toBe("object");
+      }
+      const preview = await client.callTool({
+        name: "consult",
+        arguments: { engine: "api", model: "gpt-5.4", prompt: "Synthetic preview", dryRun: true },
+      });
+      expect(preview.isError).not.toBe(true);
+      expect(preview.structuredContent).toMatchObject({ status: "dry-run", dryRun: true });
+      expect(await readdir(path.join(home, "sessions"))).toEqual(["compat-session"]);
+      const templates = await client.listResourceTemplates();
+      expect(templates.resourceTemplates.map((template) => template.uriTemplate)).toContain(
+        "oracle-session://{id}/{kind}",
+      );
+      const log = await client.readResource({ uri: "oracle-session://compat-session/log" });
+      expect(log.contents[0]).toMatchObject({ text: "Synthetic compatibility answer\n" });
+      const metadata = await client.readResource({
+        uri: "oracle-session://compat-session/metadata",
+      });
+      expect(JSON.parse((metadata.contents[0] as { text: string }).text)).toMatchObject({
+        id: "compat-session",
+        status: "completed",
+      });
+      expect(errors).toEqual([]);
+      const pid = transport.pid;
+      expect(pid).toBeTypeOf("number");
+      await client.close();
+      expect(transport.pid).toBeNull();
+    } finally {
+      await client.close();
+      await rm(home, { recursive: true, force: true });
     }
-  });
-
-  it("exposes stdio (process stays alive)", () => {
-    expect(proc.killed).toBe(false);
-    expect(proc.pid).toBeDefined();
-  });
+  }, 20_000);
 });

--- a/tests/mcp.integration.test.ts
+++ b/tests/mcp.integration.test.ts
@@ -7,104 +7,115 @@ import { StdioClientTransport as LegacyTransport } from "@modelcontextprotocol/s
 import { Client as ModernClient, LOG_LEVEL_META_KEY } from "@modelcontextprotocol/client";
 import { StdioClientTransport as ModernTransport } from "@modelcontextprotocol/client/stdio";
 
-describe.each([
-  { name: "SDK v1", Client: LegacyClient, Transport: LegacyTransport, modern: false },
-  { name: "SDK v2 legacy", Client: ModernClient, Transport: ModernTransport, modern: false },
-  { name: "SDK v2 modern", Client: ModernClient, Transport: ModernTransport, modern: true },
-])("oracle-mcp stdio compatibility: $name", ({ Client, Transport, modern }) => {
-  test("discovers tools, previews a consult, reads durable resources, and closes", async () => {
-    const home = await mkdtemp(path.join(os.tmpdir(), "oracle-mcp-compat-"));
-    const dir = path.join(home, "sessions", "compat-session");
-    await mkdir(dir, { recursive: true });
-    await writeFile(
-      path.join(dir, "meta.json"),
-      JSON.stringify({
-        id: "compat-session",
-        createdAt: new Date().toISOString(),
-        status: "completed",
-        model: "gpt-5.4",
-        mode: "api",
-        cwd: home,
-        options: { prompt: "Synthetic compatibility request", file: [], model: "gpt-5.4" },
-      }),
-    );
-    await writeFile(path.join(dir, "output.log"), "Synthetic compatibility answer\n");
-    await writeFile(
-      path.join(dir, "request.json"),
-      JSON.stringify({ prompt: "Synthetic compatibility request" }),
-    );
-    const client = new Client(
-      { name: "oracle-compatibility-proof", version: "1.0.0" },
-      modern ? { versionNegotiation: { mode: { pin: "2026-07-28" } } } : undefined,
-    );
-    const transport = new Transport({
-      command: process.execPath,
-      args: [path.join(process.cwd(), "dist/bin/oracle-mcp.js")],
-      env: { ...process.env, ORACLE_HOME_DIR: home, ORACLE_DISABLE_KEYTAR: "1" },
-      stderr: "pipe",
-    });
-    const errors: Error[] = [];
-    client.onerror = (error) => errors.push(error);
-    try {
-      await client.connect(transport);
-      if (modern) {
-        expect((client as ModernClient).getProtocolEra()).toBe("modern");
-        expect((client as ModernClient).getNegotiatedProtocolVersion()).toBe("2026-07-28");
-      }
-      const tools = await client.listTools();
-      expect(tools.tools.map((tool) => tool.name)).toEqual(
-        expect.arrayContaining(["consult", "chatgpt_image", "project_sources", "sessions"]),
+describe.each(
+  [
+    { name: "SDK v1", Client: LegacyClient, Transport: LegacyTransport, modern: false },
+    { name: "SDK v2 legacy", Client: ModernClient, Transport: ModernTransport, modern: false },
+    { name: "SDK v2 modern", Client: ModernClient, Transport: ModernTransport, modern: true },
+  ].flatMap((client) => ["standalone", "alias"].map((entrypoint) => ({ ...client, entrypoint }))),
+)(
+  "oracle-mcp stdio compatibility: $name / $entrypoint",
+  ({ Client, Transport, modern, entrypoint }) => {
+    test("discovers tools, previews a consult, reads durable resources, and closes", async () => {
+      const home = await mkdtemp(path.join(os.tmpdir(), "oracle-mcp-compat-"));
+      const dir = path.join(home, "sessions", "compat-session");
+      await mkdir(dir, { recursive: true });
+      await writeFile(
+        path.join(dir, "meta.json"),
+        JSON.stringify({
+          id: "compat-session",
+          createdAt: new Date().toISOString(),
+          status: "completed",
+          model: "gpt-5.4",
+          mode: "api",
+          cwd: home,
+          options: { prompt: "Synthetic compatibility request", file: [], model: "gpt-5.4" },
+        }),
       );
-      for (const tool of tools.tools) {
-        expect(tool.inputSchema.type).toBe("object");
-        if (tool.outputSchema) expect(tool.outputSchema.type).toBe("object");
-      }
-      const preview = await client.callTool({
-        name: "consult",
-        arguments: { engine: "api", model: "gpt-5.4", prompt: "Synthetic preview", dryRun: true },
-      });
-      expect(preview.isError).not.toBe(true);
-      expect(preview.structuredContent).toMatchObject({ status: "dry-run", dryRun: true });
-      if (modern) {
-        const messages: unknown[] = [];
-        (client as ModernClient).setNotificationHandler("notifications/message", (notification) => {
-          messages.push(notification.params);
-        });
-        await client.callTool({
-          name: "consult",
-          arguments: { engine: "api", model: "gpt-5.4", prompt: "Quiet preview", dryRun: true },
-          _meta: { [LOG_LEVEL_META_KEY]: "error" },
-        });
-        expect(messages).toEqual([]);
-        await client.callTool({
-          name: "consult",
-          arguments: { engine: "api", model: "gpt-5.4", prompt: "Verbose preview", dryRun: true },
-          _meta: { [LOG_LEVEL_META_KEY]: "info" },
-        });
-        expect(messages.length).toBeGreaterThan(0);
-      }
-      expect(await readdir(path.join(home, "sessions"))).toEqual(["compat-session"]);
-      const templates = await client.listResourceTemplates();
-      expect(templates.resourceTemplates.map((template) => template.uriTemplate)).toContain(
-        "oracle-session://{id}/{kind}",
+      await writeFile(path.join(dir, "output.log"), "Synthetic compatibility answer\n");
+      await writeFile(
+        path.join(dir, "request.json"),
+        JSON.stringify({ prompt: "Synthetic compatibility request" }),
       );
-      const log = await client.readResource({ uri: "oracle-session://compat-session/log" });
-      expect(log.contents[0]).toMatchObject({ text: "Synthetic compatibility answer\n" });
-      const metadata = await client.readResource({
-        uri: "oracle-session://compat-session/metadata",
+      const client = new Client(
+        { name: "oracle-compatibility-proof", version: "1.0.0" },
+        modern ? { versionNegotiation: { mode: { pin: "2026-07-28" } } } : undefined,
+      );
+      const transport = new Transport({
+        command: process.execPath,
+        args:
+          entrypoint === "alias"
+            ? [path.join(process.cwd(), "dist/bin/oracle-cli.js"), "oracle-mcp"]
+            : [path.join(process.cwd(), "dist/bin/oracle-mcp.js")],
+        env: { ...process.env, ORACLE_HOME_DIR: home, ORACLE_DISABLE_KEYTAR: "1" },
+        stderr: "pipe",
       });
-      expect(JSON.parse((metadata.contents[0] as { text: string }).text)).toMatchObject({
-        id: "compat-session",
-        status: "completed",
-      });
-      expect(errors).toEqual([]);
-      const pid = transport.pid;
-      expect(pid).toBeTypeOf("number");
-      await client.close();
-      expect(transport.pid).toBeNull();
-    } finally {
-      await client.close();
-      await rm(home, { recursive: true, force: true });
-    }
-  }, 20_000);
-});
+      const errors: Error[] = [];
+      client.onerror = (error) => errors.push(error);
+      try {
+        await client.connect(transport);
+        if (modern) {
+          expect((client as ModernClient).getProtocolEra()).toBe("modern");
+          expect((client as ModernClient).getNegotiatedProtocolVersion()).toBe("2026-07-28");
+        }
+        const tools = await client.listTools();
+        expect(tools.tools.map((tool) => tool.name)).toEqual(
+          expect.arrayContaining(["consult", "chatgpt_image", "project_sources", "sessions"]),
+        );
+        for (const tool of tools.tools) {
+          expect(tool.inputSchema.type).toBe("object");
+          if (tool.outputSchema) expect(tool.outputSchema.type).toBe("object");
+        }
+        const preview = await client.callTool({
+          name: "consult",
+          arguments: { engine: "api", model: "gpt-5.4", prompt: "Synthetic preview", dryRun: true },
+        });
+        expect(preview.isError).not.toBe(true);
+        expect(preview.structuredContent).toMatchObject({ status: "dry-run", dryRun: true });
+        if (modern) {
+          const messages: unknown[] = [];
+          (client as ModernClient).setNotificationHandler(
+            "notifications/message",
+            (notification) => {
+              messages.push(notification.params);
+            },
+          );
+          await client.callTool({
+            name: "consult",
+            arguments: { engine: "api", model: "gpt-5.4", prompt: "Quiet preview", dryRun: true },
+            _meta: { [LOG_LEVEL_META_KEY]: "error" },
+          });
+          expect(messages).toEqual([]);
+          await client.callTool({
+            name: "consult",
+            arguments: { engine: "api", model: "gpt-5.4", prompt: "Verbose preview", dryRun: true },
+            _meta: { [LOG_LEVEL_META_KEY]: "info" },
+          });
+          expect(messages.length).toBeGreaterThan(0);
+        }
+        expect(await readdir(path.join(home, "sessions"))).toEqual(["compat-session"]);
+        const templates = await client.listResourceTemplates();
+        expect(templates.resourceTemplates.map((template) => template.uriTemplate)).toContain(
+          "oracle-session://{id}/{kind}",
+        );
+        const log = await client.readResource({ uri: "oracle-session://compat-session/log" });
+        expect(log.contents[0]).toMatchObject({ text: "Synthetic compatibility answer\n" });
+        const metadata = await client.readResource({
+          uri: "oracle-session://compat-session/metadata",
+        });
+        expect(JSON.parse((metadata.contents[0] as { text: string }).text)).toMatchObject({
+          id: "compat-session",
+          status: "completed",
+        });
+        expect(errors).toEqual([]);
+        const pid = transport.pid;
+        expect(pid).toBeTypeOf("number");
+        await client.close();
+        expect(transport.pid).toBeNull();
+      } finally {
+        await client.close();
+        await rm(home, { recursive: true, force: true });
+      }
+    }, 20_000);
+  },
+);

--- a/tests/mcp.integration.test.ts
+++ b/tests/mcp.integration.test.ts
@@ -60,7 +60,13 @@ describe.each(
         }
         const tools = await client.listTools();
         expect(tools.tools.map((tool) => tool.name)).toEqual(
-          expect.arrayContaining(["consult", "chatgpt_image", "project_sources", "sessions"]),
+          expect.arrayContaining([
+            "consult",
+            "chatgpt_image",
+            "project_sources",
+            "sessions",
+            "wait",
+          ]),
         );
         for (const tool of tools.tools) {
           expect(tool.inputSchema.type).toBe("object");

--- a/tests/mcp.lifecycle.test.ts
+++ b/tests/mcp.lifecycle.test.ts
@@ -1,0 +1,29 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import path from "node:path";
+import { expect, test } from "vitest";
+
+const run = promisify(execFile);
+
+test("built MCP entrypoints preserve detached workers across caller lifecycle changes", async () => {
+  const { stdout } = await run(
+    process.execPath,
+    [path.join(process.cwd(), "scripts/mcp-lifecycle-proof.mjs")],
+    {
+      timeout: 90_000,
+      maxBuffer: 1024 * 1024,
+    },
+  );
+  const proof = JSON.parse(stdout);
+  expect(proof.provider).toBe("local Chat Completions fixture");
+  expect(proof.results).toHaveLength(6);
+  for (const result of proof.results) {
+    expect(result).toMatchObject({
+      waitTimeout: true,
+      cancellation: true,
+      reconnect: true,
+      completed: true,
+      requests: 1,
+    });
+  }
+}, 100_000);

--- a/tests/mcp/chatgptImage.test.ts
+++ b/tests/mcp/chatgptImage.test.ts
@@ -12,8 +12,12 @@ import { setOracleHomeDirOverrideForTest } from "../../src/oracleHome.js";
 function registerHandler(): (input: unknown) => Promise<unknown> {
   const handlers: Array<(input: unknown) => Promise<unknown>> = [];
   registerChatGptImageTool({
-    registerTool: (_name: string, _def: unknown, fn: (input: unknown) => Promise<unknown>) => {
-      handlers.push(fn);
+    registerTool: (
+      _name: string,
+      _def: unknown,
+      fn: (input: unknown, context: unknown) => Promise<unknown>,
+    ) => {
+      handlers.push((input) => fn(input, { mcpReq: { log: async () => undefined } }));
     },
     server: {
       sendLoggingMessage: async () => undefined,
@@ -55,10 +59,10 @@ describe("chatgpt_image MCP tool", () => {
       registerTool: (
         _name: string,
         def: unknown,
-        registeredHandler: (input: unknown) => Promise<unknown>,
+        registeredHandler: (input: unknown, context: unknown) => Promise<unknown>,
       ) => {
         inputSchema = (def as { inputSchema: z.ZodType }).inputSchema;
-        handler = registeredHandler;
+        handler = (input) => registeredHandler(input, { mcpReq: { log: async () => undefined } });
       },
       server: {
         sendLoggingMessage: async () => undefined,

--- a/tests/mcp/chatgptImage.test.ts
+++ b/tests/mcp/chatgptImage.test.ts
@@ -49,7 +49,7 @@ describe("chatgpt_image MCP tool", () => {
   });
 
   test("keeps the registered input schema discoverable and normalizes thinking aliases", async () => {
-    let inputSchema: z.ZodRawShape | undefined;
+    let inputSchema: z.ZodType | undefined;
     let handler: ((input: unknown) => Promise<unknown>) | undefined;
     registerChatGptImageTool({
       registerTool: (
@@ -57,7 +57,7 @@ describe("chatgpt_image MCP tool", () => {
         def: unknown,
         registeredHandler: (input: unknown) => Promise<unknown>,
       ) => {
-        inputSchema = (def as { inputSchema: z.ZodRawShape }).inputSchema;
+        inputSchema = (def as { inputSchema: z.ZodType }).inputSchema;
         handler = registeredHandler;
       },
       server: {
@@ -66,7 +66,7 @@ describe("chatgpt_image MCP tool", () => {
     } as unknown as Parameters<typeof registerChatGptImageTool>[0]);
 
     expect(inputSchema).toBeDefined();
-    expect(() => z.toJSONSchema(z.object(inputSchema!))).not.toThrow();
+    expect(() => z.toJSONSchema(inputSchema!)).not.toThrow();
     const result = (await handler?.({
       dryRun: true,
       prompt: "Create a small product mockup.",

--- a/tests/mcp/consult.test.ts
+++ b/tests/mcp/consult.test.ts
@@ -479,8 +479,12 @@ describe("summarizeModelRunsForConsult", () => {
     try {
       const handlers: Array<(input: unknown) => Promise<unknown>> = [];
       registerConsultTool({
-        registerTool: (_name: string, _def: unknown, fn: (input: unknown) => Promise<unknown>) => {
-          handlers.push(fn);
+        registerTool: (
+          _name: string,
+          _def: unknown,
+          fn: (input: unknown, context: unknown) => Promise<unknown>,
+        ) => {
+          handlers.push((input) => fn(input, { mcpReq: { log: async () => undefined } }));
         },
         server: {
           sendLoggingMessage: async () => undefined,
@@ -534,8 +538,12 @@ describe("summarizeModelRunsForConsult", () => {
     try {
       const handlers: Array<(input: unknown) => Promise<unknown>> = [];
       registerConsultTool({
-        registerTool: (_name: string, _def: unknown, fn: (input: unknown) => Promise<unknown>) => {
-          handlers.push(fn);
+        registerTool: (
+          _name: string,
+          _def: unknown,
+          fn: (input: unknown, context: unknown) => Promise<unknown>,
+        ) => {
+          handlers.push((input) => fn(input, { mcpReq: { log: async () => undefined } }));
         },
         server: {
           sendLoggingMessage: async () => undefined,
@@ -571,8 +579,12 @@ describe("summarizeModelRunsForConsult", () => {
     try {
       const handlers: Array<(input: unknown) => Promise<unknown>> = [];
       registerConsultTool({
-        registerTool: (_name: string, _def: unknown, fn: (input: unknown) => Promise<unknown>) => {
-          handlers.push(fn);
+        registerTool: (
+          _name: string,
+          _def: unknown,
+          fn: (input: unknown, context: unknown) => Promise<unknown>,
+        ) => {
+          handlers.push((input) => fn(input, { mcpReq: { log: async () => undefined } }));
         },
         server: { sendLoggingMessage: async () => undefined },
       } as unknown as Parameters<typeof registerConsultTool>[0]);
@@ -610,8 +622,12 @@ describe("summarizeModelRunsForConsult", () => {
     try {
       const handlers: Array<(input: unknown) => Promise<unknown>> = [];
       registerConsultTool({
-        registerTool: (_name: string, _def: unknown, fn: (input: unknown) => Promise<unknown>) => {
-          handlers.push(fn);
+        registerTool: (
+          _name: string,
+          _def: unknown,
+          fn: (input: unknown, context: unknown) => Promise<unknown>,
+        ) => {
+          handlers.push((input) => fn(input, { mcpReq: { log: async () => undefined } }));
         },
         server: { sendLoggingMessage: async () => undefined },
       } as unknown as Parameters<typeof registerConsultTool>[0]);
@@ -638,8 +654,12 @@ describe("summarizeModelRunsForConsult", () => {
   test("rejects unsupported consult fields instead of silently ignoring them", async () => {
     const handlers: Array<(input: unknown) => Promise<unknown>> = [];
     registerConsultTool({
-      registerTool: (_name: string, _def: unknown, fn: (input: unknown) => Promise<unknown>) => {
-        handlers.push(fn);
+      registerTool: (
+        _name: string,
+        _def: unknown,
+        fn: (input: unknown, context: unknown) => Promise<unknown>,
+      ) => {
+        handlers.push((input) => fn(input, { mcpReq: { log: async () => undefined } }));
       },
       server: {
         sendLoggingMessage: async () => undefined,

--- a/tests/mcp/consult.test.ts
+++ b/tests/mcp/consult.test.ts
@@ -155,10 +155,10 @@ describe("summarizeModelRunsForConsult", () => {
   });
 
   test("keeps the registered MCP input schema JSON-schema compatible", () => {
-    let inputSchema: z.ZodRawShape | undefined;
+    let inputSchema: z.ZodType | undefined;
     registerConsultTool({
       registerTool: (_name: string, def: unknown) => {
-        inputSchema = (def as { inputSchema: z.ZodRawShape }).inputSchema;
+        inputSchema = (def as { inputSchema: z.ZodType }).inputSchema;
       },
       server: {
         sendLoggingMessage: async () => undefined,
@@ -166,7 +166,7 @@ describe("summarizeModelRunsForConsult", () => {
     } as unknown as Parameters<typeof registerConsultTool>[0]);
 
     expect(inputSchema).toBeDefined();
-    expect(() => z.toJSONSchema(z.object(inputSchema!))).not.toThrow();
+    expect(() => z.toJSONSchema(inputSchema!)).not.toThrow();
   });
 
   test("maps per-model metadata into consult summaries", () => {

--- a/tests/mcp/consult.test.ts
+++ b/tests/mcp/consult.test.ts
@@ -40,7 +40,7 @@ describe("summarizeModelRunsForConsult", () => {
           waitForCompletion: false,
         },
         {
-          server: { sendLoggingMessage: vi.fn(async () => undefined) },
+          log: vi.fn(async () => undefined),
           launchDetached: launchDetached as never,
         },
       );
@@ -89,7 +89,7 @@ describe("summarizeModelRunsForConsult", () => {
           dryRun: true,
         },
         {
-          server: { sendLoggingMessage: vi.fn(async () => undefined) },
+          log: vi.fn(async () => undefined),
           launchDetached: launchDetached as never,
         },
       );
@@ -159,9 +159,6 @@ describe("summarizeModelRunsForConsult", () => {
     registerConsultTool({
       registerTool: (_name: string, def: unknown) => {
         inputSchema = (def as { inputSchema: z.ZodType }).inputSchema;
-      },
-      server: {
-        sendLoggingMessage: async () => undefined,
       },
     } as unknown as Parameters<typeof registerConsultTool>[0]);
 
@@ -486,9 +483,6 @@ describe("summarizeModelRunsForConsult", () => {
         ) => {
           handlers.push((input) => fn(input, { mcpReq: { log: async () => undefined } }));
         },
-        server: {
-          sendLoggingMessage: async () => undefined,
-        },
       } as unknown as Parameters<typeof registerConsultTool>[0]);
       const handler = handlers[0];
       if (!handler) throw new Error("handler not registered");
@@ -545,9 +539,6 @@ describe("summarizeModelRunsForConsult", () => {
         ) => {
           handlers.push((input) => fn(input, { mcpReq: { log: async () => undefined } }));
         },
-        server: {
-          sendLoggingMessage: async () => undefined,
-        },
       } as unknown as Parameters<typeof registerConsultTool>[0]);
       const handler = handlers[0];
       if (!handler) throw new Error("handler not registered");
@@ -586,7 +577,6 @@ describe("summarizeModelRunsForConsult", () => {
         ) => {
           handlers.push((input) => fn(input, { mcpReq: { log: async () => undefined } }));
         },
-        server: { sendLoggingMessage: async () => undefined },
       } as unknown as Parameters<typeof registerConsultTool>[0]);
       const handler = handlers[0];
       if (!handler) throw new Error("handler not registered");
@@ -629,7 +619,6 @@ describe("summarizeModelRunsForConsult", () => {
         ) => {
           handlers.push((input) => fn(input, { mcpReq: { log: async () => undefined } }));
         },
-        server: { sendLoggingMessage: async () => undefined },
       } as unknown as Parameters<typeof registerConsultTool>[0]);
       const handler = handlers[0];
       if (!handler) throw new Error("handler not registered");
@@ -660,9 +649,6 @@ describe("summarizeModelRunsForConsult", () => {
         fn: (input: unknown, context: unknown) => Promise<unknown>,
       ) => {
         handlers.push((input) => fn(input, { mcpReq: { log: async () => undefined } }));
-      },
-      server: {
-        sendLoggingMessage: async () => undefined,
       },
     } as unknown as Parameters<typeof registerConsultTool>[0]);
     const handler = handlers[0];

--- a/tests/mcp/projectSources.test.ts
+++ b/tests/mcp/projectSources.test.ts
@@ -40,8 +40,12 @@ describe("project_sources MCP tool", () => {
     runBrowserProjectSources.mockClear();
     sendLoggingMessage.mockClear();
     registerProjectSourcesTool({
-      registerTool: (_name: string, _def: unknown, fn: (input: unknown) => Promise<unknown>) => {
-        handler = fn;
+      registerTool: (
+        _name: string,
+        _def: unknown,
+        fn: (input: unknown, context: unknown) => Promise<unknown>,
+      ) => {
+        handler = (input) => fn(input, { mcpReq: { log: sendLoggingMessage } });
       },
       server: { sendLoggingMessage },
     } as unknown as Parameters<typeof registerProjectSourcesTool>[0]);

--- a/tests/mcp/wait.test.ts
+++ b/tests/mcp/wait.test.ts
@@ -6,6 +6,7 @@ import type { SessionMetadata } from "../../src/sessionStore.js";
 import { sessionStore } from "../../src/sessionStore.js";
 import { setOracleHomeDirOverrideForTest } from "../../src/oracleHome.js";
 import {
+  registerWaitTool,
   runWaitTool,
   waitForSessionTerminal,
   type SessionChangeSource,
@@ -141,6 +142,21 @@ describe("waitForSessionTerminal", () => {
     );
     expect(source.create).not.toHaveBeenCalled();
   });
+});
+
+test("the registered waiter observes the SDK v2 request cancellation signal", async () => {
+  let handler: ((input: unknown, context: unknown) => Promise<unknown>) | undefined;
+  registerWaitTool({
+    registerTool: (_name: string, _schema: unknown, callback: typeof handler) => {
+      handler = callback;
+    },
+  } as never);
+  const controller = new AbortController();
+  const reason = new Error("request was cancelled");
+  controller.abort(reason);
+  await expect(handler!({ id: "unused" }, { mcpReq: { signal: controller.signal } })).rejects.toBe(
+    reason,
+  );
 });
 
 describe("wait MCP result", () => {


### PR DESCRIPTION
Fixes #360.

Migrate the existing MCP server to SDK v2 while preserving legacy clients, tool/resource contracts, both executable entrypoints, and the detached consultations/waits now landed in #430. The wait handler reads the SDK v2 request signal; consultation progress uses request-scoped logging. A caller timeout, cancellation, or transport shutdown never cancels the detached worker.

The compatibility matrix covers SDK v1, SDK v2 legacy, and SDK v2 pinned to 2026-07-28, each through standalone oracle-mcp and the oracle oracle-mcp alias. The built worker matrix checks wait timeout, explicit cancellation, an interrupted waiter, reconnect, durable completion, and exactly one provider request. It runs automatically in the suite against a local API fixture and was also run against real OpenAI through a delayed-response proxy.

Validation: 2,064 tests passed, 43 skipped; typecheck/lint/build/docs passed. All six real API lifecycle scenarios passed, returning the detached session within 33 ms. Final review and CI links are in the proof comment. Signed-in browser execution is outside this API lifecycle proof.

This branch is rebased onto main with #458, #430, #406, #460, #461, and #383 already landed. Changelog entries remain in #462, which must land afterward. No merge or release is performed here.
