### PR TITLE
fix(serve): honor host browser attachment settings

### DIFF
--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -996,7 +996,10 @@ program
   )
   .action(async (commandOptions) => {
     const { serveRemote } = await import("../src/remote/server.js");
+    const { buildServeBrowserConfig } = await import("../src/cli/serveBrowserConfig.js");
+    const { config } = await loadUserConfig();
     await serveRemote({
+      browserConfig: buildServeBrowserConfig(program.opts<CliOptions>(), config),
       host: commandOptions.host,
       port: commandOptions.port,
       token: commandOptions.token,

--- a/docs/browser-mode.md
+++ b/docs/browser-mode.md
@@ -348,6 +348,14 @@ Key behavior:
 
 ### Remote Service Mode (`oracle serve`)
 
+To host requests through an already-running signed-in Chrome, start the service with:
+
+```bash
+oracle serve --host 127.0.0.1 --browser-attach-running --remote-chrome 127.0.0.1:9222 --browser-approval-wait 5m
+```
+
+These are **host settings**: `browser.attachRunning`, `browser.remoteChrome`, and `browser.approvalWaitMs` in the service host configuration also apply. Explicit flags override configuration; `ORACLE_BROWSER_APPROVAL_WAIT` overrides the configured wait unless the flag is supplied. Attach-running mode (or a standalone `--remote-chrome` endpoint for classic DevTools HTTP) skips cookie extraction and manual-login Chrome startup. Each run uses the selected browser; service shutdown leaves that browser running. With no attachment settings, the existing dedicated manual-login default remains. Clients cannot override the host endpoint, attach mode, or approval wait. Add `--max-concurrent-runs 2 --max-queued-runs 8` to opt into bounded admission.
+
 Prefer to keep Chrome entirely on the remote Mac (no DevTools tunneling, no manual cookie shuffling)? Use the built-in service:
 
 1. **Start the host**

--- a/scripts/serve-attach-proof.mjs
+++ b/scripts/serve-attach-proof.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+// Built service + client, synthetic DevTools endpoint, no provider account or Chrome launch.
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import http from "node:http";
+import path from "node:path";
+import os from "node:os";
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repo = fileURLToPath(new URL("..", import.meta.url));
+const require = createRequire(import.meta.url);
+const { Server: WebSocketServer } = createRequire(require.resolve("chrome-remote-interface"))("ws");
+const root = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-serve-attach-"));
+const guard = path.join(root, "refuse-launch.mjs");
+await fs.writeFile(
+  guard,
+  `import {createRequire,syncBuiltinESMExports} from "node:module";
+const cp=createRequire(import.meta.url)("node:child_process");
+const spawn=cp.spawn;
+cp.spawn=function(command,...args){
+  if(/(?:chrome|chromium)(?:\\.exe)?$/i.test(String(command)))throw new Error("UNEXPECTED_CHROME_LAUNCH");
+  return spawn.call(this,command,...args);
+};syncBuiltinESMExports();`,
+);
+const pause = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function prove(mode) {
+  const home = path.join(root, mode);
+  const clientHome = path.join(home, "client");
+  await fs.mkdir(clientHome, { recursive: true });
+  let targetRequests = 0;
+  let connections = 0;
+  const sockets = new Set();
+  const timers = new Set();
+  const wss = new WebSocketServer({ noServer: true });
+  const devtools = http.createServer((req, res) => {
+    if (req.url.startsWith("/json/new")) {
+      targetRequests++;
+      res.writeHead(500);
+      res.end("CLASSIC_ATTACH_ROUTED");
+    } else if (req.url === "/json/version") {
+      res.setHeader("Content-Type", "application/json");
+      res.end(
+        JSON.stringify({
+          webSocketDebuggerUrl: `ws://127.0.0.1:${devtools.address().port}/devtools/browser/proof`,
+        }),
+      );
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
+  });
+  devtools.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+  });
+  devtools.on("upgrade", (req, socket, head) => {
+    connections++;
+    const timer = setTimeout(() => {
+      timers.delete(timer);
+      if (socket.destroyed) return;
+      wss.handleUpgrade(req, socket, head, (ws) => {
+        ws.on("message", (raw) => {
+          const command = JSON.parse(String(raw));
+          if (command.method === "Target.createTarget") targetRequests++;
+          ws.send(
+            JSON.stringify({
+              id: command.id,
+              error: { code: -32000, message: "SERVE_ATTACH_ROUTED" },
+            }),
+          );
+        });
+      });
+    }, 100);
+    timers.add(timer);
+  });
+  await new Promise((resolve) => devtools.listen(0, "127.0.0.1", resolve));
+  const port = devtools.address().port;
+  await fs.writeFile(
+    path.join(home, "config.json"),
+    JSON.stringify({
+      browser: {
+        attachRunning: mode === "config",
+        remoteChrome: { host: "127.0.0.1", port: mode === "config" ? port : 1 },
+        approvalWaitMs: mode === "config" ? 1000 : 1,
+        maxConcurrentTabs: 2,
+      },
+    }),
+  );
+  const env = {
+    ...process.env,
+    ORACLE_HOME_DIR: home,
+    NO_COLOR: "1",
+    NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --import=${pathToFileURL(guard).href}`.trim(),
+  };
+  delete env.ORACLE_BROWSER_APPROVAL_WAIT;
+  if (mode === "environment") env.ORACLE_BROWSER_APPROVAL_WAIT = "1s";
+  const args = [
+    path.join(repo, "dist/bin/oracle-cli.js"),
+    "serve",
+    "--host",
+    "127.0.0.1",
+    "--port",
+    "0",
+    "--manual-login-profile-dir",
+    path.join(home, "profile"),
+    "--max-concurrent-runs",
+    "2",
+    "--max-queued-runs",
+    "2",
+  ];
+  if (mode !== "config") args.push("--remote-chrome", `127.0.0.1:${port}`);
+  if (mode !== "config" && mode !== "classic") args.push("--browser-attach-running");
+  if (mode === "flags") args.push("--browser-approval-wait", "1s");
+  const server = spawn(process.execPath, args, {
+    cwd: home,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const serverDone = new Promise((resolve) => server.on("exit", resolve));
+  let serverOutput = "",
+    client,
+    clientDone,
+    token;
+  server.stdout.on("data", (chunk) => {
+    serverOutput += chunk;
+  });
+  server.stderr.on("data", (chunk) => {
+    serverOutput += chunk;
+  });
+  try {
+    const deadline = Date.now() + 20_000;
+    let address;
+    while (Date.now() < deadline) {
+      token = serverOutput.match(/Access token: ([^\s]+)/)?.[1];
+      address = serverOutput.match(/Listening at (127\.0\.0\.1:\d+)/)?.[1];
+      if (token && address) break;
+      if (server.exitCode !== null) break;
+      await pause(25);
+    }
+    assert.ok(token && address, `${mode}: service did not become ready`);
+    assert.ok(
+      !serverOutput.includes("UNEXPECTED_CHROME_LAUNCH"),
+      `${mode}: service bootstrapped another Chrome`,
+    );
+    const health = await fetch(`http://${address}/health`, {
+      headers: { Authorization: `Bearer ${token}` },
+    }).then((r) => r.json());
+    assert.equal(health.admissionMode, "queue");
+    assert.equal(health.maxConcurrentRuns, 2);
+    client = spawn(
+      process.execPath,
+      [
+        path.join(repo, "dist/bin/oracle-cli.js"),
+        "--engine",
+        "browser",
+        "--model",
+        "gpt-5.5",
+        "--browser-model-strategy",
+        "current",
+        "--remote-host",
+        address,
+        "--browser-approval-wait",
+        "1ms",
+        "--wait",
+        "--no-notify",
+        "--slug",
+        `serve-routing-proof-${mode}`,
+        "--prompt",
+        "Synthetic routing proof",
+      ],
+      {
+        cwd: clientHome,
+        env: { ...env, ORACLE_HOME_DIR: clientHome, ORACLE_REMOTE_TOKEN: token },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    let output = "";
+    client.stdout.on("data", (chunk) => {
+      output += chunk;
+    });
+    client.stderr.on("data", (chunk) => {
+      output += chunk;
+    });
+    clientDone = new Promise((resolve) => client.on("exit", resolve));
+    const timeout = setTimeout(() => client.kill("SIGKILL"), 20_000);
+    const code = await clientDone;
+    clearTimeout(timeout);
+    assert.equal(code, 1, `${mode}: expected synthetic endpoint refusal`);
+    assert.equal(targetRequests, 1, `${mode}: host route did not reach its DevTools endpoint`);
+    if (mode !== "classic") {
+      assert.equal(connections, 1, `${mode}: expected one pending approval connection`);
+      assert.ok(output.includes("SERVE_ATTACH_ROUTED"), `${mode}: target creation was not reached`);
+    }
+    assert.ok(
+      !serverOutput.includes("UNEXPECTED_CHROME_LAUNCH"),
+      `${mode}: run attempted a local launch`,
+    );
+    console.log(
+      `PASS ${mode}: host route reached, no local Chrome launch, client approval override refused, bounded admission enabled`,
+    );
+  } finally {
+    client?.kill("SIGTERM");
+    server.kill("SIGTERM");
+    await Promise.race([serverDone, pause(1500)]);
+    if (server.exitCode === null && server.signalCode === null) server.kill("SIGKILL");
+    await serverDone;
+    if (clientDone) await clientDone;
+    for (const timer of timers) clearTimeout(timer);
+    for (const ws of wss.clients) ws.terminate();
+    for (const socket of sockets) socket.destroy();
+    await new Promise((resolve) => devtools.close(resolve));
+    wss.close();
+  }
+}
+try {
+  for (const mode of ["flags", "config", "environment", "classic"]) await prove(mode);
+} finally {
+  await fs.rm(root, { recursive: true, force: true });
+}

--- a/src/cli/browserConfig.ts
+++ b/src/cli/browserConfig.ts
@@ -438,7 +438,7 @@ export function resolveBrowserModelLabel(input: string | undefined, model: Model
   return trimmed;
 }
 
-function parseRemoteChromeTarget(raw: string): { host: string; port: number } {
+export function parseRemoteChromeTarget(raw: string): { host: string; port: number } {
   const target = raw.trim();
   if (!target) {
     throw new Error(

--- a/src/cli/serveBrowserConfig.ts
+++ b/src/cli/serveBrowserConfig.ts
@@ -1,0 +1,40 @@
+import type { UserConfig } from "../config.js";
+import { resolveBrowserApprovalWait } from "../browser/config.js";
+import type { RemoteHostBrowserConfig } from "../remote/server.js";
+import { parseRemoteChromeTarget } from "./browserConfig.js";
+import { applyBrowserDefaultsFromConfig, type BrowserDefaultsOptions } from "./browserDefaults.js";
+
+type ServeBrowserFlags = Pick<
+  BrowserDefaultsOptions,
+  "browserAttachRunning" | "remoteChrome" | "browserApprovalWait"
+>;
+
+export function buildServeBrowserConfig(
+  options: ServeBrowserFlags,
+  config: UserConfig,
+): RemoteHostBrowserConfig {
+  const flags: ServeBrowserFlags = {
+    browserAttachRunning: options.browserAttachRunning,
+    remoteChrome: options.remoteChrome,
+    browserApprovalWait:
+      options.browserApprovalWait ??
+      (process.env.ORACLE_BROWSER_APPROVAL_WAIT?.trim() || undefined),
+  };
+  const browser = config.browser;
+  applyBrowserDefaultsFromConfig(
+    flags,
+    {
+      browser: {
+        attachRunning: browser?.attachRunning,
+        remoteChrome: browser?.remoteChrome,
+        approvalWaitMs: browser?.approvalWaitMs,
+      },
+    },
+    (key) => (flags[key as keyof ServeBrowserFlags] === undefined ? undefined : "cli"),
+  );
+  return {
+    attachRunning: flags.browserAttachRunning ?? false,
+    remoteChrome: flags.remoteChrome ? parseRemoteChromeTarget(flags.remoteChrome) : null,
+    approvalWaitMs: resolveBrowserApprovalWait(flags.browserApprovalWait),
+  };
+}

--- a/src/remote/server.ts
+++ b/src/remote/server.ts
@@ -45,7 +45,14 @@ import {
 } from "../browser/artifacts.js";
 import type { BrowserRunWarning, SessionArtifact } from "../sessionManager.js";
 
+export type RemoteHostBrowserConfig = Pick<
+  BrowserSessionConfig,
+  "attachRunning" | "remoteChrome" | "approvalWaitMs"
+>;
+
 export interface RemoteServerOptions {
+  /** Host-owned routing; never accepted from a remote caller. */
+  browserConfig?: RemoteHostBrowserConfig;
   host?: string;
   port?: number;
   token?: string;
@@ -122,6 +129,17 @@ export async function createRemoteServer(
   deps: RemoteServerDeps = {},
 ): Promise<RemoteServerInstance> {
   const runBrowser = deps.runBrowser ?? runBrowserMode;
+  const attachedBrowser = usesHostBrowserAttachment(options.browserConfig);
+  const manualLoginDefault = !attachedBrowser && options.manualLoginDefault;
+  const hostBrowserConfig: RemoteHostBrowserConfig = options.browserConfig
+    ? {
+        attachRunning: options.browserConfig?.attachRunning,
+        remoteChrome: options.browserConfig?.remoteChrome
+          ? { ...options.browserConfig.remoteChrome }
+          : undefined,
+        approvalWaitMs: options.browserConfig?.approvalWaitMs,
+      }
+    : {};
   const server = http.createServer();
   const logger = options.logger ?? console.log;
   const authToken = options.token ?? randomBytes(16).toString("hex");
@@ -410,11 +428,14 @@ export async function createRemoteServer(
       // `browserTabRef`/`attachRunning` select a tab that may belong to somebody
       // else's run. With those reachable, a bridge token is not a permission to
       // ask ChatGPT a question — it is a permission to run code here.
-      payload.browserConfig = pickClientBrowserConfig(payload.browserConfig);
+      payload.browserConfig = {
+        ...pickClientBrowserConfig(payload.browserConfig),
+        ...hostBrowserConfig,
+      };
       // Remote runs rely on the host's authentication policy; never accept cookie payloads from clients.
       payload.browserConfig.inlineCookies = null;
       payload.browserConfig.inlineCookiesSource = null;
-      payload.browserConfig.cookieSync = options.cookieSyncDefault === true;
+      payload.browserConfig.cookieSync = !attachedBrowser && options.cookieSyncDefault === true;
 
       const clientSession =
         typeof payload.options.sessionId === "string"
@@ -425,7 +446,7 @@ export async function createRemoteServer(
       signal?.throwIfAborted();
 
       // Enforce manual-login profile when cookie sync is unavailable (e.g., Windows/WSL).
-      if (options.manualLoginDefault) {
+      if (manualLoginDefault) {
         payload.browserConfig.manualLogin = true;
         payload.browserConfig.manualLoginProfileDir = options.manualLoginProfileDir;
         payload.browserConfig.keepBrowser = true;
@@ -446,7 +467,7 @@ export async function createRemoteServer(
         // process. This separate service policy closes only a successfully
         // captured tab owned by this run, preventing one renderer leak per
         // request while incomplete/reattachable tabs remain untouched.
-        closeOwnedTabOnComplete: Boolean(options.manualLoginDefault && !clientRequestedKeepBrowser),
+        closeOwnedTabOnComplete: Boolean(manualLoginDefault && !clientRequestedKeepBrowser),
         closeOwnedTabOnCancel: !clientRequestedKeepBrowser,
         log: automationLogger,
         heartbeatIntervalMs: payload.options.heartbeatIntervalMs,
@@ -562,6 +583,12 @@ export async function serveRemote(options: RemoteServerOptions = {}): Promise<vo
     return;
   }
 
+  if (usesHostBrowserAttachment(options.browserConfig)) {
+    console.log("Using the host browser attachment; skipping local Chrome login/bootstrap.");
+    await runRemoteServer(options);
+    return;
+  }
+
   if (!preferManualLogin) {
     console.log(
       "Warning: Chrome cookie copying can invalidate an active ChatGPT session when tokens rotate. Prefer the default dedicated manual-login profile when possible.",
@@ -618,11 +645,19 @@ export async function serveRemote(options: RemoteServerOptions = {}): Promise<vo
     );
   }
 
-  const server = await createRemoteServer({
+  await runRemoteServer({
     ...options,
     manualLoginDefault: preferManualLogin,
     manualLoginProfileDir: manualProfileDir,
   });
+}
+
+function usesHostBrowserAttachment(config?: RemoteHostBrowserConfig): boolean {
+  return config?.attachRunning === true || Boolean(config?.remoteChrome);
+}
+
+async function runRemoteServer(options: RemoteServerOptions): Promise<void> {
+  const server = await createRemoteServer(options);
   await new Promise<void>((resolve) => {
     const shutdown = () => {
       console.log("Shutting down remote service...");

--- a/tests/cli/serveBrowserConfig.test.ts
+++ b/tests/cli/serveBrowserConfig.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { buildServeBrowserConfig } from "../../src/cli/serveBrowserConfig.js";
+
+beforeEach(() => vi.stubEnv("ORACLE_BROWSER_APPROVAL_WAIT", ""));
+afterEach(() => vi.unstubAllEnvs());
+
+describe("service host browser routing", () => {
+  test("keeps local bootstrap and the 20-second wait by default", () => {
+    expect(buildServeBrowserConfig({}, {})).toEqual({
+      attachRunning: false,
+      remoteChrome: null,
+      approvalWaitMs: 20_000,
+    });
+  });
+  test("loads the host route without copying conversation or credential settings", () => {
+    expect(
+      buildServeBrowserConfig(
+        {},
+        {
+          browser: {
+            attachRunning: true,
+            remoteChrome: { host: "::1", port: 9333 },
+            approvalWaitMs: 75_000,
+            thinkingTime: "pro",
+            chromePath: "/not-forwarded",
+            remoteToken: "not-forwarded",
+          },
+        },
+      ),
+    ).toEqual({
+      attachRunning: true,
+      remoteChrome: { host: "::1", port: 9333 },
+      approvalWaitMs: 75_000,
+    });
+  });
+  test("gives flags precedence over persisted host settings", () => {
+    expect(
+      buildServeBrowserConfig(
+        { browserAttachRunning: false, remoteChrome: "127.0.0.1:9444", browserApprovalWait: "5m" },
+        {
+          browser: {
+            attachRunning: true,
+            remoteChrome: { host: "::1", port: 9333 },
+            approvalWaitMs: 10,
+          },
+        },
+      ),
+    ).toEqual({
+      attachRunning: false,
+      remoteChrome: { host: "127.0.0.1", port: 9444 },
+      approvalWaitMs: 300_000,
+    });
+  });
+  test("applies environment wait above config and below the explicit flag", () => {
+    vi.stubEnv("ORACLE_BROWSER_APPROVAL_WAIT", "55s");
+    const config = { browser: { approvalWaitMs: 10 } };
+    expect(buildServeBrowserConfig({}, config).approvalWaitMs).toBe(55_000);
+    expect(buildServeBrowserConfig({ browserApprovalWait: "5m" }, config).approvalWaitMs).toBe(
+      300_000,
+    );
+  });
+  test("rejects invalid endpoints and wait budgets before starting the service", () => {
+    expect(() => buildServeBrowserConfig({ remoteChrome: "missing-port" }, {})).toThrow(
+      /remote-chrome/,
+    );
+    expect(() => buildServeBrowserConfig({ browserApprovalWait: "0" }, {})).toThrow(
+      /approval wait/,
+    );
+  });
+});

--- a/tests/remote/serveRouting.cli.test.ts
+++ b/tests/remote/serveRouting.cli.test.ts
@@ -1,0 +1,14 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import path from "node:path";
+import { expect, test } from "vitest";
+
+test("built service honors host Chrome routing without launching a local browser", async () => {
+  const { stdout } = await promisify(execFile)(
+    process.execPath,
+    [path.resolve("scripts/serve-attach-proof.mjs")],
+    { timeout: 90_000 },
+  );
+  for (const mode of ["flags", "config", "environment", "classic"])
+    expect(stdout).toContain(`PASS ${mode}:`);
+}, 95_000);

--- a/tests/remote/server.test.ts
+++ b/tests/remote/server.test.ts
@@ -29,6 +29,71 @@ const CAN_LISTEN_LOCALHOST =
   ).status === 0;
 
 describe("remote browser service", () => {
+  test.skipIf(!CAN_LISTEN_LOCALHOST).each([true, false])(
+    "enforces the host endpoint and wait over client injection (attachRunning=%s)",
+    async (attachRunning) => {
+      const hostRoute = {
+        attachRunning,
+        remoteChrome: { host: "127.0.0.1", port: 9333 },
+        approvalWaitMs: 300_000,
+      };
+      let observed = false;
+      const server = await createRemoteServer(
+        {
+          host: "127.0.0.1",
+          port: 0,
+          token: "test-host-routing",
+          logger: () => {},
+          browserConfig: hostRoute,
+          manualLoginDefault: true,
+          cookieSyncDefault: true,
+        },
+        {
+          runBrowser: async (options) => {
+            observed = true;
+            expect(options.config).toMatchObject({
+              ...hostRoute,
+              cookieSync: false,
+              thinkingTime: "pro",
+            });
+            expect(options.config?.manualLogin).not.toBe(true);
+            expect(options.config?.chromePath).toBeUndefined();
+            expect(options.closeOwnedTabOnComplete).toBe(false);
+            return {
+              answerText: "host-route",
+              answerMarkdown: "host-route",
+              tookMs: 1,
+              answerTokens: 1,
+              answerChars: 10,
+            };
+          },
+        },
+      );
+      try {
+        const execute = createRemoteBrowserExecutor({
+          host: `127.0.0.1:${server.port}`,
+          token: "test-host-routing",
+        });
+        const result = await execute({
+          prompt: "host route",
+          config: {
+            attachRunning: !attachRunning,
+            remoteChrome: { host: "untrusted.invalid", port: 1 },
+            approvalWaitMs: 1,
+            manualLogin: true,
+            chromePath: "/untrusted",
+            cookieSync: true,
+            thinkingTime: "pro",
+          },
+        });
+        expect(result.answerText).toBe("host-route");
+        expect(observed).toBe(true);
+      } finally {
+        await server.close();
+      }
+    },
+  );
+
   test.skipIf(!CAN_LISTEN_LOCALHOST)(
     "streams logs and returns results via client executor",
     async () => {


### PR DESCRIPTION
`oracle serve --browser-attach-running --remote-chrome 127.0.0.1:9222` previously ignored the host browser route and launched a separate manual-login Chrome. Forward the host attach mode, endpoint, and approval wait into service runs, and skip cookie/manual-login bootstrap when an existing-browser route is selected.

Host flags override saved configuration; the approval-wait environment override follows the normal CLI precedence. Apply only these host-owned fields after filtering each client request, so clients cannot redirect the service or shorten its approval budget. Plain `oracle serve` retains its existing defaults.

Exact-head CI: https://github.com/steipete/oracle/actions/runs/34155632649 — all four jobs passed. Local and branch autoreview: scoped-clean at P0–P2.

Validation: 2,230 tests passed, 45 skipped; lint/typecheck, build, and docs check passed. The built service and client proof covers CLI flags, saved host config, environment precedence, classic remote Chrome, no local Chrome startup, bounded admission, and rejection of a client approval-wait override. Its synthetic DevTools endpoint deliberately stops at target creation. Signed-in service/client validation will run after the orchestrator merges this PR.

Deferred changelog line:
- Remote: honor the service host’s attach-running, remote-Chrome, and approval-wait settings, reusing its signed-in browser without launching a separate manual-login Chrome while keeping routing under host control.
