### PR TITLE
docs(changelog): record browser and remote run improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - MCP: start local consultations with opt-in detached workers and wait for durable completion without cancelling the run when a client times out, cancels a wait, or reconnects. Fixes #429; thanks @oraclexing.
 - MCP: support the modern 2026-07-28 protocol through SDK v2 while preserving legacy stdio clients, tool contracts, session resources, and request-scoped progress logging. Fixes #360; thanks @fredluz.
+- Browser: keep attachment uploads and sends in the original chat, validate exact controls at delivery, and stop context/focus races without replaying a dispatched action; thanks @oraclexing.
+- Browser: optionally export captured downloadable files beside --write-output with --write-artifacts, preserving canonical artifacts, validating hashes, and avoiding filename collisions; thanks @gwelinder.
+- Browser: persist and display thinking-effort selection evidence, including remote results, without treating unverified or disabled options as confirmed selections; thanks @frontierkodiak.
+- Remote: add opt-in bounded concurrent run admission with FIFO queuing, host-cap enforcement, cancellation, and isolated artifacts while preserving default single-flight HTTP 409 behavior; thanks @frontierkodiak.
 - Browser: preserve shared Chrome across concurrent manual-login controllers, verify final lease ownership before shutdown, and harden lock recovery against transient process probes; thanks @oraclexing.
 - Browser: wait for effort slider controls to mount and become visible before selecting the requested tier; thanks @ShunmeiCho.
 - Browser: detect when a later harvest conflicts with saved conversation identities, preserve the original transcript and answer, and record explicit manual target overrides. Fixes #442; thanks @postoso.


### PR DESCRIPTION
Add the four deferred Unreleased entries for #431, #419, #397, and #400 in their requested relative user-impact order after the existing MCP headlines. Preserve Highlights and every existing/released entry.

This is a CHANGELOG.md-only delta against main. No version bump, dependency change, tag, or publication is included.

Merge this notes PR after #419 and #400. #431 and #397 are already on main; the other two implementation branches are being integrated and verified independently. Their signed-in/provider-processing limitations remain in their proof comments.

Validation: exact four-line diff, unchanged Highlights/released history, and clean P2 autoreview. Exact-head CI and final branch review will be recorded in the proof comment.
