### PR TITLE
fix(cli): cancel detached browser sessions truthfully

### DIFF
--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -45,8 +45,18 @@ import {
 import { copyToClipboard } from "../src/cli/clipboard.js";
 import { isGpt6ProAlias } from "../src/cli/browserConfig.js";
 import { buildMarkdownBundle } from "../src/cli/markdownBundle.js";
-import { shouldDetachSession, stopDetachedWorker } from "../src/cli/detach.js";
-import { launchDetachedSession } from "../src/cli/detachedSession.js";
+import {
+  shouldDetachSession,
+  shouldExitAfterTopLevelSigint,
+  stopDetachedWorker,
+} from "../src/cli/detach.js";
+import {
+  clearDetachedSessionCancellation,
+  detachedSessionCancellationPath,
+  launchDetachedSession,
+  requestDetachedSessionCancellation,
+  waitForDetachedSessionCancellation,
+} from "../src/cli/detachedSession.js";
 import { applyHiddenAliases } from "../src/cli/hiddenAliases.js";
 import type { BrowserSessionRunnerDeps } from "../src/browser/sessionRunner.js";
 import { isMediaFile } from "../src/browser/prompt.js";
@@ -80,6 +90,7 @@ import {
   isTraceValueFlag,
 } from "../src/cli/perfTrace.js";
 import { resolveBrowserFollowupReference } from "../src/cli/followup.js";
+import { BrowserRunCancelledError } from "../src/oracle/errors.js";
 
 interface CliOptions extends OptionValues {
   prompt?: string;
@@ -2585,17 +2596,29 @@ async function waitForDetachedStartGate(): Promise<void> {
 }
 
 async function attachToDetachedSession(sessionId: string, workerPid: number): Promise<void> {
+  const cancellationMarker = sessionStore
+    .getPaths(sessionId)
+    .then((paths) => detachedSessionCancellationPath(paths.dir, workerPid));
   let cancelled = false;
+  let cancellationRequest: Promise<void> | undefined;
   const cancelWorker = (): void => {
     cancelled = true;
-    try {
-      stopDetachedWorker(workerPid);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.error(chalk.red(`Unable to stop detached worker ${workerPid}: ${message}`));
-    }
+    cancellationRequest ??= cancellationMarker
+      .then((markerPath) => requestDetachedSessionCancellation(markerPath))
+      .catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(
+          chalk.red(`Unable to request cancellation from worker ${workerPid}: ${message}`),
+        );
+        try {
+          stopDetachedWorker(workerPid);
+        } catch (stopError) {
+          const stopMessage = stopError instanceof Error ? stopError.message : String(stopError);
+          console.error(chalk.red(`Unable to stop detached worker ${workerPid}: ${stopMessage}`));
+        }
+      });
   };
-  process.once("SIGINT", cancelWorker);
+  process.on("SIGINT", cancelWorker);
   try {
     const { attachSession } = await import("../src/cli/sessionDisplay.js");
     await attachSession(sessionId, {
@@ -2605,8 +2628,12 @@ async function attachToDetachedSession(sessionId: string, workerPid: number): Pr
     });
   } finally {
     process.off("SIGINT", cancelWorker);
+    await cancellationRequest;
     if (cancelled) {
-      process.exitCode = 130;
+      const finalStatus = (await sessionStore.readSession(sessionId).catch(() => null))?.status;
+      if (finalStatus !== "completed" && finalStatus !== "partial") {
+        process.exitCode = 130;
+      }
     }
   }
 }
@@ -2828,6 +2855,10 @@ async function restartSession(sessionId: string, options: RestartCommandOptions)
 async function executeSession(sessionId: string) {
   let metadata: SessionMetadata | null = null;
   let writer: ReturnType<typeof sessionStore.createLogWriter> | null = null;
+  const cancellation = new AbortController();
+  const stopCancellationMonitor = new AbortController();
+  let cancellationMarker: string | undefined;
+  let cancellationMonitor: Promise<void> | undefined;
   try {
     metadata = await sessionStore.readSession(sessionId);
     if (!metadata) {
@@ -2843,6 +2874,18 @@ async function executeSession(sessionId: string) {
     const sessionMode = getSessionMode(metadata);
     const browserConfig = getBrowserConfigFromMetadata(metadata);
     writer = sessionStore.createLogWriter(sessionId);
+    if (sessionMode === "browser") {
+      const paths = await sessionStore.getPaths(sessionId);
+      cancellationMarker = detachedSessionCancellationPath(paths.dir, process.pid);
+      cancellationMonitor = waitForDetachedSessionCancellation({
+        markerPath: cancellationMarker,
+        signal: stopCancellationMonitor.signal,
+      }).then((requested) => {
+        if (requested) {
+          cancellation.abort(new BrowserRunCancelledError("Browser run cancelled by the user."));
+        }
+      });
+    }
     const userConfig = (await loadUserConfig()).config;
     const notifications = deriveNotificationSettingsFromMetadata(
       metadata,
@@ -2860,17 +2903,19 @@ async function executeSession(sessionId: string) {
       write: writer.writeChunk,
       version: VERSION,
       notifications,
+      signal: sessionMode === "browser" ? cancellation.signal : undefined,
     });
   } catch (error) {
-    process.exitCode = 1;
+    const cancelled = error instanceof BrowserRunCancelledError;
+    process.exitCode = cancelled ? 130 : 1;
     const message = error instanceof Error ? error.message : String(error);
     if (!metadata) {
-      console.error(chalk.red(message));
+      if (!cancelled) console.error(chalk.red(message));
       return;
     }
-    writer?.logLine(`ERROR: Detached session worker failed: ${message}`);
+    if (!cancelled) writer?.logLine(`ERROR: Detached session worker failed: ${message}`);
     const latest = await sessionStore.readSession(sessionId).catch(() => null);
-    if (latest && !["completed", "partial", "error"].includes(latest.status)) {
+    if (latest && !["completed", "partial", "error", "cancelled"].includes(latest.status)) {
       await sessionStore.updateSession(sessionId, {
         status: "error",
         completedAt: new Date().toISOString(),
@@ -2883,6 +2928,14 @@ async function executeSession(sessionId: string) {
       });
     }
   } finally {
+    stopCancellationMonitor.abort();
+    await cancellationMonitor?.catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      writer?.logLine(`ERROR: Detached cancellation monitor failed: ${message}`);
+    });
+    if (cancellationMarker) {
+      await clearDetachedSessionCancellation(cancellationMarker).catch(() => undefined);
+    }
     writer?.stream.end();
   }
 }
@@ -3024,7 +3077,7 @@ async function main(): Promise<void> {
     console.log(chalk.yellow("\nCancelled."));
     process.exitCode = 130;
     // Browser/serve modes install their own SIGINT cleanup after this top-level handler.
-    if (process.listenerCount("SIGINT") <= 1) {
+    if (shouldExitAfterTopLevelSigint(process.listenerCount("SIGINT"))) {
       process.exit(130);
     }
   };

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -46,6 +46,7 @@ import { copyToClipboard } from "../src/cli/clipboard.js";
 import { isGpt6ProAlias } from "../src/cli/browserConfig.js";
 import { buildMarkdownBundle } from "../src/cli/markdownBundle.js";
 import {
+  detachedCancellationExitCode,
   shouldDetachSession,
   shouldExitAfterTopLevelSigint,
   stopDetachedWorker,
@@ -2629,12 +2630,8 @@ async function attachToDetachedSession(sessionId: string, workerPid: number): Pr
   } finally {
     process.off("SIGINT", cancelWorker);
     await cancellationRequest;
-    if (cancelled) {
-      const finalStatus = (await sessionStore.readSession(sessionId).catch(() => null))?.status;
-      if (finalStatus !== "completed" && finalStatus !== "partial") {
-        process.exitCode = 130;
-      }
-    }
+    const finalStatus = (await sessionStore.readSession(sessionId).catch(() => null))?.status;
+    process.exitCode = detachedCancellationExitCode(cancelled, finalStatus, process.exitCode);
   }
 }
 

--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -2631,6 +2631,14 @@ async function attachToDetachedSession(sessionId: string, workerPid: number): Pr
     process.off("SIGINT", cancelWorker);
     await cancellationRequest;
     const finalStatus = (await sessionStore.readSession(sessionId).catch(() => null))?.status;
+    if (
+      cancellationRequest &&
+      finalStatus &&
+      ["completed", "partial", "cancelled", "error"].includes(finalStatus)
+    ) {
+      // The parent may publish its request after the worker's final cleanup.
+      await clearDetachedSessionCancellation(await cancellationMarker);
+    }
     process.exitCode = detachedCancellationExitCode(cancelled, finalStatus, process.exitCode);
   }
 }

--- a/src/browser/chromeLifecycle.ts
+++ b/src/browser/chromeLifecycle.ts
@@ -15,6 +15,7 @@ import type { BrowserLogger, ResolvedBrowserConfig, ChromeClient } from "./types
 import { cleanupStaleProfileState } from "./profileState.js";
 import { delay } from "./utils.js";
 import { isWsl, resolveWslChromeLaunchRoute } from "./wslHost.js";
