### PR TITLE
chore: consolidate pending notes and refresh dependency patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+**Highlights:** GPT-6 Astra consultations through the API and ChatGPT's Latest picker, explicit Web Search, and safe cleanup after browser recovery.
+
+- API/browser: support GPT-6 Astra with model-specific reasoning validation, ChatGPT Latest selection, localized effort controls, and verified Pro requests; preserve browser aliases during CLI engine discovery. Thanks @oraclexing, @malvarezcastillo, @FNDEVVE, and @kiyo-e.
+- Browser: add the opt-in --browser-research search mode and MCP equivalent, verifying the English Web Search hint and staged prompt before sending, including bundled attachments; thanks @DragonFSKY.
+- Browser: let incomplete controllers exit without losing recoverable tabs, then retire explicitly owned tabs only after recovered answers and completed sessions are saved; preserve borrowed, kept, generating, reclaimed, and actively controlled targets. Fixes #435; thanks @lhysin.
+- Browser: capture visible Deep Research plan titles, steps, and planning/researching state, skip an already-finished countdown, and preserve existing session-status and submission behavior; thanks @oraclexing.
+- Browser: recognize Chinese Deep Research menu, selected-tool, and add-files controls while preserving compact English labels; thanks @oraclexing.
+- Dependencies: update Sweet Cookie to 0.4.3 and TokenTally to 0.1.5 while retaining Node >=24 and the two-day release-age policy.
+
 ## 0.19.0 - 2026-09-07
 
 **Highlights:** Durable detached MCP consultations, modern and legacy MCP client support, and clearer browser capture failures with preserved recovery evidence.

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@google/genai": "^2.21.0",
     "@google/generative-ai": "^0.24.1",
     "@modelcontextprotocol/server": "^2.0.0",
-    "@steipete/sweet-cookie": "^0.4.2",
+    "@steipete/sweet-cookie": "^0.4.3",
     "chalk": "^6.0.0",
     "chrome-launcher": "^1.2.1",
     "chrome-remote-interface": "^0.34.0",
@@ -79,7 +79,7 @@
     "qs": "^6.16.0",
     "shiki": "^4.4.3",
     "toasted-notifier": "^10.1.0",
-    "tokentally": "^0.1.4",
+    "tokentally": "^0.1.5",
     "zod": "^4.5.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       '@steipete/sweet-cookie':
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: ^0.4.3
+        version: 0.4.3
       chalk:
         specifier: ^6.0.0
         version: 6.0.0
@@ -83,8 +83,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0
       tokentally:
-        specifier: ^0.1.4
-        version: 0.1.4
+        specifier: ^0.1.5
+        version: 0.1.5
       zod:
         specifier: ^4.5.4
         version: 4.5.4
@@ -911,8 +911,8 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
-  '@steipete/sweet-cookie@0.4.2':
-    resolution: {integrity: sha512-uwu5N5HO3dpZnVdbzlM2j1ya1H4fvJDBLeSbePE0Kb64c8yie7N6Kvft5yHYxIKoHuYkIUrU4TE9VdfzGp0kWQ==}
+  '@steipete/sweet-cookie@0.4.3':
+    resolution: {integrity: sha512-+ugAbvXMl/mzmRRpGeeK4ShjWDZVR4Ul5DouKnwjhaqdozAakDyHceyagkOxRG8DYbCaQhTsuaMUod2nA3EKWQ==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -2248,8 +2248,8 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
-  tokentally@0.1.4:
-    resolution: {integrity: sha512-+sfoN+uL47rbOQFZdiWhJqZmkimTMGwsDUryWfQDVHbRJaETGu+20iGtWG4a9d+GTEVwXPVg6vtUFnBk37Q6VQ==}
+  tokentally@0.1.5:
+    resolution: {integrity: sha512-BCO6WFjqd718vjlQvXgCuLiNAnCXSs6MRnRM+7EGrTUhM4fd1LwzNXBWVvEBk4CgG68dmxhegGq8FH7eGfVABQ==}
     engines: {node: '>=24'}
 
   trim-lines@3.0.1:
@@ -3004,7 +3004,7 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@steipete/sweet-cookie@0.4.2': {}
+  '@steipete/sweet-cookie@0.4.3': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -4306,7 +4306,7 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
-  tokentally@0.1.4: {}
+  tokentally@0.1.5: {}
 
   trim-lines@3.0.1: {}
 


### PR DESCRIPTION
Collect the complete ordered Unreleased notes and contributor credit for the prepared model, Web Search, browser recovery, Deep Research plan, and localization changes. Merge this PR after the implementation PRs.

Update Sweet Cookie 0.4.2 → 0.4.3 and TokenTally 0.1.4 → 0.1.5 consistently in the manifest and lockfile. Both releases were more than 48 hours old when installed; Node >=24 and the two-day release-age policy remain intact. A fresh outdated check reports no remaining updates.

Validation: build and check passed; the full suite passed 2,230 tests / 45 skipped after building the CLI. The built CLI with the updated dependencies completed a real API request and returned `ORACLE_DEPS_OK`. Local and final branch P0–P2 autoreview are clean. Exact-head CI is green: https://github.com/steipete/oracle/actions/runs/34178931052.

No version bump, tag, release, or publication is included. The implementation entries describe the proposed merged state and must not land ahead of their code.
