### PR TITLE
chore(release): consolidate pending notes and refresh DevTools types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - MCP: start local consultations with opt-in detached workers and wait for durable completion without cancelling the run when a client times out, cancels a wait, or reconnects. Fixes #429; thanks @oraclexing.
 - MCP: support the modern 2026-07-28 protocol through SDK v2 while preserving legacy stdio clients, tool contracts, session resources, and request-scoped progress logging. Fixes #360; thanks @fredluz.
+- Browser: preserve shared Chrome across concurrent manual-login controllers, verify final lease ownership before shutdown, and harden lock recovery against transient process probes; thanks @oraclexing.
+- Browser: wait for effort slider controls to mount and become visible before selecting the requested tier; thanks @ShunmeiCho.
 - Browser: detect when a later harvest conflicts with saved conversation identities, preserve the original transcript and answer, and record explicit manual target overrides. Fixes #442; thanks @postoso.
 - Browser: fail promptly on known English Retry failures, preserve manual recovery, and keep waiting while generation remains active; apply the same guard to image output and response recovery. Fixes #457; thanks @developerisnow.
 - Gemini: update the web request protocol and model headers, preserve raw image-download fallbacks, report upstream and oversized-header failures clearly, and add an opt-in refusal of model fallback; thanks @mpeter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Browser: detect when a later harvest conflicts with saved conversation identities, preserve the original transcript and answer, and record explicit manual target overrides. Fixes #442; thanks @postoso.
 - Browser: fail promptly on known English Retry failures, preserve manual recovery, and keep waiting while generation remains active; apply the same guard to image output and response recovery. Fixes #457; thanks @developerisnow.
 - Gemini: update the web request protocol and model headers, preserve raw image-download fallbacks, report upstream and oversized-header failures clearly, and add an opt-in refusal of model fallback; thanks @mpeter.
+- Browser: bundle multiple source uploads while preserving native attachments and the existing auto format, negotiate deferred fallback bundling with remote hosts, and remove generated files after success, failure, or preparation timeout; thanks @tristanmanchester.
 - Agents: add the optional oracle-advisor skill with explicit API, browser, or render routing and per-run model/effort provenance, while retaining the existing Oracle skill. Fixes #355; thanks @genforAI.
 - Browser: wait for explicit upload state to clear before completing attachments or sending; ignore unrelated activity, hidden indicators, and filenames that resemble status text. Fixes #446; thanks @HJC704.
 - Browser: retain per-file attachment evidence, including filename-less images, and stabilize the send target without replaying a dispatched prompt. Fixes #418; thanks @hubofvalley.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 ## Unreleased
 
-- Release: attach the npm tarball and its checksums to the GitHub Release and verify them before the Homebrew tap updates, so the formula no longer points at a missing asset. Fixes #443.
+**Highlights:** Durable detached MCP consultations, modern and legacy MCP client support, and clearer browser capture failures with preserved recovery evidence.
 
-## 0.18.1 - 2026-09-05
-
-**Highlights:** More reliable browser uploads, strict remote-tab isolation, and broader support for ChatGPT's current thinking controls.
-
+- MCP: start local consultations with opt-in detached workers and wait for durable completion without cancelling the run when a client times out, cancels a wait, or reconnects. Fixes #429; thanks @oraclexing.
+- MCP: support the modern 2026-07-28 protocol through SDK v2 while preserving legacy stdio clients, tool contracts, session resources, and request-scoped progress logging. Fixes #360; thanks @fredluz.
+- Browser: detect when a later harvest conflicts with saved conversation identities, preserve the original transcript and answer, and record explicit manual target overrides. Fixes #442; thanks @postoso.
+- Browser: fail promptly on known English Retry failures, preserve manual recovery, and keep waiting while generation remains active; apply the same guard to image output and response recovery. Fixes #457; thanks @developerisnow.
+- Gemini: update the web request protocol and model headers, preserve raw image-download fallbacks, report upstream and oversized-header failures clearly, and add an opt-in refusal of model fallback; thanks @mpeter.
+- Agents: add the optional oracle-advisor skill with explicit API, browser, or render routing and per-run model/effort provenance, while retaining the existing Oracle skill. Fixes #355; thanks @genforAI.
 - Browser: wait for explicit upload state to clear before completing attachments or sending; ignore unrelated activity, hidden indicators, and filenames that resemble status text. Fixes #446; thanks @HJC704.
 - Browser: retain per-file attachment evidence, including filename-less images, and stabilize the send target without replaying a dispatched prompt. Fixes #418; thanks @hubofvalley.
 - Browser: refuse default-tab fallback when an ordinary remote run cannot create or attach its dedicated tab; thanks @ShunmeiCho.
@@ -27,7 +29,8 @@
 - Browser: restore visible macOS Chrome windows to their prior placement only when Oracle recorded that placement before hiding them.
 - CLI: keep dry-run previews free of session side effects.
 - Remote: advertise only addresses on which the service is listening.
