### PR TITLE
fix(browser): warn before implicit default model downgrades

### DIFF
--- a/bin/oracle-cli.ts
+++ b/bin/oracle-cli.ts
@@ -2226,6 +2226,8 @@ async function runRootCommand(options: CliOptions): Promise<void> {
       browserRequestedModel: cliModelArg,
       browserModelLabel: resolveBrowserModelLabel(cliModelArg, activeModel),
     });
+    config.modelIsImplicitDefault =
+      optionUsesDefault("model") && !userConfig.model && !options.browserModelLabel;
     return resolvedOptions.browserResumeConversationUrl
       ? { ...config, resumeConversationUrl: resolvedOptions.browserResumeConversationUrl }
       : config;

--- a/docs/browser-mode.md
+++ b/docs/browser-mode.md
@@ -43,6 +43,13 @@ oracle --engine browser \
 
 You can pass the same payload inline (`--browser-inline-cookies '<json or base64>'`) or via env (`ORACLE_BROWSER_COOKIES_JSON`, `ORACLE_BROWSER_COOKIES_FILE`). Cloudflare cookies (`cf_clearance`, `__cf_bm`, etc.) are only needed when you hit a challenge.
 
+When no model is supplied on the command line or in configuration, Oracle keeps
+its existing browser default. If the visible ChatGPT selection is a newer model,
+Oracle prints a model-selection warning before switching and submitting the
+prompt. Pass `--model` to choose explicitly, or `--browser-model-strategy current`
+to retain ChatGPT's selection. Explicit models, saved model preferences, and
+`current`/`ignore` strategies do not produce this warning.
+
 ## Quick example: attach to your running Chrome
 
 Use this when you already have a signed-in Chrome session running with DevTools access enabled and want Oracle to reuse that browser instead of launching its own copy.

