### PR TITLE
fix(browser): retry unavailable controller identity probes

### DIFF
--- a/docs/windows-work.md
+++ b/docs/windows-work.md
@@ -14,6 +14,8 @@ Read this file whenever you're working from Windows and add new findings so the 
 
 Future Windows gotchas belong here. Update this doc when you learn something new.
 
+- Tab-lease tests run real PowerShell process-identity probes (up to five seconds each). Their Windows test budget must cover multiple probes and registry cleanup. Failed self-identity probes are retried on the next lookup; only a successful identity is cached for the controller lifetime.
+
 - A fresh Windows worktree with `core.autocrlf=true` can make `oxfmt --check` flag otherwise unchanged files. Use LF checkout contents for validation and inspect the staged diff to keep checkout-only line-ending changes out of the PR.
 
 - ChatGPT sidebar/history labels can include phrases like "Login setup instruction"; login probes must match exact auth CTAs, not any visible text starting with login, or manual-login automation loops forever before typing.

--- a/src/browser/profileState.ts
+++ b/src/browser/profileState.ts
@@ -258,7 +258,11 @@ export async function readProcessStartTimeMs(pid: number): Promise<number | null
   if (Math.trunc(pid) === process.pid) {
     // Use the same OS identity as peer controllers, not wall time minus uptime.
     // Cache our own PID only: it cannot be reused during this process's lifetime.
-    return (ownProcessStartTime ??= queryProcessStartTimeMs(process.pid));
+    return (ownProcessStartTime ??= queryProcessStartTimeMs(process.pid).then((startedAt) => {
+      // A transient probe failure is not a permanent process identity.
+      if (startedAt === null) ownProcessStartTime = undefined;
+      return startedAt;
+    }));
   }
   return queryProcessStartTimeMs(pid);
 }

--- a/tests/browser/profileState.processIdentity.test.ts
+++ b/tests/browser/profileState.processIdentity.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, expect, test, vi } from "vitest";
+
+const { query } = vi.hoisted(() => ({ query: vi.fn() }));
+vi.mock("node:child_process", () => ({
+  execFile: Object.assign(vi.fn(), { [Symbol.for("nodejs.util.promisify.custom")]: query }),
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  query.mockReset();
+});
+
+test("retries a failed self-identity probe and caches only the successful result", async () => {
+  query.mockRejectedValueOnce(new Error("PowerShell timed out"));
+  query.mockResolvedValue({ stdout: "2026-09-11T12:00:00.000Z" });
+  const { readProcessStartTimeMs } = await import("../../src/browser/profileState.js");
+
+  await expect(readProcessStartTimeMs(process.pid)).resolves.toBeNull();
+  const expected = Date.parse("2026-09-11T12:00:00.000Z");
+  await expect(readProcessStartTimeMs(process.pid)).resolves.toBe(expected);
+  await expect(readProcessStartTimeMs(process.pid)).resolves.toBe(expected);
+  expect(query).toHaveBeenCalledTimes(2);
+});
+
+test("shares an in-flight self probe, then retries an unparseable result", async () => {
+  let complete!: (value: { stdout: string }) => void;
+  query.mockImplementationOnce(
+    () =>
+      new Promise((resolve) => {
+        complete = resolve;
+      }),
+  );
+  const { readProcessStartTimeMs } = await import("../../src/browser/profileState.js");
+  const first = readProcessStartTimeMs(process.pid);
+  const second = readProcessStartTimeMs(process.pid);
+  expect(query).toHaveBeenCalledTimes(1);
+  complete({ stdout: "" });
+  await expect(Promise.all([first, second])).resolves.toEqual([null, null]);
+
+  query.mockResolvedValue({ stdout: "2026-09-11T12:00:00.000Z" });
+  await expect(readProcessStartTimeMs(process.pid)).resolves.toBe(
+    Date.parse("2026-09-11T12:00:00.000Z"),
+  );
+  expect(query).toHaveBeenCalledTimes(2);
+});
+
+test("never caches a peer identity because its PID may be reused", async () => {
+  query.mockResolvedValueOnce({ stdout: "2026-09-11T12:00:00.000Z" });
+  query.mockResolvedValueOnce({ stdout: "2026-09-11T13:00:00.000Z" });
+  const { readProcessStartTimeMs } = await import("../../src/browser/profileState.js");
+  await expect(readProcessStartTimeMs(process.pid + 1)).resolves.toBe(
+    Date.parse("2026-09-11T12:00:00.000Z"),
+  );
+  await expect(readProcessStartTimeMs(process.pid + 1)).resolves.toBe(
+    Date.parse("2026-09-11T13:00:00.000Z"),
+  );
+  expect(query).toHaveBeenCalledTimes(2);
+});

--- a/tests/browser/tabLeaseRegistry.test.ts
+++ b/tests/browser/tabLeaseRegistry.test.ts
@@ -12,7 +12,9 @@ import {
   type BrowserTabLease,
 } from "../../src/browser/tabLeaseRegistry.js";
 
-describe("tabLeaseRegistry", () => {
+// Native Windows identity probes can each take five seconds on a busy runner.
+// Keep the real process/filesystem coverage and allow multi-probe recovery to finish.
+describe("tabLeaseRegistry", { timeout: process.platform === "win32" ? 30_000 : 5_000 }, () => {
   test("normalizes the concurrent tab limit", () => {
     expect(normalizeMaxConcurrentTabs(undefined)).toBe(3);
     expect(normalizeMaxConcurrentTabs("4")).toBe(4);


### PR DESCRIPTION
Windows CI intermittently exhausts the tab-lease tests' five-second budget while running real PowerShell identity probes, whose individual timeout is also five seconds. A failed self-identity probe was additionally cached for the controller lifetime, preventing later lock checks from recovering usable identity evidence.

Retry unavailable self identities on the next lookup, retain shared in-flight probes and successful caching, and keep peer identities uncached. Give the native Windows registry tests a 30-second budget for multiple bounded probes and cleanup; no tests or ownership checks are removed.

Validation: new regressions failed twice before the fix; focused identity/profile/registry tests pass (50 passed). Typecheck, lint, build, and isolated Codex review through P2 pass. Full-suite and real two-controller Chrome lifecycle proof are running; exact-head CI will be recorded in a follow-up proof comment.

The user-facing changelog entry will be included in the final notes/dependency PR for this batch.
