### PR TITLE
chore: consolidate browser fixes and refresh Zod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+**Highlights:** Fewer Chrome approval prompts, reliable browser harvest recovery, and generated-image delivery across remote hosts.
+
+- Browser: reuse one DevTools connection per browser endpoint and Oracle process across discovery, page sessions, and service requests, while keeping cancellation local and reconnecting after a real disconnect. Fixes #484.
+- Browser: recover saved attach-running conversations through refreshed browser WebSocket metadata, keep transient status notices out of prompt verification, and report actionable harvest errors. Fixes #482.
+- Remote: transfer generated images to the requested client path and numbered siblings, require image-capable hosts before submission, and omit host-only save locations from answers; thanks @malvarezcastillo.
+- Browser: warn before an implicit default switches away from a visibly newer selected model, including delayed picker rendering, while preserving explicit models, saved preferences, and current-model behavior. Fixes #375.
+- Browser: recognize the exact Korean Latest label (`최신`) during selection and verification; thanks @thisisjun786.
+- Dependencies: update Zod to 4.6.1 while retaining Node >=24 and the two-day release-age policy.
+
 ## 0.20.1 - 2026-09-11
 
 **Highlights:** Safer browser recovery and cancellation, with reliable effort selection across saved defaults and quota-limited accounts.

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "shiki": "^4.4.3",
     "toasted-notifier": "^10.1.0",
     "tokentally": "^0.1.6",
-    "zod": "^4.6.0"
+    "zod": "^4.6.1"
   },
   "devDependencies": {
     "@anthropic-ai/tokenizer": "^0.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         version: 0.0.4
       '@google/genai':
         specifier: ^2.21.0
-        version: 2.21.0(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.6.0))(supports-color@10.2.2)
+        version: 2.21.0(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.6.1))(supports-color@10.2.2)
       '@google/generative-ai':
         specifier: ^0.24.1
         version: 0.24.1
@@ -69,7 +69,7 @@ importers:
         version: 0.3.3
       openai:
         specifier: ^7.13.0
-        version: 7.13.0(undici@7.29.1)(ws@8.21.3)(zod@4.6.0)
+        version: 7.13.0(undici@7.29.1)(ws@8.21.3)(zod@4.6.1)
       osc-progress:
         specifier: ^0.3.3
         version: 0.3.3
@@ -86,15 +86,15 @@ importers:
         specifier: ^0.1.6
         version: 0.1.6
       zod:
-        specifier: ^4.6.0
-        version: 4.6.0
+        specifier: ^4.6.1
+        version: 4.6.1
     devDependencies:
       '@modelcontextprotocol/client':
         specifier: ^2.0.0
         version: 2.0.0
       '@modelcontextprotocol/sdk':
         specifier: ^1.30.0
-        version: 1.30.0(supports-color@10.2.2)(zod@4.6.0)
+        version: 1.30.0(supports-color@10.2.2)(zod@4.6.1)
       '@types/chrome-remote-interface':
         specifier: ^0.34.0
         version: 0.34.0
@@ -2486,8 +2486,8 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.6.0:
-    resolution: {integrity: sha512-iIvwyDnebKYpww2ta0DjaNOL8RnVLmPMhgWyOzlW9y0EIIxv5gl+H6Y0ONpt83HqjGqkk78uWp6xWtpxzZdPbw==}
+  zod@4.6.1:
+    resolution: {integrity: sha512-341aRWQsve0rvronKNTqZpjmzdbUDlFuzHaI/XLg/Ej82qffDJRRfBTCuv7+9q/rMjB6LSLyEBnW4InJeMtt/Q==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -2592,14 +2592,14 @@ snapshots:
   '@esbuild/win32-x64@0.28.2':
     optional: true
 
-  '@google/genai@2.21.0(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.6.0))(supports-color@10.2.2)':
+  '@google/genai@2.21.0(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.6.1))(supports-color@10.2.2)':
     dependencies:
       google-auth-library: 10.9.1(supports-color@10.2.2)
       p-retry: 4.6.2
       protobufjs: 8.8.0
       ws: 8.21.3
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.30.0(supports-color@10.2.2)(zod@4.6.0)
+      '@modelcontextprotocol/sdk': 1.30.0(supports-color@10.2.2)(zod@4.6.1)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -2747,13 +2747,13 @@ snapshots:
       eventsource-parser: 3.1.1
       jose: 6.2.10
       pkce-challenge: 5.0.1
-      zod: 4.6.0
+      zod: 4.6.1
 
   '@modelcontextprotocol/core@2.0.0':
     dependencies:
-      zod: 4.6.0
+      zod: 4.6.1
 
-  '@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.6.0)':
+  '@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.6.1)':
     dependencies:
       '@hono/node-server': 2.1.1(hono@4.13.5)
       ajv: 8.20.0
@@ -2770,15 +2770,15 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.6.0
-      zod-to-json-schema: 3.25.2(zod@4.6.0)
+      zod: 4.6.1
+      zod-to-json-schema: 3.25.2(zod@4.6.1)
     transitivePeerDependencies:
       - supports-color
 
   '@modelcontextprotocol/server@2.0.0':
     dependencies:
       '@modelcontextprotocol/core': 2.0.0
-      zod: 4.6.0
+      zod: 4.6.1
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -3944,11 +3944,11 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  openai@7.13.0(undici@7.29.1)(ws@8.21.3)(zod@4.6.0):
+  openai@7.13.0(undici@7.29.1)(ws@8.21.3)(zod@4.6.1):
     optionalDependencies:
       undici: 7.29.1
       ws: 8.21.3
-      zod: 4.6.0
+      zod: 4.6.1
 
   osc-progress@0.3.3: {}
 
@@ -4478,12 +4478,12 @@ snapshots:
 
   yoctocolors@2.2.0: {}
 
-  zod-to-json-schema@3.25.2(zod@4.6.0):
+  zod-to-json-schema@3.25.2(zod@4.6.1):
     dependencies:
-      zod: 4.6.0
+      zod: 4.6.1
 
   zod@3.25.76: {}
 
-  zod@4.6.0: {}
+  zod@4.6.1: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
Consolidate the batch's user-visible browser and remote-image fixes in one ordered Unreleased section, and update Zod from 4.6.0 to the eligible 4.6.1 patch with a consistent lockfile. Node >=24 and the two-day minimum release age remain unchanged; the newer 4.6.2 patch is still inside that age window.

Land this notes PR last, after #487 → #483 → #477 → #471 → #485. Each sibling fix keeps its changelog changes here to avoid squash-merge conflicts. These fixes support patch 0.20.2; this PR does not bump, tag, or publish a version.

Validation: 2,402-test dependency suite; built CLI version, dry-run, and docs checks; clean local autoreview through P2. All four exact-head CI jobs passed (https://github.com/steipete/oracle/actions/runs/34668276052), and the branch review is clean through P2. Hold this PR until the implementation PRs have landed.
