### PR TITLE
fix(browser): recover harvests through saved Chrome transport

### DIFF
--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -68,7 +68,7 @@ import { formatRenderedMarkdown } from "../src/cli/renderOutput.js";
 import { resolveRenderFlag, resolveRenderPlain } from "../src/cli/renderFlags.js";
 import { resolveGeminiModelId } from "../src/oracle/geminiModels.js";
 import type { StatusOptions } from "../src/cli/sessionCommand.js";
-import { isErrorLogged } from "../src/cli/errorUtils.js";
+import { formatCliError, isErrorLogged } from "../src/cli/errorUtils.js";
 import { resolveOutputPath } from "../src/cli/writeOutputPath.js";
 import { getCliVersion } from "../src/version.js";
 import {
@@ -3095,12 +3095,6 @@ async function main(): Promise<void> {
 }
 
 void main().catch((error: unknown) => {
-  if (error instanceof Error) {
-    if (!isErrorLogged(error)) {
-      console.error(chalk.red("✖"), error.message);
-    }
-  } else {
-    console.error(chalk.red("✖"), error);
-  }
+  if (!isErrorLogged(error)) console.error(chalk.red("✖"), formatCliError(error));
   process.exitCode = 1;
 });

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -140,6 +140,16 @@ Every run gets a default slug derived from the prompt. Override with `--slug "my
 
 ## Browser harvest identity
 
+`oracle session <id> --harvest` and `--live` reuse the saved Chrome transport,
+including the browser WebSocket endpoint and approval wait for attach-running
+sessions. This supports Chrome configurations without HTTP target discovery.
+If the saved tab is gone, recovery reopens the saved conversation through the
+same endpoint. Keep Chrome running with remote debugging enabled and allow its
+connection prompt when requested; transport failures identify the operation and
+endpoint instead of displaying an empty error. Transient ChatGPT status notices
+appended outside the user content do not invalidate the submitted prompt hash;
+the stable user message ID and exact prompt text must still match.
+
 Browser harvest and live-tail compare the observed conversation with saved
 runtime, archive, artifact-source, and transcript-header identities. A mismatch
 is retained under `browser.harvest.integrity` and shown as a browser warning;

--- a/src/browser/chromeLifecycle.ts
+++ b/src/browser/chromeLifecycle.ts
@@ -578,6 +578,7 @@ export interface RemoteTargetInfo {
   targetId?: string;
   type?: string;
   url?: string;
+  title?: string;
 }
 
 export async function listRemoteChromeTargets(options: {
@@ -616,6 +617,7 @@ export async function listRemoteChromeTargets(options: {
           targetId: target.targetId,
           type: target.type,
           url: target.url,
+          title: target.title,
         }));
       } finally {
         await browser.close().catch(() => undefined);

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -3295,6 +3295,8 @@ async function runRemoteBrowserMode(
           connectToExistingChatGptTab({
             host,
             port,
+            browserWSEndpoint,
+            approvalWaitMs: config.approvalWaitMs,
             ref: tabRef,
           }),
         (attached) => attached.client.close(),

--- a/src/browser/liveTabs.ts
+++ b/src/browser/liveTabs.ts
@@ -13,6 +13,7 @@ import { captureAssistantMarkdown, readAssistantSnapshot } from "./actions/assis
 import { buildConversationTurnListExpression } from "./conversationTurns.js";
 import { extractStableConversationIdFromUrl } from "./conversationUrl.js";
 import { delay } from "./utils.js";
+import { connectToRemoteChromeTarget, listRemoteChromeTargets } from "./chromeLifecycle.js";
 
 export const DEFAULT_REMOTE_CHROME_HOST = "127.0.0.1";
 export const DEFAULT_REMOTE_CHROME_PORT = 9222;
@@ -28,9 +29,11 @@ interface ChromeTarget {
   url?: string;
 }
 
-interface HostPort {
+export interface LiveChromeEndpoint {
   host?: string;
   port?: number;
+  browserWSEndpoint?: string;
+  approvalWaitMs?: number;
 }
 
 export interface ChatGptTabSummary {
@@ -53,6 +56,7 @@ export interface ChatGptTabSummary {
   lastAssistantSnippet: string;
   lastUserText: string;
   lastUserTextRaw?: string;
+  lastUserContentText?: string;
   lastUserMessageId?: string;
   lastUserSnippet: string;
   focused: boolean;
@@ -66,11 +70,11 @@ export interface ChatGptTabSummary {
   lastAssistantTurnId?: string;
 }
 
-interface ResolveChatGptTabOptions extends HostPort {
+interface ResolveChatGptTabOptions extends LiveChromeEndpoint {
   ref?: string;
 }
 
-interface InspectChatGptTabOptions extends HostPort {
+interface InspectChatGptTabOptions extends LiveChromeEndpoint {
   target: ChromeTarget;
 }
 
@@ -93,11 +97,28 @@ function trimToSnippet(text: string, max = 140): string {
   return `${normalized.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
 }
 
-function normalizeHostPort(input: HostPort = {}): Required<HostPort> {
+function normalizeHostPort(
+  input: LiveChromeEndpoint = {},
+): LiveChromeEndpoint & { host: string; port: number } {
   return {
     host: input.host ?? DEFAULT_REMOTE_CHROME_HOST,
     port: input.port ?? DEFAULT_REMOTE_CHROME_PORT,
+    ...(input.browserWSEndpoint
+      ? { browserWSEndpoint: input.browserWSEndpoint, approvalWaitMs: input.approvalWaitMs }
+      : {}),
   };
+}
+
+function chromeTransportError(
+  operation: string,
+  endpoint: LiveChromeEndpoint,
+  error: unknown,
+): Error {
+  const detail = error instanceof Error ? error.message.trim() : String(error ?? "").trim();
+  return new Error(
+    `Unable to ${operation} on Chrome at ${endpoint.host}:${endpoint.port}. ${detail || "Chrome returned no error details."} Check that Chrome is running and remote debugging is enabled, then retry and allow the connection prompt.`,
+    { cause: error },
+  );
 }
 
 function normalizeUrl(value: unknown): string {
@@ -252,6 +273,7 @@ function buildTabInspectionExpression(): string {
       const lastUserText = normalize(lastUserTurn?.textContent);
       const lastUserMessage = lastUserTurn?.matches?.('[data-message-author-role="user"]')
         ? lastUserTurn : lastUserTurn?.querySelector?.('[data-message-author-role="user"]');
+      const userContent = lastUserMessage?.querySelectorAll?.('[class~="whitespace-pre-wrap"]');
       const authenticated = !loginButtonExists && (promptReady || sendExists || stopExists || assistantCount > 0);
       return {
         title: normalize(document.title),
@@ -269,6 +291,7 @@ function buildTabInspectionExpression(): string {
         lastUserTurnIndex,
         lastUserText,
         lastUserTextRaw: lastUserMessage?.textContent,
+        lastUserContentText: userContent?.length === 1 ? userContent[0].textContent : undefined,
         lastUserMessageId: lastUserMessage?.getAttribute?.('data-message-id'),
         visibilityState: document.visibilityState,
         focused: Boolean(document.hasFocus?.()),
@@ -280,31 +303,69 @@ export function buildTabInspectionExpressionForTest(): string {
   return buildTabInspectionExpression();
 }
 
-export async function listChatGptTargets(options: HostPort = {}): Promise<ChromeTarget[]> {
-  const { host, port } = normalizeHostPort(options);
-  const targets = (await CDP.List({ host, port })) as ChromeTarget[];
-  return targets.filter(isChatGptTarget);
+export async function listChatGptTargets(
+  options: LiveChromeEndpoint = {},
+): Promise<ChromeTarget[]> {
+  const endpoint = normalizeHostPort(options);
+  try {
+    const targets = await listRemoteChromeTargets(endpoint);
+    return targets.filter(isChatGptTarget);
+  } catch (error) {
+    throw chromeTransportError("list ChatGPT tabs", endpoint, error);
+  }
 }
 
 export async function openChatGptTarget(
-  options: HostPort & { url?: string } = {},
+  options: LiveChromeEndpoint & { url?: string } = {},
 ): Promise<string> {
-  const { host, port } = normalizeHostPort(options);
+  const endpoint = normalizeHostPort(options);
+  const { host, port } = endpoint;
   const url = options.url ?? "https://chatgpt.com/";
-  const target = await CDP.New({ host, port, url });
-  return target.id;
+  try {
+    if (endpoint.browserWSEndpoint) {
+      const connection = await connectToRemoteChromeTarget(host, port, noopLogger, {
+        ...endpoint,
+        targetUrl: url,
+      });
+      try {
+        if (!connection.targetId) throw new Error("Chrome did not return a target ID.");
+        return connection.targetId;
+      } finally {
+        await connection.close();
+      }
+    }
+    const target = await CDP.New({ host, port, url });
+    return target.id;
+  } catch (error) {
+    throw chromeTransportError("open saved ChatGPT conversation", endpoint, error);
+  }
 }
 
-async function connectToTarget(host: string, port: number, targetId: string) {
-  const client = await CDP({ host, port, target: targetId });
+async function connectToTarget(options: LiveChromeEndpoint, targetId: string) {
+  const endpoint = normalizeHostPort(options);
+  const { host, port } = endpoint;
+  const connection = await connectToRemoteChromeTarget(host, port, noopLogger, {
+    ...endpoint,
+    targetId,
+  }).catch((error: unknown) => {
+    throw chromeTransportError("inspect ChatGPT tab", endpoint, error);
+  });
+  const client = Object.create(connection.client) as typeof connection.client;
+  // Session-bound clients detach only; the owning connection also closes its browser socket.
+  client.close = connection.close;
   const { Runtime, DOM } = client;
-  if (Runtime?.enable) {
-    await Runtime.enable();
+  try {
+    if (Runtime?.enable) {
+      await Runtime.enable();
+    }
+    if (DOM?.enable) {
+      await DOM.enable();
+    }
+    return client;
+  } catch (error) {
+    await connection.close().catch(() => undefined);
+    throw error;
   }
-  if (DOM?.enable) {
-    await DOM.enable();
-  }
-  return client;
 }
 
 export async function inspectChatGptTab(
@@ -317,7 +378,7 @@ export async function inspectChatGptTab(
     throw new Error("inspectChatGptTab requires a target with targetId.");
   }
 
-  const client = await connectToTarget(host, port, targetId);
+  const client = await connectToTarget(options, targetId);
   try {
     const { Runtime } = client;
     const evaluation = await Runtime.evaluate({
@@ -341,6 +402,7 @@ export async function inspectChatGptTab(
       lastUserTurnIndex?: number;
       lastUserText?: string;
       lastUserTextRaw?: string;
+      lastUserContentText?: string;
       lastUserMessageId?: string;
       visibilityState?: string;
       focused?: boolean;
@@ -389,6 +451,7 @@ export async function inspectChatGptTab(
       lastAssistantSnippet: trimToSnippet(lastAssistantText),
       lastUserText,
       lastUserTextRaw: info.lastUserTextRaw,
+      lastUserContentText: info.lastUserContentText,
       lastUserMessageId: info.lastUserMessageId,
       lastUserSnippet: trimToSnippet(lastUserText),
       focused: Boolean(info.focused),
@@ -432,13 +495,15 @@ export function classifyTabState(
   return "detached";
 }
 
-export async function collectChatGptTabs(options: HostPort = {}): Promise<ChatGptTabSummary[]> {
+export async function collectChatGptTabs(
+  options: LiveChromeEndpoint = {},
+): Promise<ChatGptTabSummary[]> {
   const { host, port } = normalizeHostPort(options);
-  const targets = await listChatGptTargets({ host, port });
+  const targets = await listChatGptTargets(options);
   const summaries: ChatGptTabSummary[] = [];
   for (const target of targets) {
     try {
-      const summary = await inspectChatGptTab({ host, port, target });
+      const summary = await inspectChatGptTab({ ...options, target });
       summaries.push(summary);
     } catch (error) {
       summaries.push({
@@ -524,34 +589,41 @@ export function resolveChatGptTabFromSummariesForTest(
 export async function resolveChatGptTab(
   options: ResolveChatGptTabOptions = {},
 ): Promise<ChatGptTabSummary> {
-  const { host, port } = normalizeHostPort(options);
-  const summaries = await collectChatGptTabs({ host, port });
+  const ref = options.ref?.trim();
+  if (ref && ref.toLowerCase() !== "current") {
+    const targets = await listChatGptTargets(options);
+    const exact = targets.find(
+      (target) =>
+        extractTargetId(target) === ref ||
+        target.url === ref ||
+        extractConversationIdFromUrl(target.url ?? "") === ref,
+    );
+    if (exact) return inspectChatGptTab({ ...options, target: exact });
+  }
+  const summaries = await collectChatGptTabs(options);
   return resolveChatGptTabFromSummaries(summaries, options.ref);
 }
 
 export async function connectToExistingChatGptTab(
   options: ResolveChatGptTabOptions = {},
 ): Promise<{ client: Awaited<ReturnType<typeof CDP>>; targetId: string; tab: ChatGptTabSummary }> {
-  const { host, port } = normalizeHostPort(options);
-  const tab = await resolveChatGptTab({ host, port, ref: options.ref });
-  const client = await connectToTarget(host, port, tab.targetId);
+  const tab = await resolveChatGptTab(options);
+  const client = await connectToTarget(options, tab.targetId);
   return { client, targetId: tab.targetId, tab };
 }
 
 export async function harvestChatGptTab(
   options: HarvestChatGptTabOptions = {},
 ): Promise<ChatGptTabSummary> {
-  const { host, port } = normalizeHostPort(options);
   const resolved = options.target
-    ? await inspectChatGptTab({ host, port, target: options.target })
-    : await resolveChatGptTab({ host, port, ref: options.ref });
-  const client = await connectToTarget(host, port, resolved.targetId);
+    ? await inspectChatGptTab({ ...options, target: options.target })
+    : await resolveChatGptTab(options);
+  const client = await connectToTarget(options, resolved.targetId);
   try {
     const { Runtime } = client;
     const snapshot = await readAssistantSnapshot(Runtime).catch(() => null);
     const nowSummary = await inspectChatGptTab({
-      host,
-      port,
+      ...options,
       target: {
         targetId: resolved.targetId,
         title: resolved.title,
@@ -603,8 +675,7 @@ export async function harvestChatGptTab(
       const firstFingerprint = harvested.fingerprint;
       await delay(options.stallWindowMs);
       const followup = await inspectChatGptTab({
-        host,
-        port,
+        ...options,
         target: {
           targetId: harvested.targetId,
           title: harvested.title,
@@ -623,6 +694,7 @@ export async function harvestChatGptTab(
       harvested.loginButtonExists = followup.loginButtonExists;
       harvested.lastUserText = followup.lastUserText;
       harvested.lastUserTextRaw = followup.lastUserTextRaw;
+      harvested.lastUserContentText = followup.lastUserContentText;
       harvested.lastUserMessageId = followup.lastUserMessageId;
       harvested.lastUserSnippet = followup.lastUserSnippet;
       harvested.assistantFollowsLatestUser = followup.assistantFollowsLatestUser;

--- a/src/browser/recoverConversation.ts
+++ b/src/browser/recoverConversation.ts
@@ -5,12 +5,12 @@ import { isAnswerNowPlaceholderText } from "./actions/assistantResponse.js";
 import { resolveBrowserConfig } from "./config.js";
 import { acquireManualLoginChromeForRun, isImageOnlyUiChromeText } from "./index.js";
 import { isRecoverableChatGptConversationUrl } from "./reattachability.js";
-import { harvestChatGptTab, openChatGptTarget } from "./liveTabs.js";
+import { harvestChatGptTab, openChatGptTarget, type LiveChromeEndpoint } from "./liveTabs.js";
 
 const DEFAULT_READY_TIMEOUT_MS = 30_000;
 const READY_POLL_MS = 1_000;
 
-export interface RecoveredConversation {
+export interface RecoveredConversation extends RecoveryEndpoint {
   host: string;
   port: number;
   url: string;
@@ -18,7 +18,7 @@ export interface RecoveredConversation {
   chrome: LaunchedChrome | null;
 }
 
-export interface RecoveryEndpoint {
+export interface RecoveryEndpoint extends LiveChromeEndpoint {
   host: string;
   port: number;
 }

--- a/src/cli/browserTabs.ts
+++ b/src/cli/browserTabs.ts
@@ -13,6 +13,7 @@ import {
   harvestChatGptTab,
   sessionMatchesTab,
   type ChatGptTabSummary,
+  type LiveChromeEndpoint,
 } from "../browser/liveTabs.js";
 import {
   isRecoveredConversationHarvestReady,
@@ -64,10 +65,13 @@ function harvestMatchesSessionPrompt(
     fingerprint === undefined ||
     (typeof harvested.lastUserMessageId === "string" &&
       harvested.lastUserMessageId.trim().length > 0 &&
-      browserPromptFingerprint(
-        harvested.lastUserTextRaw ?? harvested.lastUserText,
-        harvested.lastUserMessageId,
-      ) === fingerprint)
+      // ChatGPT can append transient status text outside the user's content after submission.
+      // Keep legacy full-container hashes valid and require an exact match for either form.
+      [harvested.lastUserTextRaw ?? harvested.lastUserText, harvested.lastUserContentText].some(
+        (text) =>
+          typeof text === "string" &&
+          browserPromptFingerprint(text, harvested.lastUserMessageId!) === fingerprint,
+      ))
   );
 }
 
@@ -139,7 +143,7 @@ export interface BrowserLiveTailOptions {
 
 function sessionBrowserEndpoint(
   meta: SessionMetadata | null | undefined,
-): { host: string; port: number } | null {
+): (LiveChromeEndpoint & { host: string; port: number }) | null {
   const runtime = meta?.browser?.runtime ?? {};
   const remote: { host?: string; port?: number } = meta?.browser?.config?.remoteChrome ?? {};
   const host = runtime.chromeHost ?? remote.host;
@@ -147,12 +151,23 @@ function sessionBrowserEndpoint(
   if (!host || !port) {
     return null;
   }
-  return { host, port };
+  return {
+    host,
+    port,
+    ...(runtime.chromeBrowserWSEndpoint
+      ? {
+          browserWSEndpoint: runtime.chromeBrowserWSEndpoint,
+          approvalWaitMs: resolveBrowserConfig(meta?.browser?.config).approvalWaitMs,
+        }
+      : {}),
+  };
 }
 
-function collectUniqueEndpoints(metas: SessionMetadata[]): Array<{ host: string; port: number }> {
-  const entries = new Map<string, { host: string; port: number }>();
-  entries.set(`${DEFAULT_REMOTE_CHROME_HOST}:${DEFAULT_REMOTE_CHROME_PORT}`, {
+function collectUniqueEndpoints(
+  metas: SessionMetadata[],
+): Array<LiveChromeEndpoint & { host: string; port: number }> {
+  const entries = new Map<string, LiveChromeEndpoint & { host: string; port: number }>();
+  entries.set(`${DEFAULT_REMOTE_CHROME_HOST}:${DEFAULT_REMOTE_CHROME_PORT}:http`, {
     host: DEFAULT_REMOTE_CHROME_HOST,
     port: DEFAULT_REMOTE_CHROME_PORT,
   });
@@ -161,7 +176,10 @@ function collectUniqueEndpoints(metas: SessionMetadata[]): Array<{ host: string;
     if (!endpoint) {
       continue;
     }
-    entries.set(`${endpoint.host}:${endpoint.port}`, endpoint);
+    entries.set(
+      `${endpoint.host}:${endpoint.port}:${endpoint.browserWSEndpoint ?? "http"}`,
+      endpoint,
+    );
   }
   return Array.from(entries.values());
 }
@@ -319,8 +337,7 @@ export async function harvestSessionBrowserOutput(
       harvested = await harvestSessionPrompt(
         meta,
         {
-          host: initialEndpoint.host,
-          port: initialEndpoint.port,
+          ...initialEndpoint,
           ref,
           stallWindowMs: options.stallWindowMs,
         },
@@ -343,6 +360,8 @@ export async function harvestSessionBrowserOutput(
       harvested = await harvestSessionPrompt(meta, {
         host: recovered.host,
         port: recovered.port,
+        browserWSEndpoint: recovered.browserWSEndpoint,
+        approvalWaitMs: recovered.approvalWaitMs,
         ref: recovered.ref,
         stallWindowMs: options.stallWindowMs,
       });
@@ -394,8 +413,7 @@ export async function liveTailSessionBrowserOutput(
     // Probe once to see if the live tab is still alive; recover if not.
     try {
       await harvestChatGptTab({
-        host: endpoint.host,
-        port: endpoint.port,
+        ...endpoint,
         ref: browserTabRef,
       });
     } catch (error) {
@@ -413,7 +431,12 @@ export async function liveTailSessionBrowserOutput(
         waitForReady: false,
       });
       recoveredChrome = recovered.chrome;
-      endpoint = { host: recovered.host, port: recovered.port };
+      endpoint = {
+        host: recovered.host,
+        port: recovered.port,
+        browserWSEndpoint: recovered.browserWSEndpoint,
+        approvalWaitMs: recovered.approvalWaitMs,
+      };
       browserTabRef = recovered.ref;
       requireRecoveredContent = true;
       recoveredContentDeadlineMs = Date.now() + stallThresholdMs;
@@ -421,8 +444,7 @@ export async function liveTailSessionBrowserOutput(
 
     while (true) {
       const harvested = await harvestChatGptTab({
-        host: endpoint.host,
-        port: endpoint.port,
+        ...endpoint,
         ref: browserTabRef,
       });
       const fullText = harvested.lastAssistantMarkdown ?? harvested.lastAssistantText ?? "";

--- a/src/cli/browserTabs.ts
+++ b/src/cli/browserTabs.ts
@@ -4,6 +4,7 @@ import chalk from "chalk";
 import { sessionStore } from "../sessionStore.js";
 import type { SessionMetadata } from "../sessionStore.js";
 import { resolveBrowserConfig } from "../browser/config.js";
+import { formatWebSocketHost, readDevToolsActivePortInfo } from "../browser/detect.js";
 import { browserPromptFingerprint } from "../browser/promptFingerprint.js";
 import {
   collectChatGptTabs,
@@ -141,9 +142,9 @@ export interface BrowserLiveTailOptions {
   closeAfterRecover?: boolean;
 }
 
-function sessionBrowserEndpoint(
+async function sessionBrowserEndpoint(
   meta: SessionMetadata | null | undefined,
-): (LiveChromeEndpoint & { host: string; port: number }) | null {
+): Promise<(LiveChromeEndpoint & { host: string; port: number }) | null> {
   const runtime = meta?.browser?.runtime ?? {};
   const remote: { host?: string; port?: number } = meta?.browser?.config?.remoteChrome ?? {};
   const host = runtime.chromeHost ?? remote.host;
@@ -151,28 +152,61 @@ function sessionBrowserEndpoint(
   if (!host || !port) {
     return null;
   }
+  let browserWSEndpoint = runtime.chromeBrowserWSEndpoint;
+  let livePort = port;
+  if (browserWSEndpoint) {
+    const active = runtime.chromeProfileRoot
+      ? await readDevToolsActivePortInfo(runtime.chromeProfileRoot, { host }).catch(() => null)
+      : null;
+    if (active) {
+      browserWSEndpoint = active.browserWSEndpoint;
+      livePort = active.port;
+    } else {
+      // A restarted Chrome can keep its port while changing its browser socket ID.
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 1000);
+      try {
+        const response = await fetch(`http://${formatWebSocketHost(host)}:${port}/json/version`, {
+          signal: controller.signal,
+        });
+        if (response.ok) {
+          const version = (await response.json()) as { webSocketDebuggerUrl?: string };
+          const advertised = new URL(version.webSocketDebuggerUrl ?? "");
+          if (advertised.pathname.startsWith("/devtools/browser/")) {
+            const refreshed = new URL(browserWSEndpoint);
+            refreshed.pathname = advertised.pathname;
+            browserWSEndpoint = refreshed.toString();
+          }
+        }
+      } catch {
+        // Attach-running Chrome may disable HTTP discovery; keep its saved socket.
+      } finally {
+        clearTimeout(timeout);
+        controller.abort();
+      }
+    }
+  }
   return {
     host,
-    port,
-    ...(runtime.chromeBrowserWSEndpoint
+    port: livePort,
+    ...(browserWSEndpoint
       ? {
-          browserWSEndpoint: runtime.chromeBrowserWSEndpoint,
+          browserWSEndpoint,
           approvalWaitMs: resolveBrowserConfig(meta?.browser?.config).approvalWaitMs,
         }
       : {}),
   };
 }
 
-function collectUniqueEndpoints(
+async function collectUniqueEndpoints(
   metas: SessionMetadata[],
-): Array<LiveChromeEndpoint & { host: string; port: number }> {
+): Promise<Array<LiveChromeEndpoint & { host: string; port: number }>> {
   const entries = new Map<string, LiveChromeEndpoint & { host: string; port: number }>();
   entries.set(`${DEFAULT_REMOTE_CHROME_HOST}:${DEFAULT_REMOTE_CHROME_PORT}:http`, {
     host: DEFAULT_REMOTE_CHROME_HOST,
     port: DEFAULT_REMOTE_CHROME_PORT,
   });
-  for (const meta of metas) {
-    const endpoint = sessionBrowserEndpoint(meta);
+  for (const endpoint of await Promise.all(metas.map(sessionBrowserEndpoint))) {
     if (!endpoint) {
       continue;
     }
@@ -277,7 +311,7 @@ async function maybeWriteHarvestOutput(
 
 export async function showBrowserTabsStatus(): Promise<void> {
   const metas = await sessionStore.listSessions().catch(() => [] as SessionMetadata[]);
-  const endpoints = collectUniqueEndpoints(metas);
+  const endpoints = await collectUniqueEndpoints(metas);
   let printedAny = false;
   for (const endpoint of endpoints) {
     let tabs: ChatGptTabSummary[];
@@ -322,7 +356,7 @@ export async function harvestSessionBrowserOutput(
   if (!meta) {
     throw new Error(`No session found with ID ${sessionId}.`);
   }
-  const recordedEndpoint = sessionBrowserEndpoint(meta);
+  const recordedEndpoint = await sessionBrowserEndpoint(meta);
   const initialEndpoint = recordedEndpoint ?? {
     host: DEFAULT_REMOTE_CHROME_HOST,
     port: DEFAULT_REMOTE_CHROME_PORT,
@@ -395,7 +429,7 @@ export async function liveTailSessionBrowserOutput(
   if (!meta) {
     throw new Error(`No session found with ID ${sessionId}.`);
   }
-  const recordedEndpoint = sessionBrowserEndpoint(meta);
+  const recordedEndpoint = await sessionBrowserEndpoint(meta);
   let endpoint = recordedEndpoint ?? {
     host: DEFAULT_REMOTE_CHROME_HOST,
     port: DEFAULT_REMOTE_CHROME_PORT,

--- a/src/cli/errorUtils.ts
+++ b/src/cli/errorUtils.ts
@@ -1,5 +1,13 @@
 const LOGGED_SYMBOL = Symbol("oracle.alreadyLogged");
 
+export function formatCliError(error: unknown): string {
+  const message = error instanceof Error ? error.message : typeof error === "string" ? error : "";
+  if (message.trim()) return message;
+  const code = error && typeof error === "object" && "code" in error ? error.code : undefined;
+  if (typeof code === "string" && code.trim()) return `Operation failed (${code}).`;
+  return "An unexpected error occurred. Retry with --verbose for more details.";
+}
+
 export function markErrorLogged(error: unknown): void {
   if (error instanceof Error) {
     (error as Error & { [LOGGED_SYMBOL]?: true })[LOGGED_SYMBOL] = true;

--- a/tests/browser/liveTabs.test.ts
+++ b/tests/browser/liveTabs.test.ts
@@ -78,6 +78,32 @@ describe("liveTabs helpers", () => {
     expect(observed.lastUserMessageId).toBe("current-message");
   });
 
+  test("separates the user content from a later provider error notice", () => {
+    const text = "Explain: Something went wrong. Please try again.";
+    const content = new FakeElement("div", { class: "whitespace-pre-wrap" }, [], text);
+    const notice = new FakeElement("div", {}, [], "Something went wrong. Please try again.");
+    const user = new FakeElement(
+      "div",
+      { "data-message-author-role": "user", "data-message-id": "saved" },
+      [content, notice],
+    );
+    const observed = new Function(
+      "document",
+      "Element",
+      "window",
+      "location",
+      `return ${buildTabInspectionExpressionForTest()}`,
+    )(
+      new FakeDocument([user]),
+      FakeElement,
+      { getComputedStyle: () => ({ display: "block", visibility: "visible", opacity: "1" }) },
+      { href: "https://chatgpt.com/c/saved" },
+    );
+    expect(observed.lastUserContentText).toBe(text);
+    expect(observed.lastUserTextRaw).toContain(text);
+    expect(observed.lastUserTextRaw).not.toBe(text);
+  });
+
   test("keeps a visible composer stop control running even behind a hidden legacy control", () => {
     const hidden = new FakeElement("button", { "data-testid": "stop-button" });
     hidden.getBoundingClientRect = () => ({ width: 0, height: 0, x: 0, y: 0 });

--- a/tests/browser/liveTabs.transport.test.ts
+++ b/tests/browser/liveTabs.transport.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const cdp = vi.hoisted(() => Object.assign(vi.fn(), { List: vi.fn(), New: vi.fn() }));
+vi.mock("chrome-remote-interface", () => ({ default: cdp }));
+import {
+  inspectChatGptTab,
+  listChatGptTargets,
+  openChatGptTarget,
+} from "../../src/browser/liveTabs.js";
+
+const endpoint = {
+  host: "127.0.0.1",
+  port: 9222,
+  browserWSEndpoint: "ws://127.0.0.1:9222/devtools/browser/test",
+  approvalWaitMs: 100,
+};
+
+function browserClient() {
+  return {
+    Target: {
+      getTargets: vi.fn(async () => ({
+        targetInfos: [
+          {
+            targetId: "saved",
+            type: "page",
+            title: "Saved answer",
+            url: "https://chatgpt.com/c/saved",
+          },
+        ],
+      })),
+      createTarget: vi.fn(async () => ({ targetId: "recovered" })),
+      attachToTarget: vi.fn(async () => ({ sessionId: "session" })),
+      detachFromTarget: vi.fn(async () => {}),
+      closeTarget: vi.fn(async () => {}),
+    },
+    Runtime: {
+      enable: vi.fn(async () => {}),
+      evaluate: vi.fn(async () => ({ result: { value: {} } })),
+    },
+    DOM: { enable: vi.fn(async () => {}) },
+    on: vi.fn(),
+    once: vi.fn(),
+    removeListener: vi.fn(),
+    close: vi.fn(async () => {}),
+  };
+}
+
+describe("live tab transport", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  test("uses the saved browser socket to discover targets when HTTP discovery is unavailable", async () => {
+    cdp.List.mockRejectedValue(new Error());
+    const browser = browserClient();
+    cdp.mockResolvedValue(browser);
+    expect(await listChatGptTargets(endpoint)).toEqual([
+      {
+        targetId: "saved",
+        type: "page",
+        title: "Saved answer",
+        url: "https://chatgpt.com/c/saved",
+      },
+    ]);
+    expect(cdp).toHaveBeenCalledWith({ target: endpoint.browserWSEndpoint, local: true });
+    expect(cdp.List).not.toHaveBeenCalled();
+    expect(browser.close).toHaveBeenCalledOnce();
+  });
+
+  test("reports endpoint and recovery guidance for an empty discovery error", async () => {
+    cdp.List.mockRejectedValue(new Error());
+    await expect(listChatGptTargets({ host: "127.0.0.1", port: 9222 })).rejects.toThrow(
+      /Unable to list ChatGPT tabs on Chrome at 127.0.0.1:9222.*Chrome returned no error details.*remote debugging/,
+    );
+  });
+
+  test("inspects only the named browser target and closes the socket without closing the tab", async () => {
+    const browser = browserClient();
+    cdp.mockResolvedValue(browser);
+    await inspectChatGptTab({
+      ...endpoint,
+      target: { targetId: "saved", type: "page", url: "https://chatgpt.com/c/saved" },
+    });
+    expect(browser.Target.attachToTarget).toHaveBeenCalledWith({
+      targetId: "saved",
+      flatten: true,
+    });
+    expect(browser.Runtime.enable).toHaveBeenCalledWith("session");
+    expect(browser.Target.detachFromTarget).toHaveBeenCalledWith({ sessionId: "session" });
+    expect(browser.close).toHaveBeenCalledOnce();
+    expect(browser.Target.closeTarget).not.toHaveBeenCalled();
+  });
+
+  test("closes failed inspections and preserves HTTP target connections", async () => {
+    const browser = browserClient();
+    browser.Runtime.enable.mockRejectedValue(new Error("enable failed"));
+    cdp.mockResolvedValue(browser);
+    await expect(
+      inspectChatGptTab({ host: "localhost", port: 9333, target: { id: "saved" } }),
+    ).rejects.toThrow("enable failed");
+    expect(cdp).toHaveBeenCalledWith({ host: "localhost", port: 9333, target: "saved" });
+    expect(browser.close).toHaveBeenCalledOnce();
+  });
+
+  test("explains empty errors while reopening a saved conversation", async () => {
+    cdp.mockRejectedValue(new Error());
+    await expect(
+      openChatGptTarget({ ...endpoint, url: "https://chatgpt.com/c/saved" }),
+    ).rejects.toThrow(
+      /Unable to open saved ChatGPT conversation on Chrome at 127.0.0.1:9222.*Chrome returned no error details/,
+    );
+  });
+
+  test("reopens saved conversations through the browser socket and leaves the target open", async () => {
+    const browser = browserClient();
+    cdp.mockResolvedValue(browser);
+    expect(await openChatGptTarget({ ...endpoint, url: "https://chatgpt.com/c/saved" })).toBe(
+      "recovered",
+    );
+    expect(browser.Target.createTarget).toHaveBeenCalledWith({
+      url: "https://chatgpt.com/c/saved",
+    });
+    expect(cdp.New).not.toHaveBeenCalled();
+    expect(browser.close).toHaveBeenCalledOnce();
+    expect(browser.Target.closeTarget).not.toHaveBeenCalled();
+  });
+});

--- a/tests/browser/liveTabs.transport.test.ts
+++ b/tests/browser/liveTabs.transport.test.ts
@@ -2,11 +2,9 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const cdp = vi.hoisted(() => Object.assign(vi.fn(), { List: vi.fn(), New: vi.fn() }));
 vi.mock("chrome-remote-interface", () => ({ default: cdp }));
-import {
-  inspectChatGptTab,
-  listChatGptTargets,
-  openChatGptTarget,
-} from "../../src/browser/liveTabs.js";
+let inspectChatGptTab: (typeof import("../../src/browser/liveTabs.js"))["inspectChatGptTab"];
+let listChatGptTargets: (typeof import("../../src/browser/liveTabs.js"))["listChatGptTargets"];
+let openChatGptTarget: (typeof import("../../src/browser/liveTabs.js"))["openChatGptTarget"];
 
 const endpoint = {
   host: "127.0.0.1",
@@ -46,7 +44,12 @@ function browserClient() {
 }
 
 describe("live tab transport", () => {
-  beforeEach(() => vi.resetAllMocks());
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    vi.resetModules();
+    ({ inspectChatGptTab, listChatGptTargets, openChatGptTarget } =
+      await import("../../src/browser/liveTabs.js"));
+  });
 
   test("uses the saved browser socket to discover targets when HTTP discovery is unavailable", async () => {
     cdp.List.mockRejectedValue(new Error());
@@ -62,7 +65,7 @@ describe("live tab transport", () => {
     ]);
     expect(cdp).toHaveBeenCalledWith({ target: endpoint.browserWSEndpoint, local: true });
     expect(cdp.List).not.toHaveBeenCalled();
-    expect(browser.close).toHaveBeenCalledOnce();
+    expect(browser.Target.getTargets).toHaveBeenCalledOnce();
   });
 
   test("reports endpoint and recovery guidance for an empty discovery error", async () => {
@@ -72,7 +75,7 @@ describe("live tab transport", () => {
     );
   });
 
-  test("inspects only the named browser target and closes the socket without closing the tab", async () => {
+  test("inspects only the named browser target and detaches without closing the tab", async () => {
     const browser = browserClient();
     cdp.mockResolvedValue(browser);
     await inspectChatGptTab({
@@ -85,7 +88,7 @@ describe("live tab transport", () => {
     });
     expect(browser.Runtime.enable).toHaveBeenCalledWith("session");
     expect(browser.Target.detachFromTarget).toHaveBeenCalledWith({ sessionId: "session" });
-    expect(browser.close).toHaveBeenCalledOnce();
+    expect(browser.Target.detachFromTarget).toHaveBeenCalledOnce();
     expect(browser.Target.closeTarget).not.toHaveBeenCalled();
   });
 
@@ -119,7 +122,7 @@ describe("live tab transport", () => {
       url: "https://chatgpt.com/c/saved",
     });
     expect(cdp.New).not.toHaveBeenCalled();
-    expect(browser.close).toHaveBeenCalledOnce();
+    expect(browser.Target.detachFromTarget).toHaveBeenCalledWith({ sessionId: "session" });
     expect(browser.Target.closeTarget).not.toHaveBeenCalled();
   });
 });

--- a/tests/cli/browserTabsRecover.test.ts
+++ b/tests/cli/browserTabsRecover.test.ts
@@ -164,6 +164,64 @@ describe("harvestSessionBrowserOutput recovery fallback", () => {
     );
   });
 
+  test.each(["profile", "http"])(
+    "refreshes expired saved sockets via %s for harvest and live-tail",
+    async (source) => {
+      const meta = {
+        ...baseMeta,
+        browser: {
+          ...baseMeta.browser,
+          runtime: {
+            ...baseMeta.browser?.runtime,
+            chromeBrowserWSEndpoint: "ws://127.0.0.1:9223/devtools/browser/expired",
+            ...(source === "profile" ? { chromeProfileRoot: "/synthetic/profile" } : {}),
+          },
+        },
+      };
+      const current = "ws://127.0.0.1:9223/devtools/browser/current";
+      const readActive = vi.fn(async () => ({ port: 9223, browserWSEndpoint: current }));
+      vi.doMock("../../src/browser/detect.js", async (importOriginal) => ({
+        ...(await importOriginal<typeof import("../../src/browser/detect.js")>()),
+        readDevToolsActivePortInfo: readActive,
+      }));
+      const fetchVersion = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(
+          new Response(JSON.stringify({ webSocketDebuggerUrl: current }), { status: 200 }),
+        );
+      const harvestChatGptTab = vi.fn().mockResolvedValue(completedHarvest);
+      vi.doMock("../../src/browser/liveTabs.js", async (importOriginal) => ({
+        ...(await importOriginal<typeof import("../../src/browser/liveTabs.js")>()),
+        harvestChatGptTab,
+      }));
+      vi.doMock("../../src/sessionStore.js", () => ({
+        sessionStore: { readSession: async () => meta, updateSession: vi.fn(), getPaths },
+      }));
+      const { harvestSessionBrowserOutput, liveTailSessionBrowserOutput } =
+        await import("../../src/cli/browserTabs.js");
+      try {
+        await harvestSessionBrowserOutput(meta.id, { quietOutput: true });
+        fetchVersion.mockResolvedValue(
+          new Response(JSON.stringify({ webSocketDebuggerUrl: current }), { status: 200 }),
+        );
+        await liveTailSessionBrowserOutput(meta.id);
+        expect(harvestChatGptTab.mock.calls.length).toBeGreaterThanOrEqual(3);
+        for (const [options] of harvestChatGptTab.mock.calls) {
+          expect(options).toMatchObject({
+            browserWSEndpoint: current,
+            host: "127.0.0.1",
+            port: 9223,
+          });
+        }
+        if (source === "profile") expect(fetchVersion).not.toHaveBeenCalled();
+        else expect(readActive).not.toHaveBeenCalled();
+      } finally {
+        fetchVersion.mockRestore();
+        vi.doUnmock("../../src/browser/detect.js");
+      }
+    },
+  );
+
   test("recovers the original committed prompt when ChatGPT appends a status notice", async () => {
     const prompt = "Explain: Something went wrong. Please try again.";
     const meta = {

--- a/tests/cli/browserTabsRecover.test.ts
+++ b/tests/cli/browserTabsRecover.test.ts
@@ -118,6 +118,83 @@ describe("harvestSessionBrowserOutput recovery fallback", () => {
     expect(fakeChrome.process.unref).toHaveBeenCalledTimes(1);
   });
 
+  test("retains saved browser transport during harvest and missing-tab recovery", async () => {
+    const endpoint = {
+      host: "127.0.0.1",
+      port: 9223,
+      browserWSEndpoint: "ws://127.0.0.1:9223/devtools/browser/saved",
+      approvalWaitMs: 12345,
+    };
+    const meta = {
+      ...baseMeta,
+      browser: {
+        ...baseMeta.browser,
+        config: { ...baseMeta.browser?.config, approvalWaitMs: 12345 },
+        runtime: {
+          ...baseMeta.browser?.runtime,
+          chromeBrowserWSEndpoint: endpoint.browserWSEndpoint,
+        },
+      },
+    };
+    const harvestChatGptTab = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("No ChatGPT tab matched"))
+      .mockResolvedValue(completedHarvest);
+    const recoverConversationTab = vi.fn(async () => ({
+      ...endpoint,
+      ref: "reopened",
+      chrome: null,
+    }));
+    vi.doMock("../../src/browser/liveTabs.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("../../src/browser/liveTabs.js")>()),
+      harvestChatGptTab,
+    }));
+    vi.doMock("../../src/browser/recoverConversation.js", () => ({ recoverConversationTab }));
+    vi.doMock("../../src/sessionStore.js", () => ({
+      sessionStore: { readSession: async () => meta, updateSession: vi.fn(), getPaths },
+    }));
+    const { harvestSessionBrowserOutput } = await import("../../src/cli/browserTabs.js");
+    await harvestSessionBrowserOutput("sess-recover", { quietOutput: true });
+    expect(harvestChatGptTab).toHaveBeenNthCalledWith(1, expect.objectContaining(endpoint));
+    expect(recoverConversationTab).toHaveBeenCalledWith(meta, expect.any(Function), {
+      existingEndpoint: endpoint,
+    });
+    expect(harvestChatGptTab).toHaveBeenLastCalledWith(
+      expect.objectContaining({ ...endpoint, ref: "reopened" }),
+    );
+  });
+
+  test("recovers the original committed prompt when ChatGPT appends a status notice", async () => {
+    const prompt = "Explain: Something went wrong. Please try again.";
+    const meta = {
+      ...baseMeta,
+      browser: {
+        ...baseMeta.browser,
+        runtime: {
+          ...baseMeta.browser?.runtime,
+          submittedPromptHash: browserPromptFingerprint(prompt, "current-message"),
+        },
+      },
+    };
+    const harvestChatGptTab = vi.fn().mockResolvedValue({
+      ...completedHarvest,
+      lastUserTextRaw: prompt + "Something went wrong. Please try again.",
+      lastUserContentText: prompt,
+    });
+    vi.doMock("../../src/browser/liveTabs.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("../../src/browser/liveTabs.js")>()),
+      harvestChatGptTab,
+    }));
+    vi.doMock("../../src/sessionStore.js", () => ({
+      sessionStore: { readSession: async () => meta, updateSession: vi.fn(), getPaths },
+    }));
+    const { harvestSessionBrowserOutput } = await import("../../src/cli/browserTabs.js");
+    expect(
+      (await harvestSessionBrowserOutput("sess-recover", { quietOutput: true })).lastAssistantText,
+    ).toBe(completedHarvest.lastAssistantText);
+    expect(harvestChatGptTab).toHaveBeenCalledOnce();
+  });
+
   test("does not recover when recoverIfMissing is false; surfaces the original error", async () => {
     const harvestChatGptTab = vi
       .fn()
@@ -710,5 +787,41 @@ describe("harvestSessionBrowserOutput recovery fallback", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe("browser tab endpoint discovery", () => {
+  test("preserves HTTP discovery and distinct saved browser sockets after restarts", async () => {
+    vi.resetModules();
+    const collectChatGptTabs = vi.fn(async () => []);
+    vi.doMock("../../src/browser/liveTabs.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("../../src/browser/liveTabs.js")>()),
+      collectChatGptTabs,
+    }));
+    vi.doMock("../../src/sessionStore.js", () => ({
+      sessionStore: {
+        listSessions: async () =>
+          ["old", "current"].map((id) => ({
+            ...baseMeta,
+            browser: {
+              runtime: {
+                chromeHost: "127.0.0.1",
+                chromePort: 9222,
+                chromeBrowserWSEndpoint: `ws://127.0.0.1:9222/devtools/browser/${id}`,
+              },
+            },
+          })),
+      },
+    }));
+    const { showBrowserTabsStatus } = await import("../../src/cli/browserTabs.js");
+    await showBrowserTabsStatus();
+    expect(collectChatGptTabs).toHaveBeenCalledTimes(3);
+    expect(collectChatGptTabs).toHaveBeenCalledWith({ host: "127.0.0.1", port: 9222 });
+    for (const id of ["old", "current"])
+      expect(collectChatGptTabs).toHaveBeenCalledWith(
+        expect.objectContaining({
+          browserWSEndpoint: `ws://127.0.0.1:9222/devtools/browser/${id}`,
+        }),
+      );
   });
 });

--- a/tests/cli/errorUtils.test.ts
+++ b/tests/cli/errorUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { isErrorLogged, markErrorLogged } from "../../src/cli/errorUtils.ts";
+import { isErrorLogged, markErrorLogged, formatCliError } from "../../src/cli/errorUtils.ts";
 
 describe("errorUtils", () => {
   test("marks errors as logged", () => {
@@ -13,5 +13,22 @@ describe("errorUtils", () => {
     expect(isErrorLogged("oops")).toBe(false);
     markErrorLogged("oops");
     expect(isErrorLogged("oops")).toBe(false);
+  });
+});
+
+describe("formatCliError", () => {
+  test.each([new Error(), new Error("   "), "", "\n", undefined, null])(
+    "never renders a blank failure for %s",
+    (error) => {
+      expect(formatCliError(error)).toBe(
+        "An unexpected error occurred. Retry with --verbose for more details.",
+      );
+    },
+  );
+  test("preserves useful error messages and codes", () => {
+    expect(formatCliError(new Error("missing conversation"))).toBe("missing conversation");
+    expect(formatCliError(Object.assign(new Error(), { code: "ECONNREFUSED" }))).toContain(
+      "ECONNREFUSED",
+    );
   });
 });


### PR DESCRIPTION
Direct session harvest discarded the browser WebSocket endpoint saved by attach-running sessions, then rendered an empty discovery error as only `✖`. Carry the saved transport and approval wait through discovery, inspection, existing-tab attachment, live-tail, and recovery; refresh stale socket IDs from recorded-profile metadata or bounded HTTP discovery; retain saved sockets when Chrome disables HTTP discovery.

ChatGPT can also append a transient status notice outside the committed user content. Accept the exact committed message ID and prompt-content hash without including that notice, retain existing full-container hashes, and refuse changed prompts or conversations. Contextual transport diagnostics and a top-level error fallback prevent blank failures. Cleanup detaches the page session without closing borrowed tabs.

Fixes #482.

Validation on `1f374bb45cf2aeb962beba8af6e55608bf670030`: endpoint-refresh, transport, recovery, identity, and error regressions; clean local/branch autoreview through P2; 2,458 tests in the composed batch. Its signed-in Pro run, normal reattach, and compiled harvest handler recovered the same Markdown answer with matched identity and observed `5.5Pro`, using one retained connection. A previous exact built-CLI reproduction established the blank baseline and repaired saved-conversation recovery. Actual Chrome restart was not required; refresh paths are regression-tested with controlled metadata/discovery.

Notes are consolidated in #486. All four exact-head CI jobs passed: https://github.com/steipete/oracle/actions/runs/34668531497. Land after #487.
