### PR TITLE
fix(browser): preserve and report harvest identity conflicts

### DIFF
--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -136,6 +136,20 @@ oracle status --clear --hours 168   # delete sessions older than a week
 
 Every run gets a default slug derived from the prompt. Override with `--slug "my-thing"` for stable names you can reference later (`oracle session my-thing`).
 
+## Browser harvest identity
+
+Browser harvest and live-tail compare the observed conversation with saved
+runtime, archive, artifact-source, and transcript-header identities. A mismatch
+is retained under `browser.harvest.integrity` and shown as a browser warning;
+an implicit harvest fails with `conversation-identity-mismatch` before exporting
+the newly harvested answer. Existing transcripts and answer logs are preserved.
+
+An explicit `--browser-tab` override still permits inspecting another target,
+but records the mismatch and does not reassign the original capture. Unavailable
+recorded transcript headers or unreadable recorded conversation URLs are marked
+`unverified`. Matching known conversation IDs
+does not by itself prove that an answer belongs to the original prompt.
+
 ## Naming conventions
 
 Pair `--slug` with conventional prefixes for browseability:

--- a/src/cli/browserTabs.ts
+++ b/src/cli/browserTabs.ts
@@ -7,7 +7,6 @@ import {
   collectChatGptTabs,
   DEFAULT_REMOTE_CHROME_HOST,
   DEFAULT_REMOTE_CHROME_PORT,
-  extractConversationIdFromUrl,
   formatBrowserTabState,
   harvestChatGptTab,
   sessionMatchesTab,
@@ -18,6 +17,8 @@ import {
   recoverConversationTab,
 } from "../browser/recoverConversation.js";
 import { resolveOutputPath } from "./writeOutputPath.js";
+import { persistBrowserHarvest } from "./harvestIntegrity.js";
+import type { BrowserHarvestIntegrity } from "../sessionManager.js";
 
 const LIVE_POLL_MS = 2000;
 const DEFAULT_STALL_THRESHOLD_MS = 60_000;
@@ -156,40 +157,27 @@ export function resolveSessionTabRefForTest(meta: SessionMetadata): string {
   return resolveSessionTabRef(meta);
 }
 
-async function persistHarvest(
+function printHarvestSummary(
   sessionId: string,
-  meta: SessionMetadata,
   harvested: ChatGptTabSummary,
-): Promise<void> {
-  const hash = createHash("sha1")
-    .update(harvested.lastAssistantMarkdown ?? harvested.lastAssistantText ?? "")
-    .digest("hex");
-  const browser = {
-    ...(meta.browser ?? {}),
-    harvest: {
-      targetId: harvested.targetId,
-      url: harvested.url,
-      conversationId: harvested.conversationId ?? extractConversationIdFromUrl(harvested.url),
-      harvestedAt: new Date().toISOString(),
-      assistantHash: hash,
-      state: harvested.state,
-      stopExists: harvested.stopExists,
-      sendExists: harvested.sendExists,
-      assistantCount: harvested.assistantCount,
-      currentModelLabel: harvested.currentModelLabel,
-      lastAssistantSnippet: harvested.lastAssistantSnippet,
-    },
-  };
-  await sessionStore.updateSession(sessionId, { browser });
-}
-
-function printHarvestSummary(sessionId: string, harvested: ChatGptTabSummary): void {
+  integrity: BrowserHarvestIntegrity,
+): void {
   console.log(chalk.bold(`Session: ${sessionId}`));
   console.log(`Target: ${harvested.targetId}`);
   console.log(`State: ${formatBrowserTabState(harvested)}`);
   console.log(`Model: ${harvested.currentModelLabel || "(unknown)"}`);
   console.log(`URL: ${harvested.url}`);
   console.log(`Assistant turns: ${harvested.assistantCount}`);
+  console.log(
+    `Capture identity: ${integrity.status}${integrity.explicitTarget ? " (explicit target)" : ""}`,
+  );
+  if (integrity.status === "mismatch") {
+    console.log(
+      chalk.yellow(
+        "Explicit harvest target differs from the saved capture; original artifacts are unchanged.",
+      ),
+    );
+  }
   console.log(
     `Signals: stop=${harvested.stopExists ? "yes" : "no"} send=${harvested.sendExists ? "yes" : "no"}`,
   );
@@ -304,8 +292,12 @@ export async function harvestSessionBrowserOutput(
       });
     }
 
-    await persistHarvest(sessionId, meta, harvested);
-    printHarvestSummary(sessionId, harvested);
+    const integrity = await persistBrowserHarvest(
+      sessionId,
+      harvested,
+      Boolean(options.browserTabRef),
+    );
+    printHarvestSummary(sessionId, harvested, integrity);
     const output = harvested.lastAssistantMarkdown ?? harvested.lastAssistantText ?? "";
     if (options.writeOutputPath) {
       await maybeWriteHarvestOutput(options.writeOutputPath, meta.cwd ?? process.cwd(), output);
@@ -393,8 +385,8 @@ export async function liveTailSessionBrowserOutput(
           `[${new Date().toISOString()}] state=${harvested.state} stop=${harvested.stopExists ? "yes" : "no"} ` +
           `send=${harvested.sendExists ? "yes" : "no"} model=${harvested.currentModelLabel || "(unknown)"} ` +
           `snippet=${snippet(harvested.lastAssistantSnippet || fullText, 160)}`;
+        await persistBrowserHarvest(sessionId, harvested, Boolean(options.browserTabRef));
         console.log(statusLine);
-        await persistHarvest(sessionId, meta, harvested);
       }
 
       const derivedState = harvested.stopExists
@@ -414,8 +406,12 @@ export async function liveTailSessionBrowserOutput(
           ...harvested,
           state: derivedState,
         };
-        await persistHarvest(sessionId, meta, finalHarvest);
-        printHarvestSummary(sessionId, finalHarvest);
+        const integrity = await persistBrowserHarvest(
+          sessionId,
+          finalHarvest,
+          Boolean(options.browserTabRef),
+        );
+        printHarvestSummary(sessionId, finalHarvest, integrity);
         const output = finalHarvest.lastAssistantMarkdown ?? finalHarvest.lastAssistantText ?? "";
         if (options.writeOutputPath) {
           await maybeWriteHarvestOutput(options.writeOutputPath, meta.cwd ?? process.cwd(), output);

--- a/src/cli/harvestIntegrity.ts
+++ b/src/cli/harvestIntegrity.ts
@@ -9,7 +9,7 @@ import { BrowserAutomationError } from "../oracle/errors.js";
 
 const INTEGRITY_WARNING = "browser-harvest-integrity";
 const INTEGRITY_MESSAGE =
-  "Harvested conversation differs from the saved capture. Original artifacts were preserved; inspect browser.harvest.integrity before using the answer.";
+  "Harvest or saved conversation identities conflict. Original artifacts were preserved; inspect browser.harvest.integrity before using the answer.";
 
 async function readTranscriptConversation(filename: string): Promise<string | undefined> {
   let file;
@@ -89,10 +89,13 @@ export async function persistBrowserHarvest(
 
   const observedConversationId =
     harvested.conversationId ?? extractConversationIdFromUrl(harvested.url);
-  const mismatch = Boolean(
-    observedConversationId &&
-    captured.some((entry) => entry.conversationId !== observedConversationId),
-  );
+  const capturedIds = new Set(captured.map((entry) => entry.conversationId));
+  const previousIntegrity = meta.browser?.harvest?.integrity;
+  const mismatch =
+    capturedIds.size > 1 ||
+    (observedConversationId
+      ? captured.some((entry) => entry.conversationId !== observedConversationId)
+      : previousIntegrity?.status === "mismatch");
   const integrity: BrowserHarvestIntegrity = {
     status: mismatch
       ? "mismatch"
@@ -103,7 +106,8 @@ export async function persistBrowserHarvest(
     captured,
     unverifiedSources,
     explicitTarget,
-    previousHarvestConversationId: meta.browser?.harvest?.conversationId,
+    previousHarvestConversationId:
+      meta.browser?.harvest?.conversationId ?? previousIntegrity?.previousHarvestConversationId,
   };
   const warnings = (meta.browser?.warnings ?? []).filter(
     (warning) => warning.code !== INTEGRITY_WARNING,

--- a/src/cli/harvestIntegrity.ts
+++ b/src/cli/harvestIntegrity.ts
@@ -1,0 +1,144 @@
+import fs from "node:fs/promises";
+import { constants } from "node:fs";
+import path from "node:path";
+import { createHash } from "node:crypto";
+import { sessionStore } from "../sessionStore.js";
+import type { BrowserHarvestIntegrity } from "../sessionManager.js";
+import { extractConversationIdFromUrl, type ChatGptTabSummary } from "../browser/liveTabs.js";
+import { BrowserAutomationError } from "../oracle/errors.js";
+
+const INTEGRITY_WARNING = "browser-harvest-integrity";
+const INTEGRITY_MESSAGE =
+  "Harvested conversation differs from the saved capture. Original artifacts were preserved; inspect browser.harvest.integrity before using the answer.";
+
+async function readTranscriptConversation(filename: string): Promise<string | undefined> {
+  let file;
+  try {
+    const stat = await fs.lstat(filename);
+    if (!stat.isFile() || stat.isSymbolicLink()) return undefined;
+    file = await fs.open(filename, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+    if (!(await file.stat()).isFile()) return undefined;
+    const buffer = Buffer.alloc(2_048);
+    const { bytesRead } = await file.read(buffer, 0, buffer.length, 0);
+    const match = buffer
+      .subarray(0, bytesRead)
+      .toString("utf8")
+      .match(/^# Oracle Browser Transcript\r?\n\r?\nConversation: ([^\r\n]+)\r?\n/);
+    return match ? extractConversationIdFromUrl(match[1]) : undefined;
+  } catch {
+    return undefined;
+  } finally {
+    await file?.close();
+  }
+}
+
+export async function persistBrowserHarvest(
+  sessionId: string,
+  harvested: ChatGptTabSummary,
+  explicitTarget = false,
+): Promise<BrowserHarvestIntegrity> {
+  // Harvesting can take time; compare against the latest saved capture, not the initial read.
+  const meta = await sessionStore.readSession(sessionId);
+  if (!meta) throw new Error(`No session found with ID ${sessionId}.`);
+  const captured: BrowserHarvestIntegrity["captured"] = [];
+  const unverifiedSources: string[] = [];
+  const add = (source: string, id: string | undefined) => {
+    if (id) captured.push({ source, conversationId: id });
+  };
+  const addUrl = (source: string, url: string | undefined, expectsConversation = true) => {
+    if (!url) return;
+    const id = extractConversationIdFromUrl(url);
+    add(source, id);
+    if (!id && expectsConversation) unverifiedSources.push(source);
+  };
+  add("runtime", meta.browser?.runtime?.conversationId);
+  addUrl("runtime-url", meta.browser?.runtime?.tabUrl);
+  addUrl("archive", meta.browser?.archive?.conversationUrl);
+  for (const [index, artifact] of (meta.artifacts ?? []).entries()) {
+    addUrl(
+      `artifact:${index}`,
+      artifact.sourceUrl,
+      artifact.kind === "transcript" || artifact.kind === "deep-research-report",
+    );
+  }
+
+  const artifactDir = path.join((await sessionStore.getPaths(sessionId)).dir, "artifacts");
+  const directoryStat = await fs.lstat(artifactDir).catch(() => null);
+  if (directoryStat?.isDirectory() && !directoryStat.isSymbolicLink()) {
+    const transcripts = new Map([[path.join(artifactDir, "transcript.md"), false]]);
+    for (const artifact of meta.artifacts ?? []) {
+      if (artifact.kind !== "transcript") continue;
+      const candidate = path.isAbsolute(artifact.path)
+        ? artifact.path
+        : path.resolve(artifactDir, "..", artifact.path);
+      // Stored paths must remain direct children of this session's artifact directory.
+      if (path.dirname(candidate) === artifactDir) transcripts.set(candidate, true);
+      else unverifiedSources.push("external-transcript-path");
+    }
+    for (const [filename, expected] of transcripts) {
+      const source = `transcript:${path.basename(filename)}`;
+      const id = await readTranscriptConversation(filename);
+      add(source, id);
+      if (!id && (expected || (await fs.lstat(filename).catch(() => null)))) {
+        unverifiedSources.push(source);
+      }
+    }
+  } else if (directoryStat || meta.artifacts?.some((artifact) => artifact.kind === "transcript")) {
+    unverifiedSources.push("artifact-directory");
+  }
+
+  const observedConversationId =
+    harvested.conversationId ?? extractConversationIdFromUrl(harvested.url);
+  const mismatch = Boolean(
+    observedConversationId &&
+    captured.some((entry) => entry.conversationId !== observedConversationId),
+  );
+  const integrity: BrowserHarvestIntegrity = {
+    status: mismatch
+      ? "mismatch"
+      : observedConversationId && captured.length && unverifiedSources.length === 0
+        ? "matched"
+        : "unverified",
+    observedConversationId,
+    captured,
+    unverifiedSources,
+    explicitTarget,
+    previousHarvestConversationId: meta.browser?.harvest?.conversationId,
+  };
+  const warnings = (meta.browser?.warnings ?? []).filter(
+    (warning) => warning.code !== INTEGRITY_WARNING,
+  );
+  if (mismatch) {
+    warnings.push({ code: INTEGRITY_WARNING, severity: "warning", message: INTEGRITY_MESSAGE });
+  }
+  await sessionStore.updateSession(sessionId, {
+    browser: {
+      ...meta.browser,
+      warnings,
+      harvest: {
+        targetId: harvested.targetId,
+        url: harvested.url,
+        conversationId: observedConversationId,
+        harvestedAt: new Date().toISOString(),
+        assistantHash: createHash("sha1")
+          .update(harvested.lastAssistantMarkdown ?? harvested.lastAssistantText ?? "")
+          .digest("hex"),
+        state: harvested.state,
+        stopExists: harvested.stopExists,
+        sendExists: harvested.sendExists,
+        assistantCount: harvested.assistantCount,
+        currentModelLabel: harvested.currentModelLabel,
+        lastAssistantSnippet: harvested.lastAssistantSnippet,
+        integrity,
+      },
+    },
+  });
+  if (mismatch && !explicitTarget) {
+    throw new BrowserAutomationError(INTEGRITY_MESSAGE, {
+      stage: "harvest-integrity",
+      code: "conversation-identity-mismatch",
+      integrity,
+    });
+  }
+  return integrity;
+}

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -106,6 +106,15 @@ export interface BrowserRuntimeMetadata {
 
 export type BrowserHarvestState = "running" | "completed" | "stalled" | "detached";
 
+export interface BrowserHarvestIntegrity {
+  status: "matched" | "mismatch" | "unverified";
+  observedConversationId?: string;
+  captured: Array<{ source: string; conversationId: string }>;
+  unverifiedSources: string[];
+  explicitTarget: boolean;
+  previousHarvestConversationId?: string;
+}
+
 export interface BrowserHarvestMetadata {
   targetId?: string;
   url?: string;
@@ -118,6 +127,7 @@ export interface BrowserHarvestMetadata {
   assistantCount?: number;
   currentModelLabel?: string;
   lastAssistantSnippet?: string;
+  integrity?: BrowserHarvestIntegrity;
 }
 
 export type BrowserModelSelectionEvidenceStatus =

--- a/tests/cli/browserTabsRecover.test.ts
+++ b/tests/cli/browserTabsRecover.test.ts
@@ -1,5 +1,12 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
 import type { SessionMetadata } from "../../src/sessionStore.js";
+
+const getPaths = async () => ({
+  dir: path.join(os.tmpdir(), `oracle-recovery-mock-${randomUUID()}`),
+});
 
 const baseMeta = {
   id: "sess-recover",
@@ -80,7 +87,7 @@ describe("harvestSessionBrowserOutput recovery fallback", () => {
       recoverConversationTab,
     }));
     vi.doMock("../../src/sessionStore.js", () => ({
-      sessionStore: { readSession, updateSession },
+      sessionStore: { readSession, updateSession, getPaths },
     }));
 
     const { harvestSessionBrowserOutput } = await import("../../src/cli/browserTabs.js");
@@ -125,7 +132,7 @@ describe("harvestSessionBrowserOutput recovery fallback", () => {
       recoverConversationTab,
     }));
     vi.doMock("../../src/sessionStore.js", () => ({
-      sessionStore: { readSession: async () => baseMeta, updateSession: async () => {} },
+      sessionStore: { readSession: async () => baseMeta, updateSession: async () => {}, getPaths },
     }));
 
     const { harvestSessionBrowserOutput } = await import("../../src/cli/browserTabs.js");
@@ -164,7 +171,7 @@ describe("harvestSessionBrowserOutput recovery fallback", () => {
       recoverConversationTab,
     }));
     vi.doMock("../../src/sessionStore.js", () => ({
-      sessionStore: { readSession: async () => baseMeta, updateSession: async () => {} },
+      sessionStore: { readSession: async () => baseMeta, updateSession: async () => {}, getPaths },
     }));
 
     const { harvestSessionBrowserOutput } = await import("../../src/cli/browserTabs.js");
@@ -199,7 +206,7 @@ describe("harvestSessionBrowserOutput recovery fallback", () => {
       })),
     }));
     vi.doMock("../../src/sessionStore.js", () => ({
-      sessionStore: { readSession: async () => baseMeta, updateSession: async () => {} },
+      sessionStore: { readSession: async () => baseMeta, updateSession: async () => {}, getPaths },
     }));
 
     const { harvestSessionBrowserOutput } = await import("../../src/cli/browserTabs.js");
@@ -230,7 +237,7 @@ describe("harvestSessionBrowserOutput recovery fallback", () => {
       recoverConversationTab,
     }));
     vi.doMock("../../src/sessionStore.js", () => ({
-      sessionStore: { readSession: async () => baseMeta, updateSession: async () => {} },
+      sessionStore: { readSession: async () => baseMeta, updateSession: async () => {}, getPaths },
     }));
 
     const { harvestSessionBrowserOutput } = await import("../../src/cli/browserTabs.js");

--- a/tests/cli/harvestIntegrity.test.ts
+++ b/tests/cli/harvestIntegrity.test.ts
@@ -102,6 +102,51 @@ describe("harvest capture identity", () => {
     });
   });
 
+  test("detects contradictory saved identities even on the first unidentified harvest", async () => {
+    const saved = await seed("harvest-b", "capture-a");
+    const unidentified = {
+      ...observed("harvest-b"),
+      conversationId: undefined,
+      url: "https://chatgpt.com/",
+    };
+    await expect(persistBrowserHarvest(saved.id, unidentified)).rejects.toMatchObject({
+      details: { code: "conversation-identity-mismatch" },
+    });
+  });
+
+  test.each(["capture-a", "harvest-b"])(
+    "retains known conflicts after unidentified harvests (runtime %s)",
+    async (runtimeId) => {
+      const saved = await seed(runtimeId, "capture-a");
+      await expect(persistBrowserHarvest(saved.id, observed("harvest-b"))).rejects.toMatchObject({
+        details: { code: "conversation-identity-mismatch" },
+      });
+      const unidentified = {
+        ...observed("harvest-b"),
+        conversationId: undefined,
+        url: "https://chatgpt.com/",
+      };
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        await expect(persistBrowserHarvest(saved.id, unidentified, true)).resolves.toMatchObject({
+          status: "mismatch",
+          previousHarvestConversationId: "harvest-b",
+        });
+        const meta = await sessionStore.readSession(saved.id);
+        expect(
+          meta?.browser?.warnings?.filter(
+            (warning) => warning.code === "browser-harvest-integrity",
+          ),
+        ).toHaveLength(1);
+        expect(meta?.status).toBe("completed");
+      }
+      await expect(persistBrowserHarvest(saved.id, unidentified)).rejects.toMatchObject({
+        details: { code: "conversation-identity-mismatch" },
+      });
+      expect(await fs.readFile(saved.transcript, "utf8")).toBe(saved.body);
+      expect(await fs.readFile(saved.paths.log, "utf8")).toBe("Original answer\n");
+    },
+  );
+
   test("allows an explicit target while retaining the conflict and original capture", async () => {
     const saved = await seed("capture-a");
     await expect(

--- a/tests/cli/harvestIntegrity.test.ts
+++ b/tests/cli/harvestIntegrity.test.ts
@@ -1,0 +1,188 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { persistBrowserHarvest } from "../../src/cli/harvestIntegrity.js";
+import { sessionStore } from "../../src/sessionStore.js";
+import { setOracleHomeDirOverrideForTest } from "../../src/oracleHome.js";
+import type { ChatGptTabSummary } from "../../src/browser/liveTabs.js";
+
+const url = (id: string) => `https://chatgpt.com/c/${id}`;
+function observed(id: string): ChatGptTabSummary {
+  return {
+    targetId: "new-target",
+    url: url(id),
+    conversationId: id,
+    state: "completed",
+    authenticated: true,
+    stopExists: false,
+    sendExists: true,
+    assistantCount: 1,
+    currentModelLabel: "Synthetic model",
+    lastAssistantMarkdown: "New harvest answer",
+    lastAssistantText: "New harvest answer",
+    lastAssistantSnippet: "New harvest answer",
+  } as ChatGptTabSummary;
+}
+
+describe("harvest capture identity", () => {
+  let home: string;
+  beforeEach(async () => {
+    home = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-harvest-integrity-"));
+    setOracleHomeDirOverrideForTest(home);
+  });
+  afterEach(async () => {
+    setOracleHomeDirOverrideForTest(null);
+    await fs.rm(home, { recursive: true, force: true });
+  });
+
+  async function seed(recordedId: string, transcriptId = recordedId) {
+    const meta = await sessionStore.createSession(
+      { prompt: "Synthetic original prompt", file: [], model: "gpt-5.5", mode: "browser" },
+      home,
+    );
+    const paths = await sessionStore.getPaths(meta.id);
+    await fs.mkdir(path.join(paths.dir, "artifacts"), { recursive: true });
+    const transcript = path.join(paths.dir, "artifacts", "transcript.md");
+    const body = `# Oracle Browser Transcript\n\nConversation: ${url(transcriptId)}\n\n## Answer\nOriginal answer\n`;
+    await fs.writeFile(transcript, body);
+    await fs.writeFile(paths.log, "Original answer\n");
+    await sessionStore.updateSession(meta.id, {
+      status: "completed",
+      browser: {
+        runtime: {
+          conversationId: recordedId,
+          tabUrl: url(recordedId),
+          chromeTargetId: "original-target",
+        },
+        archive: {
+          mode: "never",
+          attempted: false,
+          archived: false,
+          conversationUrl: url(recordedId),
+        },
+        warnings: [{ code: "existing", severity: "warning", message: "Existing warning" }],
+      },
+      artifacts: [{ kind: "transcript", path: transcript, sourceUrl: url(recordedId) }],
+    });
+    return { id: meta.id, paths, transcript, body };
+  }
+
+  test("persists both identities and refuses an implicit mismatch without replacing saved output", async () => {
+    const saved = await seed("capture-a");
+    await expect(persistBrowserHarvest(saved.id, observed("harvest-b"))).rejects.toMatchObject({
+      details: { stage: "harvest-integrity", code: "conversation-identity-mismatch" },
+    });
+    const meta = await sessionStore.readSession(saved.id);
+    expect(meta?.browser?.runtime?.conversationId).toBe("capture-a");
+    expect(meta?.browser?.harvest?.integrity).toMatchObject({
+      status: "mismatch",
+      observedConversationId: "harvest-b",
+      explicitTarget: false,
+      captured: expect.arrayContaining([{ source: "runtime", conversationId: "capture-a" }]),
+    });
+    expect(meta?.browser?.warnings?.map((warning) => warning.code)).toEqual([
+      "existing",
+      "browser-harvest-integrity",
+    ]);
+    expect(await fs.readFile(saved.transcript, "utf8")).toBe(saved.body);
+    expect(await fs.readFile(saved.paths.log, "utf8")).toBe("Original answer\n");
+  });
+
+  test("detects a conflicting transcript even when all metadata agrees with the harvest", async () => {
+    const saved = await seed("harvest-b", "capture-a");
+    await expect(persistBrowserHarvest(saved.id, observed("harvest-b"))).rejects.toMatchObject({
+      details: {
+        integrity: {
+          captured: expect.arrayContaining([
+            { source: "transcript:transcript.md", conversationId: "capture-a" },
+          ]),
+        },
+      },
+    });
+  });
+
+  test("allows an explicit target while retaining the conflict and original capture", async () => {
+    const saved = await seed("capture-a");
+    await expect(
+      persistBrowserHarvest(saved.id, observed("harvest-b"), true),
+    ).resolves.toMatchObject({
+      status: "mismatch",
+      explicitTarget: true,
+    });
+    expect((await sessionStore.readSession(saved.id))?.browser?.runtime?.chromeTargetId).toBe(
+      "original-target",
+    );
+    expect(await fs.readFile(saved.transcript, "utf8")).toBe(saved.body);
+  });
+
+  test("matches known identities and preserves unrelated warnings", async () => {
+    const saved = await seed("capture-a");
+    await expect(persistBrowserHarvest(saved.id, observed("capture-a"))).resolves.toMatchObject({
+      status: "matched",
+    });
+    expect(
+      (await sessionStore.readSession(saved.id))?.browser?.warnings?.map((warning) => warning.code),
+    ).toEqual(["existing"]);
+  });
+
+  test("marks unreadable provenance unverified instead of claiming an identity match", async () => {
+    const saved = await seed("capture-a");
+    await fs.writeFile(saved.transcript, "An unrecognized transcript format\n");
+    await expect(persistBrowserHarvest(saved.id, observed("capture-a"))).resolves.toMatchObject({
+      status: "unverified",
+      unverifiedSources: ["transcript:transcript.md"],
+    });
+  });
+
+  test("does not inspect a transcript path outside this session's artifact directory", async () => {
+    const saved = await seed("capture-a");
+    const outside = path.join(home, "outside.md");
+    await fs.writeFile(outside, saved.body.replaceAll("capture-a", "other-b"));
+    await sessionStore.updateSession(saved.id, {
+      artifacts: [{ kind: "transcript", path: outside, sourceUrl: url("capture-a") }],
+    });
+    await expect(persistBrowserHarvest(saved.id, observed("capture-a"))).resolves.toMatchObject({
+      status: "unverified",
+      unverifiedSources: ["external-transcript-path"],
+    });
+  });
+
+  test("does not claim a match when a recorded conversation URL is unreadable", async () => {
+    const saved = await seed("capture-a");
+    const meta = await sessionStore.readSession(saved.id);
+    await sessionStore.updateSession(saved.id, {
+      browser: {
+        ...meta?.browser,
+        archive: {
+          mode: "never",
+          attempted: false,
+          archived: false,
+          conversationUrl: "unreadable",
+        },
+      },
+    });
+    await expect(persistBrowserHarvest(saved.id, observed("capture-a"))).resolves.toMatchObject({
+      status: "unverified",
+      unverifiedSources: ["archive"],
+    });
+  });
+
+  test("does not treat image download URLs as malformed conversation provenance", async () => {
+    const saved = await seed("capture-a");
+    const meta = await sessionStore.readSession(saved.id);
+    await sessionStore.updateSession(saved.id, {
+      artifacts: [
+        ...(meta?.artifacts ?? []),
+        {
+          kind: "image",
+          path: "artifacts/image.png",
+          sourceUrl: "https://chatgpt.com/backend-api/estuary/content?id=file-synthetic",
+        },
+      ],
+    });
+    await expect(persistBrowserHarvest(saved.id, observed("capture-a"))).resolves.toMatchObject({
+      status: "matched",
+    });
+  });
+});


### PR DESCRIPTION
Fixes #442.

A later harvest can agree with current runtime metadata while the saved transcript belongs to another conversation. Compare the latest stored runtime/archive/artifact identities and bounded transcript headers with the observed harvest. Retain both identities under `browser.harvest.integrity` and preserve the original files. An implicit mismatch now fails before exporting the new answer; an explicit `--browser-tab` override remains usable but records the conflict and shows a warning.

Recorded provenance that cannot be checked is `unverified`. Download URLs are not mistaken for conversation URLs, and transcript reads stay inside the session's artifact directory. Contradictory saved identities are checked even without a new conversation ID, and repeated unidentified observations cannot clear a previously established mismatch. Existing session status values are preserved, and the normal session viewer displays the durable warning.

Validation: 2,004 tests passed, 43 skipped; typecheck/lint/build/docs checks pass. A real-filesystem run of the built persistence owner reproduced the issue where metadata agrees but the transcript header differs, retained the original transcript/log, and made the warning visible through the built CLI. Explicit-target inspection remained allowed. Independent autoreview through P2 is clean on the final candidate.

This detects the inconsistent stored result; it does not establish or fix the first cross-session ownership divergence reported in #390. Changelog credit is collected in the final notes PR. Thanks @postoso for the paired forensic evidence.