--- a/src/browser/actions/modelSelection.ts
+++ b/src/browser/actions/modelSelection.ts
@@ -37,15 +37,35 @@ export async function ensureModelSelection(
   desiredModel: string,
   logger: BrowserLogger,
   strategy: BrowserModelStrategy = "select",
-  options: { buttonWaitMs?: number; buttonPollMs?: number } = {},
+  options: { buttonWaitMs?: number; buttonPollMs?: number; implicitDefault?: boolean } = {},
 ): Promise<BrowserModelSelectionEvidence> {
   const buttonWaitMs = options.buttonWaitMs ?? MODEL_BUTTON_WAIT_MS;
   const buttonPollMs = options.buttonPollMs ?? MODEL_BUTTON_POLL_MS;
-  const deadline = Date.now() + Math.max(0, buttonWaitMs);
+  const probeDeadline = Date.now() + Math.max(0, buttonWaitMs);
+  let deadline: number | undefined;
 
   let result: ModelSelectionResult;
   let announcedWait = false;
   for (;;) {
+    if (options.implicitDefault && strategy === "select") {
+      // Wait for observable selection before a default-driven switch, just as selection waits for the picker.
+      const observed = await Runtime.evaluate({
+        expression: buildModelSelectionExpression(desiredModel, "current"),
+        awaitPromise: true,
+        returnByValue: true,
+      }).catch(() => null);
+      const label = (observed?.result?.value as { label?: unknown } | undefined)?.label;
+      if ((typeof label !== "string" || !label.trim()) && Date.now() < probeDeadline) {
+        await delay(buttonPollMs);
+        continue;
+      }
+      if (typeof label === "string" && isNewerModelLabel(label, desiredModel)) {
+        logger(
+          `[browser] Model selection warning: no model was specified, so Oracle's default will switch ChatGPT from "${label}" to "${desiredModel}" before submission. Pass --model explicitly or --browser-model-strategy current to keep the selected model.`,
+        );
+      }
+    }
+    deadline ??= Date.now() + Math.max(0, buttonWaitMs);
     const outcome = await Runtime.evaluate({
       expression: buildModelSelectionExpression(desiredModel, strategy),
       awaitPromise: true,
@@ -110,6 +130,18 @@ export async function ensureModelSelection(
       );
     }
   }
+}
+
+function isNewerModelLabel(current: string, target: string): boolean {
+  const latest = /^(?:Latest|最新|최신)$/i;
+  if (latest.test(current.trim())) return !latest.test(target.trim());
+  const version = (label: string): [number, number] | null => {
+    const match = label.match(/(?:^|gpt[- ]*|thinking\s+)(\d+)(?:\.(\d+))?/i);
+    return match ? [Number(match[1]), Number(match[2] ?? 0)] : null;
+  };
+  const from = version(current);
+  const to = version(target);
+  return Boolean(from && to && (from[0] > to[0] || (from[0] === to[0] && from[1] > to[1])));
 }
 
 function assertResolvedModelSelection(desiredModel: string, resolvedLabel: string): void {

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1716,7 +1716,10 @@ async function runBrowserModeInternal(
     if (config.desiredModel && modelStrategy !== "ignore" && !isResumingConversation) {
       modelSelectionEvidence = await raceWithDisconnect(
         withRetries(
-          () => ensureModelSelection(Runtime, config.desiredModel as string, logger, modelStrategy),
+          () =>
+            ensureModelSelection(Runtime, config.desiredModel as string, logger, modelStrategy, {
+              implicitDefault: config.modelIsImplicitDefault,
+            }),
           {
             retries: 2,
             delayMs: 300,
@@ -3423,7 +3426,10 @@ async function runRemoteBrowserMode(
     const modelStrategy = config.modelStrategy ?? DEFAULT_MODEL_STRATEGY;
     if (config.desiredModel && modelStrategy !== "ignore" && !config.resumeConversationUrl) {
       modelSelectionEvidence = await withRetries(
-        () => ensureModelSelection(Runtime, config.desiredModel as string, logger, modelStrategy),
+        () =>
+          ensureModelSelection(Runtime, config.desiredModel as string, logger, modelStrategy, {
+            implicitDefault: config.modelIsImplicitDefault,
+          }),
         {
           retries: 2,
           delayMs: 300,

--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -112,6 +112,7 @@ export interface BrowserAutomationConfig {
   keepBrowser?: boolean;
   hideWindow?: boolean;
   desiredModel?: string | null;
+  modelIsImplicitDefault?: boolean;
   modelStrategy?: BrowserModelStrategy;
   debug?: boolean;
   allowCookieErrors?: boolean;
@@ -235,6 +236,7 @@ export type ResolvedBrowserConfig = Required<
     | "chromePath"
     | "chromeCookiePath"
     | "desiredModel"
+    | "modelIsImplicitDefault"
     | "remoteChrome"
     | "remoteChromeBrowserWSEndpoint"
     | "remoteChromeProfileRoot"
@@ -251,6 +253,7 @@ export type ResolvedBrowserConfig = Required<
   attachRunning?: boolean;
   browserTabRef?: string | null;
   desiredModel?: string | null;
+  modelIsImplicitDefault?: boolean;
   modelStrategy?: BrowserModelStrategy;
   thinkingTime?: ThinkingTimeLevel;
   debugPort?: number | null;

--- a/src/mcp/tools/consult.ts
+++ b/src/mcp/tools/consult.ts
@@ -390,6 +390,7 @@ export function buildConsultBrowserConfig({
     researchMode: browserResearchMode ?? configuredBrowser.researchMode,
     archiveConversations: browserArchive ?? configuredBrowser.archiveConversations,
     desiredModel: desiredModelLabel || mapModelToBrowserLabel(runModel),
+    modelIsImplicitDefault: !inputModel && !userConfig.model && !browserModelLabel,
   };
 }
 

--- a/src/remote/server.ts
+++ b/src/remote/server.ts
@@ -930,6 +930,7 @@ const CLIENT_BROWSER_CONFIG_FIELDS = [
   "chatgptUrl",
   "url",
   "desiredModel",
+  "modelIsImplicitDefault",
   "modelStrategy",
   "thinkingTime",
   "researchMode",

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -71,6 +71,8 @@ export interface BrowserSessionConfig {
   keepBrowser?: boolean;
   hideWindow?: boolean;
   desiredModel?: string | null;
+  /** The caller omitted a model and inherited Oracle's browser default. */
+  modelIsImplicitDefault?: boolean;
   modelStrategy?: BrowserModelStrategy;
   debug?: boolean;
   allowCookieErrors?: boolean;

--- a/tests/browser/modelSelection.implicitDefault.test.ts
+++ b/tests/browser/modelSelection.implicitDefault.test.ts
@@ -1,0 +1,134 @@
+import { expect, test, vi } from "vitest";
+import { ensureModelSelection } from "../../src/browser/actions/modelSelection.js";
+import type { ChromeClient } from "../../src/browser/types.js";
+
+test.each(["GPT-5.6 Sol", "6 Pro", "Latest", "最新", "최신"])(
+  "warns before an implicit switch from %s without changing the target",
+  async (label) => {
+    const events: string[] = [];
+    const evaluate = vi
+      .fn()
+      .mockImplementationOnce(async () => ({
+        result: { value: { status: "already-selected", label } },
+      }))
+      .mockImplementationOnce(async () => {
+        events.push("select");
+        return { result: { value: { status: "switched", label: "GPT-5.5" } } };
+      });
+    const result = await ensureModelSelection(
+      { evaluate } as unknown as ChromeClient["Runtime"],
+      "GPT-5.5",
+      (line) => events.push(line),
+      "select",
+      { implicitDefault: true, buttonWaitMs: 0 },
+    );
+    expect(events[0]).toContain("Model selection warning:");
+    expect(events[0]).toContain("--browser-model-strategy current");
+    expect(events[1]).toBe("select");
+    expect(result).toMatchObject({
+      requestedModel: "GPT-5.5",
+      resolvedLabel: "GPT-5.5",
+      verified: true,
+    });
+  },
+);
+
+test.each(["GPT-5.5", "5.5Pro", "Thinking 5.4", "Pro", "Extra High", null])(
+  "does not warn for unchanged, older, or unidentified selection %s",
+  async (label) => {
+    const evaluate = vi
+      .fn()
+      .mockResolvedValueOnce({ result: { value: { status: "already-selected", label } } })
+      .mockResolvedValue({ result: { value: { status: "already-selected", label: "GPT-5.5" } } });
+    const log = vi.fn();
+    await ensureModelSelection(
+      { evaluate } as unknown as ChromeClient["Runtime"],
+      "GPT-5.5",
+      log,
+      "select",
+      { implicitDefault: true, buttonWaitMs: 0 },
+    );
+    expect(log.mock.calls.flat().some((line) => line.includes("warning"))).toBe(false);
+  },
+);
+
+test.each([false, undefined])(
+  "explicit/configured selection does not run an implicit probe (%s)",
+  async (implicitDefault) => {
+    const evaluate = vi.fn(async () => ({
+      result: { value: { status: "switched", label: "GPT-5.5" } },
+    }));
+    await ensureModelSelection(
+      { evaluate } as unknown as ChromeClient["Runtime"],
+      "GPT-5.5",
+      vi.fn((_message: string) => {}),
+      "select",
+      { implicitDefault },
+    );
+    expect(evaluate).toHaveBeenCalledOnce();
+  },
+);
+
+test("current strategy stays unchanged even with saved default provenance", async () => {
+  const evaluate = vi.fn(async () => ({
+    result: { value: { status: "already-selected", label: "GPT-5.6 Sol" } },
+  }));
+  const log = vi.fn();
+  await ensureModelSelection(
+    { evaluate } as unknown as ChromeClient["Runtime"],
+    "GPT-5.5",
+    log,
+    "current",
+    { implicitDefault: true, buttonWaitMs: 0 },
+  );
+  expect(evaluate).toHaveBeenCalledOnce();
+  expect(log.mock.calls.flat().some((line) => line.includes("warning"))).toBe(false);
+});
+
+test("waits for a late-rendered model label before warning and switching", async () => {
+  const events: string[] = [];
+  const evaluate = vi
+    .fn()
+    .mockResolvedValueOnce({ result: { value: { status: "already-selected", label: null } } })
+    .mockResolvedValueOnce({
+      result: { value: { status: "already-selected", label: "GPT-5.6 Sol" } },
+    })
+    .mockImplementationOnce(async () => {
+      events.push("select");
+      return { result: { value: { status: "switched", label: "GPT-5.5" } } };
+    });
+  await ensureModelSelection(
+    { evaluate } as unknown as ChromeClient["Runtime"],
+    "GPT-5.5",
+    (line) => events.push(line),
+    "select",
+    { implicitDefault: true, buttonWaitMs: 1000, buttonPollMs: 1 },
+  );
+  expect(events[0]).toContain("Model selection warning:");
+  expect(events[1]).toBe("select");
+  expect(evaluate).toHaveBeenCalledTimes(3);
+});
+
+test("retains the selection wait budget after an unavailable-label probe", async () => {
+  const evaluate = vi
+    .fn()
+    .mockResolvedValueOnce({ result: { value: { status: "already-selected", label: null } } })
+    .mockResolvedValueOnce({ result: { value: { status: "already-selected", label: null } } })
+    .mockResolvedValueOnce({ result: { value: { status: "button-missing" } } })
+    .mockResolvedValueOnce({
+      result: { value: { status: "already-selected", label: "GPT-5.6 Sol" } },
+    })
+    .mockResolvedValueOnce({ result: { value: { status: "switched", label: "GPT-5.5" } } });
+  const log = vi.fn((_message: string) => {});
+  const selected = await ensureModelSelection(
+    { evaluate } as unknown as ChromeClient["Runtime"],
+    "GPT-5.5",
+    log,
+    "select",
+    { implicitDefault: true, buttonWaitMs: 10, buttonPollMs: 15 },
+  );
+  expect(selected.status).toBe("switched");
+  expect(log.mock.calls.flat().some((line) => line.includes("Model selection warning:"))).toBe(
+    true,
+  );
+});

--- a/tests/mcp/consult.test.ts
+++ b/tests/mcp/consult.test.ts
@@ -277,6 +277,21 @@ describe("summarizeModelRunsForConsult", () => {
     ).toMatchObject({ desiredModel: "Latest", modelStrategy: "select" });
   });
 
+  test("marks only omitted MCP models as implicit defaults", () => {
+    const base = { userConfig: {}, env: {}, runModel: "gpt-5.5-pro" };
+    expect(buildConsultBrowserConfig(base).modelIsImplicitDefault).toBe(true);
+    expect(
+      buildConsultBrowserConfig({ ...base, inputModel: "gpt-5.5-pro" }).modelIsImplicitDefault,
+    ).toBe(false);
+    expect(
+      buildConsultBrowserConfig({ ...base, userConfig: { model: "gpt-5.5-pro" } })
+        .modelIsImplicitDefault,
+    ).toBe(false);
+    expect(
+      buildConsultBrowserConfig({ ...base, browserModelLabel: "GPT-5.5" }).modelIsImplicitDefault,
+    ).toBe(false);
+  });
+
   test("merges browser defaults from config for consult runs", () => {
     const config = buildConsultBrowserConfig({
       userConfig: {


### PR DESCRIPTION
When no model is supplied through the CLI or configuration, Oracle can switch ChatGPT away from an already selected newer model without identifying the default as the cause. Warn before that switch and submission while retaining the established default and model-selection behavior.

Carry implicit-default provenance through CLI, MCP, saved session configuration, and the remote service. Explicit models, configured preferences, and current/ignore strategies remain quiet. A delayed picker probe retains a separate selection deadline so warning detection cannot consume the selection budget.

Fixes #375.

Validation: 45 focused regression tests, typechecking, clean local/branch autoreview through P2, and five built-CLI browser scenarios through one retained connection. All four exact-head CI jobs passed: https://github.com/steipete/oracle/actions/runs/34668020695. The changelog entry is consolidated in the final maintenance-notes PR.