+import { BrowserCancellation } from "./cancellation.js";
 
 export async function launchChrome(
   config: ResolvedBrowserConfig,
@@ -585,27 +586,43 @@ export async function listRemoteChromeTargets(options: {
   browserWSEndpoint?: string;
   approvalWaitMs?: number;
   logger?: BrowserLogger;
+  signal?: AbortSignal;
 }): Promise<RemoteTargetInfo[]> {
-  if (!options.browserWSEndpoint) {
-    const targets = await CDP.List({ host: options.host, port: options.port });
-    return targets as unknown as RemoteTargetInfo[];
-  }
-  const browser = await connectToBrowserWebSocket(
-    options.host,
-    options.port,
-    options.browserWSEndpoint,
-    options.logger ?? (() => {}),
-    options.approvalWaitMs,
-  );
+  const logger = options.logger ?? (() => {});
+  const cancellation = new BrowserCancellation(options.signal, logger);
   try {
-    const result = await browser.Target.getTargets();
-    return (result.targetInfos ?? []).map((target) => ({
-      targetId: target.targetId,
-      type: target.type,
-      url: target.url,
-    }));
+    return await cancellation.run(async () => {
+      if (!options.browserWSEndpoint) {
+        const targets = await cancellation.call(() =>
+          CDP.List({ host: options.host, port: options.port }),
+        );
+        return targets as unknown as RemoteTargetInfo[];
+      }
+      const browser = await cancellation.acquire(
+        () =>
+          connectToBrowserWebSocket(
+            options.host,
+            options.port,
+            options.browserWSEndpoint!,
+            logger,
+            options.approvalWaitMs,
+          ),
+        (lateBrowser) => lateBrowser.close(),
+      );
+      try {
+        const client = cancellation.client(browser);
+        const result = await client.Target.getTargets();
+        return (result.targetInfos ?? []).map((target) => ({
+          targetId: target.targetId,
+          type: target.type,
+          url: target.url,
+        }));
+      } finally {
+        await browser.close().catch(() => undefined);
+      }
+    });
   } finally {
-    await browser.close().catch(() => undefined);
+    cancellation.dispose();
   }
 }
 

--- a/src/browser/reattach.ts
+++ b/src/browser/reattach.ts
@@ -44,6 +44,8 @@ import {
 import { waitForDeepResearchCompletion } from "./actions/deepResearch.js";
 import { CHROME_COOKIE_SYNC_WARNING, shouldSyncBrowserCookies } from "./policies.js";
 import type { BrowserRecoveryCapture } from "./recoveryTarget.js";
+import { BrowserCancellation, withoutBrowserCancellation } from "./cancellation.js";
+import { BrowserRunCancelledError } from "../oracle/errors.js";
 
 export interface ReattachDeps {
   listTargets?: () => Promise<TargetInfoLite[]>;
@@ -60,6 +62,8 @@ export interface ReattachDeps {
     config: BrowserSessionConfig | undefined,
   ) => Promise<ReattachResult>;
   promptPreview?: string;
+  signal?: AbortSignal;
+  createTemporaryProfile?: () => Promise<string>;
 }
 
 export interface ReattachResult {
@@ -74,10 +78,28 @@ export async function resumeBrowserSession(
   logger: BrowserLogger,
   deps: ReattachDeps = {},
 ): Promise<ReattachResult> {
-  const recoverSession =
-    deps.recoverSession ??
-    (async (runtimeMeta, configMeta) =>
-      resumeBrowserSessionViaNewChrome(runtimeMeta, configMeta, logger, deps));
+  const cancellation = new BrowserCancellation(deps.signal, logger);
+  try {
+    return await cancellation.run(() =>
+      resumeBrowserSessionInternal(runtime, config, logger, deps, cancellation),
+    );
+  } finally {
+    cancellation.dispose();
+  }
+}
+
+async function resumeBrowserSessionInternal(
+  runtime: BrowserRuntimeMetadata,
+  config: BrowserSessionConfig | undefined,
+  logger: BrowserLogger,
+  deps: ReattachDeps,
+  cancellation: BrowserCancellation,
+): Promise<ReattachResult> {
+  const recoverSession = deps.recoverSession
+    ? (runtimeMeta: BrowserRuntimeMetadata, configMeta: BrowserSessionConfig | undefined) =>
+        cancellation.call(() => deps.recoverSession!(runtimeMeta, configMeta))
+    : (runtimeMeta: BrowserRuntimeMetadata, configMeta: BrowserSessionConfig | undefined) =>
+        resumeBrowserSessionViaNewChrome(runtimeMeta, configMeta, logger, deps, cancellation);
   let closeAttachedConnection: (() => Promise<void>) | null = null;
   const closeAttached = async (): Promise<void> => {
     const close = closeAttachedConnection;
@@ -106,38 +128,42 @@ export async function resumeBrowserSession(
           browserWSEndpoint,
           approvalWaitMs,
           logger,
+          signal: deps.signal,
         })) as TargetInfoLite[]);
-    const targetList = (await listTargets()) as TargetInfoLite[];
+    const targetList = (await cancellation.call(listTargets)) as TargetInfoLite[];
     const target = pickTarget(targetList, liveRuntime);
-    const connection =
-      browserWSEndpoint && !deps.connect
-        ? await connectToRemoteChromeTarget(host, port ?? 9222, logger, {
-            browserWSEndpoint,
-            targetId: target?.targetId ?? target?.id,
-            closeTargetOnDispose: false,
-            approvalWaitMs,
-          })
-        : await (async () => {
-            const client = (await (
-              deps.connect ?? ((options?: unknown) => CDP(options as CDP.Options))
-            )(
-              browserWSEndpoint
-                ? {
-                    target: browserWSEndpoint,
-                    local: true,
-                    targetId: target?.targetId ?? target?.id,
-                  }
-                : {
-                    host,
-                    port,
-                    target: target?.targetId ?? target?.id,
-                  },
-            )) as unknown as ChromeClient;
-            return { client, close: () => client.close() };
-          })();
+    const connection = await cancellation.acquire(
+      () =>
+        browserWSEndpoint && !deps.connect
+          ? connectToRemoteChromeTarget(host, port ?? 9222, logger, {
+              browserWSEndpoint,
+              targetId: target?.targetId ?? target?.id,
+              closeTargetOnDispose: false,
+              approvalWaitMs,
+            })
+          : (async () => {
+              const client = (await (
+                deps.connect ?? ((options?: unknown) => CDP(options as CDP.Options))
+              )(
+                browserWSEndpoint
+                  ? {
+                      target: browserWSEndpoint,
+                      local: true,
+                      targetId: target?.targetId ?? target?.id,
+                    }
+                  : {
+                      host,
+                      port,
+                      target: target?.targetId ?? target?.id,
+                    },
+              )) as unknown as ChromeClient;
+              return { client, close: () => client.close() };
+            })(),
+      (lateConnection) => lateConnection.close(),
+    );
     closeAttachedConnection = () => connection.close();
 
-    const client: ChromeClient = connection.client;
+    const client = cancellation.client(connection.client);
     const { Runtime, DOM, Page } = client;
     const captureIdentity = async (): Promise<BrowserRecoveryCapture | undefined> => {
       const targetId = target?.targetId ?? target?.id;
@@ -211,11 +237,13 @@ export async function resumeBrowserSession(
       runtime,
       resolveBrowserConfig(config ?? {}).url,
     );
-    await waitForHydration(Runtime, timeoutMs, logger, {
-      requirePriorTurns: true,
-      requirePromptReady: false,
-      expectedConversationUrl: expectedConversationUrl ?? undefined,
-    });
+    await cancellation.call(() =>
+      waitForHydration(Runtime, timeoutMs, logger, {
+        requirePriorTurns: true,
+        requirePromptReady: false,
+        expectedConversationUrl: expectedConversationUrl ?? undefined,
+      }),
+    );
     const minTurnIndex =
       (await readPromptPreviewTurnIndex(Runtime, deps.promptPreview)) ??
       (deps.promptPreview ? null : await readConversationTurnIndex(Runtime, logger));
@@ -223,9 +251,11 @@ export async function resumeBrowserSession(
       const waitForDeepResearch =
         deps.waitForDeepResearchCompletion ?? waitForDeepResearchCompletion;
       const researchResult = await withTimeout(
-        waitForDeepResearch(Runtime, logger, timeoutMs, minTurnIndex ?? undefined, Page, client, {
-          requireScopedTargetOwner: true,
-        }),
+        cancellation.call(() =>
+          waitForDeepResearch(Runtime, logger, timeoutMs, minTurnIndex ?? undefined, Page, client, {
+            requireScopedTargetOwner: true,
+          }),
+        ),
         timeoutMs + 5_000,
         "Reattach Deep Research response timed out",
       );
@@ -239,21 +269,18 @@ export async function resumeBrowserSession(
     }
     const promptEcho = buildPromptEchoMatcher(deps.promptPreview);
     const answer = await withTimeout(
-      waitForResponse(Runtime, timeoutMs, logger, minTurnIndex ?? undefined),
+      cancellation.call(() =>
+        waitForResponse(Runtime, timeoutMs, logger, minTurnIndex ?? undefined),
+      ),
       timeoutMs + 5_000,
       "Reattach response timed out",
     );
-    const recovered = await recoverPromptEcho(
-      Runtime,
-      answer,
-      promptEcho,
-      logger,
-      minTurnIndex,
-      timeoutMs,
+    const recovered = await cancellation.call(() =>
+      recoverPromptEcho(Runtime, answer, promptEcho, logger, minTurnIndex, timeoutMs),
     );
     const markdown =
       (await withTimeout(
-        captureMarkdown(Runtime, recovered.meta, logger),
+        cancellation.call(() => captureMarkdown(Runtime, recovered.meta, logger)),
         15_000,
         "Reattach markdown capture timed out",
       )) ?? recovered.text;
@@ -268,6 +295,9 @@ export async function resumeBrowserSession(
     };
   } catch (error) {
     await closeAttached();
+    if (deps.signal?.aborted || error instanceof BrowserRunCancelledError) {
+      throw new BrowserRunCancelledError();
+    }
     const message = error instanceof Error ? error.message : String(error);
     logger(
       `Existing Chrome reattach failed (${message}); reopening browser to locate the session.`,
@@ -317,27 +347,71 @@ async function resumeBrowserSessionViaNewChrome(
   config: BrowserSessionConfig | undefined,
   logger: BrowserLogger,
   deps: ReattachDeps,
+  cancellation: BrowserCancellation,
 ): Promise<ReattachResult> {
   const resolved = resolveBrowserConfig(config ?? {});
   const manualLogin = Boolean(resolved.manualLogin);
   const userDataDir = manualLogin
     ? (resolved.manualLoginProfileDir ?? path.join(os.homedir(), ".oracle", "browser-profile"))
-    : await mkdtemp(path.join(os.tmpdir(), "oracle-reattach-"));
+    : await (
+        deps.createTemporaryProfile ?? (() => mkdtemp(path.join(os.tmpdir(), "oracle-reattach-")))
+      )();
   if (manualLogin) {
     await mkdir(userDataDir, { recursive: true });
   }
+  const cleanupProfile = async () => {
+    if (manualLogin) {
+      await cleanupStaleProfileState(userDataDir, logger, { lockRemovalMode: "never" }).catch(
+        () => undefined,
+      );
+    } else {
+      await rm(userDataDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  };
+  if (deps.signal?.aborted) {
+    if (!manualLogin) await cleanupProfile();
+    cancellation.check();
+  }
   const launch = deps.launchChrome ?? launchChrome;
   const connectToLaunchedChrome = deps.connectToChrome ?? connectToChrome;
-  const chrome = await launch(resolved, userDataDir, logger);
+  const chrome = await cancellation.acquire(
+    () => launch(resolved, userDataDir, logger),
+    async (lateChrome) => {
+      if (!resolved.keepBrowser) {
+        try {
+          await lateChrome.kill();
+        } catch {
+          // best-effort cleanup for a browser that finished launching after cancellation
+        }
+        await cleanupProfile();
+      }
+    },
+  );
   const chromeHost =
     chrome && typeof chrome === "object" && "host" in chrome && typeof chrome.host === "string"
       ? chrome.host
       : "127.0.0.1";
-  const client = await connectToLaunchedChrome(chrome.port, logger, chromeHost);
-  const cleanup = async () => {
-    if (client && typeof client.close === "function") {
+  let rawClient: Awaited<ReturnType<typeof connectToLaunchedChrome>>;
+  try {
+    rawClient = await cancellation.acquire(
+      () => connectToLaunchedChrome(chrome.port, logger, chromeHost),
+      (lateClient) => lateClient.close(),
+    );
+  } catch (error) {
+    if (!resolved.keepBrowser) {
       try {
-        await client.close();
+        await withoutBrowserCancellation(() => chrome.kill());
+      } catch {
+        // best-effort cleanup after a failed or cancelled CDP connection
+      }
+      await cleanupProfile();
+    }
+    throw error;
+  }
+  const cleanup = async () => {
+    if (rawClient && typeof rawClient.close === "function") {
+      try {
+        await rawClient.close();
       } catch {
         // ignore
       }
@@ -348,35 +422,29 @@ async function resumeBrowserSessionViaNewChrome(
       } catch {
         // ignore
       }
-      if (manualLogin) {
-        await cleanupStaleProfileState(userDataDir, logger, { lockRemovalMode: "never" }).catch(
-          () => undefined,
-        );
-      } else {
-        await rm(userDataDir, { recursive: true, force: true }).catch(() => undefined);
-      }
+      await cleanupProfile();
     }
   };
+  const client = cancellation.client(rawClient);
   const { Network, Page, Runtime, DOM, Target } = client;
-
-  if (Runtime?.enable) {
-    await Runtime.enable();
-  }
-  if (DOM && typeof DOM.enable === "function") {
-    await DOM.enable();
-  }
-  if (!resolved.headless && resolved.hideWindow) {
-    await positionChromeWindowOffscreen(client, userDataDir, logger);
-  } else if (!resolved.headless) {
-    await positionChromeWindowOnscreen(client, userDataDir, logger);
-  }
-  let appliedCookies = 0;
-  if (shouldSyncBrowserCookies(resolved, { manualLogin })) {
-    if (!resolved.inlineCookies) {
-      logger(CHROME_COOKIE_SYNC_WARNING);
+  try {
+    if (Runtime?.enable) {
+      await Runtime.enable();
     }
-    const sync = deps.syncCookies ?? syncCookies;
-    try {
+    if (DOM && typeof DOM.enable === "function") {
+      await DOM.enable();
+    }
+    if (!resolved.headless && resolved.hideWindow) {
+      await positionChromeWindowOffscreen(client, userDataDir, logger);
+    } else if (!resolved.headless) {
+      await positionChromeWindowOnscreen(client, userDataDir, logger);
+    }
+    let appliedCookies = 0;
+    if (shouldSyncBrowserCookies(resolved, { manualLogin })) {
+      if (!resolved.inlineCookies) {
+        logger(CHROME_COOKIE_SYNC_WARNING);
+      }
+      const sync = deps.syncCookies ?? syncCookies;
       appliedCookies = await sync(Network, resolved.url, resolved.chromeProfile, logger, {
         allowErrors: resolved.allowCookieErrors,
         filterNames: resolved.cookieNames ?? undefined,
@@ -384,102 +452,97 @@ async function resumeBrowserSessionViaNewChrome(
         cookiePath: resolved.chromeCookiePath ?? undefined,
         waitMs: resolved.cookieSyncWaitMs ?? 0,
       });
-    } catch (error) {
-      await cleanup();
-      throw error;
     }
-  }
 
-  await clearStaleChatGptConversationCookies(Network, Target, logger, {
-    preserveConversationIds: [
-      runtime.conversationId,
-      extractConversationIdFromUrl(runtime.tabUrl ?? ""),
-      extractConversationIdFromUrl(resolved.url),
-    ],
-  });
+    await clearStaleChatGptConversationCookies(Network, Target, logger, {
+      preserveConversationIds: [
+        runtime.conversationId,
+        extractConversationIdFromUrl(runtime.tabUrl ?? ""),
+        extractConversationIdFromUrl(resolved.url),
+      ],
+    });
 
-  await navigateToChatGPT(Page, Runtime, CHATGPT_URL, logger);
-  await ensureNotBlocked(Runtime, resolved.headless, logger);
-  await ensureLoggedIn(Runtime, logger, { appliedCookies });
-  if (resolved.url !== CHATGPT_URL) {
-    await navigateToChatGPT(Page, Runtime, resolved.url, logger);
+    await navigateToChatGPT(Page, Runtime, CHATGPT_URL, logger);
     await ensureNotBlocked(Runtime, resolved.headless, logger);
-  }
-  await ensurePromptReady(Runtime, resolved.inputTimeoutMs, logger);
-
-  const conversationUrl = buildConversationUrl(runtime, resolved.url);
-  if (conversationUrl) {
-    logger(`Reopening conversation at ${conversationUrl}`);
-    await navigateToChatGPT(Page, Runtime, conversationUrl, logger);
-    await ensureNotBlocked(Runtime, resolved.headless, logger);
+    await ensureLoggedIn(Runtime, logger, { appliedCookies });
+    if (resolved.url !== CHATGPT_URL) {
+      await navigateToChatGPT(Page, Runtime, resolved.url, logger);
+      await ensureNotBlocked(Runtime, resolved.headless, logger);
+    }
     await ensurePromptReady(Runtime, resolved.inputTimeoutMs, logger);
-  } else {
-    const opened = await openConversationFromSidebarWithRetry(
-      Runtime,
-      {
-        conversationId:
-          runtime.conversationId ?? extractConversationIdFromUrl(runtime.tabUrl ?? ""),
-        preferProjects:
-          resolved.url !== CHATGPT_URL ||
-          Boolean(
-            runtime.tabUrl && (/\/g\//.test(runtime.tabUrl) || runtime.tabUrl.includes("/project")),
-          ),
-        promptPreview: deps.promptPreview,
-      },
-      15_000,
-    );
-    if (!opened) {
-      throw new Error("Unable to locate prior ChatGPT conversation in sidebar.");
+
+    const conversationUrl = buildConversationUrl(runtime, resolved.url);
+    if (conversationUrl) {
+      logger(`Reopening conversation at ${conversationUrl}`);
+      await navigateToChatGPT(Page, Runtime, conversationUrl, logger);
+      await ensureNotBlocked(Runtime, resolved.headless, logger);
+      await ensurePromptReady(Runtime, resolved.inputTimeoutMs, logger);
+    } else {
+      const opened = await openConversationFromSidebarWithRetry(
+        Runtime,
+        {
+          conversationId:
+            runtime.conversationId ?? extractConversationIdFromUrl(runtime.tabUrl ?? ""),
+          preferProjects:
+            resolved.url !== CHATGPT_URL ||
+            Boolean(
+              runtime.tabUrl &&
+              (/\/g\//.test(runtime.tabUrl) || runtime.tabUrl.includes("/project")),
+            ),
+          promptPreview: deps.promptPreview,
+        },
+        15_000,
+      );
+      if (!opened) {
+        throw new Error("Unable to locate prior ChatGPT conversation in sidebar.");
+      }
+      await waitForLocationChange(Runtime, 15_000);
     }
-    await waitForLocationChange(Runtime, 15_000);
-  }
 
-  const waitForHydration = deps.waitForConversationHydration ?? waitForResumedConversationHydration;
-  await waitForHydration(Runtime, resolved.inputTimeoutMs, logger, {
-    requirePriorTurns: true,
-    requirePromptReady: false,
-    expectedConversationUrl: conversationUrl ?? undefined,
-  });
-  const waitForResponse = deps.waitForAssistantResponse ?? waitForAssistantResponse;
-  const captureMarkdown = deps.captureAssistantMarkdown ?? captureAssistantMarkdown;
-  const timeoutMs = resolved.timeoutMs ?? 120_000;
-  const minTurnIndex =
-    (await readPromptPreviewTurnIndex(Runtime, deps.promptPreview)) ??
-    (deps.promptPreview ? null : await readConversationTurnIndex(Runtime, logger));
-  if (resolved.researchMode === "deep") {
-    const waitForDeepResearch = deps.waitForDeepResearchCompletion ?? waitForDeepResearchCompletion;
-    const researchResult = await waitForDeepResearch(
-      Runtime,
-      logger,
-      timeoutMs,
-      minTurnIndex ?? undefined,
-      Page,
-      client,
-      {
-        requireScopedTargetOwner: true,
-      },
+    const waitForHydration =
+      deps.waitForConversationHydration ?? waitForResumedConversationHydration;
+    await cancellation.call(() =>
+      waitForHydration(Runtime, resolved.inputTimeoutMs, logger, {
+        requirePriorTurns: true,
+        requirePromptReady: false,
+        expectedConversationUrl: conversationUrl ?? undefined,
+      }),
     );
-    await cleanup();
-    return {
-      answerText: researchResult.text,
-      answerMarkdown: researchResult.text,
-    };
-  }
-  const promptEcho = buildPromptEchoMatcher(deps.promptPreview);
-  const answer = await waitForResponse(Runtime, timeoutMs, logger, minTurnIndex ?? undefined);
-  const recovered = await recoverPromptEcho(
-    Runtime,
-    answer,
-    promptEcho,
-    logger,
-    minTurnIndex,
-    timeoutMs,
-  );
-  const markdown = (await captureMarkdown(Runtime, recovered.meta, logger)) ?? recovered.text;
-  const aligned = alignPromptEchoMarkdown(recovered.text, markdown, promptEcho, logger);
+    const waitForResponse = deps.waitForAssistantResponse ?? waitForAssistantResponse;
+    const captureMarkdown = deps.captureAssistantMarkdown ?? captureAssistantMarkdown;
+    const timeoutMs = resolved.timeoutMs ?? 120_000;
+    const minTurnIndex =
+      (await readPromptPreviewTurnIndex(Runtime, deps.promptPreview)) ??
+      (deps.promptPreview ? null : await readConversationTurnIndex(Runtime, logger));
+    if (resolved.researchMode === "deep") {
+      const waitForDeepResearch =
+        deps.waitForDeepResearchCompletion ?? waitForDeepResearchCompletion;
+      const researchResult = await cancellation.call(() =>
+        waitForDeepResearch(Runtime, logger, timeoutMs, minTurnIndex ?? undefined, Page, client, {
+          requireScopedTargetOwner: true,
+        }),
+      );
+      return {
+        answerText: researchResult.text,
+        answerMarkdown: researchResult.text,
+      };
+    }
+    const promptEcho = buildPromptEchoMatcher(deps.promptPreview);
+    const answer = await cancellation.call(() =>
+      waitForResponse(Runtime, timeoutMs, logger, minTurnIndex ?? undefined),
+    );
+    const recovered = await cancellation.call(() =>
+      recoverPromptEcho(Runtime, answer, promptEcho, logger, minTurnIndex, timeoutMs),
+    );
+    const markdown =
+      (await cancellation.call(() => captureMarkdown(Runtime, recovered.meta, logger))) ??
+      recovered.text;
+    const aligned = alignPromptEchoMarkdown(recovered.text, markdown, promptEcho, logger);
 
-  await cleanup();
-  return { answerText: aligned.answerText, answerMarkdown: aligned.answerMarkdown };
+    return { answerText: aligned.answerText, answerMarkdown: aligned.answerMarkdown };
+  } finally {
+    await withoutBrowserCancellation(cleanup);
+  }
 }
 
 async function readPromptPreviewTurnIndex(

--- a/src/browser/recoveryTarget.ts
+++ b/src/browser/recoveryTarget.ts
@@ -1,4 +1,8 @@
-import type { BrowserRecoveryTarget, SessionMetadata } from "../sessionStore.js";
+import type {
+  BrowserRecoveryTarget,
+  BrowserRuntimeMetadata,
+  SessionMetadata,
+} from "../sessionStore.js";
 import { randomUUID } from "node:crypto";
 import { sessionStore } from "../sessionStore.js";
 import { connectToRemoteChromeTarget } from "./chromeLifecycle.js";
@@ -88,12 +92,52 @@ export function matchesOwnedRecoveryTarget(
   );
 }
 
+export function recoveryCaptureFromRuntime(
+  runtime: BrowserRuntimeMetadata | undefined,
+): BrowserRecoveryCapture | undefined {
+  const owned = runtime?.ownedRecoveryTarget;
+  const conversationId =
+    runtime?.conversationId ?? extractConversationIdFromUrl(runtime?.tabUrl ?? "");
+  return owned && conversationId ? { ...owned, conversationId } : undefined;
+}
+
 /** Call only after the full recovered answer and completed session have been saved. */
 export async function retireRecoveredBrowserTarget(
   sessionId: string,
   capture: BrowserRecoveryCapture | undefined,
   logger: BrowserLogger,
   deps: { connect?: typeof connectToRemoteChromeTarget } = {},
+): Promise<void> {
+  await retireOwnedBrowserTarget(sessionId, capture, logger, {
+    ...deps,
+    terminalStatus: "completed",
+    requireIdle: true,
+  });
+}
+
+/** Call only after cancellation has been persisted for the owning session. */
+export async function retireCancelledBrowserTarget(
+  sessionId: string,
+  capture: BrowserRecoveryCapture | undefined,
+  logger: BrowserLogger,
+  deps: { connect?: typeof connectToRemoteChromeTarget } = {},
+): Promise<void> {
+  await retireOwnedBrowserTarget(sessionId, capture, logger, {
+    ...deps,
+    terminalStatus: "cancelled",
+    requireIdle: false,
+  });
+}
+
+async function retireOwnedBrowserTarget(
+  sessionId: string,
+  capture: BrowserRecoveryCapture | undefined,
+  logger: BrowserLogger,
+  options: {
+    connect?: typeof connectToRemoteChromeTarget;
+    terminalStatus: "completed" | "cancelled";
+    requireIdle: boolean;
+  },
 ): Promise<void> {
   if (!capture) return;
   let connection: Awaited<ReturnType<typeof connectToRemoteChromeTarget>> | undefined;
@@ -104,14 +148,14 @@ export async function retireRecoveredBrowserTarget(
     const metadata = await sessionStore.readSession(sessionId);
     if (
       !metadata ||
-      metadata.status !== "completed" ||
+      metadata.status !== options.terminalStatus ||
       hasOtherLiveBrowserController(metadata) ||
       !matchesOwnedRecoveryTarget(metadata, capture)
     )
       return;
     const claimId = metadata.browser?.runtime?.ownedRecoveryTarget?.claimId;
     if (!claimId) return;
-    const connect = deps.connect ?? connectToRemoteChromeTarget;
+    const connect = options.connect ?? connectToRemoteChromeTarget;
     connection = await connect(capture.host, capture.port, logger, {
       targetId: capture.targetId,
       browserWSEndpoint: capture.browserWSEndpoint,
@@ -126,7 +170,7 @@ export async function retireRecoveredBrowserTarget(
     const value = state.result?.value as { url?: string; generating?: boolean } | undefined;
     if (
       !value ||
-      value.generating !== false ||
+      (options.requireIdle && value.generating !== false) ||
       extractConversationIdFromUrl(value.url ?? "") !== capture.conversationId
     )
       return;
@@ -140,17 +184,23 @@ export async function retireRecoveredBrowserTarget(
     if (await targetHasActiveController(metadata, capture)) return;
     lockedClaim = claimId;
     const locked = await Runtime.evaluate({
-      expression: buildTargetRetirementExpression(claimId, capture.conversationId!, reservationId),
+      expression: buildTargetRetirementExpression(claimId, capture.conversationId!, reservationId, {
+        allowGenerating: !options.requireIdle,
+      }),
       returnByValue: true,
     });
     if (locked.exceptionDetails || locked.result?.value !== true) return;
     const result = await Target.closeTarget({ targetId: capture.targetId });
     if (!result.success) throw new Error("Chrome refused target retirement");
     retired = true;
-    logger("Retired Oracle-owned browser tab after saving the recovered answer.");
+    logger(
+      options.terminalStatus === "completed"
+        ? "Retired Oracle-owned browser tab after saving the recovered answer."
+        : "Retired Oracle-owned browser tab after cancellation.",
+    );
   } catch (error) {
     logger(
-      `Recovered answer is saved; browser tab cleanup failed: ${error instanceof Error ? error.message : String(error)}`,
+      `${options.terminalStatus === "completed" ? "Recovered answer is saved" : "Cancellation is saved"}; browser tab cleanup failed: ${error instanceof Error ? error.message : String(error)}`,
     );
   } finally {
     if (connection && lockedClaim && !retired) {

--- a/src/browser/recoveryTarget.ts
+++ b/src/browser/recoveryTarget.ts
@@ -149,6 +149,7 @@ async function retireOwnedBrowserTarget(
     if (
       !metadata ||
       metadata.status !== options.terminalStatus ||
+      metadata.browser?.config?.keepBrowser === true ||
       hasOtherLiveBrowserController(metadata) ||
       !matchesOwnedRecoveryTarget(metadata, capture)
     )

--- a/src/browser/sessionRunner.ts
+++ b/src/browser/sessionRunner.ts
@@ -321,7 +321,7 @@ async function executeAssembledBrowserSession({
       outputPath: runOptions.outputPath,
       followUpPrompts: runOptions.browserFollowUps,
       signal,
-      closeOwnedTabOnCancel: true,
+      closeOwnedTabOnCancel: !executionBrowserConfig.keepBrowser,
       runtimeHintCb: async (runtime, modelSelection) => {
         const runtimeWithController = {
           ...runtime,

--- a/src/browser/sessionRunner.ts
+++ b/src/browser/sessionRunner.ts
@@ -18,7 +18,7 @@ import {
   cleanupGeneratedBrowserBundles,
   materializeBrowserFallback,
 } from "./prompt.js";
-import { BrowserAutomationError } from "../oracle/errors.js";
+import { BrowserAutomationError, BrowserRunCancelledError } from "../oracle/errors.js";
 import type { BrowserArchiveResult, BrowserLogger, SavedBrowserFile } from "./types.js";
 import {
   appendArtifacts,
@@ -55,6 +55,7 @@ interface RunBrowserSessionArgs {
   browserConfig: BrowserSessionConfig;
   cwd: string;
   log: (message?: string) => void;
+  signal?: AbortSignal;
 }
 
 export interface BrowserSessionRunnerDeps {
@@ -140,25 +141,29 @@ function buildBrowserRunWarnings(args: {
 }
 
 export async function runBrowserSessionExecution(
-  { runOptions, browserConfig, cwd, log }: RunBrowserSessionArgs,
+  { runOptions, browserConfig, cwd, log, signal }: RunBrowserSessionArgs,
   deps: BrowserSessionRunnerDeps = {},
 ): Promise<BrowserExecutionResult> {
   const assemblePrompt = deps.assemblePrompt ?? assembleBrowserPrompt;
   const executeBrowser = deps.executeBrowser ?? runBrowserMode;
   const persistRuntimeHint = deps.persistRuntimeHint ?? (() => {});
   const inputTimeoutMs = browserConfig.inputTimeoutMs ?? DEFAULT_BROWSER_CONFIG.inputTimeoutMs;
-  let preparationTimedOut = false;
+  let preparationAbandoned = false;
   let preparationTimeout: ReturnType<typeof setTimeout> | undefined;
+  let removePreparationAbortListener: (() => void) | undefined;
   let promptArtifacts: Awaited<ReturnType<typeof assembleBrowserPrompt>>;
+  if (signal?.aborted) {
+    throw new BrowserRunCancelledError();
+  }
   try {
     promptArtifacts = await Promise.race([
       assemblePrompt(runOptions, { cwd }).then(async (artifacts) => {
-        if (preparationTimedOut) await cleanupGeneratedBrowserBundles(artifacts);
+        if (preparationAbandoned) await cleanupGeneratedBrowserBundles(artifacts);
         return artifacts;
       }),
       new Promise<never>((_, reject) => {
         preparationTimeout = setTimeout(() => {
-          preparationTimedOut = true;
+          preparationAbandoned = true;
           reject(
             new BrowserAutomationError(
               `Browser prompt preparation timed out after ${inputTimeoutMs}ms; increase --browser-input-timeout if local files need more time.`,
@@ -171,11 +176,25 @@ export async function runBrowserSessionExecution(
           );
         }, inputTimeoutMs);
       }),
+      new Promise<never>((_, reject) => {
+        if (!signal) return;
+        const abort = () => {
+          preparationAbandoned = true;
+          reject(new BrowserRunCancelledError());
+        };
+        if (signal.aborted) {
+          abort();
+          return;
+        }
+        signal.addEventListener("abort", abort, { once: true });
+        removePreparationAbortListener = () => signal.removeEventListener("abort", abort);
+      }),
     ]);
   } finally {
     if (preparationTimeout) {
       clearTimeout(preparationTimeout);
     }
+    removePreparationAbortListener?.();
   }
   try {
     return await executeAssembledBrowserSession({
@@ -185,6 +204,7 @@ export async function runBrowserSessionExecution(
       promptArtifacts,
       executeBrowser,
       persistRuntimeHint,
+      signal,
     });
   } finally {
     await cleanupGeneratedBrowserBundles(promptArtifacts);
@@ -198,6 +218,7 @@ async function executeAssembledBrowserSession({
   promptArtifacts,
   executeBrowser,
   persistRuntimeHint,
+  signal,
 }: {
   runOptions: RunOracleOptions;
   browserConfig: BrowserSessionConfig;
@@ -205,6 +226,7 @@ async function executeAssembledBrowserSession({
   promptArtifacts: Awaited<ReturnType<typeof assembleBrowserPrompt>>;
   executeBrowser: NonNullable<BrowserSessionRunnerDeps["executeBrowser"]>;
   persistRuntimeHint: NonNullable<BrowserSessionRunnerDeps["persistRuntimeHint"]>;
+  signal?: AbortSignal;
 }): Promise<BrowserExecutionResult> {
   if (runOptions.verbose) {
     log(
@@ -298,6 +320,8 @@ async function executeAssembledBrowserSession({
       generateImagePath: runOptions.generateImage,
       outputPath: runOptions.outputPath,
       followUpPrompts: runOptions.browserFollowUps,
+      signal,
+      closeOwnedTabOnCancel: true,
       runtimeHintCb: async (runtime, modelSelection) => {
         const runtimeWithController = {
           ...runtime,
@@ -311,7 +335,7 @@ async function executeAssembledBrowserSession({
       },
     });
   } catch (error) {
-    if (error instanceof BrowserAutomationError) {
+    if (error instanceof BrowserAutomationError || error instanceof BrowserRunCancelledError) {
       throw error;
     }
     const message = error instanceof Error ? error.message : "Browser automation failed.";

--- a/src/browser/targetClaim.ts
+++ b/src/browser/targetClaim.ts
@@ -28,6 +28,7 @@ export function buildTargetRetirementExpression(
   claimId: string,
   conversationId: string,
   reservationId: string,
+  options: { allowGenerating?: boolean } = {},
 ): string {
   return `(() => {
     let claim;
@@ -36,7 +37,7 @@ export function buildTargetRetirementExpression(
     const id = location.pathname.match(/\\/c\\/([^/]+)/)?.[1];
     if (id !== ${JSON.stringify(conversationId)}) return false;
     const generating = Array.from(document.querySelectorAll(${JSON.stringify(STOP_BUTTON_SELECTORS.join(","))})).some(node => node.getBoundingClientRect().width > 0 && node.getBoundingClientRect().height > 0);
-    if (generating) return false;
+    if (generating && !${JSON.stringify(options.allowGenerating === true)}) return false;
     claim.retiring = true;
     claim.retirementId = ${JSON.stringify(reservationId)};
     try { sessionStorage.setItem('oracle:target-claim', JSON.stringify(claim)); } catch { return false; }

--- a/src/cli/detach.ts
+++ b/src/cli/detach.ts
@@ -1,6 +1,7 @@
 import type { EngineMode } from "./engine.js";
 import type { ModelName, ReasoningMode } from "../oracle.js";
 import { isProModel } from "../oracle/modelResolver.js";
+import { isGpt6ProAlias } from "./browserConfig.js";
 
 export function shouldDetachSession({
   // Params kept for policy tweaks.
@@ -20,12 +21,16 @@ export function shouldDetachSession({
   // Keep long local browser Pro work in a separate process even while the CLI
   // stays attached to its session log. If the foreground stream is interrupted,
   // the worker can still finish the browser run and persist the answer.
-  if (engine === "browser" && isProModel(model)) return true;
+  if (engine === "browser" && (isProModel(model) || isGpt6ProAlias(model))) return true;
   // For API runs, explicit --wait keeps execution in the foreground.
   if (waitPreference) return false;
   // Pro-tier API runs start detached by default.
   if ((isProModel(model) || reasoningMode === "pro") && engine === "api") return true;
   return false;
+}
+
+export function shouldExitAfterTopLevelSigint(remainingListenerCount: number): boolean {
+  return remainingListenerCount === 0;
 }
 
 export function stopDetachedWorker(

--- a/src/cli/detach.ts
+++ b/src/cli/detach.ts
@@ -33,6 +33,15 @@ export function shouldExitAfterTopLevelSigint(remainingListenerCount: number): b
   return remainingListenerCount === 0;
 }
 
+export function detachedCancellationExitCode(
+  cancelled: boolean,
+  finalStatus: string | undefined,
+  currentExitCode: NodeJS.Process["exitCode"],
+): NodeJS.Process["exitCode"] {
+  if (!cancelled) return currentExitCode;
+  return finalStatus === "completed" || finalStatus === "partial" ? 0 : 130;
+}
+
 export function stopDetachedWorker(
   workerPid: number,
   kill: (pid: number, signal: NodeJS.Signals) => void = process.kill,

--- a/src/cli/detachedSession.ts
+++ b/src/cli/detachedSession.ts
@@ -1,6 +1,53 @@
 import { spawn } from "node:child_process";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
+import { access, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
+
+const CANCELLATION_MARKER = ".cancel-requested";
+
+export function detachedSessionCancellationPath(sessionDir: string, workerPid: number): string {
+  return path.join(sessionDir, `${CANCELLATION_MARKER}-${workerPid}`);
+}
+
+export async function requestDetachedSessionCancellation(markerPath: string): Promise<void> {
+  await writeFile(markerPath, "cancel\n", "utf8");
+}
+
+export async function clearDetachedSessionCancellation(markerPath: string): Promise<void> {
+  await rm(markerPath, { force: true });
+}
+
+export async function waitForDetachedSessionCancellation({
+  markerPath,
+  signal,
+  pollIntervalMs = 100,
+}: {
+  markerPath: string;
+  signal: AbortSignal;
+  pollIntervalMs?: number;
+}): Promise<boolean> {
+  while (!signal.aborted) {
+    try {
+      await access(markerPath);
+      return true;
+    } catch (error) {
+      if (!(error instanceof Error) || (error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+    try {
+      await delay(pollIntervalMs, undefined, { signal });
+    } catch (error) {
+      if (signal.aborted && error instanceof Error && error.name === "AbortError") {
+        return false;
+      }
+      throw error;
+    }
+  }
+  return false;
+}
 
 export interface DetachedSessionSpawnSpec {
   command: string;

--- a/src/cli/sessionDisplay.ts
+++ b/src/cli/sessionDisplay.ts
@@ -488,7 +488,10 @@ export async function attachSession(
   }
 
   const shouldTrimIntro =
-    initialStatus === "completed" || initialStatus === "partial" || initialStatus === "error";
+    initialStatus === "completed" ||
+    initialStatus === "partial" ||
+    initialStatus === "error" ||
+    initialStatus === "cancelled";
   if (options?.renderPrompt !== false) {
     const prompt = await readStoredPrompt(sessionId);
     if (prompt) {
@@ -626,7 +629,12 @@ export async function attachSession(
     if (!latest) {
       break;
     }
-    if (latest.status === "completed" || latest.status === "partial" || latest.status === "error") {
+    if (
+      latest.status === "completed" ||
+      latest.status === "partial" ||
+      latest.status === "error" ||
+      latest.status === "cancelled"
+    ) {
       await printNew();
       flushRemainder();
       if (!options?.suppressMetadata) {
@@ -658,7 +666,11 @@ export async function attachSession(
       if (!settled) {
         break;
       }
-      if (settled.status === "completed" || settled.status === "partial") {
+      if (
+        settled.status === "completed" ||
+        settled.status === "partial" ||
+        settled.status === "cancelled"
+      ) {
         continue;
       }
       await printNew();

--- a/src/cli/sessionRunner.ts
+++ b/src/cli/sessionRunner.ts
@@ -36,7 +36,6 @@ import {
   deriveNotificationSettingsFromMetadata,
 } from "./notifier.js";
 import { sessionStore } from "../sessionStore.js";
-import { wait } from "../sessionManager.js";
 import { runMultiModelApiSession, type MultiModelRunSummary } from "../oracle/multiModelRunner.js";
 import { MODEL_CONFIGS, DEFAULT_SYSTEM_PROMPT } from "../oracle/config.js";
 import { isKnownModel } from "../oracle/modelResolver.js";
@@ -49,13 +48,18 @@ import { sanitizeOscProgress } from "./oscUtils.js";
 import { readFiles } from "../oracle/files.js";
 import { cwd as getCwd } from "node:process";
 import { resumeBrowserSession } from "../browser/reattach.js";
-import { retireRecoveredBrowserTarget } from "../browser/recoveryTarget.js";
+import {
+  recoveryCaptureFromRuntime,
+  retireCancelledBrowserTarget,
+  retireRecoveredBrowserTarget,
+} from "../browser/recoveryTarget.js";
 import { hasRecoverableChatGptConversation } from "../browser/reattachability.js";
-import { estimateTokenCount } from "../browser/utils.js";
+import { delay, estimateTokenCount } from "../browser/utils.js";
 import type { BrowserLogger, SavedBrowserFile } from "../browser/types.js";
 import { computeFileSha256, sanitizeArtifactFilename } from "../browser/artifacts.js";
 import { formatElapsed } from "../oracle/format.js";
 import { formatBrowserReattachGuidance } from "./reattachGuidance.js";
+import { BrowserRunCancelledError } from "../oracle/errors.js";
 
 const isTty = process.stdout.isTTY;
 const dim = (text: string): string => (isTty ? kleur.dim(text) : text);
@@ -72,6 +76,7 @@ export interface SessionRunParams {
   notifications?: NotificationSettings;
   browserDeps?: BrowserSessionRunnerDeps;
   muteStdout?: boolean;
+  signal?: AbortSignal;
 }
 
 export async function performSessionRun({
@@ -86,6 +91,7 @@ export async function performSessionRun({
   notifications,
   browserDeps,
   muteStdout = false,
+  signal,
 }: SessionRunParams): Promise<void> {
   const writeInline = (chunk: string): boolean => {
     // Keep session logs intact while still echoing inline output to the user.
@@ -104,6 +110,45 @@ export async function performSessionRun({
   const notificationSettings =
     notifications ?? deriveNotificationSettingsFromMetadata(sessionMeta, process.env);
   const modelForStatus = runOptions.model ?? sessionMeta.model;
+  const checkBrowserCancellation = (): void => {
+    if (mode === "browser" && signal?.aborted) throw new BrowserRunCancelledError();
+  };
+  const finalizeBrowserCancellation = async (
+    cancellationError: BrowserRunCancelledError,
+  ): Promise<never> => {
+    const completedAt = new Date().toISOString();
+    log("Browser run cancelled.");
+    if (modelForStatus) {
+      await sessionStore.updateModelRun(sessionMeta.id, modelForStatus, {
+        status: "cancelled",
+        completedAt,
+        response: { status: "cancelled" },
+        error: undefined,
+        transport: undefined,
+      });
+    }
+    await sessionStore.updateSession(sessionMeta.id, {
+      status: "cancelled",
+      completedAt,
+      errorMessage: undefined,
+      mode,
+      browser: browserConfig
+        ? {
+            ...currentBrowser,
+            config: browserConfig,
+          }
+        : undefined,
+      response: { status: "cancelled" },
+      error: undefined,
+      transport: undefined,
+    });
+    await retireCancelledBrowserTarget(
+      sessionMeta.id,
+      recoveryCaptureFromRuntime(currentBrowser?.runtime),
+      log,
+    );
+    throw cancellationError;
+  };
   try {
     if (mode === "browser") {
       if (!browserConfig) {
@@ -141,19 +186,23 @@ export async function performSessionRun({
           browserConfig,
           cwd,
           log,
+          signal,
         },
         runnerDeps,
       );
+      checkBrowserCancellation();
       const writtenOutputPath = await writeAssistantOutput(
         runOptions.writeOutputPath,
         result.answerText ?? "",
         log,
       );
+      checkBrowserCancellation();
       const outputArtifacts = await copyBrowserOutputArtifacts({
         outputPath: writtenOutputPath,
         savedFiles: runOptions.writeArtifacts ? result.savedFiles : undefined,
         log,
       });
+      checkBrowserCancellation();
       const browserWarnings = [...(result.warnings ?? []), ...outputArtifacts.warnings];
       await sendSessionNotification(
         {
@@ -168,13 +217,16 @@ export async function performSessionRun({
         log,
         result.answerText?.slice(0, 140),
       );
+      checkBrowserCancellation();
       if (modelForStatus) {
         await sessionStore.updateModelRun(sessionMeta.id, modelForStatus, {
           status: "completed",
           completedAt: new Date().toISOString(),
           usage: result.usage,
         });
+        checkBrowserCancellation();
       }
+      checkBrowserCancellation();
       await sessionStore.updateSession(sessionMeta.id, {
         status: "completed",
         completedAt: new Date().toISOString(),
@@ -527,6 +579,9 @@ export async function performSessionRun({
       error: undefined,
     });
   } catch (error: unknown) {
+    if (error instanceof BrowserRunCancelledError) {
+      return await finalizeBrowserCancellation(error);
+    }
     const message = formatError(error);
     log(`ERROR: ${message}`);
     markErrorLogged(error);
@@ -556,6 +611,11 @@ export async function performSessionRun({
       const runtime = (userError.details as { runtime?: BrowserRuntimeMetadata } | undefined)
         ?.runtime;
       const recoverableRuntime = runtime ?? currentBrowser?.runtime;
+      currentBrowser = {
+        ...currentBrowser,
+        config: browserConfig,
+        runtime: recoverableRuntime,
+      };
       if (
         !hasRecoverableChatGptConversation(recoverableRuntime) &&
         recoverableRuntime?.promptSubmitted !== true
@@ -633,23 +693,32 @@ export async function performSessionRun({
         configuredIntervalMs > 0
           ? configuredIntervalMs
           : Math.max(1_000, Math.min(browserConfig?.timeoutMs ?? 30_000, 30_000));
-      const success = await autoReattachUntilComplete({
-        sessionMeta,
-        runtime: recoverableRuntime ?? undefined,
-        browserConfig: {
-          ...browserConfig,
-          autoReattachIntervalMs: connectionLostIntervalMs,
-          autoReattachDelayMs: browserConfig?.autoReattachDelayMs ?? 0,
-          autoReattachTimeoutMs:
-            browserConfig?.autoReattachTimeoutMs ?? browserConfig?.timeoutMs ?? 120_000,
-        },
-        browserMetadata: currentBrowser,
-        runOptions,
-        modelForStatus,
-        notificationSettings,
-        log,
-        maxAttempts: configuredIntervalMs > 0 ? undefined : 1,
-      });
+      let success: boolean;
+      try {
+        success = await autoReattachUntilComplete({
+          sessionMeta,
+          runtime: recoverableRuntime ?? undefined,
+          browserConfig: {
+            ...browserConfig,
+            autoReattachIntervalMs: connectionLostIntervalMs,
+            autoReattachDelayMs: browserConfig?.autoReattachDelayMs ?? 0,
+            autoReattachTimeoutMs:
+              browserConfig?.autoReattachTimeoutMs ?? browserConfig?.timeoutMs ?? 120_000,
+          },
+          browserMetadata: currentBrowser,
+          runOptions,
+          modelForStatus,
+          notificationSettings,
+          log,
+          maxAttempts: configuredIntervalMs > 0 ? undefined : 1,
+          signal,
+        });
+      } catch (recoveryError) {
+        if (signal?.aborted || recoveryError instanceof BrowserRunCancelledError) {
+          return await finalizeBrowserCancellation(new BrowserRunCancelledError());
+        }
+        throw recoveryError;
+      }
       if (success) {
         return;
       }
@@ -670,6 +739,11 @@ export async function performSessionRun({
       };
       const autoReattachIntervalMs = browserConfig?.autoReattachIntervalMs ?? 0;
       const autoRuntime = runtime ?? currentBrowser?.runtime;
+      currentBrowser = {
+        ...currentBrowser,
+        config: browserConfig,
+        runtime: autoRuntime,
+      };
       const willAutoReattach = autoReattachIntervalMs > 0 && Boolean(autoRuntime);
       if (willAutoReattach) {
         if (modelForStatus) {
@@ -693,16 +767,25 @@ export async function performSessionRun({
           response: timeoutResponse,
           error: timeoutError,
         });
-        const success = await autoReattachUntilComplete({
-          sessionMeta,
-          runtime: autoRuntime,
-          browserConfig,
-          browserMetadata: currentBrowser,
-          runOptions,
-          modelForStatus,
-          notificationSettings,
-          log,
-        });
+        let success: boolean;
+        try {
+          success = await autoReattachUntilComplete({
+            sessionMeta,
+            runtime: autoRuntime,
+            browserConfig,
+            browserMetadata: currentBrowser,
+            runOptions,
+            modelForStatus,
+            notificationSettings,
+            log,
+            signal,
+          });
+        } catch (recoveryError) {
+          if (signal?.aborted || recoveryError instanceof BrowserRunCancelledError) {
+            return await finalizeBrowserCancellation(new BrowserRunCancelledError());
+          }
+          throw recoveryError;
+        }
         if (success) {
           return;
         }
@@ -1255,6 +1338,7 @@ async function autoReattachUntilComplete({
   notificationSettings,
   log,
   maxAttempts,
+  signal,
 }: {
   sessionMeta: SessionMetadata;
   runtime?: BrowserRuntimeMetadata;
@@ -1265,6 +1349,7 @@ async function autoReattachUntilComplete({
   notificationSettings: NotificationSettings;
   log: (message?: string) => void;
   maxAttempts?: number;
+  signal?: AbortSignal;
 }): Promise<boolean> {
   if (!runtime || !browserConfig) {
     log(dim("Auto-reattach disabled: missing runtime or browser config."));
@@ -1281,6 +1366,9 @@ async function autoReattachUntilComplete({
     120_000;
   const maxTotalMs = 2 * 60 * 60 * 1000; // 2h hard cap; avoid infinite polling by default.
   const maxDeadline = Date.now() + maxTotalMs;
+  const checkCancellation = (): void => {
+    if (signal?.aborted) throw new BrowserRunCancelledError();
+  };
   const attemptLimit =
     typeof maxAttempts === "number" && maxAttempts > 0
       ? Math.floor(maxAttempts)
@@ -1288,7 +1376,7 @@ async function autoReattachUntilComplete({
 
   if (delayMs > 0) {
     log(dim(`Auto-reattach starting in ${formatElapsed(delayMs)}...`));
-    await wait(delayMs);
+    await delay(delayMs, signal);
   }
   if (Number.isFinite(attemptLimit)) {
     log(dim(`Auto-reattach will try up to ${attemptLimit} attempt(s).`));
@@ -1307,6 +1395,7 @@ async function autoReattachUntilComplete({
 
   let attempt = 0;
   for (;;) {
+    checkCancellation();
     const remainingBudgetMs = maxDeadline - Date.now();
     if (remainingBudgetMs <= 0) {
       log(
@@ -1324,9 +1413,14 @@ async function autoReattachUntilComplete({
         ...browserConfig,
         timeoutMs,
       };
-      const result = await resumeBrowserSession(runtime, reattachConfig, logger, {
-        promptPreview: sessionMeta.promptPreview,
-      });
+      const result = await awaitBrowserCancellation(
+        resumeBrowserSession(runtime, reattachConfig, logger, {
+          promptPreview: sessionMeta.promptPreview,
+          signal,
+        }),
+        signal,
+      );
+      checkCancellation();
       captureSucceeded = true;
       const answerText = result.answerMarkdown || result.answerText || "";
       const outputTokens = estimateTokenCount(answerText);
@@ -1339,12 +1433,15 @@ async function autoReattachUntilComplete({
         existingArtifacts: sessionMeta.artifacts,
         logger,
       });
+      checkCancellation();
       const paths = await sessionStore.getPaths(sessionMeta.id);
+      checkCancellation();
       await fs.appendFile(
         paths.log,
         `[auto-reattach] captured assistant response on attempt ${attempt}\nAnswer:\n${answerText}\n`,
         "utf8",
       );
+      checkCancellation();
       if (modelForStatus) {
         await sessionStore.updateModelRun(sessionMeta.id, modelForStatus, {
           status: "completed",
@@ -1356,8 +1453,10 @@ async function autoReattachUntilComplete({
             totalTokens: outputTokens,
           },
         });
+        checkCancellation();
       }
       await writeAssistantOutput(runOptions.writeOutputPath, answerText, log);
+      checkCancellation();
       await sendSessionNotification(
         {
           sessionId: sessionMeta.id,
@@ -1374,6 +1473,7 @@ async function autoReattachUntilComplete({
         log,
         answerText.slice(0, 140),
       );
+      checkCancellation();
       await sessionStore.updateSession(sessionMeta.id, {
         status: "completed",
         completedAt: new Date().toISOString(),
@@ -1398,6 +1498,9 @@ async function autoReattachUntilComplete({
       await retireRecoveredBrowserTarget(sessionMeta.id, result.captureTarget, logger);
       return true;
     } catch (error) {
+      if (signal?.aborted || error instanceof BrowserRunCancelledError) {
+        throw new BrowserRunCancelledError();
+      }
       if (captureSucceeded) {
         const message = formatError(error);
         if (modelForStatus) {
@@ -1439,7 +1542,22 @@ async function autoReattachUntilComplete({
       );
       return false;
     }
-    await wait(Math.min(intervalMs, remainingAfterAttemptMs));
+    await delay(Math.min(intervalMs, remainingAfterAttemptMs), signal);
+  }
+}
+
+async function awaitBrowserCancellation<T>(task: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return task;
+  if (signal.aborted) throw new BrowserRunCancelledError();
+  let abort: (() => void) | undefined;
+  const cancelled = new Promise<never>((_, reject) => {
+    abort = () => reject(new BrowserRunCancelledError());
+    signal.addEventListener("abort", abort, { once: true });
+  });
+  try {
+    return await Promise.race([task, cancelled]);
+  } finally {
+    if (abort) signal.removeEventListener("abort", abort);
   }
 }
 

--- a/tests/browser/chromeLifecycle.test.ts
+++ b/tests/browser/chromeLifecycle.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { BrowserRunCancelledError } from "../../src/oracle/errors.js";
 
 const cdpNewMock = vi.fn();
 const cdpCloseMock = vi.fn();
@@ -894,6 +895,27 @@ describe("closeBlankChromeTabs", () => {
     await expect(waiting).resolves.toEqual([]);
     expect(browser.close).toHaveBeenCalledOnce();
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("closes the browser-level CDP connection when target discovery is cancelled", async () => {
+    const cancellation = new AbortController();
+    const browser = {
+      Target: { getTargets: vi.fn(() => new Promise(() => undefined)) },
+      close: vi.fn(async () => {}),
+    };
+    cdpMock.mockResolvedValueOnce(browser);
+    const { listRemoteChromeTargets } = await import("../../src/browser/chromeLifecycle.js");
+    const waiting = listRemoteChromeTargets({
+      host: "127.0.0.1",
+      port: 9222,
+      browserWSEndpoint: "ws://127.0.0.1:9222/devtools/browser/abc",
+      signal: cancellation.signal,
+    });
+    await vi.waitFor(() => expect(browser.Target.getTargets).toHaveBeenCalledOnce());
+    cancellation.abort();
+
+    await expect(waiting).rejects.toThrow(BrowserRunCancelledError);
+    expect(browser.close).toHaveBeenCalledOnce();
   });
 
   test("cleans up a connection approved after its deadline without creating a tab", async () => {

--- a/tests/browser/reattach.test.ts
+++ b/tests/browser/reattach.test.ts
@@ -1,10 +1,11 @@
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, stat } from "node:fs/promises";
 import { describe, expect, test, vi } from "vitest";
 import { resumeBrowserSession, __test__ } from "../../src/browser/reattach.js";
 import * as chromeLifecycle from "../../src/browser/chromeLifecycle.js";
 import type { BrowserLogger, ChromeClient } from "../../src/browser/types.js";
+import { BrowserRunCancelledError } from "../../src/oracle/errors.js";
 
 type FakeTarget = { id?: string; targetId?: string; type?: string; url?: string };
 type FakeClient = {
@@ -24,6 +25,66 @@ type FakeClient = {
 };
 
 describe("resumeBrowserSession", () => {
+  test("removes a temporary recovery profile created as cancellation arrives", async () => {
+    const cancellation = new AbortController();
+    const launchChrome = vi.fn();
+    let profileDir = "";
+    const createTemporaryProfile = async () => {
+      profileDir = await mkdtemp(path.join(os.tmpdir(), "oracle-reattach-cancel-test-"));
+      cancellation.abort();
+      return profileDir;
+    };
+
+    await expect(
+      resumeBrowserSession({}, {}, vi.fn() as BrowserLogger, {
+        signal: cancellation.signal,
+        createTemporaryProfile,
+        launchChrome: launchChrome as never,
+      }),
+    ).rejects.toThrow(BrowserRunCancelledError);
+
+    expect(launchChrome).not.toHaveBeenCalled();
+    await expect(stat(profileDir)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  test("cancels an in-flight response wait without falling back to a new browser", async () => {
+    const cancellation = new AbortController();
+    const close = vi.fn(async () => {});
+    const recoverSession = vi.fn();
+    const waitForAssistantResponse = vi.fn(() => new Promise<never>(() => undefined));
+    const runtime = {
+      chromePort: 9222,
+      chromeTargetId: "saved-tab",
+      tabUrl: "https://chatgpt.com/c/saved",
+    };
+    const evaluate = vi.fn(async ({ expression }: { expression: string }) => ({
+      result: { value: expression === "location.href" ? runtime.tabUrl : 2 },
+    }));
+    const connect = vi.fn(async () => ({
+      Runtime: { enable: vi.fn(), evaluate },
+      DOM: { enable: vi.fn() },
+      close,
+    })) as unknown as (options?: unknown) => Promise<ChromeClient>;
+
+    const logger = vi.fn() as BrowserLogger;
+    const execution = resumeBrowserSession(runtime, { timeoutMs: 60_000 }, logger, {
+      signal: cancellation.signal,
+      listTargets: vi.fn(async () => [
+        { targetId: "saved-tab", type: "page", url: runtime.tabUrl },
+      ]),
+      connect,
+      waitForConversationHydration: vi.fn(async () => 2),
+      waitForAssistantResponse,
+      recoverSession,
+    });
+    await vi.waitFor(() => expect(waitForAssistantResponse).toHaveBeenCalledOnce());
+    cancellation.abort();
+
+    await expect(execution).rejects.toThrow(BrowserRunCancelledError);
+    expect(close).toHaveBeenCalledOnce();
+    expect(recoverSession).not.toHaveBeenCalled();
+  });
+
   test("uses the saved approval wait for both browser-level reattach connections", async () => {
     const list = vi
       .spyOn(chromeLifecycle, "listRemoteChromeTargets")

--- a/tests/browser/reattach.test.ts
+++ b/tests/browser/reattach.test.ts
@@ -36,11 +36,18 @@ describe("resumeBrowserSession", () => {
     };
 
     await expect(
-      resumeBrowserSession({}, {}, vi.fn() as BrowserLogger, {
-        signal: cancellation.signal,
-        createTemporaryProfile,
-        launchChrome: launchChrome as never,
-      }),
+      resumeBrowserSession(
+        {},
+        // Windows defaults to the persistent manual-login profile, so pin the
+        // temporary-profile path this test is exercising on every platform.
+        { manualLogin: false },
+        vi.fn() as BrowserLogger,
+        {
+          signal: cancellation.signal,
+          createTemporaryProfile,
+          launchChrome: launchChrome as never,
+        },
+      ),
     ).rejects.toThrow(BrowserRunCancelledError);
 
     expect(launchChrome).not.toHaveBeenCalled();

--- a/tests/browser/recoveryTarget.test.ts
+++ b/tests/browser/recoveryTarget.test.ts
@@ -124,6 +124,18 @@ test("retires an owned generating tab after cancellation is persisted", async ()
 
   expect(closeTarget).toHaveBeenCalledWith({ targetId: capture.targetId });
 });
+
+test("preserves a kept tab when cancelled metadata still contains its ownership claim", async () => {
+  await sessionStore.updateSession(metadata.id, {
+    status: "cancelled",
+    browser: { ...metadata.browser, config: { keepBrowser: true } },
+  });
+
+  await retireCancelledBrowserTarget(metadata.id, capture, () => {});
+
+  expect(connectToRemoteChromeTarget).not.toHaveBeenCalled();
+  expect(closeTarget).not.toHaveBeenCalled();
+});
 const harvested = (patch: Partial<ChatGptTabSummary> = {}): ChatGptTabSummary => ({
   ...capture,
   url: "https://chatgpt.com/c/recovery",

--- a/tests/browser/recoveryTarget.test.ts
+++ b/tests/browser/recoveryTarget.test.ts
@@ -7,6 +7,8 @@ import { setOracleHomeDirOverrideForTest } from "../../src/oracleHome.js";
 import { connectToRemoteChromeTarget } from "../../src/browser/chromeLifecycle.js";
 import {
   matchesOwnedRecoveryTarget,
+  recoveryCaptureFromRuntime,
+  retireCancelledBrowserTarget,
   retireRecoveredBrowserTarget,
 } from "../../src/browser/recoveryTarget.js";
 import { completeOwnedBrowserHarvest } from "../../src/cli/recoveredBrowserHarvest.js";
@@ -69,8 +71,9 @@ beforeEach(async () => {
     },
   }));
   closeTarget = vi.fn(async () => {
-    expect((await sessionStore.readSession(metadata.id))?.status).toBe("completed");
-    expect(await sessionStore.readLog(metadata.id)).toContain(answer);
+    const status = (await sessionStore.readSession(metadata.id))?.status;
+    expect(["completed", "cancelled"]).toContain(status);
+    if (status === "completed") expect(await sessionStore.readLog(metadata.id)).toContain(answer);
     return { success: true };
   });
   createTarget = vi.fn(async () => ({ targetId: "replacement" }));
@@ -96,6 +99,30 @@ afterEach(async () => {
   vi.restoreAllMocks();
   setOracleHomeDirOverrideForTest(null);
   await fs.rm(root, { recursive: true, force: true });
+});
+
+test("derives the exact owned recovery capture from runtime metadata", () => {
+  expect(
+    recoveryCaptureFromRuntime({
+      conversationId: capture.conversationId,
+      ownedRecoveryTarget: capture,
+    }),
+  ).toEqual(capture);
+});
+
+test("retires an owned generating tab after cancellation is persisted", async () => {
+  await sessionStore.updateSession(metadata.id, { status: "cancelled" });
+  evaluate.mockImplementation(async ({ expression }: { expression: string }) => ({
+    result: {
+      value: expression.includes("claim.retiring = true")
+        ? true
+        : { url: "https://chatgpt.com/c/recovery", generating: true },
+    },
+  }));
+
+  await retireCancelledBrowserTarget(metadata.id, capture, () => {});
+
+  expect(closeTarget).toHaveBeenCalledWith({ targetId: capture.targetId });
 });
 const harvested = (patch: Partial<ChatGptTabSummary> = {}): ChatGptTabSummary => ({
   ...capture,

--- a/tests/browser/sessionRunner.test.ts
+++ b/tests/browser/sessionRunner.test.ts
@@ -294,6 +294,43 @@ describe("runBrowserSessionExecution", () => {
     expect(log).toHaveBeenCalled();
   });
 
+  test("preserves an explicit keep-browser preference during cancellation", async () => {
+    const executeBrowser = vi.fn(async () => ({
+      answerText: "ok",
+      answerMarkdown: "ok",
+      tookMs: 1000,
+      answerTokens: 1,
+      answerChars: 2,
+    }));
+
+    await runBrowserSessionExecution(
+      {
+        runOptions: baseRunOptions,
+        browserConfig: { keepBrowser: true },
+        cwd: "/repo",
+        log: vi.fn(),
+      },
+      {
+        assemblePrompt: async () => ({
+          markdown: "prompt",
+          composerText: "prompt",
+          estimatedInputTokens: 1,
+          attachments: [],
+          inlineFileCount: 0,
+          tokenEstimateIncludesInlineFiles: false,
+          attachmentsPolicy: "auto",
+          attachmentMode: "inline",
+          fallback: null,
+        }),
+        executeBrowser,
+      },
+    );
+
+    expect(executeBrowser).toHaveBeenCalledWith(
+      expect.objectContaining({ closeOwnedTabOnCancel: false }),
+    );
+  });
+
   test("passes browser resume conversation URL to executeBrowser", async () => {
     const executeBrowser = vi.fn(async () => ({
       answerText: "ok",

--- a/tests/browser/sessionRunner.test.ts
+++ b/tests/browser/sessionRunner.test.ts
@@ -8,6 +8,8 @@ import {
   buildBrowserRunWarningsForTest,
   runBrowserSessionExecution,
 } from "../../src/browser/sessionRunner.js";
+import { BrowserRunCancelledError } from "../../src/oracle/errors.js";
+import type { BrowserPromptArtifacts } from "../../src/browser/prompt.js";
 
 const baseRunOptions: RunOracleOptions = {
   prompt: "Hello world",
@@ -19,6 +21,114 @@ const baseRunOptions: RunOracleOptions = {
 const baseConfig: BrowserSessionConfig = {};
 
 describe("runBrowserSessionExecution", () => {
+  test("does not start prompt preparation for an already cancelled run", async () => {
+    const cancellation = new AbortController();
+    cancellation.abort();
+    const assemblePrompt = vi.fn();
+    const executeBrowser = vi.fn();
+
+    await expect(
+      runBrowserSessionExecution(
+        {
+          runOptions: baseRunOptions,
+          browserConfig: baseConfig,
+          cwd: "/repo",
+          log: vi.fn(),
+          signal: cancellation.signal,
+        },
+        { assemblePrompt, executeBrowser },
+      ),
+    ).rejects.toThrow(BrowserRunCancelledError);
+
+    expect(assemblePrompt).not.toHaveBeenCalled();
+    expect(executeBrowser).not.toHaveBeenCalled();
+  });
+
+  test("cancellation wins during prompt preparation and cleans late bundles", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "oracle-cancel-preparation-"));
+    const bundleDir = path.join(root, "oracle-browser-bundle-test");
+    const bundlePath = path.join(bundleDir, "context.txt");
+    const cancellation = new AbortController();
+    let resolvePrompt!: (value: BrowserPromptArtifacts) => void;
+    const assemblePrompt = vi.fn(
+      () =>
+        new Promise<BrowserPromptArtifacts>((resolve) => {
+          resolvePrompt = resolve;
+        }),
+    );
+    const executeBrowser = vi.fn();
+
+    try {
+      const execution = runBrowserSessionExecution(
+        {
+          runOptions: baseRunOptions,
+          browserConfig: { inputTimeoutMs: 60_000 },
+          cwd: "/repo",
+          log: vi.fn(),
+          signal: cancellation.signal,
+        },
+        { assemblePrompt, executeBrowser },
+      );
+      cancellation.abort();
+      await expect(execution).rejects.toThrow(BrowserRunCancelledError);
+
+      await fs.mkdir(bundleDir, { recursive: true });
+      await fs.writeFile(bundlePath, "public test bundle", "utf8");
+      resolvePrompt({
+        markdown: "prompt",
+        composerText: "prompt",
+        estimatedInputTokens: 1,
+        attachments: [{ path: bundlePath, displayPath: "context.txt", generatedBundle: true }],
+        inlineFileCount: 0,
+        tokenEstimateIncludesInlineFiles: false,
+        attachmentsPolicy: "auto",
+        attachmentMode: "bundle",
+        fallback: null,
+        bundled: { originalCount: 1, bundlePath },
+      });
+
+      await vi.waitFor(async () => {
+        await expect(fs.stat(bundleDir)).rejects.toThrow();
+      });
+      expect(executeBrowser).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("preserves browser cancellation as a cancellation", async () => {
+    const cancellation = new AbortController();
+    const executeBrowser = vi.fn(async () => {
+      throw new BrowserRunCancelledError();
+    });
+
+    await expect(
+      runBrowserSessionExecution(
+        {
+          runOptions: baseRunOptions,
+          browserConfig: baseConfig,
+          cwd: "/repo",
+          log: vi.fn(),
+          signal: cancellation.signal,
+        },
+        {
+          assemblePrompt: async () => ({
+            markdown: "prompt",
+            composerText: "prompt",
+            estimatedInputTokens: 1,
+            attachments: [],
+            inlineFileCount: 0,
+            tokenEstimateIncludesInlineFiles: false,
+            attachmentsPolicy: "auto",
+            attachmentMode: "inline",
+            fallback: null,
+          }),
+          executeBrowser,
+        },
+      ),
+    ).rejects.toThrow(BrowserRunCancelledError);
+  });
+
   test("bounds browser prompt preparation with the configured input timeout", async () => {
     vi.useFakeTimers();
     const executeBrowser = vi.fn();
@@ -81,6 +191,7 @@ describe("runBrowserSessionExecution", () => {
   test("logs stats and returns usage/runtime", async () => {
     const log = vi.fn();
     const persistRuntimeHint = vi.fn();
+    const cancellation = new AbortController();
     const executeBrowser = vi.fn(async (options) => {
       await options.runtimeHintCb?.(
         {
@@ -134,6 +245,7 @@ describe("runBrowserSessionExecution", () => {
         browserConfig: baseConfig,
         cwd: "/repo",
         log,
+        signal: cancellation.signal,
       },
       {
         assemblePrompt: async () => ({
@@ -172,6 +284,12 @@ describe("runBrowserSessionExecution", () => {
     expect(persistRuntimeHint).toHaveBeenCalledWith(
       expect.objectContaining({ chromePort: 9999, chromeHost: "127.0.0.1", chromeTargetId: "t-1" }),
       expect.objectContaining({ resolvedLabel: "Pro", verified: true }),
+    );
+    expect(executeBrowser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        signal: cancellation.signal,
+        closeOwnedTabOnCancel: true,
+      }),
     );
     expect(log).toHaveBeenCalled();
   });

--- a/tests/browser/targetClaim.test.ts
+++ b/tests/browser/targetClaim.test.ts
@@ -6,7 +6,7 @@ import {
   normalizeChromeHost,
 } from "../../src/browser/targetClaim.js";
 
-function renderer() {
+function renderer(options: { generating?: boolean } = {}) {
   const storage = new Map<string, string>();
   const sessionStorage = {
     getItem: (key: string) => storage.get(key) ?? null,
@@ -25,7 +25,16 @@ function renderer() {
       "location",
       "document",
       `return ${expression}`,
-    )({}, window, sessionStorage, { pathname: "/c/owned" }, { querySelectorAll: () => [] });
+    )(
+      {},
+      window,
+      sessionStorage,
+      { pathname: "/c/owned" },
+      {
+        querySelectorAll: () =>
+          options.generating ? [{ getBoundingClientRect: () => ({ width: 1, height: 1 }) }] : [],
+      },
+    );
   };
   return { run, storage, sessionStorage };
 }
@@ -34,6 +43,18 @@ test("retirement survives document replacement and excludes a new controller", (
   expect(run(buildTargetClaimExpression("original"))).toBe(true);
   expect(run(buildTargetRetirementExpression("original", "owned", "reservation-a"))).toBe(true);
   expect(run(buildTargetClaimExpression("new-controller"))).toBe(false);
+});
+test("explicit cancellation retirement can close a generating owned target", () => {
+  const { run } = renderer({ generating: true });
+  expect(run(buildTargetClaimExpression("original"))).toBe(true);
+  expect(run(buildTargetRetirementExpression("original", "owned", "reservation-a"))).toBe(false);
+  expect(
+    run(
+      buildTargetRetirementExpression("original", "owned", "reservation-b", {
+        allowGenerating: true,
+      }),
+    ),
+  ).toBe(true);
 });
 test("borrower ownership survives document replacement and blocks original retirement", () => {
   const { run } = renderer();

--- a/tests/cli/detach.test.ts
+++ b/tests/cli/detach.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test, vi } from "vitest";
-import { shouldDetachSession, stopDetachedWorker } from "../../src/cli/detach.js";
+import {
+  shouldDetachSession,
+  shouldExitAfterTopLevelSigint,
+  stopDetachedWorker,
+} from "../../src/cli/detach.js";
 
 describe("shouldDetachSession", () => {
   test("disables detach when env disables it", () => {
@@ -71,6 +75,19 @@ describe("shouldDetachSession", () => {
     },
   );
 
+  test.each([true, false])(
+    "isolates GPT-6 Pro browser runs while wait preference is %s",
+    (waitPreference) => {
+      const result = shouldDetachSession({
+        engine: "browser",
+        model: "gpt-6-pro" as never,
+        waitPreference,
+        disableDetachEnv: false,
+      });
+      expect(result).toBe(true);
+    },
+  );
+
   test("keeps non-pro browser runs inline", () => {
     const result = shouldDetachSession({
       engine: "browser",
@@ -107,5 +124,10 @@ describe("shouldDetachSession", () => {
       disableDetachEnv: false,
     });
     expect(result).toBe(true);
+  });
+
+  test("lets a remaining session SIGINT handler finish cancellation", () => {
+    expect(shouldExitAfterTopLevelSigint(1)).toBe(false);
+    expect(shouldExitAfterTopLevelSigint(0)).toBe(true);
   });
 });

--- a/tests/cli/detach.test.ts
+++ b/tests/cli/detach.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
 import {
+  detachedCancellationExitCode,
   shouldDetachSession,
   shouldExitAfterTopLevelSigint,
   stopDetachedWorker,
@@ -129,5 +130,12 @@ describe("shouldDetachSession", () => {
   test("lets a remaining session SIGINT handler finish cancellation", () => {
     expect(shouldExitAfterTopLevelSigint(1)).toBe(false);
     expect(shouldExitAfterTopLevelSigint(0)).toBe(true);
+  });
+
+  test("restores success when completion wins after the parent recorded SIGINT", () => {
+    expect(detachedCancellationExitCode(true, "completed", 130)).toBe(0);
+    expect(detachedCancellationExitCode(true, "partial", 130)).toBe(0);
+    expect(detachedCancellationExitCode(true, "cancelled", 130)).toBe(130);
+    expect(detachedCancellationExitCode(false, "completed", undefined)).toBeUndefined();
   });
 });

--- a/tests/cli/detachedSession.test.ts
+++ b/tests/cli/detachedSession.test.ts
@@ -1,4 +1,6 @@
 import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
 import { EventEmitter } from "node:events";
 import { PassThrough, Writable } from "node:stream";
 import { pathToFileURL } from "node:url";
@@ -6,11 +8,35 @@ import type { ChildProcess } from "node:child_process";
 import { describe, expect, test, vi } from "vitest";
 import {
   buildDetachedSessionSpawnSpec,
+  clearDetachedSessionCancellation,
+  detachedSessionCancellationPath,
   launchDetachedSession,
+  requestDetachedSessionCancellation,
   resolveOracleCliEntrypoint,
+  waitForDetachedSessionCancellation,
 } from "../../src/cli/detachedSession.js";
 
 describe("detached session launcher", () => {
+  test("observes a cancellation requested before the worker starts waiting", async () => {
+    const sessionDir = await mkdtemp(path.join(os.tmpdir(), "oracle-cancel-marker-"));
+    const markerPath = detachedSessionCancellationPath(sessionDir, 4242);
+    const stop = new AbortController();
+
+    try {
+      await requestDetachedSessionCancellation(markerPath);
+      await expect(
+        waitForDetachedSessionCancellation({ markerPath, signal: stop.signal, pollIntervalMs: 1 }),
+      ).resolves.toBe(true);
+      await clearDetachedSessionCancellation(markerPath);
+      expect(detachedSessionCancellationPath(sessionDir, 4243)).not.toBe(markerPath);
+      await expect(
+        waitForDetachedSessionCancellation({ markerPath, signal: AbortSignal.abort() }),
+      ).resolves.toBe(false);
+    } finally {
+      await rm(sessionDir, { recursive: true, force: true });
+    }
+  });
+
   test("uses a hidden detached Node child with a gated session handoff", () => {
     const spec = buildDetachedSessionSpawnSpec({
       sessionId: "long-pro-session",

--- a/tests/cli/sessionDisplay.test.ts
+++ b/tests/cli/sessionDisplay.test.ts
@@ -395,6 +395,43 @@ describe("attachSession rendering", () => {
     );
   });
 
+  test("treats a cancelled detached session as terminal without rewriting it as error", async () => {
+    const runningMeta: SessionMetadata = {
+      ...baseMeta,
+      status: "running",
+      mode: "browser",
+      lifecycle: {
+        engine: "browser",
+        execution: "background",
+        attached: false,
+        detached: true,
+        workerPid: process.pid,
+        reattachCommand: "oracle session sess",
+      },
+    } as SessionMetadata;
+    const cancelledMeta: SessionMetadata = {
+      ...runningMeta,
+      status: "cancelled",
+      completedAt: new Date().toISOString(),
+      lifecycle: {
+        ...runningMeta.lifecycle,
+        workerPid: 2_147_483_647,
+      },
+    } as SessionMetadata;
+    readSessionMetadataMock.mockResolvedValueOnce(runningMeta).mockResolvedValue(cancelledMeta);
+    readSessionLogMock.mockResolvedValue("Browser run cancelled.");
+    readSessionRequestMock.mockResolvedValue({ prompt: "Prompt here" });
+
+    await attachSession("sess", {
+      renderMarkdown: false,
+      suppressMetadata: true,
+      propagateFailure: true,
+    });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(sessionStoreMock.updateSession).not.toHaveBeenCalled();
+  });
+
   test("does not reattach while the detached browser worker is alive", async () => {
     const runningMeta: SessionMetadata = {
       ...baseMeta,

--- a/tests/cli/sessionRunner.test.ts
+++ b/tests/cli/sessionRunner.test.ts
@@ -61,6 +61,7 @@ import {
   OracleTransportError,
   runOracle,
 } from "../../src/oracle.ts";
+import { BrowserRunCancelledError } from "../../src/oracle/errors.ts";
 import {
   runMultiModelApiSession,
   type ModelExecutionResult,
@@ -1401,6 +1402,268 @@ describe("performSessionRun", () => {
     expect(logLines).not.toContain("Next steps (browser fallback)");
     expect(logLines).not.toContain("--engine api");
     expect(logLines).not.toContain("This run did not return cleanly");
+  });
+
+  test("records browser cancellation truthfully for the session and model", async () => {
+    vi.mocked(runBrowserSessionExecution).mockRejectedValueOnce(new BrowserRunCancelledError());
+
+    await expect(
+      performSessionRun({
+        sessionMeta: baseSessionMeta,
+        runOptions: baseRunOptions,
+        mode: "browser",
+        browserConfig: { chromePath: null },
+        cwd: "/tmp",
+        log,
+        write,
+        version: cliVersion,
+      }),
+    ).rejects.toThrow(BrowserRunCancelledError);
+
+    expect(sessionStoreMock.updateModelRun).toHaveBeenCalledWith(
+      baseSessionMeta.id,
+      "gpt-5.2-pro",
+      expect.objectContaining({ status: "cancelled", completedAt: expect.any(String) }),
+    );
+    expect(sessionStoreMock.updateSession).toHaveBeenCalledWith(
+      baseSessionMeta.id,
+      expect.objectContaining({
+        status: "cancelled",
+        completedAt: expect.any(String),
+        response: { status: "cancelled" },
+      }),
+    );
+  });
+
+  test("cancellation during normal browser output persistence cannot commit completion", async () => {
+    const cancellation = new AbortController();
+    vi.mocked(runBrowserSessionExecution).mockResolvedValueOnce({
+      usage: { inputTokens: 1, outputTokens: 1, reasoningTokens: 0, totalTokens: 2 },
+      elapsedMs: 10,
+      runtime: { chromePort: 9222 },
+      answerText: "answer",
+    });
+    let finishOutput!: () => void;
+    vi.mocked(fsPromises.writeFile).mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishOutput = resolve;
+        }),
+    );
+
+    const execution = performSessionRun({
+      sessionMeta: baseSessionMeta,
+      runOptions: { ...baseRunOptions, writeOutputPath: "/tmp/browser-cancelled.md" },
+      mode: "browser",
+      browserConfig: { chromePath: null },
+      cwd: "/tmp",
+      log,
+      write,
+      version: cliVersion,
+      signal: cancellation.signal,
+    });
+    await vi.waitFor(() => expect(fsPromises.writeFile).toHaveBeenCalledOnce());
+    cancellation.abort();
+    finishOutput();
+
+    await expect(execution).rejects.toThrow(BrowserRunCancelledError);
+    expect(sessionStoreMock.updateSession).toHaveBeenLastCalledWith(
+      baseSessionMeta.id,
+      expect.objectContaining({ status: "cancelled" }),
+    );
+    expect(sessionStoreMock.updateSession).not.toHaveBeenCalledWith(
+      baseSessionMeta.id,
+      expect.objectContaining({ status: "completed" }),
+    );
+  });
+
+  test("cancels during an auto-reattach delay without starting recovery", async () => {
+    const cancellation = new AbortController();
+    vi.mocked(runBrowserSessionExecution).mockRejectedValueOnce(
+      new BrowserAutomationError("recoverable disconnect", {
+        stage: "connection-lost",
+        recoverableDisconnect: true,
+        runtime: {
+          chromePort: 9222,
+          tabUrl: "https://chatgpt.com/c/demo",
+          promptSubmitted: true,
+        },
+      }),
+    );
+
+    const execution = performSessionRun({
+      sessionMeta: baseSessionMeta,
+      runOptions: baseRunOptions,
+      mode: "browser",
+      browserConfig: {
+        chromePath: null,
+        autoReattachDelayMs: 60_000,
+        autoReattachIntervalMs: 1_000,
+      },
+      cwd: "/tmp",
+      log,
+      write,
+      version: cliVersion,
+      signal: cancellation.signal,
+    });
+    await vi.waitFor(() =>
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("Auto-reattach starting")),
+    );
+    cancellation.abort();
+
+    await expect(execution).rejects.toThrow(BrowserRunCancelledError);
+    expect(vi.mocked(resumeBrowserSession)).not.toHaveBeenCalled();
+    expect(sessionStoreMock.updateSession).toHaveBeenCalledWith(
+      baseSessionMeta.id,
+      expect.objectContaining({ status: "cancelled" }),
+    );
+  });
+
+  test("cancellation interrupts an active auto-reattach attempt", async () => {
+    const cancellation = new AbortController();
+    vi.mocked(runBrowserSessionExecution).mockRejectedValueOnce(
+      new BrowserAutomationError("recoverable disconnect", {
+        stage: "connection-lost",
+        recoverableDisconnect: true,
+        runtime: {
+          chromePort: 9222,
+          tabUrl: "https://chatgpt.com/c/demo",
+          promptSubmitted: true,
+        },
+      }),
+    );
+    vi.mocked(resumeBrowserSession).mockImplementationOnce(() => new Promise(() => undefined));
+
+    const execution = performSessionRun({
+      sessionMeta: baseSessionMeta,
+      runOptions: baseRunOptions,
+      mode: "browser",
+      browserConfig: { chromePath: null },
+      cwd: "/tmp",
+      log,
+      write,
+      version: cliVersion,
+      signal: cancellation.signal,
+    });
+    await vi.waitFor(() => expect(resumeBrowserSession).toHaveBeenCalledTimes(1));
+    cancellation.abort();
+
+    await expect(execution).rejects.toThrow(BrowserRunCancelledError);
+    expect(sessionStoreMock.updateSession).toHaveBeenLastCalledWith(
+      baseSessionMeta.id,
+      expect.objectContaining({ status: "cancelled" }),
+    );
+    expect(sessionStoreMock.updateSession).not.toHaveBeenCalledWith(
+      baseSessionMeta.id,
+      expect.objectContaining({ status: "completed" }),
+    );
+  });
+
+  test("cancellation during recovered artifact persistence cannot commit completion", async () => {
+    const cancellation = new AbortController();
+    vi.mocked(runBrowserSessionExecution).mockRejectedValueOnce(
+      new BrowserAutomationError("recoverable disconnect", {
+        stage: "connection-lost",
+        recoverableDisconnect: true,
+        runtime: {
+          chromePort: 9222,
+          tabUrl: "https://chatgpt.com/c/demo",
+          promptSubmitted: true,
+        },
+      }),
+    );
+    vi.mocked(resumeBrowserSession).mockResolvedValueOnce({
+      answerText: "recovered answer",
+      answerMarkdown: "recovered answer",
+    });
+    let finishArtifacts!: (value: []) => void;
+    vi.mocked(ensureSessionArtifacts).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishArtifacts = resolve;
+        }),
+    );
+
+    const execution = performSessionRun({
+      sessionMeta: baseSessionMeta,
+      runOptions: baseRunOptions,
+      mode: "browser",
+      browserConfig: { chromePath: null },
+      cwd: "/tmp",
+      log,
+      write,
+      version: cliVersion,
+      signal: cancellation.signal,
+    });
+    await vi.waitFor(() => expect(ensureSessionArtifacts).toHaveBeenCalledOnce());
+    cancellation.abort();
+    finishArtifacts([]);
+
+    await expect(execution).rejects.toThrow(BrowserRunCancelledError);
+    expect(sessionStoreMock.updateSession).toHaveBeenLastCalledWith(
+      baseSessionMeta.id,
+      expect.objectContaining({ status: "cancelled" }),
+    );
+    expect(sessionStoreMock.updateSession).not.toHaveBeenCalledWith(
+      baseSessionMeta.id,
+      expect.objectContaining({ status: "completed" }),
+    );
+  });
+
+  test("recovery completion remains terminal once its final session write begins", async () => {
+    const cancellation = new AbortController();
+    vi.mocked(runBrowserSessionExecution).mockRejectedValueOnce(
+      new BrowserAutomationError("recoverable disconnect", {
+        stage: "connection-lost",
+        recoverableDisconnect: true,
+        runtime: {
+          chromePort: 9222,
+          tabUrl: "https://chatgpt.com/c/demo",
+          promptSubmitted: true,
+        },
+      }),
+    );
+    vi.mocked(resumeBrowserSession).mockResolvedValueOnce({
+      answerText: "recovered answer",
+      answerMarkdown: "recovered answer",
+    });
+    let completionStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      completionStarted = resolve;
+    });
+    let finishCompletion!: () => void;
+    sessionStoreMock.updateSession.mockImplementation((_id, patch) => {
+      if (patch.status !== "completed") return Promise.resolve();
+      completionStarted();
+      return new Promise<void>((resolve) => {
+        finishCompletion = resolve;
+      });
+    });
+
+    const execution = performSessionRun({
+      sessionMeta: baseSessionMeta,
+      runOptions: baseRunOptions,
+      mode: "browser",
+      browserConfig: { chromePath: null },
+      cwd: "/tmp",
+      log,
+      write,
+      version: cliVersion,
+      signal: cancellation.signal,
+    });
+    await started;
+    cancellation.abort();
+    finishCompletion();
+
+    await expect(execution).resolves.toBeUndefined();
+    expect(sessionStoreMock.updateSession).not.toHaveBeenCalledWith(
+      baseSessionMeta.id,
+      expect.objectContaining({ status: "cancelled" }),
+    );
+    expect(sessionStoreMock.updateSession).toHaveBeenLastCalledWith(
+      baseSessionMeta.id,
+      expect.objectContaining({ status: "completed" }),
+    );
   });
 
   test("preserves persisted runtime hints when browser automation fails without runtime details", async () => {


### PR DESCRIPTION
Long browser consultations need a detached worker even while the foreground CLI waits for them. Ctrl-C now requests cancellation from that worker, and the worker persists cancelled session/model state while cleaning up resources it owns. Cancellation and completion races preserve the terminal outcome, including cancellation during reattachment and output persistence.

The maintainer repair also preserves explicitly kept tabs during final target retirement and removes a late cancellation marker when worker completion wins. API wait/detach behavior remains governed by the existing separate policy. Thanks @pdurlej.

Validation: 111 focused cancellation/session tests plus target-retirement and detach coverage pass; lint/typecheck and build pass. The real built CLI/Chrome matrix verifies normal cancellation (exit 130), keep-browser cancellation (exit 130 with the target retained), and a paused foreground process receiving Ctrl-C after worker completion (exit 0). All three verify worker exit, terminal model/session metadata, and marker removal. Required isolated review and exact-head CI are recorded in the proof comment.

The changelog entry is centralized in the final notes/dependency PR for this batch.
