### PR TITLE
feat(skills): add an explicit-transport Oracle advisor

### DIFF
--- a/docs/advisor.md
+++ b/docs/advisor.md
@@ -1,0 +1,32 @@
+# Transport-explicit advisory consultations
+
+The optional `oracle-advisor` skill separates the advisory request from the
+transport used to execute it. It reuses Oracle's current CLI/MCP integration;
+the existing `oracle` skill remains available unchanged.
+
+| Transport      | Execution today                                            | Evidence and recovery                                                                              |
+| -------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| API            | An authorized configured provider, selected explicitly     | Stored session, provider route, response and usage metadata; inspect before retrying               |
+| Browser        | Authorized signed-in ChatGPT or supported browser provider | Stored session and available conversation/selection evidence; reattach after an incomplete capture |
+| Render         | Local context bundle for manual handoff                    | Bundle only; no automatic answer, completion claim, or session reference                           |
+| Native desktop | Not implemented                                            | A shared desktop UI does not establish a supported delegation capability                           |
+
+An advisory request specifies its prompt/files, allowed transport, required
+model/effort, output contract, and fresh-versus-follow-up intent. Its result
+includes the answer or incomplete state, available durable references,
+requested and observed/effective settings, selection evidence, and uncertainty.
+These are reporting requirements for the skill, not a new executable schema.
+
+Unavailable transport and unsatisfied model/effort constraints remain visible.
+An already authorized fallback can be used; otherwise the caller chooses it.
+The advisory model does not acquire permission to edit the repository.
+
+Future native execution would require a documented callable interface with
+model/effort control, submission, completion, result reading, and durable
+references. No private desktop protocol or native adapter is part of this
+skill. HTTP protocols, new MCP tools, and core backend abstractions are also
+outside this change.
+
+Copy `skills/oracle-advisor` from the source repository into the host's skill
+directory, just as for the existing skill. See [Coding Agents](agents.md) for
+host setup and [MCP](mcp.md) for the current tools.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -18,6 +18,12 @@ Drop this into the project's `AGENTS.md` or `CLAUDE.md`:
 
 That's enough for most agents to discover and use Oracle correctly. The patterns below cover the deeper integrations.
 
+For explicit API/browser/render selection and per-run model/effort provenance,
+use the optional `skills/oracle-advisor` companion skill instead. It reuses the
+existing backends and does not implement native desktop delegation. See
+[Advisory consultations](advisor.md) for its capability boundary and result
+contract. The existing `skills/oracle` workflow remains available unchanged.
+
 ## Claude Code
 
 ### As an MCP server (recommended)

--- a/skills/oracle-advisor/SKILL.md
+++ b/skills/oracle-advisor/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: oracle-advisor
+description: Request a second-model consultation with explicit API, browser, or render transport and per-run provenance. Use when transport choice or model/effort evidence is part of the request; the existing oracle skill remains the browser-first workflow.
+---
+
+# Oracle advisor
+
+Use Oracle to ask an advisory model about selected context. The advisor returns
+advice; the calling agent remains responsible for checking it and making edits.
+This skill reuses the existing Oracle CLI and MCP tools. It does not add a new
+command, MCP method, or native desktop adapter.
+
+## Select the allowed transport
+
+Honor the caller's transport, model, effort, files, output requirements, and
+choice of a fresh consultation or an explicit follow-up. Existing authorization
+persists; do not ask again when a permitted route is already clear.
+
+- **API:** use an explicitly configured and authorized provider. Pass
+  `--engine api` and the requested model; preserve required reasoning settings.
+- **Browser:** use the authorized signed-in browser route. Pass
+  `--engine browser`; confirm the requested model and effort through Oracle's
+  selection evidence. Browser availability alone does not authorize a fallback.
+- **Render:** use `--render` to prepare a bundle for manual handoff. This creates
+  no model answer or completed consultation; report the bundle as ready to send.
+- **Native desktop:** unavailable in this skill. Chat, Work, and Codex sharing a
+  UI is not evidence of an agent-callable delegation interface. Do not improvise
+  private IPC, cookie extraction, or UI automation as a native adapter.
+
+If the requested route is unavailable, use an alternative only when the caller
+has already allowed it. Otherwise explain the missing capability and ask for
+the transport choice. Never silently reduce the required model or effort.
+
+## Run the consultation
+
+Inspect `oracle --help --verbose` for the installed version. For an execution
+route, preview the exact bundle with the chosen engine and `--dry-run full`;
+for render, inspect the rendered bundle directly. Use `--files-report` for token
+estimates. A preview's predicted route is not execution evidence. Include the problem,
+relevant constraints, and the requested answer format in the prompt. Send only
+the selected task context, with credentials excluded.
+
+Examples using an installed Oracle:
+
+```bash
+oracle --engine api --model gpt-5.4 --wait \
+  --prompt "Review this package metadata for compatibility risks." --file package.json
+
+oracle --engine browser --model gpt-5.6-sol --browser-thinking-time pro \
+  --prompt "Review this package metadata for compatibility risks." --file package.json
+
+oracle --render \
+  --prompt "Review this package metadata for compatibility risks." --file package.json
+```
+
+MCP callers can use `consult` with explicit `engine`, `model`, and browser
+controls, and inspect `sessions` with `detail:true`. If a call detaches or times
+out, inspect its existing session before retrying; do not create a duplicate
+consultation. Use `--followup <session-id>` only when continuing that conversation
+is intended. Preserve a browser conversation with the existing explicit
+archive/keep controls when the caller requests it.
+
+## Return evidence with the advice
+
+Keep required model and effort separate. Report the answer (or the incomplete state), transport, session reference,
+available conversation reference, requested model/effort, observed or effective
+values, and the evidence supporting each observation. Use session metadata and
+logs; mark missing observations as unknown.
+
+A configured API model is a requested/effective route, not independent proof of
+the backend that served it. A browser picker label proves UI selection, not
+server-side execution identity. A completed answer alone cannot prove an effort
+constraint. If a required constraint is contradicted or remains unverified,
+report that the consultation did not satisfy it, even if text was returned.
+
+Keep uncertainty attached to the relevant claim. Verify the advice against the
+repository and tests before acting on it.


### PR DESCRIPTION
Fixes #355 (the approved companion-skill phase).

Add `oracle-advisor` alongside the existing Oracle skill. It reuses current API, browser, and render commands with explicit transport selection and per-run provenance. Required model and effort remain distinct; unverified or contradicted requirements remain visible even when an answer completed. Native desktop execution is not implemented or inferred from a shared UI.

The capability document and agent setup guide explain the boundary. No existing skill, CLI default, MCP method, or backend is replaced. Changelog credit is collected in the final notes PR.

Validation: skill validator and docs/help checks pass; the built CLI validates the browser preview and generates the render bundle. An independent forward test honored a render-only fallback and produced the exact package.json bundle without provider/browser execution; a completed High-effort result was correctly reported as failing a required Pro constraint. Existing API commands have real-provider proof in this pass. Autoreview through P2 is clean on the final candidate.

Thanks @genforAI for the RFC.