-- Dependencies: refresh provider SDKs, browser and terminal utilities, schema/query tooling, development dependencies, pnpm, and Pages actions; update OpenAI to 7.10, Google GenAI to 2.21, Inquirer to 14.2.1, Puppeteer to 25.10, Fast URI to 4.1.4, and Vitest to 5 while retaining Node >=24 and the two-day release-age policy.
+- Release: attach the npm tarball and its checksums to the GitHub Release and verify them before the Homebrew tap updates, so the formula no longer points at a missing asset. Fixes #443.
+- Dependencies: refresh provider SDKs, browser and terminal utilities, schema/query tooling, development dependencies, pnpm, and Pages actions; update OpenAI to 7.10, Google GenAI to 2.21, Inquirer to 14.2.1, Puppeteer to 25.10, Fast URI to 4.1.4, Vitest to 5, and Chrome DevTools protocol to 0.0.1692173 while retaining Node >=24 and the two-day release-age policy.
 
 ## 0.18.0 — 2026-08-14
 

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@types/inquirer": "^9.0.10",
     "@types/node": "^26.4.1",
     "@vitest/coverage-v8": "5.0.0",
-    "devtools-protocol": "0.0.1691330",
+    "devtools-protocol": "0.0.1692173",
     "es-toolkit": "^1.52.0",
     "esbuild": "^0.28.2",
     "oxfmt": "0.66.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  devtools-protocol: 0.0.1691330
+  devtools-protocol: 0.0.1692173
   hono: 4.13.5
   '@hono/node-server': 2.1.1
   fast-uri: 4.1.4
@@ -108,8 +108,8 @@ importers:
         specifier: 5.0.0
         version: 5.0.0(vitest@5.0.0)
       devtools-protocol:
-        specifier: 0.0.1691330
-        version: 0.0.1691330
+        specifier: 0.0.1692173
+        version: 0.0.1692173
       es-toolkit:
         specifier: ^1.52.0
         version: 1.52.0
@@ -1205,7 +1205,7 @@ packages:
     resolution: {integrity: sha512-5v9GQFhTktFvotn/OFNJBmKLKRAb6n9r0bVCwf7sHgWc3/JryK0bj1nn93L3pHFrfgcsu6Be6EWsDi+1XHTGDg==}
     engines: {node: '>=20.19.0 <22.0.0 || >=22.12.0'}
     peerDependencies:
-      devtools-protocol: 0.0.1691330
+      devtools-protocol: 0.0.1692173
 
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
@@ -1297,8 +1297,8 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  devtools-protocol@0.0.1691330:
-    resolution: {integrity: sha512-OfaeaWlWpHppJz5Y+75+X+l7rzDkMVOITQZUkYNN7xmAnFk10sjUj/z/vymuyK4aQBimeImX39Y+LuRpMWi+ag==}
+  devtools-protocol@0.0.1692173:
+    resolution: {integrity: sha512-Bdn2rAjjjPz5v5e0Hn9SKju6DDfEt3xWqA0OT65vIr39VCLvpoEy8BRx+2g085ZuPKcJO8gcZgzvUi7Pya93yg==}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -3013,7 +3013,7 @@ snapshots:
 
   '@types/chrome-remote-interface@0.34.0':
     dependencies:
-      devtools-protocol: 0.0.1691330
+      devtools-protocol: 0.0.1692173
 
   '@types/deep-eql@4.0.2': {}
 
@@ -3236,9 +3236,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  chromium-bidi@17.0.2(devtools-protocol@0.0.1691330):
+  chromium-bidi@17.0.2(devtools-protocol@0.0.1692173):
     dependencies:
-      devtools-protocol: 0.0.1691330
+      devtools-protocol: 0.0.1692173
       mitt: 3.0.1
       zod: 3.25.76
 
@@ -3316,7 +3316,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  devtools-protocol@0.0.1691330: {}
+  devtools-protocol@0.0.1692173: {}
 
   dotenv@17.4.2: {}
 
@@ -4047,8 +4047,8 @@ snapshots:
   puppeteer-core@25.10.0:
     dependencies:
       '@puppeteer/browsers': 3.2.2
-      chromium-bidi: 17.0.2(devtools-protocol@0.0.1691330)
-      devtools-protocol: 0.0.1691330
+      chromium-bidi: 17.0.2(devtools-protocol@0.0.1692173)
+      devtools-protocol: 0.0.1692173
       typed-query-selector: 2.12.2
       webdriver-bidi-protocol: 0.4.3
       ws: 8.21.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 overrides:
-  devtools-protocol: 0.0.1691330
+  devtools-protocol: 0.0.1692173
   hono: 4.13.5
   "@hono/node-server": 2.1.1
   fast-uri: 4.1.4


### PR DESCRIPTION
Rebased onto main after #459, #451, and #445 landed. The delta contains only CHANGELOG.md, package.json, pnpm-workspace.yaml, and pnpm-lock.yaml.

Unreleased retains Highlights, the seven earlier phase-two implementations, and earlier unpublished release notes. It now includes the landed shared-Chrome controller-lifetime repair (thanks @oraclexing) and effort-control readiness repair (thanks @ShunmeiCho), placed near the top by user impact. Released history is unchanged. No entry claims the pending #431/#419/#397/#400 repairs have landed.

The existing devtools-protocol 0.0.1692173 update remains consistent across the manifest, workspace override, and lockfile. Node >=24 and the two-day release-age policy remain unchanged.

The updated combined tree passed 2,117 tests (45 skipped), lint/typecheck/build, built CLI help, and the six-client/entrypoint MCP lifecycle fixture matrix. Final branch review and exact-head CI are recorded in the proof comment.

This PR now targets main directly. No version bump, merge, tag, release, or publication is included. The proposed 0.19.0 release remains gated on the outstanding queue and signed-in browser/recovery proof.
